### PR TITLE
__future__ imports should come after shebangs.

### DIFF
--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -1,6 +1,6 @@
-from __future__ import absolute_import
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import copy
 from pprint import pprint
 import logging

--- a/analytics_utils/__init__.py
+++ b/analytics_utils/__init__.py
@@ -1,10 +1,10 @@
-from __future__ import absolute_import
-from __future__ import print_function
 #!/usr/bin/env python
 
 # Adapted get_pqa_mask function from stacker.py by Josh Sixsmith & Alex IP of Geoscience Australia
 # https://github.com/GeoscienceAustralia/agdc/blob/master/src/stacker.py
 
+from __future__ import absolute_import
+from __future__ import print_function
 import math
 import csv
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 # -*- coding: utf-8 -*-
 #
 # AGDC documentation build configuration file, created by
@@ -13,6 +12,7 @@ from __future__ import absolute_import
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from __future__ import absolute_import
 import sys
 import os
 

--- a/execution_engine/__init__.py
+++ b/execution_engine/__init__.py
@@ -1,7 +1,7 @@
-from __future__ import absolute_import
-from __future__ import print_function
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+from __future__ import print_function
 import copy
 from pprint import pprint
 import logging

--- a/gdf/netcdf_builder.py
+++ b/gdf/netcdf_builder.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
 # -------------------------------------------------------------------------------
 # Name:         netcdf_builder
 # Purpose:      Selection of functions to open, create and manage netCDF
@@ -92,6 +90,8 @@ from __future__ import print_function
 #  OrderedDict
 #  https://code.google.com/p/netcdf4-python/
 
+from __future__ import absolute_import
+from __future__ import print_function
 import os
 import re
 


### PR DESCRIPTION
A fix for #16 (missed by 10 minutes).

This moves the `__future__` imports below the shebang line, to avoid breaking command-line usage.
