### PR TITLE
Remove version package dependency in favour of built-in sys

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,8 +24,7 @@ print(sys.path)
 # Test Import
 import datacube
 
-from version import get_version
-__version = get_version()
+__version = '%i.%i' % (sys.version_info.major, sys.version_info.minor)
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 


### PR DESCRIPTION
This removes the need for using another package just to get "2.7" from a system. 
