### PR TITLE
Fix sat_path/row and station data in prep scripts

### DIFF
--- a/utils/galsprepare.py
+++ b/utils/galsprepare.py
@@ -103,10 +103,10 @@ def prep_dataset(fields, path):
         'instrument': {'name': fields["instrument"]},
         'acquisition': {
             'groundstation': {
-                'name': _STATIONS[fields["groundstation"]],
-                'aos': str(aos),
-                'los': str(los)
-            }
+                'code': _STATIONS[fields["groundstation"]]
+            },
+            'aos': str(aos),
+            'los': str(los)
         },
         'extent': {
             'from_dt': str(start_time),
@@ -118,8 +118,8 @@ def prep_dataset(fields, path):
             'projection': get_projection(path/next(iter(images.values()))['path'])
         },
         'image': {
-            'satellite_ref_point_start': {'path': int(fields["path"]), 'row': int(fields["row"])},
-            'satellite_ref_point_end': {'path': int(fields["path"]), 'row': int(fields["row"])},
+            'satellite_ref_point_start': {'x': int(fields["path"]), 'y': int(fields["row"])},
+            'satellite_ref_point_end': {'x': int(fields["path"]), 'y': int(fields["row"])},
             'bands': images
         },
         'lineage': {'source_datasets': {}}

--- a/utils/usgslsprepare.py
+++ b/utils/usgslsprepare.py
@@ -188,10 +188,10 @@ def prep_dataset(fields, path):
         'instrument': {'name': fields["instrument"]},
         'acquisition': {
             'groundstation': {
-                'name': groundstation,
-                'aos': str(aos),
-                'los': str(los)
-            }
+                'code': groundstation,
+            },
+            'aos': str(aos),
+            'los': str(los)
         },
         'extent': {
             'from_dt': str(start_time),
@@ -203,8 +203,8 @@ def prep_dataset(fields, path):
             'projection': projdict   
         },
         'image': {
-            'satellite_ref_point_start': {'path': int(fields["path"]), 'row': int(fields["row"])},
-            'satellite_ref_point_end': {'path': int(fields["path"]), 'row': int(fields["row"])},
+            'satellite_ref_point_start': {'x': int(fields["path"]), 'y': int(fields["row"])},
+            'satellite_ref_point_end': {'x': int(fields["path"]), 'y': int(fields["row"])},
             'bands': images
         },
        


### PR DESCRIPTION
PR fixes metadata preparation scripts for GA and USGS Landsat data which incorrectly specified the data used for `sat_path`, `sat_row`, and `gsi` according to [`default-metadata-types.yaml`](https://github.com/data-cube/agdc-v2/blob/develop/datacube/index/default-metadata-types.yaml). Corrected `row`/`path` to `y`/`x` for the path/row data and `name` to `code` for the ground station data.

I also moved the `aos` and `los` specifications to the correct place when ingesting "telemetry" data, just in case these prep scripts are ever used for anything other than the "eo" datasets (which get the time information through the `extent` fields).

This all hinges on me understanding the `default-metadata-types.yaml` usage, but I tried indexing some data with the changes applied and the database is now recording these fields when they previously did not:

``` bash
$ datacube-search datasets ...
-[ 9 ]-------------------------------------------------------------------------------------------------------------
dataset_type_id  | 1
gsi              | 
id               | 104832f9-e09b-45a6-ae58-72a0d5136f8a
instrument       | TM
lat              | [40.7324012646456,42.7768735557142]
lon              | [-72.8858806917623,-69.8556033602703]
metadata_type    | eo
metadata_type_id | 1
orbit            | 
platform         | LANDSAT_5
product          | ls5_espa_scene
product_type     | ESPA
sat_path         | 
sat_row          | 
time             | 2011-11-05T15:14:38+00:00 to 2011-11-05T15:15:02+00:00
-[ 10 ]------------------------------------------------------------------------------------------------------------
dataset_type_id  | 1
gsi              | GNC
id               | 701b03ad-7e9b-4cb9-a21a-44a801737d2d
instrument       | TM
lat              | [40.7728701272661,42.7348565691638]
lon              | [-74.3123605394179,-71.3810836112756]
metadata_type    | eo
metadata_type_id | 1
orbit            | 
platform         | LANDSAT_5
product          | ls5_espa_scene
product_type     | ESPA
sat_path         | 13 to 13
sat_row          | 31 to 31
time             | 2011-11-12T15:20:37+00:00 to 2011-11-12T15:21:01+00:00
```

Any clue if there is an easy way to fix the database info for the existing data? The path/row information is very important to me (not using NBAR so sensor geometry matters!), but I haven't ran AGDC against too much data to make a complete do over troublesome if needed.
