### PR TITLE
Add support for gridspec origin convention

### DIFF
--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -655,7 +655,7 @@ class GridSpec(object):
         :rtype: (float,float)
         """
         def coord(index, resolution, size, origin):
-            return (index + (1 if resolution < 0 else 0)) * size + origin
+            return (index + (1 if resolution < 0 and size > 0 else 0)) * size + origin
 
         return tuple(coord(index, res, size, origin) for index, res, size, origin in
                      zip(tile_index[::-1], self.resolution, self.tile_size, self.origin))
@@ -719,6 +719,8 @@ class GridSpec(object):
 
         >>> list(GridSpec.grid_range(-4.0, -1.0, 3.0))
         [-2, -1]
+        >>> list(GridSpec.grid_range(1.0, 4.0, -3.0))
+        [-2, -1]
         >>> list(GridSpec.grid_range(-3.0, 0.0, 3.0))
         [-1]
         >>> list(GridSpec.grid_range(-2.0, 1.0, 3.0))
@@ -730,6 +732,8 @@ class GridSpec(object):
         >>> list(GridSpec.grid_range(1.0, 4.0, 3.0))
         [0, 1]
         """
+        if step < 0.0:
+            lower, upper, step = -upper, -lower, -step
         assert step > 0.0
         return range(int(math.floor(lower / step)), int(math.ceil(upper / step)))
 

--- a/docs/ops/config.rst
+++ b/docs/ops/config.rst
@@ -280,8 +280,10 @@ storage
         if the projection is geographic, otherwise use ``x`` and ``y``
 
     origin
-        Coordinates of the bottom-left(?) corner of the (0,0) tile specified in projection units. Use ``latitude`` and
-        ``longitude`` if the projection is geographic, otherwise use ``x`` and ``y``
+        Coordinates of the bottom-left or top-left corner of the (0,0) tile specified in projection units. If
+        coordinates are for top-left corner, ensure that the ``latitude`` or ``y`` dimension of ``tile_size`` is
+        negative so tile indexes count downward. Use ``latitude`` and ``longitude`` if the projection is geographic,
+        otherwise use ``x`` and ``y``
 
     resolution
         Resolution for the data to be stored in specified in projection units.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 
 import numpy
-from datacube.model import GeoPolygon, GeoBox, CRS, GridSpec
+from datacube.model import BoundingBox, GeoPolygon, GeoBox, CRS, GridSpec
 
 
 def test_geobox():
@@ -29,3 +29,23 @@ def test_grispec():
     assert set(cells.keys()) == {(0, 1), (0, 2), (1, 0), (1, 1), (1, 2), (2, 0), (2, 1)}
     assert numpy.isclose(cells[(2, 0)].coordinates['longitude'].values, numpy.linspace(12.05, 12.95, num=10)).all()
     assert numpy.isclose(cells[(2, 0)].coordinates['latitude'].values, numpy.linspace(10.95, 10.05, num=10)).all()
+
+
+def test_gridspec_upperleft():
+    """ Test to ensure grid indexes can be counted correctly from bottom left or top left
+    """
+    tile_bbox = BoundingBox(left=1934400.0, top=2414800.0, right=2084400.000, bottom=2264800.000)
+    bbox = BoundingBox(left=1934615, top=2379460, right=1937615, bottom=2376460)
+    # Upper left - validated against WELD product tile calculator
+    # http://globalmonitoring.sdstate.edu/projects/weld/tilecalc.php
+    gs = GridSpec(crs=CRS('EPSG:5070'), tile_size=(-150000, 150000), resolution=(-30, 30),
+                  origin=(3314800.0, -2565600.0))
+    cells = {index: geobox for index, geobox in list(gs.tiles(bbox))}
+    assert set(cells.keys()) == {(30, 6)}
+    assert cells[(30, 6)].extent.boundingbox == tile_bbox
+
+    gs = GridSpec(crs=CRS('EPSG:5070'), tile_size=(150000, 150000), resolution=(-30, 30),
+                  origin=(14800.0, -2565600.0))
+    cells = {index: geobox for index, geobox in list(gs.tiles(bbox))}
+    assert set(cells.keys()) == {(30, 15)}  # WELD grid spec has 21 vertical cells -- 21 - 6 = 15
+    assert cells[(30, 15)].extent.boundingbox == tile_bbox


### PR DESCRIPTION
This addition follows the addition of `origin` to the `GridSpec` configuration in helping to make tiled data output from the ingestion compatible with existing gridded data. The `origin` specification allows the data to co-align and this proposed change would also allow the tile indexes to be identical by allowing users to count indexes relative to an upper left instead of the current bottom left. My interest in this change comes from wanting our tiled data to be in line with data from the Landsat WELD project grid specification (which IIRC is also being used for the USGS LCMAP project).

I've added a test that was validated against the WELD tile lookup calculator, and I've also run an ingest with the proposed changes. The tile indices created from this ingest run using `convention = "upperleft"` match and since the `origin` addition the tiles also coalign. The current "convention" of counting from the bottom left is still default and I don't think I've affected any calculations for that case.

Happy to iterate on any aspect of this with you all. Thanks!
