### PR TITLE
load datasets bypassing query

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -144,7 +144,7 @@ class Datacube(object):
     def load(self, product=None, measurements=None,
              output_crs=None, resolution=None, resampling=None,
              stack=False, dask_chunks=None,
-             like=None, fuse_func=None, align=None, **query):
+             like=None, fuse_func=None, align=None, datasets=None, **query):
         """
         Load data as an ``xarray`` object.  Each measurement will be a data variable in the :class:`xarray.Dataset`.
 
@@ -271,12 +271,15 @@ class Datacube(object):
         :param fuse_func: Function used to fuse/combine/reduce data with the ``group_by`` parameter. By default,
             data is simply copied over the top of each other, in a relatively undefined manner. This function can
             perform a specific combining step, eg. for combining GA PQ data.
+            
+        :param datasets: Default None. If this is a non-empty list of :class:`datacube.model.Dataset` objects, these will
+            be loaded instead of querying the database (datacube index) for :class:`datacube.model.Dataset` objects.
 
         :return: Requested data as a :class:`xarray.Dataset`.
             As a :class:`xarray.DataArray` if the ``stack`` variable is supplied.
         :rtype: :class:`xarray.Dataset` or :class:`xarray.DataArray`
         """
-        observations = self.product_observations(product=product, like=like, **query)
+        observations = datasets or self.product_observations(product=product, like=like, **query)
         if not observations:
             return None if stack else xarray.Dataset()
 

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -271,9 +271,11 @@ class Datacube(object):
         :param fuse_func: Function used to fuse/combine/reduce data with the ``group_by`` parameter. By default,
             data is simply copied over the top of each other, in a relatively undefined manner. This function can
             perform a specific combining step, eg. for combining GA PQ data.
-            
-        :param datasets: Default None. If this is a non-empty list of :class:`datacube.model.Dataset` objects, these will
-            be loaded instead of querying the database (datacube index) for :class:`datacube.model.Dataset` objects.
+
+        :param datasets: Default None. If this is a non-empty list of
+            :class:`datacube.model.Dataset` objects, these will be loaded
+            instead of querying the database (datacube index) for
+            :class:`datacube.model.Dataset` objects.
 
         :return: Requested data as a :class:`xarray.Dataset`.
             As a :class:`xarray.DataArray` if the ``stack`` variable is supplied.


### PR DESCRIPTION
A simple way to convert datacube datasets to xarray datasets.

For experimenting with task apps (producing datasets that have not yet been indexed), this would get the benefits that `xarray.open_dataset` lack and avoid:
```python
from unittest import mock
with mock.patch('datacube.api.core.Datacube.product_observations') as po:
    po.return_value = [dataset]
    n = dc.load(product='ls5_nbar_albers', measurements=['swir1','nir','green'])
with mock.patch('datacube.api.core.Datacube.product_observations') as po:
    po.return_value = result
    w = dc.load(product='wofs_albers')
```