### PR TITLE
Switch travis to conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,18 @@
-language: python
 dist: trusty
+sudo: false  # Use the new travis docker based infrastructure
 
 git:
   # We need a deeper depth for 'git descibe' to ensure
   # we can reach the last tagged version.
   depth: 99999
 
-python:
-  - "2.7"
-  - "3.5"
-
-# Use the new travis docker based infrastructure
-sudo: false
+language: python
+matrix:
+  include:
+    - python: "3.5"
+      env: CONDA_ENV_FILE=.travis/environment_py35.yaml
+    - python: "2.7"
+      env: CONDA_ENV_FILE=.travis/environment_py27.yaml
 
 cache:
   directories:
@@ -22,27 +23,32 @@ addons:
   postgresql: "9.5"
   services:
     - postgresql
-  apt:
-    packages:
-    - libhdf5-serial-dev
-    - libnetcdf-dev
-    - libproj-dev
-    - libgdal1-dev
-    - libudunits2-dev
-    - libblas-dev
-    - liblapack-dev
-    - gfortran
 
 before_install:
   # Create a database for the integration tests.
   - createdb agdcintegration
 
 install:
-  - export CPLUS_INCLUDE_PATH="/usr/include/gdal"
-  - export C_INCLUDE_PATH="/usr/include/gdal"
-  - travis_retry pip install --upgrade pip pytest six
-  - travis_retry pip install pylint==1.6.4 gdal==1.10.0 compliance-checker
-  - travis_retry pip install .[analytics,test,interactive]
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -f -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+
+  # travis specific goo
+  - conda config --set always_yes yes --set changeps1 no
+  - conda config --show-sources
+  - conda config --show
+
+  - conda config --prepend channels conda-forge
+  - conda update --all
+
+  # print conda info
+  - conda info -a
+
+  - conda env create -n agdc --file $CONDA_ENV_FILE
+  - source activate agdc
+  - pip install .[analytics,test,interactive] --no-deps --upgrade
+
   - pip freeze
 
 script:
@@ -59,4 +65,3 @@ notifications:
     rooms:
       secure: SCM9YZ215qZnDHHQrbgWQtaKa46ZgtsEbg8XPqdyhQdMnhXDQkNA8aJIFHaPNKs2MRfqXEz1dTigjAr7OlxlvENKdVXJDGvccaJlLWX6WckfkPinWE1nvEIR18MME4jEDp06jGww+eqBU0xniHGNa66EABiQml41XQTO3lHFzwAdx0uqG5o0irqkDGqeKW1QrZ++nUwx5W+0CJGNZO06yTIUQp6B8wfMnmaoVUUjw2xuQqUdub4TbnpGlj5T8yLbKayaMjlfGbznq7VcM+2hrT0vnKOZSu5qPBlmA7DYq9IGN3sFFa095WtRfstHGOWAHgDljgm0K/EJWAW7Pv7uAmx30I9RPA1sNq1ZxVJ4RwH5ZebRiaBVh43ik5l/vNrr4wZNLeRhgGUiCxEHrix5ZNahZAv/LDZrddRyspDLmgXsCb+ExPsHwamhieVAvjB24aDL8tj8Es1A75Ai1mtcCwuYGHQzeDAlTGP5XdJQWrpcySFkouMg85DPSNz++YSBzgNR+z7pPH7Hxc01ofplXB10AMMP0IgDyZNJ2JjqttDjrMKTrfXsakEb66mXBsJDg9qBPWV5R6GOcGVBMo1JnGWFoD9IGihTWdyxv7+TEZ/w+F8hyErqFzVkMwER/BwYiT/euIVIm/ZEgRpISwZmNWTg6tXo+M5WUZtQGGmAERI=
       secure: ADGOG3YqqYnLq2vT+3eIVr+Gr91Zp0+6n7V4C0hZziAf2wE6fKSqk9xamWad4a96c+kGnlK7xzUuqPretcfCY3ANFnZKtqyckBnMuU+wlUvCee9nybXmqXB+hfuNSVkeVkC51yVTzsnNhj5ASDy4OdD+duGUn9gY2fgHVf2WK8V98tFmt1kviV4h2me/d1+wNLu6hmtRWGW7klpY4Oz9pP6HruFvbTh28H2VArnpiT2t8PIEsNTIZNnOQOVUtUEdecB0svFRXKqCdklVns6wlyWsPpHWZ7HuxRy8K/wutKR85EFVxWiS9jCFSjPlzYBsyQyWq1oKiDVtusIha2XtsTMq1D+3wnPH1T8yFyqD4xuFCG0mkk99hGHlgCvYLDhzYLZdj2zcTewF3Oye3oxnoaeSRcsIS7i93Z9qxdWRIh093ZUr+rQ2hw6r2SSGBLaE+9pnlkVPU+JoeGHo9PsZzPKGMyUeSkQaLuBbTc4V308uAodPfJge0+BAz2TWe6w+bOrem+QaMtInGXcuAIWjQfFpxjOjBeegatobSitTvxPjeNgRrZTjPWEqAOgBEqcRcAymKP7bI8IOFSmH5KdLE6niB0yiatWOKQu8BVSRpZ4CiPK3MyVe09x0g5HCQJZ+bEjkDnCpkKtXTBuT9U8CHzTUqxfeZ3hiEOZFWPvVOyk=
-

--- a/.travis/environment_py27.yaml
+++ b/.travis/environment_py27.yaml
@@ -1,0 +1,30 @@
+name: agdc
+dependencies:
+- python=2.7
+- pyyaml
+- sqlalchemy
+- python-dateutil
+- jsonschema
+- cachetools
+- numpy
+- numexpr
+- rasterio
+- singledispatch
+- netcdf4
+- psycopg2
+- gdal
+- dask
+- xarray
+- pylint # testing
+- pep8 # testing
+- fiona # movie generator app
+- mock # testing
+- hypothesis # testing
+- matplotlib # pixel drill app
+- pathlib
+- compliance-checker
+- pip:
+  - pypeg2
+  - pytest-cov # testing
+  - pytest-logging
+  - pytest-faulthandler

--- a/.travis/environment_py35.yaml
+++ b/.travis/environment_py35.yaml
@@ -1,0 +1,30 @@
+name: agdc
+dependencies:
+- python=3.5
+- pyyaml
+- sqlalchemy
+- python-dateutil
+- jsonschema
+- cachetools
+- numpy
+- numexpr
+- rasterio
+- singledispatch
+- netcdf4
+- psycopg2
+- gdal
+- dask
+- xarray
+- pylint # testing
+- pep8 # testing
+- fiona # movie generator app
+- mock # testing
+- hypothesis # testing
+- matplotlib # pixel drill app
+- pathlib
+- compliance-checker
+- pip:
+  - pypeg2
+  - pytest-cov # testing
+  - pytest-logging
+  - pytest-faulthandler


### PR DESCRIPTION
Travis containers come with ancient version of GDAL (libgdal1-dev 1.10). We require a number of bugfixes only available in the newer versions.
We're also recommend using conda/conda-forge environments more and more; this way people can copy our travis setup for their purposes