### PR TITLE
Documented example list_products() looks very different to the current system output

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -97,11 +97,11 @@ class Datacube(object):
             return rows
 
         keys = set(k for r in rows for k in r)
-        main_cols = ['id', 'name', 'description']
+        main_cols = ['name', 'description']
         grid_cols = ['crs', 'resolution', 'tile_size', 'spatial_dimensions']
-        other_cols = list(keys - set(main_cols) - set(grid_cols))
+        other_cols = sorted(list(keys - set(main_cols) - set(grid_cols)))
         cols = main_cols + other_cols + grid_cols
-        return pandas.DataFrame(rows, columns=cols).set_index('id')
+        return pandas.DataFrame(rows, columns=cols).set_index('name')
 
     def list_measurements(self, show_archived=False, with_pandas=True):
         """
@@ -577,10 +577,13 @@ def datatset_type_to_row(dt):
         'name': dt.name,
         'description': dt.definition['description'],
     }
-    # Only show fields whose value is fixed for this product.
+    # Only show columns for fields whose value is fixed for this product.
     # (ie, those set in the product definition, not differing between datasets).
     # Otherwise there's a sea of NaN fields.
-    row.update({k: v for (k, v) in dt.fields.items() if v is not None})
+    product_fields = {k: v for (k, v) in dt.fields.items() if v is not None}
+    row.update(product_fields)
+
+    row['search_fields'] = list(sorted(k for (k, v) in dt.fields.items() if v is None))
     if dt.grid_spec is not None:
         row.update({
             'crs': dt.grid_spec.crs,

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -574,11 +574,13 @@ def set_resampling_method(measurements, resampling=None):
 
 def datatset_type_to_row(dt):
     row = {
-        'id': dt.id,
         'name': dt.name,
         'description': dt.definition['description'],
     }
-    row.update(dt.fields)
+    # Only show fields whose value is fixed for this product.
+    # (ie, those set in the product definition, not differing between datasets).
+    # Otherwise there's a sea of NaN fields.
+    row.update({k: v for (k, v) in dt.fields.items() if v is not None})
     if dt.grid_spec is not None:
         row.update({
             'crs': dt.grid_spec.crs,

--- a/datacube/utils/__init__.py
+++ b/datacube/utils/__init__.py
@@ -643,6 +643,9 @@ class DocReader(object):
                 continue
         return fields
 
+    def __dir__(self):
+        return self.fields.keys()
+
 
 def import_function(func_ref):
     """

--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -211,8 +211,9 @@ def check_open_with_dc(index):
 
     products_df = dc.list_products()
     assert len(products_df)
-    assert len(products_df[products_df['name'].isin(['ls5_nbar_albers'])])
-    assert len(products_df[products_df['name'].isin(['ls5_pq_albers'])])
+    assert 'ls5_nbar_albers' in products_df.index
+    assert 'ls5_pq_albers' in products_df.index
+    assert 'fake_product' not in products_df.index
 
     assert len(dc.list_measurements())
 


### PR DESCRIPTION
Arek pointed out, while working through the example notebooks, that the system looked broken because `list_products()` output a large unreadable table of NaNs (which is very different to the notebook's expected output):
![verbose-list-products](https://cloud.githubusercontent.com/assets/25688/23689544/7efe5392-040f-11e7-8b2a-d84b3c4e76c5.png)

If the purpose of the command is to view available products, it makes
more sense to only show the fixed (match) fields specific to the product to highlight their definitions/differences.

The id field should also be hidden, as it's a postgres implementation
detail. On all UIs and APIs the unique 'name' field is effectively the
id.

Attached patch makes those changes. This fix is up for discussion, as I may be misunderstanding the usage of `list_products()`.

