### PR TITLE
Remove platform and GA-specific fields from the default eo metadata type

### DIFF
--- a/datacube/index/default-metadata-types.yaml
+++ b/datacube/index/default-metadata-types.yaml
@@ -114,38 +114,6 @@ dataset:
             - [extent, to_dt]
             - [extent, center_dt]
 
-        gsi:
-            description: Ground Station Identifier (eg. ASA)
-            offset: [acquisition, groundstation, code]
-            indexed: false
-
-        orbit:
-            description: Orbit number
-            offset: [acquisition, platform_orbit]
-            type: integer
-
-        sat_path:
-            description: Landsat path
-
-            type: integer-range
-            min_offset:
-            - [image, satellite_ref_point_start, x]
-            max_offset:
-            - [image, satellite_ref_point_end, x]
-            # If an end is not specified, use the start.
-            - [image, satellite_ref_point_start, x]
-
-        sat_row:
-            description: Landsat row
-
-            type: integer-range
-            min_offset:
-            - [image, satellite_ref_point_start, y]
-            max_offset:
-            - [image, satellite_ref_point_end, y]
-            # If an end is not specified, use the start.
-            - [image, satellite_ref_point_start, y]
-
 ---
 
 name: telemetry

--- a/datacube/index/default-metadata-types.yaml
+++ b/datacube/index/default-metadata-types.yaml
@@ -2,8 +2,7 @@ name: eo
 description: |
     Earth Observation datasets.
 
-    Type of datasets produced by the eodatasets library.
-    (or of similar structure)
+    Expected metadata structure produced by the eodatasets library, as used internally at GA.
 
     https://github.com/GeoscienceAustralia/eo-datasets
 
@@ -118,10 +117,9 @@ dataset:
 
 name: telemetry
 description: |
-    telemetry datasets.
+    Satellite telemetry datasets.
 
-    Type of datasets produced by the eodatasets library.
-    (or of similar structure)
+    Expected metadata structure produced by telemetry datasets from the eodatasets library, as used internally at GA.
 
     https://github.com/GeoscienceAustralia/eo-datasets
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -15,6 +15,10 @@ v1.2.3
 
  - URI searches are now better supported from the cli: `datacube dataset search uri = file:///some/uri/here`
 
+ - Platform-specific (Landsat) fields have been removed from the default `eo`
+   metadata type in order to keep it minimal. Users & products can still add
+   their own metadata types to use extra fields.
+
  - We are now part of Open Data Cube, and have a new home at https://github.com/opendatacube/datacube-core
 
 v1.2.2

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -149,27 +149,27 @@ def dict_api(index):
 
 
 @pytest.fixture
-def ls5_nbar_gtiff_doc(default_metadata_type):
+def ls5_telem_doc(telemetry_metadata_type):
     return {
-        "name": "ls5_nbart_p54_gtiff",
+        "name": "ls5_telem_test",
         "description": 'LS5 Test',
         "metadata": {
             "platform": {
                 "code": "LANDSAT_5"
             },
-            "product_type": "nbart",
-            "ga_level": "P54",
+            "product_type": "satellite_telemetry_data",
+            "ga_level": "P00",
             "format": {
-                "name": "GeoTIFF"
+                "name": "RCC"
             }
         },
-        "metadata_type": default_metadata_type.name  # "eo"
+        "metadata_type": telemetry_metadata_type.name
     }
 
 
 @pytest.fixture
-def ls5_nbar_gtiff_type(index, ls5_nbar_gtiff_doc):
-    return index.products.add_document(ls5_nbar_gtiff_doc)
+def ls5_telem_type(index, ls5_telem_doc):
+    return index.products.add_document(ls5_telem_doc)
 
 
 @pytest.fixture
@@ -224,6 +224,11 @@ def default_metadata_type_docs():
 @pytest.fixture
 def default_metadata_type_doc(default_metadata_type_docs):
     return [doc for doc in default_metadata_type_docs if doc['name'] == 'eo'][0]
+
+
+@pytest.fixture
+def telemetry_metadata_type_doc(default_metadata_type_docs):
+    return [doc for doc in default_metadata_type_docs if doc['name'] == 'telemetry'][0]
 
 
 @pytest.fixture

--- a/integration_tests/extensive-eo-metadata.yaml
+++ b/integration_tests/extensive-eo-metadata.yaml
@@ -1,0 +1,101 @@
+# An example of a larger metadata type as used by GA...
+name: eo_full
+description: |
+    Earth Observation datasets.
+    Type of datasets produced by the eodatasets library.
+    (or of similar structure)
+    https://github.com/GeoscienceAustralia/eo-datasets
+dataset:
+    id: ['id']
+    creation_dt: ['creation_dt']
+    label: ['ga_label']
+    measurements: ['image', 'bands']
+    grid_spatial: ['grid_spatial', 'projection']
+    format: ['format', 'name']
+    sources: ['lineage', 'source_datasets']
+
+    search_fields:
+        platform:
+            description: Platform code
+            offset: [platform, code]
+
+        instrument:
+            description: Instrument name
+            offset: [instrument, name]
+
+        product_type:
+            description: Product code
+            offset: [product_type]
+
+        format:
+            description: File format (GeoTiff, NetCDF)
+            offset: [format, name]
+            indexed: false
+
+        lat:
+            description: Latitude range
+            type: float-range
+            max_offset:
+            - [extent, coord, ur, lat]
+            - [extent, coord, lr, lat]
+            - [extent, coord, ul, lat]
+            - [extent, coord, ll, lat]
+            min_offset:
+            - [extent, coord, ur, lat]
+            - [extent, coord, lr, lat]
+            - [extent, coord, ul, lat]
+            - [extent, coord, ll, lat]
+
+        lon:
+            description: Longitude range
+            type: float-range
+            max_offset:
+            - [extent, coord, ul, lon]
+            - [extent, coord, ur, lon]
+            - [extent, coord, ll, lon]
+            - [extent, coord, lr, lon]
+            min_offset:
+            - [extent, coord, ul, lon]
+            - [extent, coord, ur, lon]
+            - [extent, coord, ll, lon]
+            - [extent, coord, lr, lon]
+
+        time:
+            description: Acquisition time
+            type: datetime-range
+            min_offset:
+            - [extent, from_dt]
+            - [extent, center_dt]
+            max_offset:
+            - [extent, to_dt]
+            - [extent, center_dt]
+
+        gsi:
+            description: Ground Station Identifier (eg. ASA)
+            offset: [acquisition, groundstation, code]
+            indexed: false
+
+        orbit:
+            description: Orbit number
+            offset: [acquisition, platform_orbit]
+            indexed: true
+
+        sat_path:
+            description: Landsat path
+            type: integer-range
+            min_offset:
+            - [image, satellite_ref_point_start, x]
+            max_offset:
+            - [image, satellite_ref_point_end, x]
+            # If an end is not specified, use the start.
+            - [image, satellite_ref_point_start, x]
+
+        sat_row:
+            description: Landsat row
+            type: integer-range
+            min_offset:
+            - [image, satellite_ref_point_start, y]
+            max_offset:
+            - [image, satellite_ref_point_end, y]
+            # If an end is not specified, use the start.
+            - [image, satellite_ref_point_start, y]

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -238,7 +238,7 @@ def test_update_dataset(index, ls5_telem_doc, example_ls5_nbar_metadata_doc):
     assert updated.local_uri == 'file:///test/doc5.yaml'
 
 
-def test_update_dataset_type(index, ls5_telem_type, ls5_telem_doc, telemetry_metadata_type_doc):
+def test_update_dataset_type(index, ls5_telem_type, ls5_telem_doc, ga_metadata_type_doc):
     """
     :type ls5_telem_type: datacube.model.DatasetType
     :type index: datacube.index._api.Index
@@ -262,7 +262,7 @@ def test_update_dataset_type(index, ls5_telem_type, ls5_telem_doc, telemetry_met
 
     # Specifying metadata type definition (rather than name) should be allowed
     full_doc = copy.deepcopy(ls5_telem_doc)
-    full_doc['metadata_type'] = telemetry_metadata_type_doc
+    full_doc['metadata_type'] = ga_metadata_type_doc
     index.products.update_document(full_doc)
 
     # Remove fixed field, forcing a new index to be created (as datasets can now differ for the field).

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -8,9 +8,8 @@ import copy
 
 import pytest
 
-from datacube.index.postgres import PostgresDb
 from datacube.index.postgres._fields import NumericRangeDocField, PgField
-from datacube.model import DatasetType
+from datacube.model import MetadataType
 from datacube.model import Range, Dataset
 from datacube.utils import changes
 
@@ -61,50 +60,61 @@ def test_metadata_indexes_views_exist(db, default_metadata_type):
     assert _object_exists(db, 'dv_eo_dataset')
 
 
-def test_dataset_indexes_views_exist(db, ls5_nbar_gtiff_type):
+def test_dataset_indexes_views_exist(db, ls5_telem_type):
     """
     :type db: datacube.index.postgres._connections.PostgresDb
-    :type ls5_nbar_gtiff_type: datacube.model.DatasetType
+    :type ls5_telem_type: datacube.model.DatasetType
     """
-    assert ls5_nbar_gtiff_type.name == 'ls5_nbart_p54_gtiff'
+    assert ls5_telem_type.name == 'ls5_telem_test'
 
     # Ensure field indexes were created for the dataset type (following the naming conventions):
-    assert _object_exists(db, "dix_ls5_nbart_p54_gtiff_orbit")
+    assert _object_exists(db, "dix_ls5_telem_test_orbit")
 
     # Ensure it does not create a 'platform' index, because that's a fixed field
     # (ie. identical in every dataset of the type)
-    assert not _object_exists(db, "dix_ls5_nbart_p54_gtiff_platform")
+    assert not _object_exists(db, "dix_ls5_telem_test_platform")
 
     # Ensure view was created (following naming conventions)
-    assert _object_exists(db, 'dv_ls5_nbart_p54_gtiff_dataset')
+    assert _object_exists(db, 'dv_ls5_telem_test_dataset')
 
     # Ensure view was created (following naming conventions)
-    assert not _object_exists(db, 'dix_ls5_nbart_p54_gtiff_gsi'), "indexed=false field gsi shouldn't have an index"
+    assert not _object_exists(db, 'dix_ls5_telem_test_gsi'), "indexed=false field gsi shouldn't have an index"
 
 
-def test_dataset_composite_indexes_exist(db, ls5_nbar_gtiff_type):
+def test_dataset_composite_indexes_exist(db, ls5_telem_type):
     # This type has fields named lat/lon/time, so composite indexes should now exist for them:
     # (following the naming conventions)
-    assert _object_exists(db, "dix_ls5_nbart_p54_gtiff_time_lat_lon")
-    assert _object_exists(db, "dix_ls5_nbart_p54_gtiff_lat_lon_time")
+    assert _object_exists(db, "dix_ls5_telem_test_sat_path_sat_row_time")
 
     # But no individual field indexes for these
-    assert not _object_exists(db, "dix_ls5_nbart_p54_gtiff_lat")
-    assert not _object_exists(db, "dix_ls5_nbart_p54_gtiff_lon")
-    assert not _object_exists(db, "dix_ls5_nbart_p54_gtiff_time")
+    assert not _object_exists(db, "dix_ls5_telem_test_sat_path")
+    assert not _object_exists(db, "dix_ls5_telem_test_sat_row")
+    assert not _object_exists(db, "dix_ls5_telem_test_time")
 
 
-def test_field_expression_unchanged(ls5_nbar_gtiff_type):
-    # type: (DatasetType) -> None
+def test_field_expression_unchanged(default_metadata_type, telemetry_metadata_type):
+    # type: (MetadataType, MetadataType) -> None
 
     # We're checking for accidental changes here in our field-to-SQL code
 
     # If we started outputting a different expression they would quietly no longer match the expression
     # indexes that exist in our DBs.
 
-    # The lat field on the default 'eo' metadata type.
-    # A multi-valued float range.
-    field = ls5_nbar_gtiff_type.metadata_type.dataset_fields['lat']
+    # The time field on the default 'eo' metadata type.
+    field = default_metadata_type.dataset_fields['time']
+    assert isinstance(field, PgField)
+    assert field.sql_expression == (
+        "tstzrange("
+        "least("
+        "agdc.common_timestamp(agdc.dataset.metadata #>> '{extent, from_dt}'), "
+        "agdc.common_timestamp(agdc.dataset.metadata #>> '{extent, center_dt}')"
+        "), greatest("
+        "agdc.common_timestamp(agdc.dataset.metadata #>> '{extent, to_dt}'), "
+        "agdc.common_timestamp(agdc.dataset.metadata #>> '{extent, center_dt}')"
+        "), '[]')"
+    )
+
+    field = default_metadata_type.dataset_fields['lat']
     assert isinstance(field, PgField)
     assert field.sql_expression == (
         "agdc.float8range("
@@ -116,19 +126,20 @@ def test_field_expression_unchanged(ls5_nbar_gtiff_type):
         "greatest("
         "CAST(agdc.dataset.metadata #>> '{extent, coord, ur, lat}' AS DOUBLE PRECISION), "
         "CAST(agdc.dataset.metadata #>> '{extent, coord, lr, lat}' AS DOUBLE PRECISION), "
-        "CAST(agdc.dataset.metadata #>> '{extent, coord, ul, lat}' AS DOUBLE PRECISION),"
-        " CAST(agdc.dataset.metadata #>> '{extent, coord, ll, lat}' AS DOUBLE PRECISION)), "
-        "'[]')")
+        "CAST(agdc.dataset.metadata #>> '{extent, coord, ul, lat}' AS DOUBLE PRECISION), "
+        "CAST(agdc.dataset.metadata #>> '{extent, coord, ll, lat}' AS DOUBLE PRECISION)"
+        "), '[]')"
+    )
 
     # A single string value
-    field = ls5_nbar_gtiff_type.metadata_type.dataset_fields['platform']
+    field = default_metadata_type.dataset_fields['platform']
     assert isinstance(field, PgField)
     assert field.sql_expression == (
         "agdc.dataset.metadata #>> '{platform, code}'"
     )
 
     # A single integer value
-    field = ls5_nbar_gtiff_type.metadata_type.dataset_fields['orbit']
+    field = telemetry_metadata_type.dataset_fields['orbit']
     assert isinstance(field, PgField)
     assert field.sql_expression == (
         "CAST(agdc.dataset.metadata #>> '{acquisition, platform_orbit}' AS INTEGER)"
@@ -141,18 +152,18 @@ def _object_exists(db, index_name):
     return val == ('agdc.%s' % index_name)
 
 
-def test_idempotent_add_dataset_type(index, ls5_nbar_gtiff_type, ls5_nbar_gtiff_doc):
+def test_idempotent_add_dataset_type(index, ls5_telem_type, ls5_telem_doc):
     """
-    :type ls5_nbar_gtiff_type: datacube.model.DatasetType
+    :type ls5_telem_type: datacube.model.DatasetType
     :type index: datacube.index._api.Index
     """
-    assert index.products.get_by_name(ls5_nbar_gtiff_type.name) is not None
+    assert index.products.get_by_name(ls5_telem_type.name) is not None
 
     # Re-add should have no effect, because it's equal to the current one.
-    index.products.add_document(ls5_nbar_gtiff_doc)
+    index.products.add_document(ls5_telem_doc)
 
     # But if we add the same type with differing properties we should get an error:
-    different_telemetry_type = copy.deepcopy(ls5_nbar_gtiff_doc)
+    different_telemetry_type = copy.deepcopy(ls5_telem_doc)
     different_telemetry_type['metadata']['ga_label'] = 'something'
     with pytest.raises(ValueError):
         index.products.add_document(different_telemetry_type)
@@ -160,15 +171,15 @@ def test_idempotent_add_dataset_type(index, ls5_nbar_gtiff_type, ls5_nbar_gtiff_
         # TODO: Support for adding/changing search fields?
 
 
-def test_update_dataset(index, ls5_nbar_gtiff_doc, example_ls5_nbar_metadata_doc):
+def test_update_dataset(index, ls5_telem_doc, example_ls5_nbar_metadata_doc):
     """
     :type index: datacube.index._api.Index
     """
-    ls5_nbar_gtiff_type = index.products.add_document(ls5_nbar_gtiff_doc)
-    assert ls5_nbar_gtiff_type
+    ls5_telem_type = index.products.add_document(ls5_telem_doc)
+    assert ls5_telem_type
 
     example_ls5_nbar_metadata_doc['lineage']['source_datasets'] = {}
-    dataset = Dataset(ls5_nbar_gtiff_type, example_ls5_nbar_metadata_doc, 'file:///test/doc.yaml', sources={})
+    dataset = Dataset(ls5_telem_type, example_ls5_nbar_metadata_doc, 'file:///test/doc.yaml', sources={})
     dataset = index.datasets.add(dataset)
     assert dataset
 
@@ -179,7 +190,7 @@ def test_update_dataset(index, ls5_nbar_gtiff_doc, example_ls5_nbar_metadata_doc
 
     # update location
     assert index.datasets.get(dataset.id).local_uri == 'file:///test/doc.yaml'
-    update = Dataset(ls5_nbar_gtiff_type, example_ls5_nbar_metadata_doc, 'file:///test/doc2.yaml', sources={})
+    update = Dataset(ls5_telem_type, example_ls5_nbar_metadata_doc, 'file:///test/doc2.yaml', sources={})
     index.datasets.update(update)
     updated = index.datasets.get(dataset.id)
     assert updated.local_uri == 'file:///test/doc2.yaml'
@@ -187,7 +198,7 @@ def test_update_dataset(index, ls5_nbar_gtiff_doc, example_ls5_nbar_metadata_doc
     # adding more metadata should always be allowed
     doc = copy.deepcopy(updated.metadata_doc)
     doc['test1'] = {'some': 'thing'}
-    update = Dataset(ls5_nbar_gtiff_type, doc, updated.local_uri)
+    update = Dataset(ls5_telem_type, doc, updated.local_uri)
     index.datasets.update(update)
     updated = index.datasets.get(dataset.id)
     assert updated.metadata_doc['test1'] == {'some': 'thing'}
@@ -196,7 +207,7 @@ def test_update_dataset(index, ls5_nbar_gtiff_doc, example_ls5_nbar_metadata_doc
     # adding more metadata and changing location
     doc = copy.deepcopy(updated.metadata_doc)
     doc['test2'] = {'some': 'other thing'}
-    update = Dataset(ls5_nbar_gtiff_type, doc, 'file:///test/doc3.yaml')
+    update = Dataset(ls5_telem_type, doc, 'file:///test/doc3.yaml')
     index.datasets.update(update)
     updated = index.datasets.get(dataset.id)
     assert updated.metadata_doc['test1'] == {'some': 'thing'}
@@ -206,7 +217,7 @@ def test_update_dataset(index, ls5_nbar_gtiff_doc, example_ls5_nbar_metadata_doc
     # changing stuff isn't allowed by default
     doc = copy.deepcopy(updated.metadata_doc)
     doc['product_type'] = 'foobar'
-    update = Dataset(ls5_nbar_gtiff_type, doc, 'file:///test/doc4.yaml')
+    update = Dataset(ls5_telem_type, doc, 'file:///test/doc4.yaml')
     with pytest.raises(ValueError):
         index.datasets.update(update)
     updated = index.datasets.get(dataset.id)
@@ -218,7 +229,7 @@ def test_update_dataset(index, ls5_nbar_gtiff_doc, example_ls5_nbar_metadata_doc
     # allowed changes go through
     doc = copy.deepcopy(updated.metadata_doc)
     doc['product_type'] = 'foobar'
-    update = Dataset(ls5_nbar_gtiff_type, doc, 'file:///test/doc5.yaml')
+    update = Dataset(ls5_telem_type, doc, 'file:///test/doc5.yaml')
     index.datasets.update(update, {('product_type',): changes.allow_any})
     updated = index.datasets.get(dataset.id)
     assert updated.metadata_doc['test1'] == {'some': 'thing'}
@@ -227,55 +238,55 @@ def test_update_dataset(index, ls5_nbar_gtiff_doc, example_ls5_nbar_metadata_doc
     assert updated.local_uri == 'file:///test/doc5.yaml'
 
 
-def test_update_dataset_type(index, ls5_nbar_gtiff_type, ls5_nbar_gtiff_doc, default_metadata_type_doc):
+def test_update_dataset_type(index, ls5_telem_type, ls5_telem_doc, telemetry_metadata_type_doc):
     """
-    :type ls5_nbar_gtiff_type: datacube.model.DatasetType
+    :type ls5_telem_type: datacube.model.DatasetType
     :type index: datacube.index._api.Index
     """
-    assert index.products.get_by_name(ls5_nbar_gtiff_type.name) is not None
+    assert index.products.get_by_name(ls5_telem_type.name) is not None
 
     # Update with a new description
-    ls5_nbar_gtiff_doc['description'] = "New description"
-    index.products.update_document(ls5_nbar_gtiff_doc)
+    ls5_telem_doc['description'] = "New description"
+    index.products.update_document(ls5_telem_doc)
     # Ensure was updated
-    assert index.products.get_by_name(ls5_nbar_gtiff_type.name).definition['description'] == "New description"
+    assert index.products.get_by_name(ls5_telem_type.name).definition['description'] == "New description"
 
     # Remove some match rules (looser rules -- that match more datasets -- should be allowed)
-    assert 'format' in ls5_nbar_gtiff_doc['metadata']
-    del ls5_nbar_gtiff_doc['metadata']['format']['name']
-    del ls5_nbar_gtiff_doc['metadata']['format']
-    index.products.update_document(ls5_nbar_gtiff_doc)
+    assert 'format' in ls5_telem_doc['metadata']
+    del ls5_telem_doc['metadata']['format']['name']
+    del ls5_telem_doc['metadata']['format']
+    index.products.update_document(ls5_telem_doc)
     # Ensure was updated
-    updated_type = index.products.get_by_name(ls5_nbar_gtiff_type.name)
-    assert updated_type.definition['metadata'] == ls5_nbar_gtiff_doc['metadata']
+    updated_type = index.products.get_by_name(ls5_telem_type.name)
+    assert updated_type.definition['metadata'] == ls5_telem_doc['metadata']
 
     # Specifying metadata type definition (rather than name) should be allowed
-    full_doc = copy.deepcopy(ls5_nbar_gtiff_doc)
-    full_doc['metadata_type'] = default_metadata_type_doc
+    full_doc = copy.deepcopy(ls5_telem_doc)
+    full_doc['metadata_type'] = telemetry_metadata_type_doc
     index.products.update_document(full_doc)
 
     # Remove fixed field, forcing a new index to be created (as datasets can now differ for the field).
-    assert not _object_exists(index._db, 'dix_ls5_nbart_p54_gtiff_product_type')
-    del ls5_nbar_gtiff_doc['metadata']['product_type']
-    index.products.update_document(ls5_nbar_gtiff_doc)
+    assert not _object_exists(index._db, 'dix_ls5_telem_test_product_type')
+    del ls5_telem_doc['metadata']['product_type']
+    index.products.update_document(ls5_telem_doc)
     # Ensure was updated
-    assert _object_exists(index._db, 'dix_ls5_nbart_p54_gtiff_product_type')
-    updated_type = index.products.get_by_name(ls5_nbar_gtiff_type.name)
-    assert updated_type.definition['metadata'] == ls5_nbar_gtiff_doc['metadata']
+    assert _object_exists(index._db, 'dix_ls5_telem_test_product_type')
+    updated_type = index.products.get_by_name(ls5_telem_type.name)
+    assert updated_type.definition['metadata'] == ls5_telem_doc['metadata']
 
     # But if we make metadata more restrictive we get an error:
-    different_telemetry_type = copy.deepcopy(ls5_nbar_gtiff_doc)
+    different_telemetry_type = copy.deepcopy(ls5_telem_doc)
     assert 'ga_label' not in different_telemetry_type['metadata']
     different_telemetry_type['metadata']['ga_label'] = 'something'
     with pytest.raises(ValueError):
         index.products.update_document(different_telemetry_type)
     # Check was not updated.
-    updated_type = index.products.get_by_name(ls5_nbar_gtiff_type.name)
+    updated_type = index.products.get_by_name(ls5_telem_type.name)
     assert 'ga_label' not in updated_type.definition['metadata']
 
     # But works when unsafe updates are allowed.
     index.products.update_document(different_telemetry_type, allow_unsafe_updates=True)
-    updated_type = index.products.get_by_name(ls5_nbar_gtiff_type.name)
+    updated_type = index.products.get_by_name(ls5_telem_type.name)
     assert updated_type.definition['metadata']['ga_label'] == 'something'
 
 
@@ -318,41 +329,41 @@ def test_update_metadata_type(index, default_metadata_type_docs, default_metadat
     assert isinstance(updated_type.dataset_fields['time'], NumericRangeDocField)
 
 
-def test_filter_types_by_fields(index, ls5_nbar_gtiff_type):
+def test_filter_types_by_fields(index, ls5_telem_type):
     """
-    :type ls5_nbar_gtiff_type: datacube.model.DatasetType
+    :type ls5_telem_type: datacube.model.DatasetType
     :type index: datacube.index._api.Index
     """
     assert index.products
-    res = list(index.products.get_with_fields(['lat', 'lon', 'platform']))
-    assert res == [ls5_nbar_gtiff_type]
+    res = list(index.products.get_with_fields(['sat_path', 'sat_row', 'platform']))
+    assert res == [ls5_telem_type]
 
-    res = list(index.products.get_with_fields(['lat', 'lon', 'platform', 'favorite_icecream']))
+    res = list(index.products.get_with_fields(['sat_path', 'sat_row', 'platform', 'favorite_icecream']))
     assert len(res) == 0
 
 
-def test_filter_types_by_search(index, ls5_nbar_gtiff_type):
+def test_filter_types_by_search(index, ls5_telem_type):
     """
-    :type ls5_nbar_gtiff_type: datacube.model.DatasetType
+    :type ls5_telem_type: datacube.model.DatasetType
     :type index: datacube.index._api.Index
     """
     assert index.products
 
     # No arguments, return all.
     res = list(index.products.search())
-    assert res == [ls5_nbar_gtiff_type]
+    assert res == [ls5_telem_type]
 
     # Matching fields
     res = list(index.products.search(
-        product_type='nbart',
-        product='ls5_nbart_p54_gtiff'
+        product_type='satellite_telemetry_data',
+        product='ls5_telem_test'
     ))
-    assert res == [ls5_nbar_gtiff_type]
+    assert res == [ls5_telem_type]
 
     # Matching fields and non-available fields
     res = list(index.products.search(
-        product_type='nbart',
-        product='ls5_nbart_p54_gtiff',
+        product_type='satellite_telemetry_data',
+        product='ls5_telem_test',
         lat=Range(142.015625, 142.015625),
         lon=Range(-12.046875, -12.046875)
     ))
@@ -360,20 +371,20 @@ def test_filter_types_by_search(index, ls5_nbar_gtiff_type):
 
     # Matching fields and available fields
     [(res, q)] = list(index.products.search_robust(
-        product_type='nbart',
-        product='ls5_nbart_p54_gtiff',
-        lat=Range(142.015625, 142.015625),
-        lon=Range(-12.046875, -12.046875)
+        product_type='satellite_telemetry_data',
+        product='ls5_telem_test',
+        sat_path=Range(142.015625, 142.015625),
+        sat_row=Range(-12.046875, -12.046875)
     ))
-    assert res == ls5_nbar_gtiff_type
-    assert 'lat' in q
-    assert 'lon' in q
+    assert res == ls5_telem_type
+    assert 'sat_path' in q
+    assert 'sat_row' in q
 
     # Or expression test
     res = list(index.products.search(
-        product_type=['nbart', 'nbar'],
+        product_type=['satellite_telemetry_data', 'nbar'],
     ))
-    assert res == [ls5_nbar_gtiff_type]
+    assert res == [ls5_telem_type]
 
     # Mismatching fields
     res = list(index.products.search(
@@ -382,8 +393,8 @@ def test_filter_types_by_search(index, ls5_nbar_gtiff_type):
     assert res == []
 
 
-def test_update_metadata_type(db, index, ls5_nbar_gtiff_type):
-    type_doc = copy.deepcopy(ls5_nbar_gtiff_type.metadata_type.definition)
+def test_update_metadata_type_doc(db, index, ls5_telem_type):
+    type_doc = copy.deepcopy(ls5_telem_type.metadata_type.definition)
     type_doc['dataset']['search_fields']['test_indexed'] = {
         'description': 'indexed test field',
         'offset': ['test', 'indexed']
@@ -396,6 +407,6 @@ def test_update_metadata_type(db, index, ls5_nbar_gtiff_type):
 
     index.metadata_types.update_document(type_doc)
 
-    assert ls5_nbar_gtiff_type.name == 'ls5_nbart_p54_gtiff'
-    assert _object_exists(db, "dix_ls5_nbart_p54_gtiff_test_indexed")
-    assert not _object_exists(db, "dix_ls5_nbart_p54_gtiff_test_not_indexed")
+    assert ls5_telem_type.name == 'ls5_telem_test'
+    assert _object_exists(db, "dix_ls5_telem_test_test_indexed")
+    assert not _object_exists(db, "dix_ls5_telem_test_test_not_indexed")

--- a/integration_tests/index/test_search.py
+++ b/integration_tests/index/test_search.py
@@ -562,7 +562,7 @@ def test_search_returning_rows(index, pseudo_ls8_type,
     }
 
 
-def test_searches_only_type(index, pseudo_ls8_type, pseudo_ls8_dataset, ls5_nbar_gtiff_type):
+def test_searches_only_type(index, pseudo_ls8_type, pseudo_ls8_dataset, ls5_telem_type):
     """
     :type index: datacube.index._api.Index
     :type pseudo_ls8_type: datacube.model.DatasetType
@@ -592,7 +592,7 @@ def test_searches_only_type(index, pseudo_ls8_type, pseudo_ls8_dataset, ls5_nbar
 
     # No results when searching for a different dataset type.
     datasets = index.datasets.search_eager(
-        product=ls5_nbar_gtiff_type.name,
+        product=ls5_telem_type.name,
         platform='LANDSAT_8',
         instrument='OLI_TIRS'
     )
@@ -683,7 +683,7 @@ def test_fetch_all_of_md_type(index, pseudo_ls8_dataset):
     assert len(results) == 0
 
 
-def test_count_searches(index, pseudo_ls8_type, pseudo_ls8_dataset, ls5_nbar_gtiff_type):
+def test_count_searches(index, pseudo_ls8_type, pseudo_ls8_dataset, ls5_telem_type):
     """
     :type index: datacube.index._api.Index
     :type pseudo_ls8_type: datacube.model.DatasetType
@@ -711,7 +711,7 @@ def test_count_searches(index, pseudo_ls8_type, pseudo_ls8_dataset, ls5_nbar_gti
 
     # No results when searching for a different dataset type.
     datasets = index.datasets.count(
-        product=ls5_nbar_gtiff_type.name,
+        product=ls5_telem_type.name,
         platform='LANDSAT_8',
         instrument='OLI_TIRS'
     )
@@ -758,7 +758,7 @@ def test_get_dataset_with_children(index, ls5_dataset_w_children):
     assert list(level1.sources['satellite_telemetry_data'].sources) == []
 
 
-def test_count_by_product_searches(index, pseudo_ls8_type, pseudo_ls8_dataset, ls5_nbar_gtiff_type):
+def test_count_by_product_searches(index, pseudo_ls8_type, pseudo_ls8_dataset, ls5_telem_type):
     """
     :type index: datacube.index._api.Index
     :type pseudo_ls8_type: datacube.model.DatasetType
@@ -786,7 +786,7 @@ def test_count_by_product_searches(index, pseudo_ls8_type, pseudo_ls8_dataset, l
 
     # No results when searching for a different dataset type.
     products = tuple(index.datasets.count_by_product(
-        product=ls5_nbar_gtiff_type.name,
+        product=ls5_telem_type.name,
         platform='LANDSAT_8',
         instrument='OLI_TIRS'
     ))
@@ -1161,7 +1161,7 @@ _EXPECTED_OUTPUT_HEADER = 'dataset_type_id,gsi,id,instrument,lat,lon,metadata_do
                           'orbit,platform,product,product_type,sat_path,sat_row,time,uri'
 
 
-def test_csv_structure(global_integration_cli_args, pseudo_ls8_type, ls5_nbar_gtiff_type,
+def test_csv_structure(global_integration_cli_args, pseudo_ls8_type, ls5_telem_type,
                        pseudo_ls8_dataset, pseudo_ls8_dataset2):
     output = _csv_search_raw(['datasets', ' -40 < lat < -10'], global_integration_cli_args)
     lines = [line.strip() for line in output.split('\n') if line]

--- a/integration_tests/index/test_search.py
+++ b/integration_tests/index/test_search.py
@@ -25,6 +25,7 @@ from datacube.index._api import Index
 from datacube.index.postgres import PostgresDb
 from datacube.model import Dataset
 from datacube.model import DatasetType
+from datacube.model import MetadataType
 from datacube.model import Range
 from datacube.scripts import dataset as dataset_script
 
@@ -33,11 +34,9 @@ try:
 except ImportError:
     pass
 
-_EXAMPLE_LS7_NBAR_DATASET_FILE = Path(__file__).parent.joinpath('ls7-nbar-example.yaml')
-
 
 @pytest.fixture
-def pseudo_ls8_type(index, default_metadata_type):
+def pseudo_ls8_type(index, ga_metadata_type):
     index.products.add_document({
         'name': 'ls8_telemetry',
         'description': 'telemetry test',
@@ -53,8 +52,7 @@ def pseudo_ls8_type(index, default_metadata_type):
                 'name': 'PSEUDOMD'
             }
         },
-        # We're actually using 'eo' because we do lat/lon searches below...
-        'metadata_type': default_metadata_type.name
+        'metadata_type': ga_metadata_type.name
     })
     return index.products.get_by_name('ls8_telemetry')
 
@@ -418,8 +416,8 @@ def test_search_by_product(index, pseudo_ls8_type, pseudo_ls8_dataset, indexed_l
 def test_search_or_expressions(index,
                                pseudo_ls8_type, pseudo_ls8_dataset,
                                ls5_dataset_nbar_type, ls5_dataset_w_children,
-                               telemetry_metadata_type):
-    # type: (Index, DatasetType, Dataset, DatasetType, Dataset) -> None
+                               default_metadata_type, telemetry_metadata_type):
+    # type: (Index, DatasetType, Dataset, DatasetType, Dataset, MetadataType, MetadataType) -> None
 
     # Four datasets:
     # Our standard LS8
@@ -459,7 +457,11 @@ def test_search_or_expressions(index,
     # eo OR telemetry: return all
     datasets = index.datasets.search_eager(
         metadata_type=[
+            # LS5 + children
+            default_metadata_type.name,
+            # Nothing
             telemetry_metadata_type.name,
+            # LS8 dataset
             pseudo_ls8_type.metadata_type.name
         ]
     )
@@ -659,13 +661,11 @@ def test_search_conflicting_types(index, pseudo_ls8_dataset, pseudo_ls8_type):
 
 
 def test_fetch_all_of_md_type(index, pseudo_ls8_dataset):
-    """
-    :type index: datacube.index._api.Index
-    :type pseudo_ls8_dataset: datacube.model.Dataset
-    """
+    # type: (Index, Dataset) -> None
+
     # Get every dataset of the md type.
     results = index.datasets.search_eager(
-        metadata_type='eo'
+        metadata_type=pseudo_ls8_dataset.metadata_type.name
     )
     assert len(results) == 1
     assert results[0].id == pseudo_ls8_dataset.id
@@ -684,11 +684,8 @@ def test_fetch_all_of_md_type(index, pseudo_ls8_dataset):
 
 
 def test_count_searches(index, pseudo_ls8_type, pseudo_ls8_dataset, ls5_telem_type):
-    """
-    :type index: datacube.index._api.Index
-    :type pseudo_ls8_type: datacube.model.DatasetType
-    :type pseudo_ls8_dataset: datacube.model.Dataset
-    """
+    # type: (Index, DatasetType, Dataset) -> None
+
     # The dataset should have been matched to the telemetry type.
     assert pseudo_ls8_dataset.type.id == pseudo_ls8_type.id
     assert index.datasets.search_eager()
@@ -759,11 +756,8 @@ def test_get_dataset_with_children(index, ls5_dataset_w_children):
 
 
 def test_count_by_product_searches(index, pseudo_ls8_type, pseudo_ls8_dataset, ls5_telem_type):
-    """
-    :type index: datacube.index._api.Index
-    :type pseudo_ls8_type: datacube.model.DatasetType
-    :type pseudo_ls8_dataset: datacube.model.Dataset
-    """
+    # type: (Index, DatasetType, Dataset, DatasetType) -> None
+
     # The dataset should have been matched to the telemetry type.
     assert pseudo_ls8_dataset.type.id == pseudo_ls8_type.id
     assert index.datasets.search_eager()
@@ -811,9 +805,7 @@ def test_count_by_product_searches(index, pseudo_ls8_type, pseudo_ls8_dataset, l
 
 
 def test_count_time_groups(index, pseudo_ls8_type, pseudo_ls8_dataset):
-    """
-    :type index: datacube.index._api.Index
-    """
+    # type: (Index, DatasetType, Dataset) -> None
 
     # 'from_dt': datetime.datetime(2014, 7, 26, 23, 48, 0, 343853),
     # 'to_dt': datetime.datetime(2014, 7, 26, 23, 52, 0, 343853),
@@ -841,7 +833,7 @@ def test_count_time_groups(index, pseudo_ls8_type, pseudo_ls8_dataset):
     ]
 
 
-@pytest.mark.usefixtures('default_metadata_type',
+@pytest.mark.usefixtures('ga_metadata_type',
                          'indexed_ls5_scene_dataset_types')
 def test_source_filter(global_integration_cli_args, index, example_ls5_dataset_path, ls5_nbar_ingest_config):
     opts = list(global_integration_cli_args)
@@ -862,6 +854,9 @@ def test_source_filter(global_integration_cli_args, index, example_ls5_dataset_p
 
     all_nbar = index.datasets.search_eager(product='ls5_nbar_scene')
     assert len(all_nbar) == 1
+    all_level1 = index.datasets.search_eager(product='ls5_level1_scene')
+    assert len(all_level1) == 1
+    assert all_level1[0].metadata.gsi == 'ASA'
 
     dss = index.datasets.search_eager(
         product='ls5_nbar_scene',
@@ -979,6 +974,7 @@ def test_cli_info(index, global_integration_cli_args, pseudo_ls8_dataset, pseudo
         '- file:///tmp/location2',
         '- file:///tmp/location1',
         'fields:',
+        '    format: PSEUDOMD',
         '    gsi: null',
         '    instrument: OLI_TIRS',
         '    lat: {begin: -31.37116, end: -29.23394}',
@@ -1157,8 +1153,8 @@ def test_csv_search_via_cli(global_integration_cli_args, pseudo_ls8_type, pseudo
 
 
 # Headers are currently in alphabetical order.
-_EXPECTED_OUTPUT_HEADER = 'dataset_type_id,gsi,id,instrument,lat,lon,metadata_doc,metadata_type,metadata_type_id,' \
-                          'orbit,platform,product,product_type,sat_path,sat_row,time,uri'
+_EXPECTED_OUTPUT_HEADER = 'dataset_type_id,format,gsi,id,instrument,lat,lon,metadata_doc,metadata_type,' \
+                          'metadata_type_id,orbit,platform,product,product_type,sat_path,sat_row,time,uri'
 
 
 def test_csv_structure(global_integration_cli_args, pseudo_ls8_type, ls5_telem_type,

--- a/integration_tests/telemetry-collection.yaml
+++ b/integration_tests/telemetry-collection.yaml
@@ -1,9 +1,0 @@
-name: landsat_telemetry
-description: Landsat telemetry data
-metadata_type: eo
-
-match:
-    metadata:
-        product_type: satellite_telemetry_data
-    # Higher priority than the default
-    priority: 50

--- a/integration_tests/test_config_tool.py
+++ b/integration_tests/test_config_tool.py
@@ -137,7 +137,7 @@ def test_list_users_does_not_fail(global_integration_cli_args, local_config):
     assert result.exit_code == 0
 
 
-def test_db_init_noop(global_integration_cli_args, local_config, ls5_nbar_gtiff_type):
+def test_db_init_noop(global_integration_cli_args, local_config, ls5_telem_type):
     # Run on an existing database.
     result = _run_cli(
         global_integration_cli_args,
@@ -149,10 +149,10 @@ def test_db_init_noop(global_integration_cli_args, local_config, ls5_nbar_gtiff_
     assert result.exit_code == 0
     assert 'Updated.' in result.output
     # It should not rebuild indexes by default
-    assert 'Dropping index: dix_{}'.format(ls5_nbar_gtiff_type.name) not in result.output
+    assert 'Dropping index: dix_{}'.format(ls5_telem_type.name) not in result.output
 
 
-def test_db_init_rebuild(global_integration_cli_args, local_config, ls5_nbar_gtiff_type):
+def test_db_init_rebuild(global_integration_cli_args, local_config, ls5_telem_type):
 
     # We set the field creation logging to debug, as we assert its logging output below.
     _dynamic._LOG.setLevel(logging.DEBUG)
@@ -168,13 +168,13 @@ def test_db_init_rebuild(global_integration_cli_args, local_config, ls5_nbar_gti
     assert result.exit_code == 0
     assert 'Updated.' in result.output
     # It should have recreated views and indexes.
-    assert 'Dropping index: dix_{}'.format(ls5_nbar_gtiff_type.name) in result.output
-    assert 'Creating index: dix_{}'.format(ls5_nbar_gtiff_type.name) in result.output
+    assert 'Dropping index: dix_{}'.format(ls5_telem_type.name) in result.output
+    assert 'Creating index: dix_{}'.format(ls5_telem_type.name) in result.output
     assert 'Dropping view: {schema}.dv_{name}_dataset'.format(
-        schema=SCHEMA_NAME, name=ls5_nbar_gtiff_type.name
+        schema=SCHEMA_NAME, name=ls5_telem_type.name
     ) in result.output
     assert 'Creating view: {schema}.dv_{name}_dataset'.format(
-        schema=SCHEMA_NAME, name=ls5_nbar_gtiff_type.name
+        schema=SCHEMA_NAME, name=ls5_telem_type.name
     ) in result.output
 
 


### PR DESCRIPTION
Keeping the default metadata types small is advantageous as it reduces unnecessary indexes.

Fields `gsi`, `orbit`, `path` and `row` are better placed in a Landsat (or other) specific metadata type, as GA already does with our `landsat_scene` type.

This only changes the default settings, so it will only apply to newly-created cubes.