### PR TITLE
Allow delete command to take a list of users

### DIFF
--- a/datacube/index/_api.py
+++ b/datacube/index/_api.py
@@ -107,26 +107,26 @@ class UserResource(object):
     def __init__(self, db):
         self._db = db
 
-    def grant_role(self, role, *users):
+    def grant_role(self, role, *usernames):
         """
         Grant a role to users
         """
         with self._db.connect() as connection:
-            connection.grant_role(role, users)
+            connection.grant_role(role, usernames)
 
-    def create_user(self, user_name, password, role):
+    def create_user(self, username, password, role):
         """
         Create a new user.
         """
         with self._db.connect() as connection:
-            connection.create_user(user_name, password, role)
+            connection.create_user(username, password, role)
 
-    def delete_user(self, user_name):
+    def delete_user(self, *usernames):
         """
         Delete a user
         """
         with self._db.connect() as connection:
-            connection.drop_user(user_name)
+            connection.drop_users(usernames)
 
     def list_users(self):
         """
@@ -134,5 +134,5 @@ class UserResource(object):
         :rtype: list[(str, str, str)]
         """
         with self._db.connect() as connection:
-            for user in connection.list_users():
-                yield user
+            for role, user, description in connection.list_users():
+                yield role, user, description

--- a/datacube/index/postgres/_api.py
+++ b/datacube/index/postgres/_api.py
@@ -804,10 +804,12 @@ class PostgresDbAPI(object):
         pg_role = tables.to_pg_role(role)
         tables.create_user(self._connection, username, password, pg_role)
 
-    def drop_user(self, username):
-        tables.drop_user(self._connection, username)
+    def drop_users(self, users):
+        # type: (Iterable[str]) -> None
+        tables.drop_user(self._connection, *users)
 
     def grant_role(self, role, users):
+        # type: (str, Iterable[str]) -> None
         """
         Grant a role to a user.
         """

--- a/datacube/index/postgres/tables/_core.py
+++ b/datacube/index/postgres/tables/_core.py
@@ -179,8 +179,9 @@ def create_user(conn, username, key, role):
     )
 
 
-def drop_user(engine, username):
-    engine.execute('drop role {username}'.format(username=username))
+def drop_user(engine, *usernames):
+    for username in usernames:
+        engine.execute('drop role {username}'.format(username=username))
 
 
 def grant_role(engine, role, users):

--- a/datacube/scripts/user.py
+++ b/datacube/scripts/user.py
@@ -63,11 +63,11 @@ def create_user(config, index, role, user):
 
 
 @user_cmd.command('delete')
-@click.argument('user', nargs=1)
+@click.argument('users', nargs=-1)
 @ui.pass_index()
 @ui.pass_config
-def delete_user(config, index, user):
+def delete_user(config, index, users):
     """
     Delete a User
     """
-    index.users.delete_user(user)
+    index.users.delete_user(*users)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -15,9 +15,11 @@ v1.2.3
 
  - URI searches are now better supported from the cli: `datacube dataset search uri = file:///some/uri/here`
 
+ - `datacube user delete` now supports multiple user arguments.
+
  - Platform-specific (Landsat) fields have been removed from the default `eo`
    metadata type in order to keep it minimal. Users & products can still add
-   their own metadata types to use extra fields.
+   their own metadata types to use additional fields.
 
  - We are now part of Open Data Cube, and have a new home at https://github.com/opendatacube/datacube-core
 


### PR DESCRIPTION
For consistency with other commands, user friendliness from bash, principle
of least surprise, etc.

(none of the user commands currently have integration tests due to the
added permissions required on the db server, so this is continuing that
trend.)