### PR TITLE
User creation improvements

### DIFF
--- a/datacube/index/_api.py
+++ b/datacube/index/_api.py
@@ -58,9 +58,7 @@ class Index(object):
     :type metadata_types: datacube.index._datasets.MetadataTypeResource
     """
     def __init__(self, db):
-        """
-        :type db: datacube.index.postgres._api.PostgresDb
-        """
+        # type: (PostgresDb) -> None
         self._db = db
 
         self.users = UserResource(db)
@@ -105,6 +103,7 @@ class Index(object):
 
 class UserResource(object):
     def __init__(self, db):
+        # type: (PostgresDb) -> None
         self._db = db
 
     def grant_role(self, role, *usernames):
@@ -114,12 +113,12 @@ class UserResource(object):
         with self._db.connect() as connection:
             connection.grant_role(role, usernames)
 
-    def create_user(self, username, password, role):
+    def create_user(self, username, password, role, description=None):
         """
         Create a new user.
         """
         with self._db.connect() as connection:
-            connection.create_user(username, password, role)
+            connection.create_user(username, password, role, description=description)
 
     def delete_user(self, *usernames):
         """

--- a/datacube/index/postgres/_api.py
+++ b/datacube/index/postgres/_api.py
@@ -800,9 +800,9 @@ class PostgresDbAPI(object):
         for row in result:
             yield tables.from_pg_role(row['role_name']), row['user_name'], row['description']
 
-    def create_user(self, username, password, role):
+    def create_user(self, username, password, role, description=None):
         pg_role = tables.to_pg_role(role)
-        tables.create_user(self._connection, username, password, pg_role)
+        tables.create_user(self._connection, username, password, pg_role, description=description)
 
     def drop_users(self, users):
         # type: (Iterable[str]) -> None

--- a/datacube/index/postgres/tables/_core.py
+++ b/datacube/index/postgres/tables/_core.py
@@ -192,7 +192,7 @@ def _escape_pg_identifier(engine, name):
     return engine.execute("select quote_ident(%s)", name).scalar()
 
 
-def create_user(conn, username, key, role):
+def create_user(conn, username, key, role, description=None):
     if role not in USER_ROLES:
         raise ValueError('Unknown role %r. Expected one of %r' % (role, USER_ROLES))
     username = _escape_pg_identifier(conn, username)
@@ -200,6 +200,10 @@ def create_user(conn, username, key, role):
         'create user {username} password %s in role {role}'.format(username=username, role=role),
         key
     )
+    if description:
+        conn.execute(
+            'comment on role {username} is %s'.format(username=username), description
+        )
 
 
 def drop_user(engine, *usernames):

--- a/datacube/scripts/user.py
+++ b/datacube/scripts/user.py
@@ -5,6 +5,8 @@ import base64
 import logging
 import click
 
+from datacube.config import LocalConfig
+from datacube.index._api import Index
 from datacube.ui import click as ui
 from datacube.ui.click import cli
 
@@ -45,14 +47,16 @@ def grant(index, role, users):
 @click.argument('role',
                 type=click.Choice(USER_ROLES), nargs=1)
 @click.argument('user', nargs=1)
+@click.option('--description')
 @ui.pass_index()
 @ui.pass_config
-def create_user(config, index, role, user):
+def create_user(config, index, role, user, description):
+    # type: (LocalConfig, Index, str, str, str) -> None
     """
     Create a User
     """
     password = base64.urlsafe_b64encode(os.urandom(12)).decode('utf-8')
-    index.users.create_user(user, password, role)
+    index.users.create_user(user, password, role, description=description)
 
     click.echo('{host}:{port}:*:{username}:{password}'.format(
         host=config.db_hostname or 'localhost',


### PR DESCRIPTION
- Escape the username in create/drop commands
- Allow description to be specified for a user. GA sets a description for users and it's printed in `user list`, but we didn't expose a public api before.