### PR TITLE
Update docs related to conda-forge datacube package

### DIFF
--- a/docs/about/release_process.rst
+++ b/docs/about/release_process.rst
@@ -41,6 +41,9 @@ stable version.
         python setup.py sdist bdist_wheel
         twine upload dist/*
 
+#. Update conda-forge recipe
+    Follow the instrucions under **Updating datacube-feedstock** in the `Datcube Feedstock`_ repository
+
 #. Update the default version on `raijin`
     Follow the instructions under **Update default version** in the `Datacube Environment`_ repository
 
@@ -57,3 +60,5 @@ stable version.
 .. _Jira: https://gaautobots.atlassian.net/projects/ACDD?selectedItem=com.atlassian.jira.jira-projects-plugin%3Arelease-page&status=unreleased
 
 .. _Datacube Environment: https://github.com/GeoscienceAustralia/ga-datacube-env#data-cube-module
+
+.. _Datcube Feedstock: https://github.com/conda-forge/datacube-feedstock#updating-datacube-feedstock

--- a/docs/ops/conda.rst
+++ b/docs/ops/conda.rst
@@ -30,29 +30,22 @@ Create the environment
 
 .. code::
 
-    conda create --name datacube python=3.5 cachetools dask gdal jsonschema netcdf4 numexpr numpy pathlib psycopg2 python-dateutil pyyaml rasterio singledispatch sqlalchemy xarray
+    conda create --name cubeenv python=3.5 datacube
 
 Activate the environment on **Linux** and **OS X**
 
 .. code::
 
-    source activate datacube
+    source activate cubeenv
 
 Activate the environment on **Windows**
 
 .. code::
 
-    activate datacube
+    activate cubeenv
 
 Find out more about managing virtual environments here https://conda.io/docs/using/envs.html
 
-
-Install datacube
-----------------
-
-.. code::
-
-    pip install datacube
 
 Install other packages
 ----------------------


### PR DESCRIPTION
Conda forge package for datacube 1.2.2 is live. I've updated install docs to recommend using the new package and added a release process step to update the package on conda-forge.

Tests pass on windows py3.6.