### PR TITLE
Deprecate descriptor API

### DIFF
--- a/datacube/api/_api.py
+++ b/datacube/api/_api.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 from itertools import chain, groupby
+import warnings
 
 import numpy
 
@@ -49,6 +50,8 @@ class API(object):
         :param datacube:
         :type datacube: :class:`datacube.Datacube`
         """
+        warnings.warn("Descriptor interface is deprecated.", DeprecationWarning)
+
         if datacube is not None:
             self.datacube = datacube
         elif index is not None:

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import, division, print_function
 import logging
 import datetime
 import collections
+import warnings
 
 from dateutil import tz
 from pandas import to_datetime as pandas_to_datetime
@@ -123,6 +124,7 @@ class Query(object):
 class DescriptorQuery(Query):
     def __init__(self, descriptor_request=None):
         super(DescriptorQuery, self).__init__()
+        warnings.warn("Descriptor interface is deprecated.", DeprecationWarning)
 
         if descriptor_request is None:
             descriptor_request = {}


### PR DESCRIPTION
Are we ready to remove the "descriptor" API?

It seems to be unused except by AE/EE. Probably AE+EE should also be moved from "core" if somebody is interested in maintaining it?

Descriptors addressed the problem of wanting to separate database index queries from file-system data retrievals, and chose nested dicts as the intermediary (suggestive of a JSON web interface). However, the same problem has also been addressed by the GridWorkflow API (for current datacube apps), and also by pieces underlying the datacube.load API (exposed to most users). Consolidating interfaces where possible should simplify continued development. 