### PR TITLE
Improvements to model api friendliness: properties, error messages

### DIFF
--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -733,7 +733,10 @@ class DatasetResource(object):
 
     def _add_sources(self, dataset, sources_policy='verify'):
         if dataset.sources is None:
-            raise ValueError("Dataset has missing (None) sources. Was this loaded without include_sources=True?")
+            raise ValueError('Dataset has missing (None) sources. Was this loaded without include_sources=True?\n'
+                             'Note that: \n'
+                             '  sources=None means "not loaded", '
+                             '  sources={}   means there are no sources (eg. raw telemetry data)')
 
         if sources_policy == 'ensure':
             for source in dataset.sources.values():

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -234,14 +234,24 @@ class Dataset(object):
         def xytuple(obj):
             return obj['x'], obj['y']
 
+        # If no projection or crs, they have no extent.
         projection = self.metadata.grid_spatial
+        if not projection:
+            return None
+        crs = self.crs
+        if not crs:
+            _LOG.debug("No CRS, assuming no extent (dataset %s)", self.id)
+            return None
 
-        if 'valid_data' in projection:
-            return geometry.Geometry(projection['valid_data'], crs=self.crs)
-        else:
-            geo_ref_points = projection['geo_ref_points']
+        valid_data = projection.get('valid_data')
+        geo_ref_points = projection.get('geo_ref_points')
+        if valid_data:
+            return geometry.Geometry(valid_data, crs=crs)
+        elif geo_ref_points:
             return geometry.polygon([xytuple(geo_ref_points[key]) for key in ('ll', 'ul', 'ur', 'lr', 'll')],
-                                    crs=self.crs)
+                                    crs=crs)
+
+        return None
 
     def __eq__(self, other):
         return self.id == other.id

--- a/datacube/utils/__init__.py
+++ b/datacube/utils/__init__.py
@@ -578,6 +578,9 @@ class DocReader(object):
         Traceback (most recent call last):
         ...
         AttributeError: Unknown field 'lon'. Expected one of ['lat']
+        >>> # If that section of doc doesn't exist, treat the value not specified (None)
+        >>> d = DocReader({'platform': ['platform', 'code']}, {}, doc={})
+        >>> d.platform
         """
         self.__dict__['_doc'] = doc
 
@@ -596,7 +599,7 @@ class DocReader(object):
         offset = self._system_offsets.get(name)
         field = self._search_fields.get(name)
         if offset:
-            return get_doc_offset(offset, self._doc)
+            return get_doc_offset_safe(offset, self._doc)
         elif field:
             return field.extract(self._doc)
         else:

--- a/datacube/utils/geometry.py
+++ b/datacube/utils/geometry.py
@@ -95,18 +95,21 @@ class CRS(object):
     True
     >>> CRS('EPSG:3577') == CRS('EPSG:4326')
     False
-    >>> CRS('cupcakes')
-    Traceback (most recent call last):
-        ...
-    datacube.utils.geometry.InvalidCRSError: Not a valid CRS: 'cupcakes'
+    >>> # Due to Py 2 and 3 inconsistency in traceback formatting, we need to wrap the exceptions. Yuck.
+    >>> try:
+    ...    CRS('cupcakes')
+    ... except InvalidCRSError as e:
+    ...    print(e)
+    Not a valid CRS: 'cupcakes'
     >>> # This one validly parses, but returns "Corrupt data" from gdal when used.
-    >>> CRS('PROJCS["unnamed",'
-    ... 'GEOGCS["WGS 84", DATUM["WGS_1984", SPHEROID["WGS 84",6378137,298.257223563, AUTHORITY["EPSG","7030"]],'
-    ... 'AUTHORITY["EPSG","6326"]], PRIMEM["Greenwich",0, AUTHORITY["EPSG","8901"]],'
-    ... 'UNIT["degree",0.0174532925199433, AUTHORITY["EPSG","9122"]], AUTHORITY["EPSG","4326"]]]')
-    Traceback (most recent call last):
-        ...
-    datacube.utils.geometry.InvalidCRSError: Not a valid CRS: 'PROJCS["...
+    >>> try:
+    ...     CRS('PROJCS["unnamed",'
+    ...     'GEOGCS["WGS 84", DATUM["WGS_1984", SPHEROID["WGS 84",6378137,298.257223563, AUTHORITY["EPSG","7030"]],'
+    ...     'AUTHORITY["EPSG","6326"]], PRIMEM["Greenwich",0, AUTHORITY["EPSG","8901"]],'
+    ...     'UNIT["degree",0.0174532925199433, AUTHORITY["EPSG","9122"]], AUTHORITY["EPSG","4326"]]]')
+    ... except InvalidCRSError as e:
+    ...    print(e)
+    Not a valid CRS: 'PROJCS["...
     """
 
     def __init__(self, crs_str):

--- a/datacube/utils/geometry.py
+++ b/datacube/utils/geometry.py
@@ -49,9 +49,14 @@ class CRSProjProxy(object):
 @cachetools.cached({})
 def _make_crs(crs_str):
     crs = osr.SpatialReference()
-    crs.SetFromUserInput(crs_str)
-    if not crs.ExportToProj4() or crs.IsGeographic() == crs.IsProjected():
-        raise ValueError('Not a valid CRS: %s' % crs_str)
+
+    result = crs.SetFromUserInput(crs_str)
+    if result == ogr.OGRERR_NONE:
+        raise ValueError('Not a recognised CRS string: %r' % crs_str)
+
+    if crs.IsGeographic() == crs.IsProjected():
+        raise ValueError('CRS must be geographic or projected: %r' % crs_str)
+
     return crs
 
 

--- a/datacube/utils/geometry.py
+++ b/datacube/utils/geometry.py
@@ -98,7 +98,7 @@ class CRS(object):
     >>> CRS('cupcakes')
     Traceback (most recent call last):
         ...
-    ValueError: Not a recognised CRS string: 'cupcakes'
+    datacube.utils.geometry.InvalidCRSError: Not a valid CRS: 'cupcakes'
     >>> # This one validly parses, but returns "Corrupt data" from gdal when used.
     >>> CRS('PROJCS["unnamed",'
     ... 'GEOGCS["WGS 84", DATUM["WGS_1984", SPHEROID["WGS 84",6378137,298.257223563, AUTHORITY["EPSG","7030"]],'
@@ -106,7 +106,7 @@ class CRS(object):
     ... 'UNIT["degree",0.0174532925199433, AUTHORITY["EPSG","9122"]], AUTHORITY["EPSG","4326"]]]')
     Traceback (most recent call last):
         ...
-    ValueError: Not a valid CRS: ...
+    datacube.utils.geometry.InvalidCRSError: Not a valid CRS: 'PROJCS["...
     """
 
     def __init__(self, crs_str):

--- a/integration_tests/test_model.py
+++ b/integration_tests/test_model.py
@@ -1,5 +1,3 @@
-import pytest
-
 from datacube.model import Dataset
 from datacube.model import MetadataType
 
@@ -32,7 +30,7 @@ def test_crs_parse(indexed_ls5_scene_dataset_types):
             }
         }
 
-    })
+    }, local_uri=None)
     assert str(d.crs) == 'EPSG:3577'
 
     # Valid datum/zone as seen on our LS5 scene, should infer crs.
@@ -53,8 +51,12 @@ def test_crs_parse(indexed_ls5_scene_dataset_types):
                 "resampling_option": "CUBIC_CONVOLUTION"
             }
         }
-    })
+    }, local_uri=None)
     assert str(d.crs) == 'EPSG:28351'
+
+    # No projection specified in the dataset
+    d = Dataset(product, {}, local_uri=None)
+    assert d.crs is None
 
     # Invalid datum/zone, can't infer
     d = Dataset(product, {
@@ -74,8 +76,7 @@ def test_crs_parse(indexed_ls5_scene_dataset_types):
                 "resampling_option": "CUBIC_CONVOLUTION"
             }
         }
-    })
-    with pytest.raises(RuntimeError,
-                       message="Can't figure out projection: "
-                               "possibly invalid zone (-60) for datum ('GDA94')."):
-        crs = d.crs
+    }, local_uri=None)
+    # Prints warning: Can't figure out projection: possibly invalid zone (-60) for datum ('GDA94')."
+    # We still return None, rather than error, as they didn't specify a CRS explicitly
+    assert d.crs is None

--- a/integration_tests/test_model.py
+++ b/integration_tests/test_model.py
@@ -32,6 +32,7 @@ def test_crs_parse(indexed_ls5_scene_dataset_types):
 
     }, local_uri=None)
     assert str(d.crs) == 'EPSG:3577'
+    assert d.extent is not None
 
     # Valid datum/zone as seen on our LS5 scene, should infer crs.
     d = Dataset(product, {
@@ -53,10 +54,12 @@ def test_crs_parse(indexed_ls5_scene_dataset_types):
         }
     }, local_uri=None)
     assert str(d.crs) == 'EPSG:28351'
+    assert d.extent is not None
 
     # No projection specified in the dataset
     d = Dataset(product, {}, local_uri=None)
     assert d.crs is None
+    assert d.extent is None
 
     # Invalid datum/zone, can't infer
     d = Dataset(product, {

--- a/integration_tests/test_model.py
+++ b/integration_tests/test_model.py
@@ -1,0 +1,81 @@
+import pytest
+
+from datacube.model import Dataset
+from datacube.model import MetadataType
+
+
+def test_crs_parse(indexed_ls5_scene_dataset_types):
+    # type: (MetadataType) -> None
+    product = indexed_ls5_scene_dataset_types[2]
+
+    # Explicit CRS, should load fine.
+    # Taken from LS8_OLI_NBAR_3577_-14_-11_20140601021126000000.nc
+    d = Dataset(product, {
+        "grid_spatial": {
+            "projection": {
+                "valid_data": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [[-1396453.986271351, -1100000.0], [-1400000.0, -1100000.0],
+                         [-1400000.0, -1053643.4714392645], [-1392296.4215373022, -1054399.795365491],
+                         [-1390986.9858215596, -1054531.808155645],
+                         [-1390806.366757733, -1054585.3982497198],
+                         [-1396453.986271351, -1100000.0]]
+                    ]
+                },
+                "geo_ref_points": {
+                    "ll": {"x": -1400000.0, "y": -1100000.0},
+                    "lr": {"x": -1300000.0, "y": -1100000.0},
+                    "ul": {"x": -1400000.0, "y": -1000000.0},
+                    "ur": {"x": -1300000.0, "y": -1000000.0}},
+                "spatial_reference": "EPSG:3577"
+            }
+        }
+
+    })
+    assert str(d.crs) == 'EPSG:3577'
+
+    # Valid datum/zone as seen on our LS5 scene, should infer crs.
+    d = Dataset(product, {
+        "grid_spatial": {
+            "projection": {
+                "zone": -51,
+                "datum": "GDA94",
+                "ellipsoid": "GRS80",
+                "orientation": "NORTH_UP",
+                "geo_ref_points": {
+                    "ll": {"x": 537437.5, "y": 5900512.5},
+                    "lr": {"x": 781687.5, "y": 5900512.5},
+                    "ul": {"x": 537437.5, "y": 6117112.5},
+                    "ur": {"x": 781687.5, "y": 6117112.5}
+                },
+                "map_projection": "UTM",
+                "resampling_option": "CUBIC_CONVOLUTION"
+            }
+        }
+    })
+    assert str(d.crs) == 'EPSG:28351'
+
+    # Invalid datum/zone, can't infer
+    d = Dataset(product, {
+        "grid_spatial": {
+            "projection": {
+                "zone": -60,
+                "datum": "GDA94",
+                "ellipsoid": "GRS80",
+                "orientation": "NORTH_UP",
+                "geo_ref_points": {
+                    "ll": {"x": 537437.5, "y": 5900512.5},
+                    "lr": {"x": 781687.5, "y": 5900512.5},
+                    "ul": {"x": 537437.5, "y": 6117112.5},
+                    "ur": {"x": 781687.5, "y": 6117112.5}
+                },
+                "map_projection": "UTM",
+                "resampling_option": "CUBIC_CONVOLUTION"
+            }
+        }
+    })
+    with pytest.raises(RuntimeError,
+                       message="Can't figure out projection: "
+                               "possibly invalid zone (-60) for datum ('GDA94')."):
+        crs = d.crs


### PR DESCRIPTION
- Explain in the indexing `sources=None` error message how to fix it (we hit this error during the USGS prototype in the TIM)
- `dataset.crs` and `dataset.extent` computed properties previously threw an error for missing info as they assumed all fields were in the document. This is different behaviour to other properties. They now   return None if there's no relevant information in the metadata. 
    This allows for expressions like:

        if not dataset.extent: 
              do_something()


            

- Other misc error message improvements and expanded tests