### PR TITLE
Support remote (non-file) base locations within model

### DIFF
--- a/datacube/compat.py
+++ b/datacube/compat.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 # We're using references that don't exist in python 3 (unicode, long):
 # pylint: skip-file
+
 """
 Compatibility helpers for Python 2 and 3.
 
@@ -22,7 +23,9 @@ if not PY2:
     range = range
 
     import configparser
+
     NoOptionError = configparser.NoOptionError
+
 
     def read_config(default_text=None):
         config = configparser.ConfigParser()
@@ -31,9 +34,16 @@ if not PY2:
         return config
 
 
+    # noinspection PyUnresolvedReferences
     from urllib.parse import urlparse, urljoin
+    # noinspection PyUnresolvedReferences
     from urllib.request import url2pathname
+    # noinspection PyUnresolvedReferences
     from itertools import zip_longest
+    # noinspection PyUnresolvedReferences
+    import urllib.parse as url_parse_module
+
+
 else:
     text_type = unicode
     string_types = (str, unicode)
@@ -46,7 +56,9 @@ else:
 
     import ConfigParser
     from io import StringIO
+
     NoOptionError = ConfigParser.NoOptionError
+
 
     def read_config(default_text=None):
         config = ConfigParser.SafeConfigParser()
@@ -54,9 +66,15 @@ else:
             config.readfp(StringIO(default_text))
         return config
 
+
+    # noinspection PyUnresolvedReferences
     from urlparse import urlparse, urljoin
+    # noinspection PyUnresolvedReferences
     from urllib import url2pathname
+    # noinspection PyUnresolvedReferences
     from itertools import izip_longest as zip_longest
+    # noinspection PyUnresolvedReferences
+    import urlparse as url_parse_module
 
 
 def with_metaclass(meta, *bases):

--- a/datacube/index/postgres/_api.py
+++ b/datacube/index/postgres/_api.py
@@ -37,28 +37,25 @@ except ImportError:
 def _dataset_uri_field(table):
     return table.c.uri_scheme + ':' + table.c.uri_body
 
-# Fields for selecting dataset with the latest local uri
-# Need to alias the table otherwise we can get name collisions when joining with dataset_location outside of this query
-SELECTED_DATASET_LOCATION = DATASET_LOCATION.alias('selected_dataset_location')
-_DATASET_SELECT_W_LOCAL = (
-    DATASET,
-    # The most recent file uri. We may want more advanced path selection in the future...
-    select([
-        _dataset_uri_field(SELECTED_DATASET_LOCATION),
-    ]).where(
-        and_(
-            SELECTED_DATASET_LOCATION.c.dataset_ref == DATASET.c.id,
-            SELECTED_DATASET_LOCATION.c.uri_scheme == 'file'
-        )
-    ).order_by(
-        SELECTED_DATASET_LOCATION.c.added.desc()
-    ).limit(1).label('uri')
-)
 
-# Fields for selecting dataset with a single joined uri (specify join yourself in your query)
-_DATASET_SELECT_W_URI = (
+# Fields for selecting dataset with uris
+# Need to alias the table, as queries may join the location table for filtering.
+SELECTED_DATASET_LOCATION = DATASET_LOCATION.alias('selected_dataset_location')
+_DATASET_SELECT_FIELDS = (
     DATASET,
-    _dataset_uri_field(DATASET_LOCATION).label('uri')
+    # All active URIs, from newest to oldest
+    func.array(
+        select([
+            _dataset_uri_field(SELECTED_DATASET_LOCATION)
+        ]).where(
+            and_(
+                SELECTED_DATASET_LOCATION.c.dataset_ref == DATASET.c.id,
+                SELECTED_DATASET_LOCATION.c.archived == None
+            )
+        ).order_by(
+            SELECTED_DATASET_LOCATION.c.added.desc()
+        ).label('uris')
+    ).label('uris')
 )
 
 PGCODE_UNIQUE_CONSTRAINT = '23505'
@@ -211,25 +208,27 @@ class PostgresDbAPI(object):
         )
         return res.rowcount > 0
 
-    def ensure_dataset_location(self, dataset_id, uri):
+    def ensure_dataset_locations(self, dataset_id, uris):
         """
         Add a location to a dataset if it is not already recorded.
         :type dataset_id: str or uuid.UUID
-        :type uri: str
+        :type uris: list[str]
         """
-        scheme, body = _split_uri(uri)
 
-        try:
-            self._connection.execute(
-                DATASET_LOCATION.insert(),
-                dataset_ref=dataset_id,
-                uri_scheme=scheme,
-                uri_body=body,
-            )
-        except IntegrityError as e:
-            if e.orig.pgcode == PGCODE_UNIQUE_CONSTRAINT:
-                raise DuplicateRecordError('Location already exists: %s' % uri)
-            raise
+        for uri in uris:
+            scheme, body = _split_uri(uri)
+
+            try:
+                self._connection.execute(
+                    DATASET_LOCATION.insert(),
+                    dataset_ref=dataset_id,
+                    uri_scheme=scheme,
+                    uri_body=body,
+                )
+            except IntegrityError as e:
+                if e.orig.pgcode == PGCODE_UNIQUE_CONSTRAINT:
+                    raise DuplicateRecordError('Location already exists: %s' % uri)
+                raise
 
     def contains_dataset(self, dataset_id):
         return bool(
@@ -246,7 +245,7 @@ class PostgresDbAPI(object):
         scheme, body = _split_uri(uri)
         return self._connection.execute(
             select(
-                _DATASET_SELECT_W_URI
+                _DATASET_SELECT_FIELDS
             ).select_from(
                 DATASET_LOCATION.join(DATASET)
             ).where(
@@ -292,13 +291,13 @@ class PostgresDbAPI(object):
 
     def get_dataset(self, dataset_id):
         return self._connection.execute(
-            select(_DATASET_SELECT_W_LOCAL).where(DATASET.c.id == dataset_id)
+            select(_DATASET_SELECT_FIELDS).where(DATASET.c.id == dataset_id)
         ).first()
 
     def get_derived_datasets(self, dataset_id):
         return self._connection.execute(
             select(
-                _DATASET_SELECT_W_LOCAL
+                _DATASET_SELECT_FIELDS
             ).select_from(
                 DATASET.join(DATASET_SOURCE, DATASET.c.id == DATASET_SOURCE.c.dataset_ref)
             ).where(
@@ -342,7 +341,7 @@ class PostgresDbAPI(object):
 
         # join the adjacency list with datasets table
         query = select(
-            _DATASET_SELECT_W_LOCAL + (aggd.c.sources, aggd.c.classes)
+            _DATASET_SELECT_FIELDS + (aggd.c.sources, aggd.c.classes)
         ).select_from(aggd.join(DATASET, DATASET.c.id == aggd.c.dataset_ref))
 
         return self._connection.execute(query).fetchall()
@@ -356,7 +355,7 @@ class PostgresDbAPI(object):
         """
         # Find any storage types whose 'dataset_metadata' document is a subset of the metadata.
         return self._connection.execute(
-            select(_DATASET_SELECT_W_LOCAL).where(DATASET.c.metadata.contains(metadata))
+            select(_DATASET_SELECT_FIELDS).where(DATASET.c.metadata.contains(metadata))
         ).fetchall()
 
     @staticmethod
@@ -377,7 +376,7 @@ class PostgresDbAPI(object):
                 for f in select_fields
             )
         else:
-            select_columns = _DATASET_SELECT_W_LOCAL
+            select_columns = _DATASET_SELECT_FIELDS
 
         if with_source_ids:
             # Include the IDs of source datasets

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -75,7 +75,7 @@ class Dataset(object):
     :param list[str] uris: All active uris for the dataset
     """
 
-    def __init__(self, type_, metadata_doc, uris, sources=None,
+    def __init__(self, type_, metadata_doc, local_uri=None, uris=None, sources=None,
                  indexed_by=None, indexed_time=None, archived_time=None):
         assert isinstance(type_, DatasetType)
 
@@ -86,6 +86,16 @@ class Dataset(object):
         #: or inside a NetCDF file, and as JSON-B inside the database index.
         #: :type: dict
         self.metadata_doc = metadata_doc
+
+        if local_uri:
+            warnings.warn(
+                "Dataset.local_uri has been replaced with list Dataset.uris",
+                DeprecationWarning
+            )
+            if not uris:
+                uris = []
+
+            uris.append(local_uri)
 
         #: Active URIs in order from newest to oldest
         self.uris = uris

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -72,10 +72,10 @@ class Dataset(object):
 
     :type type_: DatasetType
     :param dict metadata_doc: the document (typically a parsed json/yaml)
-    :param str local_uri: A URI to access this dataset locally.
+    :param list[str] uris: All active uris for the dataset
     """
 
-    def __init__(self, type_, metadata_doc, local_uri, sources=None,
+    def __init__(self, type_, metadata_doc, uris, sources=None,
                  indexed_by=None, indexed_time=None, archived_time=None):
         assert isinstance(type_, DatasetType)
 
@@ -87,11 +87,8 @@ class Dataset(object):
         #: :type: dict
         self.metadata_doc = metadata_doc
 
-        #: The most recent local file available to access the data, if any.
-        #: Note that a dataset can have multiple uris, not all of which are local files.
-        #: To get all uris for a dataset, use index.datasets.get_locations()
-        #: :type: str
-        self.local_uri = local_uri
+        #: Active URIs in order from newest to oldest
+        self.uris = uris
 
         #: The datasets that this dataset is derived from (if requested on load).
         #: :type: dict[str, Dataset]
@@ -114,6 +111,18 @@ class Dataset(object):
     @property
     def metadata_type(self):
         return self.type.metadata_type if self.type else None
+
+    @property
+    def local_uri(self):
+        """
+        The latest local file uri, if any.
+        :rtype: str
+        """
+        local_uris = [uri for uri in self.uris if uri.startswith('file:')]
+        if local_uris:
+            return local_uris[0]
+
+        return None
 
     @property
     def local_path(self):

--- a/datacube/model/utils.py
+++ b/datacube/model/utils.py
@@ -8,12 +8,13 @@ import uuid
 
 import numpy
 import xarray
+import yaml
 from pandas import to_datetime
 
 import datacube
-from datacube.utils import geometry
 from datacube.model import Dataset
-import yaml
+from datacube.utils import geometry
+
 try:
     from yaml import CSafeDumper as SafeDumper
 except ImportError:
@@ -190,7 +191,7 @@ def make_dataset(product, sources, extent, center_time, valid_data=None, uri=Non
 
     return Dataset(product,
                    document,
-                   local_uri=uri,
+                   uris=[uri] if uri else None,
                    sources={str(idx): dataset for idx, dataset in enumerate(sources)})
 
 

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -71,7 +71,7 @@ def create_dataset(dataset_doc, uri, rules):
     dataset_type = find_matching_product(rules, dataset_doc)
     sources = {cls: create_dataset(source_doc, None, rules)
                for cls, source_doc in dataset_type.dataset_reader(dataset_doc).sources.items()}
-    return Dataset(dataset_type, dataset_doc, uri, sources=sources)
+    return Dataset(dataset_type, dataset_doc, uris=[uri] if uri else None, sources=sources)
 
 
 def load_rules_from_file(filename, index):
@@ -266,7 +266,7 @@ def build_dataset_info(index, dataset, show_sources=False, show_derived=False, d
     if dataset.indexed_time is not None:
         info['indexed'] = dataset.indexed_time
 
-    info['locations'] = index.datasets.get_locations(dataset.id)
+    info['locations'] = dataset.uris
     info['fields'] = dataset.metadata.search_fields
 
     if depth < max_depth:

--- a/datacube_apps/stacker/stacker.py
+++ b/datacube_apps/stacker/stacker.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 import datacube
 from datacube.api import Tile
+from datacube.model import Dataset
 from datacube.model.utils import xr_apply, datasets_to_doc
 from datacube.storage import netcdf_writer
 from datacube.storage.storage import create_netcdf_storage_unit
@@ -174,8 +175,9 @@ def do_stack_task(config, task):
 
 def make_updated_tile(old_datasets, new_uri, geobox):
     def update_dataset_location(labels, dataset):
+        # type: (object, Dataset) -> list
         new_dataset = copy.copy(dataset)
-        new_dataset.local_uri = new_uri
+        new_dataset.uris = [new_uri]
         return [dataset]
 
     updated_datasets = xr_apply(old_datasets, update_dataset_location, dtype='O')

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -187,13 +187,20 @@ def test_update_dataset(index, ls5_telem_doc, example_ls5_nbar_metadata_doc):
     index.datasets.update(dataset)
     updated = index.datasets.get(dataset.id)
     assert updated.local_uri == 'file:///test/doc.yaml'
+    assert updated.uris == ['file:///test/doc.yaml']
 
     # update location
     assert index.datasets.get(dataset.id).local_uri == 'file:///test/doc.yaml'
     update = Dataset(ls5_telem_type, example_ls5_nbar_metadata_doc, uris=['file:///test/doc2.yaml'], sources={})
     index.datasets.update(update)
     updated = index.datasets.get(dataset.id)
+
+    # New locations are appended on update.
+    # They may be indexing the same dataset from a different location: we don't want to remove the original location.
+    # Returns the most recently added
     assert updated.local_uri == 'file:///test/doc2.yaml'
+    # But both still exist (newest-to-oldest order)
+    assert updated.uris == ['file:///test/doc2.yaml', 'file:///test/doc.yaml']
 
     # adding more metadata should always be allowed
     doc = copy.deepcopy(updated.metadata_doc)
@@ -203,6 +210,7 @@ def test_update_dataset(index, ls5_telem_doc, example_ls5_nbar_metadata_doc):
     updated = index.datasets.get(dataset.id)
     assert updated.metadata_doc['test1'] == {'some': 'thing'}
     assert updated.local_uri == 'file:///test/doc2.yaml'
+    assert len(updated.uris) == 2
 
     # adding more metadata and changing location
     doc = copy.deepcopy(updated.metadata_doc)
@@ -213,8 +221,9 @@ def test_update_dataset(index, ls5_telem_doc, example_ls5_nbar_metadata_doc):
     assert updated.metadata_doc['test1'] == {'some': 'thing'}
     assert updated.metadata_doc['test2'] == {'some': 'other thing'}
     assert updated.local_uri == 'file:///test/doc3.yaml'
+    assert len(updated.uris) == 3
 
-    # changing stuff isn't allowed by default
+    # changing existing metadata fields isn't allowed by default
     doc = copy.deepcopy(updated.metadata_doc)
     doc['product_type'] = 'foobar'
     update = Dataset(ls5_telem_type, doc, uris=['file:///test/doc4.yaml'])
@@ -225,18 +234,19 @@ def test_update_dataset(index, ls5_telem_doc, example_ls5_nbar_metadata_doc):
     assert updated.metadata_doc['test2'] == {'some': 'other thing'}
     assert updated.metadata_doc['product_type'] == 'nbar'
     assert updated.local_uri == 'file:///test/doc3.yaml'
+    assert len(updated.uris) == 3
 
     # allowed changes go through
     doc = copy.deepcopy(updated.metadata_doc)
     doc['product_type'] = 'foobar'
     # Backwards compat: third argument was a single local uri.
-    update = Dataset(ls5_telem_type, doc, 'file:///test/doc5.yaml')
+    update = Dataset(ls5_telem_type, doc, 'file:///test/doc4.yaml')
     index.datasets.update(update, {('product_type',): changes.allow_any})
     updated = index.datasets.get(dataset.id)
     assert updated.metadata_doc['test1'] == {'some': 'thing'}
     assert updated.metadata_doc['test2'] == {'some': 'other thing'}
     assert updated.metadata_doc['product_type'] == 'foobar'
-    assert updated.local_uri == 'file:///test/doc5.yaml'
+    assert updated.local_uri == 'file:///test/doc4.yaml'
 
 
 def test_update_dataset_type(index, ls5_telem_type, ls5_telem_doc, ga_metadata_type_doc):

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -179,7 +179,7 @@ def test_update_dataset(index, ls5_telem_doc, example_ls5_nbar_metadata_doc):
     assert ls5_telem_type
 
     example_ls5_nbar_metadata_doc['lineage']['source_datasets'] = {}
-    dataset = Dataset(ls5_telem_type, example_ls5_nbar_metadata_doc, 'file:///test/doc.yaml', sources={})
+    dataset = Dataset(ls5_telem_type, example_ls5_nbar_metadata_doc, uris=['file:///test/doc.yaml'], sources={})
     dataset = index.datasets.add(dataset)
     assert dataset
 
@@ -190,7 +190,7 @@ def test_update_dataset(index, ls5_telem_doc, example_ls5_nbar_metadata_doc):
 
     # update location
     assert index.datasets.get(dataset.id).local_uri == 'file:///test/doc.yaml'
-    update = Dataset(ls5_telem_type, example_ls5_nbar_metadata_doc, 'file:///test/doc2.yaml', sources={})
+    update = Dataset(ls5_telem_type, example_ls5_nbar_metadata_doc, uris=['file:///test/doc2.yaml'], sources={})
     index.datasets.update(update)
     updated = index.datasets.get(dataset.id)
     assert updated.local_uri == 'file:///test/doc2.yaml'
@@ -207,7 +207,7 @@ def test_update_dataset(index, ls5_telem_doc, example_ls5_nbar_metadata_doc):
     # adding more metadata and changing location
     doc = copy.deepcopy(updated.metadata_doc)
     doc['test2'] = {'some': 'other thing'}
-    update = Dataset(ls5_telem_type, doc, 'file:///test/doc3.yaml')
+    update = Dataset(ls5_telem_type, doc, uris=['file:///test/doc3.yaml'])
     index.datasets.update(update)
     updated = index.datasets.get(dataset.id)
     assert updated.metadata_doc['test1'] == {'some': 'thing'}
@@ -217,7 +217,7 @@ def test_update_dataset(index, ls5_telem_doc, example_ls5_nbar_metadata_doc):
     # changing stuff isn't allowed by default
     doc = copy.deepcopy(updated.metadata_doc)
     doc['product_type'] = 'foobar'
-    update = Dataset(ls5_telem_type, doc, 'file:///test/doc4.yaml')
+    update = Dataset(ls5_telem_type, doc, uris=['file:///test/doc4.yaml'])
     with pytest.raises(ValueError):
         index.datasets.update(update)
     updated = index.datasets.get(dataset.id)
@@ -229,6 +229,7 @@ def test_update_dataset(index, ls5_telem_doc, example_ls5_nbar_metadata_doc):
     # allowed changes go through
     doc = copy.deepcopy(updated.metadata_doc)
     doc['product_type'] = 'foobar'
+    # Backwards compat: third argument was a single local uri.
     update = Dataset(ls5_telem_type, doc, 'file:///test/doc5.yaml')
     index.datasets.update(update, {('product_type',): changes.allow_any})
     updated = index.datasets.get(dataset.id)

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -237,7 +237,7 @@ def test_index_dataset_with_location(index, default_metadata_type):
     second_file = Path('/tmp/second/something.yaml').absolute()
 
     type_ = index.products.add_document(_pseudo_telemetry_dataset_type)
-    dataset = Dataset(type_, _telemetry_dataset, first_file.as_uri(), sources={})
+    dataset = Dataset(type_, _telemetry_dataset, uris=[first_file.as_uri()], sources={})
     index.datasets.add(dataset)
     stored = index.datasets.get(dataset.id)
 
@@ -279,7 +279,7 @@ def test_index_dataset_with_location(index, default_metadata_type):
     assert len(locations) == 1
 
     # Ingesting with a new path should add the second one too.
-    dataset.local_uri = second_file.as_uri()
+    dataset.uris = [second_file.as_uri()]
     index.datasets.add(dataset)
     stored = index.datasets.get(dataset.id)
     locations = index.datasets.get_locations(dataset.id)
@@ -290,7 +290,7 @@ def test_index_dataset_with_location(index, default_metadata_type):
     assert stored.local_path == Path(second_file)
 
     # Ingestion again without location should have no effect.
-    dataset.local_uri = None
+    dataset.uri = None
     index.datasets.add(dataset)
     stored = index.datasets.get(dataset.id)
     locations = index.datasets.get_locations(dataset.id)
@@ -304,6 +304,6 @@ def test_index_dataset_with_location(index, default_metadata_type):
     # Add a second dataset with a different location (to catch lack of joins, filtering etc)
     second_ds_doc = copy.deepcopy(_telemetry_dataset)
     second_ds_doc['id'] = '366f32d8-e1f8-11e6-94b4-185e0f80a5c0'
-    index.datasets.add(Dataset(type_, second_ds_doc, second_file.as_uri(), sources={}))
+    index.datasets.add(Dataset(type_, second_ds_doc, uris=[second_file.as_uri()], sources={}))
     dataset_ids = [d.id for d in index.datasets.get_datasets_for_location(first_file.as_uri())]
     assert dataset_ids == [dataset.id]

--- a/tests/index/test_api_index_dataset.py
+++ b/tests/index/test_api_index_dataset.py
@@ -150,12 +150,12 @@ _EXAMPLE_DATASET_TYPE = DatasetType(
 
 def _build_dataset(doc):
     sources = {name: _build_dataset(src) for name, src in doc['lineage']['source_datasets'].items()}
-    return Dataset(_EXAMPLE_DATASET_TYPE, doc, 'file://test.zzz', sources)
+    return Dataset(_EXAMPLE_DATASET_TYPE, doc, uris=['file://test.zzz'], sources=sources)
 
 
 _EXAMPLE_NBAR_DATASET = _build_dataset(_EXAMPLE_NBAR)
 
-DatasetRecord = namedtuple('DatasetRecord', ['id', 'metadata', 'dataset_type_ref', 'uri',
+DatasetRecord = namedtuple('DatasetRecord', ['id', 'metadata', 'dataset_type_ref', 'uris',
                                              'added', 'added_by', 'archived'])
 
 
@@ -175,7 +175,7 @@ class MockDb(object):
     def get_dataset(self, id):
         return self.dataset.get(id, None)
 
-    def ensure_dataset_location(self, *args, **kwargs):
+    def ensure_dataset_locations(self, *args, **kwargs):
         return
 
     def insert_dataset(self, metadata_doc, dataset_id, dataset_type_id):


### PR DESCRIPTION
This adds support for the base uri to be a remote location, so that the bands can correctly be computed relative to that uri. It also adds them to the dataset model for convenient use.

The previous use of remote locations (such as s3 urls) was specified as an absolute `s3://` url on each individual band path, overriding the base location of the dataset (which was a bogus local uri).

* All active locations for a dataset are now available as a property (`dataset.uris`), rather than just the latest file location (at `dataset.local_uri` or `dataset.local_path`). The latter properties are still available for convenience and backwards compatibility. There is almost always only one (or rarely two) active locations per dataset, so the load overhead shouldn't be large.
* The cli (`datacube dataset add`) does not yet support remote locations directly as they try to load the given path as a local file. That can be done in a future change, but is lower priority.
