### PR TITLE
Extract xarray geoextensions

### DIFF
--- a/datacube/__init__.py
+++ b/datacube/__init__.py
@@ -6,7 +6,7 @@ Provides access to multi-dimensional data, with a focus on Earth observations da
 
 To use this module, see the `Developer Guide <http://datacube-core.readthedocs.io/en/stable/dev/developer.html>`_.
 
-The main class to access the datacube is :py:class:`datacube.Datacube`.
+The main class to access the datacube is :class:`datacube.Datacube`.
 
 To initialise this class, you will need a config pointing to a database, such as a file with the following::
 
@@ -21,5 +21,8 @@ from .version import __version__
 from .api import Datacube
 from .config import set_options
 import warnings
+from .utils import xarray_geoextensions
 
+
+# Ensure deprecation warnings from datacube modules are shown
 warnings.filterwarnings('always', category=DeprecationWarning, module=r'^datacube\.')

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -40,30 +40,6 @@ THREADING_REQS_AVAILABLE = ('SharedArray' in sys.modules and 'pathos.threading' 
 Group = namedtuple('Group', ['key', 'datasets'])
 
 
-def _xarray_affine(obj):
-    dims = obj.crs.dimensions
-    xres, xoff = data_resolution_and_offset(obj[dims[1]].values)
-    yres, yoff = data_resolution_and_offset(obj[dims[0]].values)
-    return Affine.translation(xoff, yoff) * Affine.scale(xres, yres)
-
-
-def _xarray_extent(obj):
-    return obj.geobox.extent
-
-
-def _xarray_geobox(obj):
-    dims = obj.crs.dimensions
-    return geometry.GeoBox(obj[dims[1]].size, obj[dims[0]].size, obj.affine, obj.crs)
-
-
-xarray.Dataset.geobox = property(_xarray_geobox)
-xarray.Dataset.affine = property(_xarray_affine)
-xarray.Dataset.extent = property(_xarray_extent)
-xarray.DataArray.geobox = property(_xarray_geobox)
-xarray.DataArray.affine = property(_xarray_affine)
-xarray.DataArray.extent = property(_xarray_extent)
-
-
 class Datacube(object):
     """
     Interface to search, read and write a datacube.

--- a/datacube/utils/xarray_geoextensions.py
+++ b/datacube/utils/xarray_geoextensions.py
@@ -9,6 +9,7 @@ This extension is reliant on an `xarray` object having a `.crs` property of type
 `.geobox`, `.affine` and `.extent` respectively.
 
 """
+from __future__ import absolute_import
 from affine import Affine
 import xarray
 

--- a/datacube/utils/xarray_geoextensions.py
+++ b/datacube/utils/xarray_geoextensions.py
@@ -1,0 +1,39 @@
+"""
+Add geometric extensions to :class:`xarray.Dataset` and :class:`xarray.DataArray` for use
+with Data Cube by Monkey Patching those classes.
+
+This extension is reliant on an `xarray` object having a `.crs` property of type
+:class:`datacube.utils.geometry.CRS`. This is used to inspect the spatial dimensions of the
+:class:`Dataset` or :class:`DataArray`, and provide new attributes for accessing a
+:class:`datacube.utils.geometry.GeoBox`, affine transform and extent for the dataset as
+`.geobox`, `.affine` and `.extent` respectively.
+
+"""
+from affine import Affine
+import xarray
+
+from datacube.utils import data_resolution_and_offset, geometry
+
+
+def _xarray_affine(obj):
+    dims = obj.crs.dimensions
+    xres, xoff = data_resolution_and_offset(obj[dims[1]].values)
+    yres, yoff = data_resolution_and_offset(obj[dims[0]].values)
+    return Affine.translation(xoff, yoff) * Affine.scale(xres, yres)
+
+
+def _xarray_extent(obj):
+    return obj.geobox.extent
+
+
+def _xarray_geobox(obj):
+    dims = obj.crs.dimensions
+    return geometry.GeoBox(obj[dims[1]].size, obj[dims[0]].size, obj.affine, obj.crs)
+
+
+xarray.Dataset.geobox = property(_xarray_geobox)
+xarray.Dataset.affine = property(_xarray_affine)
+xarray.Dataset.extent = property(_xarray_extent)
+xarray.DataArray.geobox = property(_xarray_geobox)
+xarray.DataArray.affine = property(_xarray_affine)
+xarray.DataArray.extent = property(_xarray_extent)


### PR DESCRIPTION
These are used throughout the codebase, and should be visibly separate.