### PR TITLE
Add support for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     docker:
       - image: python:3.6
         environment:
-          CONDA_ENV_FILE: .travis/environment_py27.yaml
+          CONDA_ENV_FILE: .travis/environment_py35.yaml
           DATABASE_URL: postgresql://ubuntu@localhost/circle_test?sslmode=disable
       - image: postgres:9.6
         environment:
@@ -13,11 +13,6 @@ jobs:
           POSTGRES_PASSWORD: ""
     working_directory: ~/datacube-core
     steps:
-          # Create Postgres users and database
-      # Note the YAML heredoc '|' for nicer formatting
-      # - run: |
-      #     sudo -u root createuser -h localhost --superuser ubuntu &&
-      #     sudo createdb -h localhost test_db
       - run:
           name: Install Conda + Setup Conda
           working_directory: ~
@@ -51,7 +46,7 @@ jobs:
       #     key: datacube-core-{{ .Branch }}-{{ checksum "yarn.lock" }}
       #     paths:
       #       - "/home/ubuntu/.yarn-cache"
-      
+
       - run:
           name: Run All Tests
           command: |
@@ -67,11 +62,11 @@ jobs:
             source activate agdc
             make html
 
-      # - store_artifacts:
-      #     path: test-reports/coverage
-      #     destination: reports
       - store_artifacts:
           path: docs/_build/html
           destination: docs
+      # - store_artifacts:
+      #     path: test-reports/coverage
+      #     destination: reports
       # - store_test_results:
       #     path: "test-reports/"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,77 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: python:3.6
+        environment:
+          CONDA_ENV_FILE: .travis/environment_py27.yaml
+          DATABASE_URL: postgresql://ubuntu@localhost/circle_test?sslmode=disable
+      - image: postgres:9.6
+        environment:
+          POSTGRES_USER: root
+          POSTGRES_DB: agdcintegration
+          POSTGRES_PASSWORD: ""
+    working_directory: ~/datacube-core
+    steps:
+          # Create Postgres users and database
+      # Note the YAML heredoc '|' for nicer formatting
+      # - run: |
+      #     sudo -u root createuser -h localhost --superuser ubuntu &&
+      #     sudo createdb -h localhost test_db
+      - run:
+          name: Install Conda + Setup Conda
+          working_directory: ~
+          command: |
+            wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+            bash miniconda.sh -f -b -p $HOME/miniconda
+            export PATH="$HOME/miniconda/bin:$PATH"
+            hash -r
+            conda config --set always_yes yes --set changeps1 no
+            conda config --show-sources
+            conda config --show
+            conda config --prepend channels conda-forge
+            conda update --all
+            conda info -a
+
+      - checkout
+
+      - run:
+          name: Setup Environment
+          command: |
+            export PATH="$HOME/miniconda/bin:$PATH"
+            conda env create -q -n agdc --file .travis/environment_py35.yaml
+            source activate agdc
+            conda install -q sphinx sphinx_rtd_theme mock click # Stuff for docs
+            pip install .[analytics,test,interactive,docs] --no-deps --upgrade
+
+      # - restore_cache:
+      #     key: projectname-{{ .Branch }}-{{ checksum "yarn.lock" }}
+      # - run: yarn && pip install -r requirements.txt
+      # - save_cache:
+      #     key: datacube-core-{{ .Branch }}-{{ checksum "yarn.lock" }}
+      #     paths:
+      #       - "/home/ubuntu/.yarn-cache"
+      
+      - run:
+          name: Run All Tests
+          command: |
+            export PATH="$HOME/miniconda/bin:$PATH"
+            source activate agdc
+            ./check-code.sh integration_tests
+
+      - run:
+          name: Build Documentation
+          working_directory: ~/datacube-core/docs
+          command: |
+            export PATH="$HOME/miniconda/bin:$PATH"
+            source activate agdc
+            make html
+
+      # - store_artifacts:
+      #     path: test-reports/coverage
+      #     destination: reports
+      - store_artifacts:
+          path: docs/_build/html
+          destination: docs
+      # - store_test_results:
+      #     path: "test-reports/"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,23 @@ jobs:
           command: |
             export PATH="$HOME/miniconda/bin:$PATH"
             source activate agdc
-            ./check-code.sh integration_tests
+
+            pep8 tests integration_tests examples utils --max-line-length 120
+
+            pylint -j 2 --reports no datacube datacube_apps
+
+            # Run tests, taking coverage.
+            # Users can specify extra folders as arguments.
+            py.test --junitxml=test-reports/pytest-datacube.log -r sx --cov datacube --durations=5 datacube tests datacube_apps integration_tests
+
+
+      - store_artifacts:
+          path: test-reports
+          destination: reports
+
+      - store_test_results:
+          path: test-reports
+
 
       - run:
           name: Build Documentation
@@ -65,8 +81,3 @@ jobs:
       - store_artifacts:
           path: docs/_build/html
           destination: docs
-      # - store_artifacts:
-      #     path: test-reports/coverage
-      #     destination: reports
-      # - store_test_results:
-      #     path: "test-reports/"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,8 @@ jobs:
           name: Install Conda + Setup Conda
           working_directory: ~
           command: |
-            wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-            bash miniconda.sh -f -b -p $HOME/miniconda
+            wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
+            bash ~/miniconda.sh -f -b -p $HOME/miniconda
             export PATH="$HOME/miniconda/bin:$PATH"
             hash -r
             conda config --set always_yes yes --set changeps1 no


### PR DESCRIPTION
This PR adds a configuration to build and test `datacube-core` using the [CircleCI](https://circleci.com/) continuous integration tool. It is available for free for open source projects, and has some notable improvements over the TravisCI.

The first reason to move is support for saving build artefacts. We can build and store docs docs for every commit and Pull Requests. It's is currently impossible to do this with ReadTheDocs.

CircleCI also has better tools for debugging build failures, such as SSHing in to a failed build. This allows interactive examination to determine the cause.

**Note:** This configuration doesn't support uploading code coverage or test statistics anywhere. This should be added before we consider switching completely. There's no problem with running Travis and Circle in parallel.