### PR TITLE
[notready] Last steps before switching to CircleCI and turning off TravisCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
         environment:
           CONDA_ENV_FILE: .travis/environment_py35.yaml
           DATABASE_URL: postgresql://ubuntu@localhost/circle_test?sslmode=disable
+          CONDA_ENV_NAME: datacube
       - image: postgres:9.6
         environment:
           POSTGRES_USER: root
@@ -34,15 +35,15 @@ jobs:
           name: Setup Environment
           command: |
             export PATH="$HOME/miniconda/bin:$PATH"
-            conda env create -q -n agdc --file .travis/environment_py35.yaml
-            source activate agdc
+            conda env create -q -n $CONDA_ENV_NAME --file .travis/environment_py35.yaml
+            source activate $CONDA_ENV_NAME
             conda install -q sphinx sphinx_rtd_theme mock click # Stuff for docs
 
       - run:
           name: Install Data Cube Code
           command: |
             export PATH="$HOME/miniconda/bin:$PATH"
-            source activate agdc
+            source activate $CONDA_ENV_NAME
 
             pip install . --no-deps --upgrade
 
@@ -58,7 +59,7 @@ jobs:
           name: Run All Tests
           command: |
             export PATH="$HOME/miniconda/bin:$PATH"
-            source activate agdc
+            source activate $CONDA_ENV_NAME
 
             pep8 tests integration_tests examples utils --max-line-length 120
 
@@ -82,7 +83,7 @@ jobs:
           working_directory: ~/datacube-core/docs
           command: |
             export PATH="$HOME/miniconda/bin:$PATH"
-            source activate agdc
+            source activate $CONDA_ENV_NAME
             make html
 
       - store_artifacts:
@@ -91,7 +92,7 @@ jobs:
 
       - run:
           name: Upload Code Coverage to coveralls.io
-          run: |
+          command: |
             export PATH="$HOME/miniconda/bin:$PATH"
-            source activate agdc
+            source activate $CONDA_ENV_NAME
             coveralls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,14 @@ jobs:
             conda env create -q -n agdc --file .travis/environment_py35.yaml
             source activate agdc
             conda install -q sphinx sphinx_rtd_theme mock click # Stuff for docs
-            pip install .[analytics,test,interactive,docs] --no-deps --upgrade
+
+      - run:
+          name: Install Data Cube Code
+          command: |
+            export PATH="$HOME/miniconda/bin:$PATH"
+            source activate agdc
+
+            pip install . --no-deps --upgrade
 
       # - restore_cache:
       #     key: projectname-{{ .Branch }}-{{ checksum "yarn.lock" }}
@@ -81,3 +88,10 @@ jobs:
       - store_artifacts:
           path: docs/_build/html
           destination: docs
+
+      - run:
+          name: Upload Code Coverage to coveralls.io
+          run: |
+            export PATH="$HOME/miniconda/bin:$PATH"
+            source activate agdc
+            coveralls


### PR DESCRIPTION
It would be nice to use only one CI service. This PR will address the last few shortcomings with CircleCI, so that we can switch over to it from TravisCI.

- [x] Upload code coverage to coveralls.io
- [ ] Test against supported python versions (2.7, 3.6).

Update 1: Turns out, the v2 beta of CircleCI which I've been using, doesn't have a nice way of running multiple parallel builds at once, as we are doing in Travis. Will have to do more work to get it working, or hope that they fix it when they come out of beta.