### PR TITLE
[ready] Stacking, NetCDF metadata rewrite and NCML utils

### DIFF
--- a/datacube/ui/task_app.py
+++ b/datacube/ui/task_app.py
@@ -155,6 +155,12 @@ def validate_year(ctx, param, value):
                                  'or as an inclusive range (eg 1996-2001)')
 
 
+def break_query_into_years(time_query, **kwargs):
+    if time_query is None:
+        return kwargs
+    return [{'time': time_range}.update(kwargs) for time_range in year_splitter(*time_query)]
+
+
 def year_splitter(start, end):
     """
     Produces a list of time ranges based that represent each year in the range.

--- a/datacube_apps/ncml.py
+++ b/datacube_apps/ncml.py
@@ -33,26 +33,37 @@ def get_filename(config, cell_index, year=None):
     return file_path_template.format(tile_index=cell_index, start_time=year)
 
 
-def make_ncml_tasks(index, config, cell_index=None, year=None, **kwargs):
+def make_ncml_tasks(index, config, cell_index=None, year=None, cell_index_list=None, **kwargs):
     product = config['product']
 
     query = {}
     if year is not None:
         query['time'] = datetime(year=year, month=1, day=1), datetime(year=year + 1, month=1, day=1)
 
-    config['nested_years'] = kwargs.get('nested_years', [])
-
     gw = datacube.api.GridWorkflow(index=index, product=product.name)
-    cells = gw.list_cells(product=product.name, cell_index=cell_index, **query)
-    for (cell_index, tile) in cells.items():
-        output_filename = get_filename(config, cell_index, year)
-        yield dict(tile=tile,
-                   cell_index=cell_index,
-                   output_filename=output_filename)
+
+    if cell_index_list is None:
+        if cell_index is not None:
+            cell_index_list = [cell_index]
+        else:
+            cell_index_list = []
+
+    for cell_index in cell_index_list:
+        cells = gw.list_cells(product=product.name, cell_index=cell_index, **query)
+        for (cell_index, tile) in cells.items():
+            output_filename = get_filename(config, cell_index, year)
+            yield dict(tile=tile,
+                       cell_index=cell_index,
+                       output_filename=output_filename)
 
 
-def make_ncml_config(index, config, export_path=None, **query):
+def make_ncml_config(index, config, export_path=None, nested_years=None, **query):
     config['product'] = index.products.get_by_name(config['output_type'])
+
+    config['nested_years'] = nested_years if nested_years is not None else []
+
+    if export_path is not None:
+        config['location'] = export_path
 
     if not os.access(config['location'], os.W_OK):
         _LOG.warning('Current user appears not have write access output location: %s', config['location'])
@@ -100,11 +111,13 @@ def do_ncml_task(config, task):
 
 def write_ncml_file(ncml_filename, file_locations, header_attrs):
     filename = Path(ncml_filename)
-    if filename.exists():
-        raise RuntimeError('NCML already exists: %s' % filename)
+    temp_filename = Path().joinpath(*filename.parts[:-1]) / '.tmp' / filename.parts[-1]
+
+    if temp_filename.exists():
+        temp_filename.unlink()
 
     try:
-        filename.parent.mkdir(parents=True)
+        temp_filename.parent.mkdir(parents=True)
     except OSError:
         pass
 
@@ -114,7 +127,7 @@ def write_ncml_file(ncml_filename, file_locations, header_attrs):
             <remove name="dataset_nchar" type="dimension" />
         </netcdf>"""
 
-    with open(ncml_filename, 'w') as ncml_file:
+    with open(str(temp_filename), 'w') as ncml_file:
         ncml_file.write('<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">\n')
 
         for key, value in header_attrs.items():
@@ -128,11 +141,10 @@ def write_ncml_file(ncml_filename, file_locations, header_attrs):
         ncml_file.write('  </aggregation>\n')
         ncml_file.write('</netcdf>\n')
 
+    if filename.exists():
+        filename.unlink()
 
-#: pylint: disable=invalid-name
-cell_index_option = click.option('--cell-index', 'cell_index',
-                                 help='Limit to a particular cell (e.g. 14,-11)',
-                                 callback=task_app.validate_cell_index, default=None)
+    temp_filename.rename(filename)
 
 
 @click.group(name=APP_NAME, help='NCML creation utility')
@@ -146,9 +158,16 @@ command_options = datacube.ui.click.compose(
     datacube.ui.click.config_option,
     datacube.ui.click.pass_index(app_name=APP_NAME),
     datacube.ui.click.logfile_option,
-    cell_index_option,
+    task_app.cell_index_option,
+    task_app.cell_index_list_option,
     task_app.queue_size_option,
+    task_app.load_tasks_option,
+    task_app.save_tasks_option,
     datacube.ui.click.executor_cli_options,
+    click.option('--export-path', 'export_path',
+                 help='Write the stacked files to an external location instead of the location in the app config',
+                 default=None,
+                 type=click.Path(exists=True, writable=True, file_okay=False)),
 )
 
 

--- a/datacube_apps/ncml.py
+++ b/datacube_apps/ncml.py
@@ -176,6 +176,10 @@ command_options = datacube.ui.click.compose(
 @click.argument('app_config')
 @task_app.task_app(make_config=make_ncml_config, make_tasks=make_ncml_tasks)
 def full(index, config, tasks, executor, queue_size, **kwargs):
+    """Create ncml files for the full time depth of the product
+
+    e.g. datacube-ncml full <app_config_yaml>
+    """
     click.echo('Starting datacube ncml utility...')
 
     task_func = partial(do_ncml_task, config)
@@ -188,6 +192,13 @@ def full(index, config, tasks, executor, queue_size, **kwargs):
 @click.argument('nested_years', nargs=-1, type=click.INT)
 @task_app.task_app(make_config=make_ncml_config, make_tasks=make_ncml_tasks)
 def nest(index, config, tasks, executor, queue_size, **kwargs):
+    """Create ncml files for the full time, with nested ncml files covering the given years
+
+    e.g. datacube-ncml nest <app_config_yaml> 2016 2017
+
+    This will refer to the actual files (hopefully stacked), and make ncml files for the given (ie unstacked) years.
+    Use the `update` command when new data is added to a year, without having to rerun for the entire time depth.
+    """
     click.echo('Starting datacube ncml utility...')
 
     task_func = partial(do_ncml_task, config)
@@ -200,6 +211,12 @@ def nest(index, config, tasks, executor, queue_size, **kwargs):
 @click.argument('year', type=click.INT)
 @task_app.task_app(make_config=make_ncml_config, make_tasks=make_ncml_tasks)
 def update(index, config, tasks, executor, queue_size, **kwargs):
+    """Update a single year ncml file
+
+    e.g datacube-ncml <app_config_yaml> 1996
+
+    This can be used to update an existing ncml file created with `nest` when new data is added.
+    """
     click.echo('Starting datacube ncml utility...')
 
     task_func = partial(do_ncml_task, config)

--- a/datacube_apps/stacker/__init__.py
+++ b/datacube_apps/stacker/__init__.py
@@ -4,5 +4,6 @@ Module for stacking datasets along the time dimension in a single file.
 """
 from __future__ import absolute_import
 from .stacker import main
+from .fixer import fixer as fixer_main
 
-__all__ = ['main']
+__all__ = ['main', 'fixer_main']

--- a/datacube_apps/stacker/fixer.py
+++ b/datacube_apps/stacker/fixer.py
@@ -82,25 +82,28 @@ def make_fixer_tasks(index, config, **kwargs):
     # Tile -> locations -> unique locations -> tile
     # Just regex the filenames
 
+    query = {kw: arg for kw, arg in kwargs.items() if kw in ['cell_index'] and arg is not None}
     gw = datacube.api.GridWorkflow(index=index, product=config['product'].name)
 
-    query = {kw: arg for kw, arg in kwargs.items() if kw in ['time', 'cell_index'] and arg is not None}
-    cells = gw.list_cells(product=config['product'].name, **query)
-    for cell_index, cell in cells.items():
-        files_to_fix = get_single_dataset_paths(cell)
-        if files_to_fix:
-            for time, tile in cell.split('time'):
-                source_path = tile.sources.values.item()[0].local_path
-                if source_path in files_to_fix:
-                    tile = gw.update_tile_lineage(tile)
-                    start_time = '{0:%Y%m%d%H%M%S%f}'.format(pd.Timestamp(time).to_datetime())
-                    output_filename = get_filename(config, cell_index, start_time)
-                    _LOG.info('Fixing required for: time=%s, cell=%s. Output=%s',
-                              start_time, cell_index, output_filename)
-                    yield dict(start_time=time,
-                               tile=tile,
-                               cell_index=cell_index,
-                               output_filename=output_filename)
+    time_query_list = task_app.year_splitter(*kwargs['time']) if 'time' in kwargs else [None]
+
+    for time_query in time_query_list:
+        cells = gw.list_cells(product=config['product'].name, time=time_query, **query)
+        for cell_index, cell in cells.items():
+            files_to_fix = get_single_dataset_paths(cell)
+            if files_to_fix:
+                for time, tile in cell.split('time'):
+                    source_path = tile.sources.values.item()[0].local_path
+                    if source_path in files_to_fix:
+                        tile = gw.update_tile_lineage(tile)
+                        start_time = '{0:%Y%m%d%H%M%S%f}'.format(pd.Timestamp(time).to_datetime())
+                        output_filename = get_filename(config, cell_index, start_time)
+                        _LOG.info('Fixing required for: time=%s, cell=%s. Output=%s',
+                                  start_time, cell_index, output_filename)
+                        yield dict(start_time=time,
+                                   tile=tile,
+                                   cell_index=cell_index,
+                                   output_filename=output_filename)
 
 
 def make_fixer_config(index, config, export_path=None, **query):

--- a/datacube_apps/stacker/fixer.py
+++ b/datacube_apps/stacker/fixer.py
@@ -9,18 +9,20 @@ import datetime
 import itertools
 import logging
 import os
+import re
 import socket
 from functools import partial
+from collections import Counter
 
 import click
 import dask.array as da
 import dask
 from dateutil import tz
-import pandas as pd
 from pathlib import Path
+import pandas as pd
+import xarray as xr
 
 import datacube
-from datacube.api import Tile
 from datacube.model import Dataset
 from datacube.model.utils import xr_apply, datasets_to_doc
 from datacube.storage import netcdf_writer
@@ -32,7 +34,7 @@ from datacube.ui.click import to_pathlib
 _LOG = logging.getLogger(__name__)
 
 
-APP_NAME = 'datacube-stacker'
+APP_NAME = 'datacube-fixer'
 
 
 def get_filename(config, cell_index, year):
@@ -61,54 +63,47 @@ def get_temp_file(final_output_path):
     return tmp_path
 
 
-def year_splitter(start, end):
-    """
-    Produces a list of time ranges based that represent each year in the range.
-
-    `year_splitter('1992', '1993')` returns:
-
-    ::
-        [('1992-01-01 00:00:00', '1992-12-31 23:59:59.9999999'),
-         ('1993-01-01 00:00:00', '1993-12-31 23:59:59.9999999')]
-
-    :param start str: start year
-    :param end str: end year
-    :return Generator[tuple(str, str)]: strings representing the ranges
-    """
-    start_ts = pd.Timestamp(start)
-    end_ts = pd.Timestamp(end)
-    for p in pd.period_range(start=start_ts, end=end_ts, freq='A'):
-        yield str(p.start_time), str(p.end_time)
+FIND_TIME_RE = re.compile(r'.+_(?P<start_time>\d+)(?:_v\d+)?\.nc\Z')
 
 
-def make_stacker_tasks(index, config, **kwargs):
-    product = config['product']
-    query = {kw: arg for kw, arg in kwargs.items() if kw in ['cell_index'] and arg is not None}
+def get_single_dataset_paths(cell):
+    cnt = Counter(ds.local_path for ds in itertools.chain(*cell.sources.values))
+    files_to_fix = [local_path for local_path, count in cnt.items()
+                    if count == 1 and FIND_TIME_RE.search(str(local_path)).groups()]
+    return files_to_fix
 
-    gw = datacube.api.GridWorkflow(index=index, product=product.name)
 
-    time_query_list = year_splitter(*kwargs['time']) if 'time' in kwargs else [None]
+def make_fixer_tasks(index, config, **kwargs):
+    # Find tiles with bad metadata
+    # In this case, they will be single timeslices
+    # Typically for particular years: the first and last for each product
+    # But for 2016, nothing will be stacked
+    # So we could do it based on NetCDF properties, and for all single-dataset locations
+    # Tile -> locations -> unique locations -> tile
+    # Just regex the filenames
 
-    for time_query in time_query_list:
-        cells = gw.list_cells(product=product.name, time=time_query, **query)
-        for (cell_index, tile) in cells.items():
-            for (year, year_tile) in tile.split_by_time(freq='A'):
-                storage_files = set(ds.local_path for ds in itertools.chain(*year_tile.sources.values))
-                if len(storage_files) > 1:
-                    year_tile = gw.update_tile_lineage(year_tile)
-                    output_filename = get_filename(config, cell_index, year)
-                    _LOG.info('Stacking required for: year=%s, cell=%s. Output=%s', year, cell_index, output_filename)
-                    yield dict(year=year,
-                               tile=year_tile,
+    gw = datacube.api.GridWorkflow(index=index, product=config['product'].name)
+
+    query = {kw: arg for kw, arg in kwargs.items() if kw in ['time', 'cell_index'] and arg is not None}
+    cells = gw.list_cells(product=config['product'].name, **query)
+    for cell_index, cell in cells.items():
+        files_to_fix = get_single_dataset_paths(cell)
+        if files_to_fix:
+            for time, tile in cell.split('time'):
+                source_path = tile.sources.values.item()[0].local_path
+                if source_path in files_to_fix:
+                    tile = gw.update_tile_lineage(tile)
+                    start_time = '{0:%Y%m%d%H%M%S%f}'.format(pd.Timestamp(time).to_datetime())
+                    output_filename = get_filename(config, cell_index, start_time)
+                    _LOG.info('Fixing required for: time=%s, cell=%s. Output=%s',
+                              start_time, cell_index, output_filename)
+                    yield dict(start_time=time,
+                               tile=tile,
                                cell_index=cell_index,
                                output_filename=output_filename)
-                elif len(storage_files) == 1:
-                    [only_filename] = storage_files
-                    _LOG.info('Stacking not required for: year=%s, cell=%s. existing=%s',
-                              year, cell_index, only_filename)
 
 
-def make_stacker_config(index, config, export_path=None, **query):
+def make_fixer_config(index, config, export_path=None, **query):
     config['product'] = index.products.get_by_name(config['output_type'])
 
     if export_path is not None:
@@ -138,7 +133,14 @@ def make_stacker_config(index, config, export_path=None, **query):
 
 
 def get_history_attribute(config, task):
-    return '{dt} {user} {app} ({ver}) {args}  # {comment}'.format(
+    tile = task['tile']
+    input_path = str(tile.sources[0].item()[0].local_path)
+    # original_dataset = xr.open_dataset(input_path)
+    # original_history = original_dataset.attrs.get('history', '')
+    original_history = 'Original file at {}'.format(input_path)
+    if original_history:
+        original_history += '\n'
+    new_history = '{dt} {user} {app} ({ver}) {args}  # {comment}'.format(
         dt=datetime.datetime.now(tz.tzlocal()).isoformat(),
         user=os.environ.get('USERNAME') or os.environ.get('USER'),
         app=APP_NAME,
@@ -147,18 +149,19 @@ def get_history_attribute(config, task):
                         str(config['version']),
                         str(config['taskfile_version']),
                         task['output_filename'],
-                        str(task['year']),
+                        str(task['start_time']),
                         str(task['cell_index'])
                        ]),
-        comment='Stacking datasets for a year into a single NetCDF file'
+        comment='Updating NetCDF metadata from config file'
     )
+    return original_history + new_history
 
 
 def _unwrap_dataset_list(labels, dataset_list):
     return dataset_list[0]
 
 
-def do_stack_task(config, task):
+def do_fixer_task(config, task):
     global_attributes = config['global_attributes']
     global_attributes['history'] = get_history_attribute(config, task)
 
@@ -254,14 +257,14 @@ def process_result(index, result):
               type=click.Path(exists=True, writable=True, file_okay=False))
 @task_app.queue_size_option
 @task_app.task_app_options
-@task_app.task_app(make_config=make_stacker_config, make_tasks=make_stacker_tasks)
-def main(index, config, tasks, executor, queue_size, **kwargs):
-    click.echo('Starting stacking utility...')
+@task_app.task_app(make_config=make_fixer_config, make_tasks=make_fixer_tasks)
+def fixer(index, config, tasks, executor, queue_size, **kwargs):
+    click.echo('Starting fixer utility...')
 
-    task_func = partial(do_stack_task, config)
+    task_func = partial(do_fixer_task, config)
     process_func = partial(process_result, index) if config['index_datasets'] else None
     task_app.run_tasks(tasks, executor, task_func, process_func, queue_size)
 
 
 if __name__ == '__main__':
-    main()
+    fixer()

--- a/datacube_apps/stacker/stacker.py
+++ b/datacube_apps/stacker/stacker.py
@@ -61,33 +61,13 @@ def get_temp_file(final_output_path):
     return tmp_path
 
 
-def year_splitter(start, end):
-    """
-    Produces a list of time ranges based that represent each year in the range.
-
-    `year_splitter('1992', '1993')` returns:
-
-    ::
-        [('1992-01-01 00:00:00', '1992-12-31 23:59:59.9999999'),
-         ('1993-01-01 00:00:00', '1993-12-31 23:59:59.9999999')]
-
-    :param start str: start year
-    :param end str: end year
-    :return Generator[tuple(str, str)]: strings representing the ranges
-    """
-    start_ts = pd.Timestamp(start)
-    end_ts = pd.Timestamp(end)
-    for p in pd.period_range(start=start_ts, end=end_ts, freq='A'):
-        yield str(p.start_time), str(p.end_time)
-
-
 def make_stacker_tasks(index, config, **kwargs):
     product = config['product']
     query = {kw: arg for kw, arg in kwargs.items() if kw in ['cell_index'] and arg is not None}
 
     gw = datacube.api.GridWorkflow(index=index, product=product.name)
 
-    time_query_list = year_splitter(*kwargs['time']) if 'time' in kwargs else [None]
+    time_query_list = task_app.year_splitter(*kwargs['time']) if 'time' in kwargs else [None]
 
     for time_query in time_query_list:
         cells = gw.list_cells(product=product.name, time=time_query, **query)

--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -199,10 +199,10 @@ def check_open_with_dc(index):
     dataset_like = dc.load(product='ls5_nbar_albers', measurements=['blue'], like=dataset)
     assert (dataset.blue == dataset_like.blue).all()
 
-    data_array = dc.load(product='ls5_nbar_albers',
-                         latitude=(-35, -36), longitude=(149, 150),
-                         measurements=['blue'], group_by='solar_day')
-    assert data_array.shape
+    solar_day_dataset = dc.load(product='ls5_nbar_albers',
+                                latitude=(-35, -36), longitude=(149, 150),
+                                measurements=['blue'], group_by='solar_day')
+    assert 0 < solar_day_dataset.time.size <= dataset.time.size
 
     dataset = dc.load(product='ls5_nbar_albers', latitude=(-35.2, -35.3), longitude=(149.1, 149.2), align=(5, 20))
     assert dataset.geobox.affine.f % abs(dataset.geobox.affine.e) == 5

--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -202,6 +202,7 @@ def check_open_with_dc(index):
     data_array = dc.load(product='ls5_nbar_albers',
                          latitude=(-35, -36), longitude=(149, 150),
                          measurements=['blue'], group_by='solar_day')
+    assert data_array.shape
 
     dataset = dc.load(product='ls5_nbar_albers', latitude=(-35.2, -35.3), longitude=(149.1, 149.2), align=(5, 20))
     assert dataset.geobox.affine.f % abs(dataset.geobox.affine.e) == 5

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,8 @@ setup(
             'datacube-search = datacube.scripts.search_tool:cli',
             'datacube = datacube.scripts.cli_app:cli',
             'datacube-stacker = datacube_apps.stacker:main',
+            'datacube-fixer = datacube_apps.stacker:fixer_main',
+            'datacube-ncml = datacube_apps.ncml:ncml_app',
             'pixeldrill = datacube_apps.pixeldrill:main [interactive]',
             'movie_generator = datacube_apps.movie_generator:main'
         ]

--- a/tests/api/test_grid_workflow.py
+++ b/tests/api/test_grid_workflow.py
@@ -126,13 +126,12 @@ def test_gridworkflow():
     assert len(padded_tile[1, -2, ti].sources.values[0]) == 2
 
 
-def test_cell():
-    """ Test GridWorkflow with padding option. """
+def test_gridworkflow_with_time_depth():
+    """Test GridWorkflow with time series.
+    Also test `Tile` methods `split` and `split_by_time`
+    """
     from mock import MagicMock
     import datetime
-
-    # ----- fake a datacube -----
-    # e.g. let there be a dataset that coincides with a grid cell
 
     fakecrs = geometry.CRS('EPSG:4326')
 
@@ -156,7 +155,7 @@ def test_cell():
     fakeindex.datasets.get_field_names.return_value = ['time']  # permit query on time
     fakeindex.datasets.search_eager.return_value = list(make_fake_datasets(100))
 
-    # ------ test without padding ----
+    # ------ test with time dimension ----
 
     from datacube.api.grid_workflow import GridWorkflow
     gw = GridWorkflow(fakeindex, gridspec)
@@ -164,8 +163,12 @@ def test_cell():
 
     cells = gw.list_cells(**query)
     for cell_index, cell in cells.items():
+
+        #  test Tile.split()
         for label, tile in cell.split('time'):
             assert tile.shape == (1, 10, 10)
+
+        #  test Tile.split_by_time()
         for year, year_cell in cell.split_by_time(freq='A'):
             for t in year_cell.sources.time.values:
                 assert str(t)[:4] == year

--- a/tests/api/test_grid_workflow.py
+++ b/tests/api/test_grid_workflow.py
@@ -124,3 +124,48 @@ def test_gridworkflow():
     assert len(padded_tile) == 1
     assert padded_tile[1, -2, ti].shape == (1, 14, 14)
     assert len(padded_tile[1, -2, ti].sources.values[0]) == 2
+
+
+def test_cell():
+    """ Test GridWorkflow with padding option. """
+    from mock import MagicMock
+    import datetime
+
+    # ----- fake a datacube -----
+    # e.g. let there be a dataset that coincides with a grid cell
+
+    fakecrs = geometry.CRS('EPSG:4326')
+
+    grid = 100  # spatial frequency in crs units
+    pixel = 10  # square pixel linear dimension in crs units
+    # if cell(0,0) has lower left corner at grid origin,
+    # and cell indices increase toward upper right,
+    # then this will be cell(1,-2).
+    gridspec = GridSpec(crs=fakecrs, tile_size=(grid, grid), resolution=(-pixel, pixel))  # e.g. product gridspec
+
+    def make_fake_datasets(num_datasets):
+        start_time = datetime.datetime(2001, 2, 15)
+        delta = datetime.timedelta(days=16)
+        for i in range(num_datasets):
+            fakedataset = MagicMock()
+            fakedataset.extent = geometry.box(left=grid, bottom=-grid, right=2*grid, top=-2*grid, crs=fakecrs)
+            fakedataset.center_time = start_time + (delta * i)
+            yield fakedataset
+
+    fakeindex = MagicMock()
+    fakeindex.datasets.get_field_names.return_value = ['time']  # permit query on time
+    fakeindex.datasets.search_eager.return_value = list(make_fake_datasets(100))
+
+    # ------ test without padding ----
+
+    from datacube.api.grid_workflow import GridWorkflow
+    gw = GridWorkflow(fakeindex, gridspec)
+    query = dict(product='fake_product_name')
+
+    cells = gw.list_cells(**query)
+    for cell_index, cell in cells.items():
+        for label, tile in cell.split('time'):
+            assert tile.shape == (1, 10, 10)
+        for year, year_cell in cell.split_by_time(freq='A'):
+            for t in year_cell.sources.time.values:
+                assert str(t)[:4] == year


### PR DESCRIPTION
Add two new tools, one for generating NCML and another for rewriting NetCDF metadata.

* Fix date range bug for the year-end boundary (no longer drops "time" for Dec 31).
* Altered NCML to be able to query full depth of a product without using an unreasonable amount of memory.
* NCML now uses a temp file (as it can't use the `_v9999` method other apps use)