### PR TITLE
[ready] Add templates for pull requests and issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,16 @@
+### Expected behaviour
+
+
+### Actual behaviour
+
+... eg. Incorrect result, python stacktrace, etc. ...
+
+
+### Steps to reproduce the behaviour
+
+... Include code, command line parameters as appropriate ...
+
+### Environment information
+
+* Which ``datacube --version`` are you using?
+* What datacube deployment/enviornment are you running against?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+### Reason for this pull request
+
+...
+
+
+### Proposed changes
+
+- 
+- 
+
+
+
+ - [ ] Closes #xxxx
+ - [ ] Tests added / passed
+ - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes
+
+<!--
+See https://github.com/blog/2111-issue-and-pull-request-templates for more
+information on pull request templates.
+
+-->


### PR DESCRIPTION
### Reason for this pull request

It's daunting to be faced with a blank screen when starting a pull request or issue. Github lets us have per-repo templates to make sure the important information we need is included.

I'm not beholden to the exact content, and it's more than okay for things to be edited and changed around, but it seems like a nice starting point.

See https://github.com/blog/2111-issue-and-pull-request-templates for more information.