### PR TITLE
Multi band for MODIS

### DIFF
--- a/datacube/storage/storage.py
+++ b/datacube/storage/storage.py
@@ -541,7 +541,7 @@ class DatasetSource(BaseRasterDataSource):
             if isinstance(band, integer_types):
                 return band
             else:
-                _LOG.warn('Expected "band" property to be of integer type')
+                _LOG.warning('Expected "band" property to be of integer type')
 
         if 'netcdf' not in self._dataset.format.lower():
             layer_id = self._measurement.get('layer', 1)

--- a/datacube/storage/storage.py
+++ b/datacube/storage/storage.py
@@ -534,6 +534,15 @@ class DatasetSource(BaseRasterDataSource):
         super(DatasetSource, self).__init__(filename, nodata=nodata)
 
     def get_bandnumber(self, src):
+
+        # If `band` property is set to an integer it overrides any other logic
+        band = self._measurement.get('band')
+        if band is not None:
+            if isinstance(band, integer_types):
+                return band
+            else:
+                _LOG.warn('Expected "band" property to be of integer type')
+
         if 'netcdf' not in self._dataset.format.lower():
             layer_id = self._measurement.get('layer', 1)
             return layer_id if isinstance(layer_id, integer_types) else 1

--- a/docs/config_samples/dataset_types/modis_tiles.yaml
+++ b/docs/config_samples/dataset_types/modis_tiles.yaml
@@ -166,43 +166,123 @@ measurements:
             0: best
             1: good
             255: fill
-    - name: 'BRDF_Albedo_Parameters_Band1'
+    - name: 'BRDF_Albedo_Parameters_Band1_iso'
       dtype: int16
       units: '1'
       nodata: 32767
-    - name: 'BRDF_Albedo_Parameters_Band2'
+    - name: 'BRDF_Albedo_Parameters_Band1_vol'
+      dtype: int16
+      units: '1'
+      nodata: 32767
+    - name: 'BRDF_Albedo_Parameters_Band1_geo'
+      dtype: int16
+      units: '1'
+      nodata: 32767
+    - name: 'BRDF_Albedo_Parameters_Band2_iso'
       dtype: uint16
       units: '1'
       nodata: 32767
-    - name: 'BRDF_Albedo_Parameters_Band3'
+    - name: 'BRDF_Albedo_Parameters_Band2_vol'
       dtype: uint16
       units: '1'
       nodata: 32767
-    - name: 'BRDF_Albedo_Parameters_Band4'
+    - name: 'BRDF_Albedo_Parameters_Band2_geo'
       dtype: uint16
       units: '1'
       nodata: 32767
-    - name: 'BRDF_Albedo_Parameters_Band5'
+    - name: 'BRDF_Albedo_Parameters_Band3_iso'
       dtype: uint16
       units: '1'
       nodata: 32767
-    - name: 'BRDF_Albedo_Parameters_Band6'
+    - name: 'BRDF_Albedo_Parameters_Band3_vol'
       dtype: uint16
       units: '1'
       nodata: 32767
-    - name: 'BRDF_Albedo_Parameters_Band7'
+    - name: 'BRDF_Albedo_Parameters_Band3_geo'
       dtype: uint16
       units: '1'
       nodata: 32767
-    - name: 'BRDF_Albedo_Parameters_nir'
+    - name: 'BRDF_Albedo_Parameters_Band4_iso'
       dtype: uint16
       units: '1'
       nodata: 32767
-    - name: 'BRDF_Albedo_Parameters_shortwave'
+    - name: 'BRDF_Albedo_Parameters_Band4_vol'
       dtype: uint16
       units: '1'
       nodata: 32767
-    - name: 'BRDF_Albedo_Parameters_vis'
+    - name: 'BRDF_Albedo_Parameters_Band4_geo'
+      dtype: uint16
+      units: '1'
+      nodata: 32767
+    - name: 'BRDF_Albedo_Parameters_Band5_iso'
+      dtype: uint16
+      units: '1'
+      nodata: 32767
+    - name: 'BRDF_Albedo_Parameters_Band5_vol'
+      dtype: uint16
+      units: '1'
+      nodata: 32767
+    - name: 'BRDF_Albedo_Parameters_Band5_geo'
+      dtype: uint16
+      units: '1'
+      nodata: 32767
+    - name: 'BRDF_Albedo_Parameters_Band6_iso'
+      dtype: uint16
+      units: '1'
+      nodata: 32767
+    - name: 'BRDF_Albedo_Parameters_Band6_vol'
+      dtype: uint16
+      units: '1'
+      nodata: 32767
+    - name: 'BRDF_Albedo_Parameters_Band6_geo'
+      dtype: uint16
+      units: '1'
+      nodata: 32767
+    - name: 'BRDF_Albedo_Parameters_Band7_iso'
+      dtype: uint16
+      units: '1'
+      nodata: 32767
+    - name: 'BRDF_Albedo_Parameters_Band7_vol'
+      dtype: uint16
+      units: '1'
+      nodata: 32767
+    - name: 'BRDF_Albedo_Parameters_Band7_geo'
+      dtype: uint16
+      units: '1'
+      nodata: 32767
+    - name: 'BRDF_Albedo_Parameters_nir_iso'
+      dtype: uint16
+      units: '1'
+      nodata: 32767
+    - name: 'BRDF_Albedo_Parameters_nir_vol'
+      dtype: uint16
+      units: '1'
+      nodata: 32767
+    - name: 'BRDF_Albedo_Parameters_nir_geo'
+      dtype: uint16
+      units: '1'
+      nodata: 32767
+    - name: 'BRDF_Albedo_Parameters_shortwave_iso'
+      dtype: uint16
+      units: '1'
+      nodata: 32767
+    - name: 'BRDF_Albedo_Parameters_shortwave_vol'
+      dtype: uint16
+      units: '1'
+      nodata: 32767
+    - name: 'BRDF_Albedo_Parameters_shortwave_geo'
+      dtype: uint16
+      units: '1'
+      nodata: 32767
+    - name: 'BRDF_Albedo_Parameters_vis_iso'
+      dtype: uint16
+      units: '1'
+      nodata: 32767
+    - name: 'BRDF_Albedo_Parameters_vis_vol'
+      dtype: uint16
+      units: '1'
+      nodata: 32767
+    - name: 'BRDF_Albedo_Parameters_vis_geo'
       dtype: uint16
       units: '1'
       nodata: 32767

--- a/utils/modisprepare.py
+++ b/utils/modisprepare.py
@@ -48,10 +48,22 @@ def fill_image_data(doc, granule_path):
             assert format_ == subds[0][:index - 1]
 
         layer = subds[0][index + len(quoted) + 1:]
-        bands[layer.split(':')[-1]] = {
-            'path': granule_path.name,
-            'layer': layer
-        }
+
+        band_name = layer.split(':')[-1]
+
+        if band_name.find('_Parameters_') >= 0:
+            for band, suffix in enumerate(['iso', 'vol', 'geo'], 1):
+                bands[band_name + '_' + suffix] = {
+                    'band': band,
+                    'path': granule_path.name,
+                    'layer': layer
+                }
+
+        else:
+            bands[band_name] = {
+                'path': granule_path.name,
+                'layer': layer
+            }
     del gran_file
 
     if not format_:


### PR DESCRIPTION
### Reason for this pull request

To support modis collection 6 (MCD43A1) data files, or more generically HDF files that have multi-band datasets in them.   

### Proposed changes

- Add extra parameter `band` in `image/bands/{band,path,layer}`.
   - When `band` parameter is present and contains an integer, read only that band.
   - Original behaviour when `layer` is used as band indicator still present
- Updated `modisprepare` script and modis product definition
   - `BRDF_Albedo_Parameters_xxx` is now 3 layers `BRDF_Albedo_Parameters_xxx_{iso,vol,geo}`


### Not done items

 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes
