### PR TITLE
improvements to test runs: less disk space usage, multi-core pylint

### DIFF
--- a/check-code.sh
+++ b/check-code.sh
@@ -6,7 +6,7 @@ set -x
 
 pep8 tests integration_tests examples utils --max-line-length 120
 
-pylint --reports no datacube datacube_apps
+pylint -j 2 --reports no datacube datacube_apps
 
 # Run tests, taking coverage.
 # Users can specify extra folders as arguments.

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -18,6 +18,8 @@ Usability Improvements
 
  - Make `celery` and `redis` optional when installing.
 
+ - Significantly reduced disk space usage for integration tests
+
 v1.4.1 (25 May 2017)
 --------------------
 

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -211,6 +211,7 @@ def create_empty_geotiff(path):
                 'height': 8521,
                 'nodata': -999.0,
                 'transform': [25.0, 0.0, 638000.0, 0.0, -25.0, 6276000.0],
+                'compress': 'lzw',
                 'width': 9721}
     with rasterio.open(path, 'w', **metadata) as dst:
         pass


### PR DESCRIPTION
This brings required test disk space on my machine from 7.5G to 142MB, and it matches the compression used on GA's current ls5 scenes (lzw).

It also re-adds '-j 2' to pylint, which was probably removed while it was crashing.
