### PR TITLE
Only deploy from main repo, not from forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,7 @@ deploy:
   skip_cleanup: true
   on:
     branch: develop
+    repo: opendatacube/datacube-core
     python: "3.6"
 
 notifications:


### PR DESCRIPTION
It's annoying to have failing builds on your forks due to failed deployment steps.



- Pin deployment to `opendatacube/datacube-core`