### PR TITLE
Update project name in printed '--version'

### DIFF
--- a/datacube/ui/click.py
+++ b/datacube/ui/click.py
@@ -31,7 +31,7 @@ def _print_version(ctx, param, value):
 
     click.echo(
         '{prog}, version {version}'.format(
-            prog='Data Cube',
+            prog='Open Data Cube core',
             version=__version__
         )
     )


### PR DESCRIPTION
- The project name is now "Open Data Cube", not just "Data Cube"
-  When using the Click arguments in other scripts, it's worth clarifying that the version printed is the core version, not the script version, so I've appended 'core'.

Flashy demo:

    jez@kveikur:~/prog/datacube (develop) $ datacube --version
    Open Data Cube core, version 1.4.1+100.ged4183b
    jez@kveikur:~/prog/datacube (develop) $ 
