### PR TITLE
Update Travis to deploy again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,8 @@ deploy:
     upload_dir: $DEPLOY_PATH
     skip_cleanup: true
     on:
-      condition: $TRAVIS_BRANCH = "develop" || ! -z "${TRAVIS_TAG}"  # develop branch or tags
+      all_branches: true  # Let the condition below decide if the branch is to be deployed
+      condition: $TRAVIS_BRANCH = "develop" || $TRAVIS_BRANCH = "deployment-automation" || ! -z "${TRAVIS_TAG}"  # develop branch or tags
       repo: opendatacube/datacube-core
       python: "3.6"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ deploy:
     skip_cleanup: true
     on:
       all_branches: true  # Let the condition below decide if the branch is to be deployed
-      condition: $TRAVIS_BRANCH = "develop" || $TRAVIS_BRANCH = "deployment-automation" || ! -z "${TRAVIS_TAG}"  # develop branch or tags
+      condition: $TRAVIS_BRANCH = "develop" || ! -z "${TRAVIS_TAG}"  # develop branch or tags
       repo: opendatacube/datacube-core
       python: "3.6"
 


### PR DESCRIPTION
The travis deploy step by default only works on the `master` branch, and `branch: deploy` is ignored when `tags: true` is set.

To have a deploy step that is triggered by both, we need to set `all-branches: true` to let the `condition: <ugly bash code>` work out if deployment is required.