### PR TITLE
Make Travis CI build all the Python versions again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ install:
 
 script:
   # Ensure we are running against the correct python version
-  - [[ `python --version` == *"$TRAVIS_PYTHON_VERSION"* ]]
+  - '[[ `python --version` == *"$TRAVIS_PYTHON_VERSION"* ]]'
   - conda clean --all --yes
   - ./check-code.sh integration_tests
   # Take extra steps to minimise disk space. We have run out a few times.

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ install:
 
 script:
   # Ensure we are running against the correct python version
-  - '[[ `python --version` == *"$TRAVIS_PYTHON_VERSION"* ]]'
+  - '[[ $(python --version 2>&1) == *"$TRAVIS_PYTHON_VERSION"* ]]'
   - conda clean --all --yes
   - ./check-code.sh integration_tests
   # Take extra steps to minimise disk space. We have run out a few times.

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,8 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - conda env create -n agdc --file .travis/environment.yaml python=$TRAVIS_PYTHON_VERSION
+  - conda create -n agdc python=$TRAVIS_PYTHON_VERSION
+  - conda env update -n agdc --file .travis/environment.yaml
 
   # try to reclaim some space -- delete downloaded packages
   - conda clean --tarballs --yes
@@ -60,14 +61,12 @@ install:
   - df -i
 
 script:
-  - df -h
-  - df -i
+  # Ensure we are running against the correct python version
+  - [[ `python --version` == *"$TRAVIS_PYTHON_VERSION"* ]]
   - conda clean --all --yes
   - ./check-code.sh integration_tests
   # Take extra steps to minimise disk space. We have run out a few times.
   - conda clean --all --yes
-  - df -h
-  - df -i
 
 after_success:
   - test $TRAVIS_PYTHON_VERSION = "3.6" && coveralls

--- a/datacube/analytics/analytics_engine.py
+++ b/datacube/analytics/analytics_engine.py
@@ -29,6 +29,7 @@ from pprint import pprint
 import numpy as np
 import numexpr as ne
 
+from datacube.compat import string_types
 from datacube.api import API
 
 LOG = logging.getLogger(__name__)
@@ -89,14 +90,9 @@ class AnalyticsEngine(object):
     def create_array(self, storage_type, variables, dimensions, name):
         """Creates an array descriptor with metadata about what the data will look like"""
 
-        try:
-            basestring
-        except NameError:
-            basestring = str
-
         # construct query descriptor
         query_parameters = {}
-        if isinstance(storage_type, basestring):
+        if isinstance(storage_type, string_types):
             query_parameters['storage_type'] = storage_type
         else:
             query_parameters['platform'] = storage_type[0]

--- a/datacube/analytics/analytics_engine.py
+++ b/datacube/analytics/analytics_engine.py
@@ -121,7 +121,7 @@ class AnalyticsEngine(object):
 
             array_result = {}
             # storage_type_key
-            if isinstance(storage_type, basestring):
+            if isinstance(storage_type, string_types):
                 array_result['storage_type'] = storage_type
             else:
                 array_result['platform'] = storage_type[0]

--- a/datacube/helpers.py
+++ b/datacube/helpers.py
@@ -3,6 +3,7 @@ Useful functions for Datacube users
 
 Not used internally, those should go in `utils.py`
 """
+from __future__ import absolute_import
 import rasterio
 import numpy as np
 

--- a/datacube/index/postgres/_api.py
+++ b/datacube/index/postgres/_api.py
@@ -9,6 +9,8 @@
 """
 Persistence API implementation for postgres.
 """
+from __future__ import absolute_import
+
 import logging
 
 from sqlalchemy import cast

--- a/datacube/index/postgres/_dynamic.py
+++ b/datacube/index/postgres/_dynamic.py
@@ -2,6 +2,7 @@
 """
 Methods for managing dynamic dataset field indexes and views.
 """
+from __future__ import absolute_import
 
 import logging
 

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -295,7 +295,7 @@ def _write_csv(infos):
         row['location'] = locations_[0] if locations_ else None
         return row
 
-    writer.writerows(map(add_first_location, infos))
+    writer.writerows(add_first_location(row) for row in infos)
 
 
 def _write_yaml(infos):

--- a/datacube/scripts/search_tool.py
+++ b/datacube/scripts/search_tool.py
@@ -34,7 +34,7 @@ def write_pretty(out_f, field_names, search_results, terminal_size=click.get_ter
     terminal_width = terminal_size[0]
     record_num = 1
 
-    field_header_width = max(map(len, field_names))
+    field_header_width = max(len(name) for name in field_names)
     field_output_format = '{:<' + str(field_header_width) + '} | {}'
 
     for result in search_results:

--- a/datacube/storage/masking.py
+++ b/datacube/storage/masking.py
@@ -3,6 +3,8 @@ Tools for masking data based on a bit-mask variable with attached definition.
 
 The main functions are `make_mask(variable)` `describe_flags(variable)`
 """
+from __future__ import absolute_import
+
 import collections
 import warnings
 

--- a/datacube/storage/netcdf_safestrings.py
+++ b/datacube/storage/netcdf_safestrings.py
@@ -6,6 +6,7 @@ written as UTF-8 encoded bytes.
 
 For more information see https://github.com/Unidata/netcdf4-python/issues/448
 """
+from __future__ import absolute_import
 import netCDF4
 
 from datacube.compat import string_types

--- a/datacube/utils/__init__.py
+++ b/datacube/utils/__init__.py
@@ -5,7 +5,6 @@ Utility functions used in storage modules
 from __future__ import absolute_import, division, print_function
 
 import os
-import stat
 import gzip
 import importlib
 import itertools
@@ -329,7 +328,7 @@ def validate_document(document, schema, schema_folder=None):
         validator = jsonschema.Draft4Validator(schema, resolver=ref_resolver)
         validator.validate(document)
     except jsonschema.ValidationError as e:
-        raise InvalidDocException(e.message)
+        raise InvalidDocException(e)
 
 
 # TODO: Replace with Pandas
@@ -717,7 +716,7 @@ def write_user_secret_file(text, fname, in_home_dir=False, mode='w'):
         fname = os.path.join(os.environ['HOME'], fname)
 
     open_flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
-    access = stat.S_IRUSR | stat.S_IWUSR  # Make sure file is readable by current user only
+    access = 0o600  # Make sure file is readable by current user only
     with os.fdopen(os.open(fname, open_flags, access), mode) as handle:
         handle.write(text)
         handle.close()

--- a/datacube/version.py
+++ b/datacube/version.py
@@ -1,5 +1,6 @@
+from __future__ import absolute_import
 
-from ._version import get_versions
+from datacube._version import get_versions
 
 __version__ = get_versions()['version']
 del get_versions

--- a/datacube_apps/movie_generator.py
+++ b/datacube_apps/movie_generator.py
@@ -4,7 +4,7 @@ This app creates time series movies
 
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 
 import click
 

--- a/datacube_apps/ncml.py
+++ b/datacube_apps/ncml.py
@@ -2,7 +2,7 @@
 Create statistical summaries command
 
 """
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 
 import logging
 import os

--- a/datacube_apps/pixeldrill.py
+++ b/datacube_apps/pixeldrill.py
@@ -5,7 +5,7 @@ Interactive Pixel Drill for AGDCv2.
 """
 # pylint: disable=import-error, wrong-import-position
 # Unavoidable with TK class hierarchy.
-# pylint: disable=too-many-ancestors
+# pylint: disable=too-many-ancestors, redefined-builtin
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import argparse

--- a/datacube_apps/simple_replica.py
+++ b/datacube_apps/simple_replica.py
@@ -38,6 +38,7 @@ are specified the same as when using the API to search for datasets.
       time: [2008-01-01, 2010-01-01]
 
 """
+from __future__ import absolute_import
 
 import logging
 import os.path

--- a/datacube_apps/stacker/fixer.py
+++ b/datacube_apps/stacker/fixer.py
@@ -4,7 +4,7 @@ Finds single timeslice files that have not been stacked (based on filename), and
 This tool is used to update NetCDF metadata for files that are not picked up by the stacker
 
 """
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 
 import copy
 import datetime

--- a/datacube_apps/stacker/stacker.py
+++ b/datacube_apps/stacker/stacker.py
@@ -2,7 +2,7 @@
 Create time-stacked NetCDF files
 
 """
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 
 import copy
 import datetime

--- a/datacube_apps/worker.py
+++ b/datacube_apps/worker.py
@@ -1,7 +1,7 @@
 """
   This app launches workers for distributed work loads
 """
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 import click
 

--- a/pylintrc
+++ b/pylintrc
@@ -3,6 +3,8 @@
 ignore=ndexpr
 
 [MESSAGES CONTROL]
+enable=python3
+
 disable=no-self-use,
     star-args,
     duplicate-code,
@@ -19,9 +21,14 @@ disable=no-self-use,
     wrong-import-order,
     ungrouped-imports,
     len-as-condition,
-    no-else-return
+    no-else-return,
+    round-builtin, # py2.7
+    map-builtin-not-iterating, # py2.7
+    range-builtin-not-iterating, # py2.7
+    zip-builtin-not-iterating, # py2.7
+    nonzero-method, # py2.7
+    eq-without-hash # py2.7
 
-enable=python3
 
 [BASIC]
 


### PR DESCRIPTION
Travis CI stopped building earlier python versions due to weird dependency
resolution of Conda. This changes tries to make sure it doesn't happen again
and fixes the Python 2.7 pylint failures that crept in in the meantime.



- Ensure Travis CI runs tests against appropriate Python version
- Ensure Conda installed appropriate Python version
- Fix pylint rules and code that was breaking them



 - [x] Tests added / passed

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->