### PR TITLE
Document comparison fixes

### DIFF
--- a/datacube/utils/changes.py
+++ b/datacube/utils/changes.py
@@ -118,21 +118,9 @@ def check_doc_unchanged(original, new, doc_name):
     """
     Raise an error if any fields have been modified on a document.
 
-    :param original:
-    :param new:
-    :param doc_name:
-    :return:
-
-
-    >>> check_doc_unchanged({'a': 1}, {'a': 1}, 'Letters')
-    >>> check_doc_unchanged({'a': 1}, {'a': 2}, 'Letters')
-    Traceback (most recent call last):
-    ...
-    datacube.utils.changes.DocumentMismatchError: Letters differs from stored (a: 1!=2)
-    >>> check_doc_unchanged({'a': {'b': 1}}, {'a': {'b': 2}}, 'Letters')
-    Traceback (most recent call last):
-    ...
-    datacube.utils.changes.DocumentMismatchError: Letters differs from stored (a.b: 1!=2)
+    :param original: original document
+    :param new: new document to compare against the original
+    :param doc_name: Label used to name the document
     """
     changes = get_doc_changes(original, new)
 

--- a/datacube/utils/changes.py
+++ b/datacube/utils/changes.py
@@ -76,44 +76,20 @@ MISSING = MissingSentinel()
 
 def get_doc_changes(original, new, base_prefix=()):
     """
-    Return a list of changed fields between two dict structures.
+    Return a list of `changed fields` between two dict structures.
+
+    A `changed field` is represented by a 3-tuple made up of:
+
+    1. `offset` to the change - a tuple of `item` accessors on the document.
+    2. What is in `original` - Either a single value, a dict or list, or :data:`MISSING`.
+    3. What is in `new`
+
+    If the documents are identical, an empty list is returned.
 
     :type original: Union[dict, list, int]
     :rtype: list[(tuple, object, object)]
 
 
-    >>> get_doc_changes(1, 1)
-    []
-    >>> get_doc_changes({}, {})
-    []
-    >>> get_doc_changes({'a': 1}, {'a': 1})
-    []
-    >>> get_doc_changes({'a': {'b': 1}}, {'a': {'b': 1}})
-    []
-    >>> get_doc_changes([1, 2, 3], [1, 2, 3])
-    []
-    >>> get_doc_changes([1, 2, [3, 4, 5]], [1, 2, [3, 4, 5]])
-    []
-    >>> get_doc_changes(1, 2)
-    [((), 1, 2)]
-    >>> get_doc_changes([1, 2, 3], [2, 1, 3])
-    [((0,), 1, 2), ((1,), 2, 1)]
-    >>> get_doc_changes([1, 2, [3, 4, 5]], [1, 2, [3, 6, 7]])
-    [((2, 1), 4, 6), ((2, 2), 5, 7)]
-    >>> get_doc_changes({'a': 1}, {'a': 2})
-    [(('a',), 1, 2)]
-    >>> get_doc_changes({'a': 1}, {'a': 2})
-    [(('a',), 1, 2)]
-    >>> get_doc_changes({'a': 1}, {'b': 1})
-    [(('a',), 1, missing), (('b',), missing, 1)]
-    >>> get_doc_changes({'a': {'b': 1}}, {'a': {'b': 2}})
-    [(('a', 'b'), 1, 2)]
-    >>> get_doc_changes({}, {'b': 1})
-    [(('b',), missing, 1)]
-    >>> get_doc_changes({'a': {'c': 1}}, {'a': {'b': 1}})
-    [(('a', 'b'), missing, 1), (('a', 'c'), 1, missing)]
-    >>> get_doc_changes({}, None, base_prefix=('a',))
-    [(('a',), {}, None)]
     """
     changed_fields = []
     if original == new:
@@ -140,7 +116,7 @@ class DocumentMismatchError(Exception):
 
 def check_doc_unchanged(original, new, doc_name):
     """
-    Complain if any fields have been modified on a document.
+    Raise an error if any fields have been modified on a document.
 
     :param original:
     :param new:
@@ -161,10 +137,10 @@ def check_doc_unchanged(original, new, doc_name):
     changes = get_doc_changes(original, new)
 
     if changes:
-        raise ValueError(
+        raise DocumentMismatchError(
             '{} differs from stored ({})'.format(
                 doc_name,
-                ', '.join(['{}: {!r}!={!r}'.format('.'.join(offset), v1, v2) for offset, v1, v2 in changes])
+                ', '.join(['{}: {!r}!={!r}'.format('.'.join(map(str, offset)), v1, v2) for offset, v1, v2 in changes])
             )
         )
 

--- a/datacube/utils/changes.py
+++ b/datacube/utils/changes.py
@@ -128,11 +128,11 @@ def check_doc_unchanged(original, new, doc_name):
     >>> check_doc_unchanged({'a': 1}, {'a': 2}, 'Letters')
     Traceback (most recent call last):
     ...
-    ValueError: Letters differs from stored (a: 1!=2)
+    datacube.utils.changes.DocumentMismatchError: Letters differs from stored (a: 1!=2)
     >>> check_doc_unchanged({'a': {'b': 1}}, {'a': {'b': 2}}, 'Letters')
     Traceback (most recent call last):
     ...
-    ValueError: Letters differs from stored (a.b: 1!=2)
+    datacube.utils.changes.DocumentMismatchError: Letters differs from stored (a.b: 1!=2)
     """
     changes = get_doc_changes(original, new)
 

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -165,7 +165,7 @@ def test_idempotent_add_dataset_type(index, ls5_telem_type, ls5_telem_doc):
     # But if we add the same type with differing properties we should get an error:
     different_telemetry_type = copy.deepcopy(ls5_telem_doc)
     different_telemetry_type['metadata']['ga_label'] = 'something'
-    with pytest.raises(ValueError):
+    with pytest.raises(changes.DocumentMismatchError):
         index.products.add_document(different_telemetry_type)
 
         # TODO: Support for adding/changing search fields?

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -18,6 +18,7 @@ from dateutil import tz
 from datacube.index._api import Index
 from datacube.index.exceptions import DuplicateRecordError, MissingRecordError
 from datacube.index.postgres import PostgresDb
+from datacube.utils.changes import DocumentMismatchError
 from datacube.model import Dataset
 
 _telemetry_uuid = UUID('4ec8fe97-e8b9-11e4-87ff-1040f381a756')
@@ -236,7 +237,7 @@ def test_index_dataset_with_sources(index, default_metadata_type):
     index.datasets.add(child, sources_policy='ensure')
     index.datasets.add(child, sources_policy='skip')
 
-    with pytest.raises(ValueError):  # TODO: should be DocumentMismatchError
+    with pytest.raises(DocumentMismatchError):
         index.datasets.add(child, sources_policy='verify')
 
 

--- a/tests/index/test_api_index_dataset.py
+++ b/tests/index/test_api_index_dataset.py
@@ -13,6 +13,7 @@ from uuid import UUID
 from datacube.index._datasets import DatasetResource
 from datacube.index.exceptions import DuplicateRecordError
 from datacube.model import DatasetType, MetadataType, Dataset
+from datacube.utils.changes import DocumentMismatchError
 
 _nbar_uuid = UUID('f2f12372-8366-11e5-817e-1040f381a756')
 _ortho_uuid = UUID('5cf41d98-eda9-11e4-8a8e-1040f381a756')
@@ -229,7 +230,7 @@ def test_index_dataset():
 
     ds2 = deepcopy(_EXAMPLE_NBAR_DATASET)
     ds2.metadata_doc['product_type'] = 'zzzz'
-    with pytest.raises(ValueError):
+    with pytest.raises(DocumentMismatchError):
         dataset = datasets.add(ds2)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -126,14 +126,17 @@ doc_changes = [
     ({'a': {'c': 1}}, {'a': {'b': 1}}, [(('a', 'b'), MISSING, 1), (('a', 'c'), 1, MISSING)])
 ]
 
+
 @pytest.mark.parametrize("v1, v2, expected", doc_changes)
 def test_get_doc_changes(v1, v2, expected):
     rval = get_doc_changes(v1, v2)
     assert rval == expected
 
+
 def test_get_doc_changes():
     rval = get_doc_changes({}, None, base_prefix=('a',))
     assert rval == [(('a',), {}, None)]
+
 
 @pytest.mark.parametrize("v1, v2, expected", doc_changes)
 def test_check_doc_unchanged(v1, v2, expected):
@@ -143,4 +146,3 @@ def test_check_doc_unchanged(v1, v2, expected):
     else:
         # No Error Raised
         check_doc_unchanged(v1, v2, 'name')
-

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -146,3 +146,14 @@ def test_check_doc_unchanged(v1, v2, expected):
     else:
         # No Error Raised
         check_doc_unchanged(v1, v2, 'name')
+
+
+def test_more_check_doc_unchanged():
+    # No exception raised
+    check_doc_unchanged({'a': 1}, {'a': 1}, 'Letters')
+
+    with pytest.raises(DocumentMismatchError, message='Letters differs from stored (a: 1!=2)'):
+        check_doc_unchanged({'a': 1}, {'a': 2}, 'Letters')
+
+    with pytest.raises(DocumentMismatchError, message='Letters differs from stored (a.b: 1!=2)'):
+        check_doc_unchanged({'a': {'b': 1}}, {'a': {'b': 2}}, 'Letters')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,6 +13,7 @@ from hypothesis import given
 from hypothesis.strategies import integers, text
 
 from datacube.utils import uri_to_local_path, clamp, gen_password, write_user_secret_file, slurp
+from datacube.utils.changes import check_doc_unchanged, get_doc_changes, MISSING, DocumentMismatchError
 from datacube.utils.dates import date_sequence
 
 
@@ -105,3 +106,41 @@ def test_write_user_secret_file(txt):
     os.remove(fname)
     assert txt == txt_back
     assert slurp(fname) is None
+
+
+doc_changes = [
+    (1, 1, []),
+    ({}, {}, []),
+    ({'a': 1}, {'a': 1}, []),
+    ({'a': {'b': 1}}, {'a': {'b': 1}}, []),
+    ([1, 2, 3], [1, 2, 3], []),
+    ([1, 2, [3, 4, 5]], [1, 2, [3, 4, 5]], []),
+    (1, 2, [((), 1, 2)]),
+    ([1, 2, 3], [2, 1, 3], [((0,), 1, 2), ((1,), 2, 1)]),
+    ([1, 2, [3, 4, 5]], [1, 2, [3, 6, 7]], [((2, 1), 4, 6), ((2, 2), 5, 7)]),
+    ({'a': 1}, {'a': 2}, [(('a',), 1, 2)]),
+    ({'a': 1}, {'a': 2}, [(('a',), 1, 2)]),
+    ({'a': 1}, {'b': 1}, [(('a',), 1, MISSING), (('b',), MISSING, 1)]),
+    ({'a': {'b': 1}}, {'a': {'b': 2}}, [(('a', 'b'), 1, 2)]),
+    ({}, {'b': 1}, [(('b',), MISSING, 1)]),
+    ({'a': {'c': 1}}, {'a': {'b': 1}}, [(('a', 'b'), MISSING, 1), (('a', 'c'), 1, MISSING)])
+]
+
+@pytest.mark.parametrize("v1, v2, expected", doc_changes)
+def test_get_doc_changes(v1, v2, expected):
+    rval = get_doc_changes(v1, v2)
+    assert rval == expected
+
+def test_get_doc_changes():
+    rval = get_doc_changes({}, None, base_prefix=('a',))
+    assert rval == [(('a',), {}, None)]
+
+@pytest.mark.parametrize("v1, v2, expected", doc_changes)
+def test_check_doc_unchanged(v1, v2, expected):
+    if expected != []:
+        with pytest.raises(DocumentMismatchError):
+            rval = check_doc_unchanged(v1, v2, 'name')
+    else:
+        # No Error Raised
+        check_doc_unchanged(v1, v2, 'name')
+


### PR DESCRIPTION
### Reason for this pull request
I was trying to setup a new database for testing, based on data from the production database, and was getting weird and useless error messages. This 

### Proposed changes
- Raise a more specific exception when documents don't match
- Make all the tests pass again
- Improve pydoc on functions


<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
