### PR TITLE
User creation test fixes

### DIFF
--- a/integration_tests/test_config_tool.py
+++ b/integration_tests/test_config_tool.py
@@ -10,7 +10,6 @@ from pathlib import Path
 import re
 
 import pytest
-import sqlalchemy
 from click.testing import CliRunner
 
 import datacube.scripts.cli_app


### PR DESCRIPTION
### Reason for this pull request
The integration tests for creating and deleting user accounts on PostgreSQL were sometimes failing on windows.

The usernames were supposed to be randomised and cleaned up, but the random number generator always created the same number, and the roles weren't necessarily removed, which was causing the failures.


### Proposed changes
- Change the test to use a _pytest fixture_, and ensure usernames doesn't exist before and after the test.


 - [x] Tests added / passed
 - [ ] **N/A** ~~Fully documented, including `docs/about/whats_new.rst` for all changes~~

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
