### PR TITLE
Db load rigor

### DIFF
--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -145,8 +145,8 @@ class MetadataTypeResource(object):
                 concurrently=not allow_table_lock
             )
 
-        self.get_by_name_unsafe.cache_clear()
-        self.get_unsafe.cache_clear()
+        self.get_by_name.cache_clear()
+        self.get.cache_clear()
         return self.get_by_name(metadata_type.name)
 
     def update_document(self, definition, allow_unsafe_updates=False):
@@ -161,26 +161,11 @@ class MetadataTypeResource(object):
         """
         return self.update(self.from_doc(definition), allow_unsafe_updates=allow_unsafe_updates)
 
+    @lru_cache()
     def get(self, id_):
         """
         :rtype: datacube.model.MetadataType
         """
-        try:
-            return self.get_unsafe(id_)
-        except KeyError:
-            return None
-
-    def get_by_name(self, name):
-        """
-        :rtype: datacube.model.MetadataType
-        """
-        try:
-            return self.get_by_name_unsafe(name)
-        except KeyError:
-            return None
-
-    @lru_cache()
-    def get_unsafe(self, id_):
         with self._db.connect() as connection:
             record = connection.get_metadata_type(id_)
         if record is None:
@@ -188,7 +173,10 @@ class MetadataTypeResource(object):
         return self._make_from_query_row(record)
 
     @lru_cache()
-    def get_by_name_unsafe(self, name):
+    def get_by_name(self, name):
+        """
+        :rtype: datacube.model.MetadataType
+        """
         with self._db.connect() as connection:
             record = connection.get_metadata_type_by_name(name)
         if not record:
@@ -431,8 +419,8 @@ class ProductResource(object):
                 concurrently=not allow_table_lock
             )
 
-        self.get_by_name_unsafe.cache_clear()
-        self.get_unsafe.cache_clear()
+        self.get_by_name.cache_clear()
+        self.get.cache_clear()
         return self.get_by_name(product.name)
 
     def update_document(self, definition, allow_unsafe_updates=False, allow_table_lock=False):
@@ -465,6 +453,7 @@ class ProductResource(object):
         type_ = self.from_doc(definition)
         return self.add(type_)
 
+    @lru_cache()
     def get(self, id_):
         """
         Retrieve Product by id
@@ -472,25 +461,6 @@ class ProductResource(object):
         :param int id_: id of the Product
         :rtype: DatasetType
         """
-        try:
-            return self.get_unsafe(id_)
-        except KeyError:
-            return None
-
-    def get_by_name(self, name):
-        """
-        Retrieve Product by name
-
-        :param str name: name of the Product
-        :rtype: DatasetType
-        """
-        try:
-            return self.get_by_name_unsafe(name)
-        except KeyError:
-            return None
-
-    @lru_cache()
-    def get_unsafe(self, id_):
         with self._db.connect() as connection:
             result = connection.get_dataset_type(id_)
         if not result:
@@ -498,7 +468,13 @@ class ProductResource(object):
         return self._make(result)
 
     @lru_cache()
-    def get_by_name_unsafe(self, name):
+    def get_by_name(self, name):
+        """
+        Retrieve Product by name
+
+        :param str name: name of the Product
+        :rtype: DatasetType
+        """
         with self._db.connect() as connection:
             result = connection.get_dataset_type_by_name(name)
         if not result:

--- a/datacube/index/postgres/_api.py
+++ b/datacube/index/postgres/_api.py
@@ -294,7 +294,7 @@ class PostgresDbAPI(object):
     def get_dataset(self, dataset_id):
         return self._connection.execute(
             select(_DATASET_SELECT_FIELDS).where(DATASET.c.id == dataset_id)
-        ).one()
+        ).first()
 
     def get_derived_datasets(self, dataset_id):
         return self._connection.execute(
@@ -568,22 +568,22 @@ class PostgresDbAPI(object):
     def get_dataset_type(self, id_):
         return self._connection.execute(
             DATASET_TYPE.select().where(DATASET_TYPE.c.id == id_)
-        ).one()
+        ).first()
 
     def get_metadata_type(self, id_):
         return self._connection.execute(
             METADATA_TYPE.select().where(METADATA_TYPE.c.id == id_)
-        ).one()
+        ).first()
 
     def get_dataset_type_by_name(self, name):
         return self._connection.execute(
             DATASET_TYPE.select().where(DATASET_TYPE.c.name == name)
-        ).one()
+        ).first()
 
     def get_metadata_type_by_name(self, name):
         return self._connection.execute(
             METADATA_TYPE.select().where(METADATA_TYPE.c.name == name)
-        ).one()
+        ).first()
 
     def add_dataset_type(self,
                          name,

--- a/datacube/index/postgres/_api.py
+++ b/datacube/index/postgres/_api.py
@@ -294,7 +294,7 @@ class PostgresDbAPI(object):
     def get_dataset(self, dataset_id):
         return self._connection.execute(
             select(_DATASET_SELECT_FIELDS).where(DATASET.c.id == dataset_id)
-        ).first()
+        ).one()
 
     def get_derived_datasets(self, dataset_id):
         return self._connection.execute(
@@ -568,22 +568,22 @@ class PostgresDbAPI(object):
     def get_dataset_type(self, id_):
         return self._connection.execute(
             DATASET_TYPE.select().where(DATASET_TYPE.c.id == id_)
-        ).first()
+        ).one()
 
     def get_metadata_type(self, id_):
         return self._connection.execute(
             METADATA_TYPE.select().where(METADATA_TYPE.c.id == id_)
-        ).first()
+        ).one()
 
     def get_dataset_type_by_name(self, name):
         return self._connection.execute(
             DATASET_TYPE.select().where(DATASET_TYPE.c.name == name)
-        ).first()
+        ).one()
 
     def get_metadata_type_by_name(self, name):
         return self._connection.execute(
             METADATA_TYPE.select().where(METADATA_TYPE.c.name == name)
-        ).first()
+        ).one()
 
     def add_dataset_type(self,
                          name,

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -81,9 +81,6 @@ def load_rules_from_file(filename, index):
 
     for rule in rules:
         type_ = index.products.get_by_name(rule['type'])
-        if not type_:
-            _LOG.error('DatasetType %s does not exists', rule['type'])
-            return
         if not changes.contains(type_.metadata_doc, rule['metadata']):
             _LOG.error('DatasetType %s can\'t be matched by its own rule', rule['type'])
             return
@@ -97,9 +94,6 @@ def load_rules_from_types(index, type_names=None):
     if type_names:
         for name in type_names:
             type_ = index.products.get_by_name(name)
-            if not type_:
-                _LOG.error('DatasetType %s does not exists', name)
-                return
             types.append(type_)
     else:
         types += index.products.get_all()

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -203,11 +203,11 @@ def test_get_missing_things(index):
     assert missing_thing is None, "get() should return none when it doesn't exist"
 
     id_ = sys.maxsize
-    missing_thing = index.metadata_types.get(id_)
-    assert missing_thing is None, "get() should return none when it doesn't exist"
+    with pytest.raises(KeyError, message="get metadata_type should raise an exception when one doesn't exist"):
+        index.metadata_types.get(id_)
 
-    missing_thing = index.products.get(id_)
-    assert missing_thing is None, "get() should return none when it doesn't exist"
+    with pytest.raises(KeyError, message="get product should raise an exception when one doesn't exist"):
+        index.products.get(id_)
 
 
 def test_index_dataset_with_sources(index, default_metadata_type):


### PR DESCRIPTION
### Reason for this pull request

Some of our database API for loading a specific record by _name_ or _id_ was returning None when the record wasn't found.

This pattern required calling code to check the return value before using it, which wasn't clearly documented and wasn't happening in quite a few places.

This has led to crashing programs with confusing errors and exceptions being shown to users, when they had connected to the wrong database, or when requesting a non-existant name. The error was about no such attribute on `NoneType`

I think a better pattern for these calls is to raise an exception if the record isn't found. This frees up the calling code from having to handle the possible error immediately and allows the error to bubble up and be handled at a more appropriate level.

### Proposed changes

- Replace the `get()` and `get_by_name()` with their `_unsafe()` counterparts.
- Update tests and code to use `try/except` instead of `if` for handling the non-existant data case.



 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
