### PR TITLE
.travis/environment.yaml

### DIFF
--- a/.travis/environment.yaml
+++ b/.travis/environment.yaml
@@ -28,7 +28,7 @@ dependencies:
 - matplotlib # pixel drill app
 - pathlib
 - compliance-checker
-- boto3
+- boto3 = 1.4.3
 - pathos
 - zstandard
 - compliance-checker = 3.0.3

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ extras_require = {
     'doc': ['Sphinx', 'setuptools'],
     'replicas': ['paramiko', 'sshtunnel', 'tqdm'],
     'celery': ['celery>=4', 'redis'],
-    's3': ['boto3', 'SharedArray', 'pathos', 'zstandard'],
+    's3': ['boto3==1.4.3', 'SharedArray', 'pathos', 'zstandard'],
     'test': tests_require,
 }
 # An 'all' option, following ipython naming conventions.


### PR DESCRIPTION
### Reason for this pull request

There were some changes that didn't make into the s3-driver pull request:
- Fixing boto3 version to 1.4.3, due to performance degradation with 1.4.4.
- Made create_storage multi-threaded with a use_threads parameter.
  - s3 (s3 storage) and s3-file (disk storage) performance is better with this.

### Proposed changes

setup.py
 - fixing boto3 to 1.4.3 (1.4.4 is significantly slower, need to investigate)

datacube/api/core.py
 - use_threads parameter for create_storage for multi-threaded IO.



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
