### PR TITLE
Remove decimated read

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -623,20 +623,20 @@ class Datacube(object):
 
 def get_simple_loader(sources, geobox, fuse_func, skip_broken_datasets, driver_manager):
     def data_provider(measurement):
-        data = numpy.full(sources.shape + geobox.shape, measurement['nodata'], dtype=measurement['dtype'])
+        destination = numpy.full(sources.shape + geobox.shape, measurement['nodata'], dtype=measurement['dtype'])
         for index, datasets in numpy.ndenumerate(sources.values):
-            load_measurement_data(data[index], datasets, geobox, measurement, fuse_func=fuse_func,
+            load_measurement_data(destination[index], datasets, geobox, measurement, fuse_func=fuse_func,
                                   skip_broken_datasets=skip_broken_datasets,
                                   driver_manager=driver_manager)
-        return data
+        return destination
     return data_provider
 
 
 def get_threaded_loader(sources, geobox, fuse_func, skip_broken_datasets, driver_manager):
     def data_provider(measurement):
         def work_load_data(array_name, index, datasets):
-            data = sa.attach(array_name)
-            load_measurement_data(data[index], datasets, geobox, measurement, fuse_func=fuse_func,
+            destination = sa.attach(array_name)
+            load_measurement_data(destination[index], datasets, geobox, measurement, fuse_func=fuse_func,
                                   skip_broken_datasets=skip_broken_datasets,
                                   driver_manager=driver_manager)
 
@@ -659,18 +659,18 @@ def get_lazy_loader(sources, geobox, fuse_func, skip_broken_datasets, driver_man
     return data_provider
 
 
-def load_measurement_data(dest, datasets, geobox, measurement, skip_broken_datasets=False,
+def load_measurement_data(destination, datasets, geobox, measurement, skip_broken_datasets=False,
                           fuse_func=None, driver_manager=None):
-    """Loads data for a single Dataset Measurement, storing it into ``dest``.
+    """Loads data for a single Dataset Measurement, storing it into ``destination``.
 
     Requires a :class:`DriverManager` to find an appropriate driver to load the dataset.
 
     """
     reproject_and_fuse([driver_manager.get_datasource(dataset, measurement['name']) for dataset in datasets],
-                       dest,
+                       destination,
                        geobox.affine,
                        geobox.crs,
-                       dest.dtype.type(measurement['nodata']),
+                       destination.dtype.type(measurement['nodata']),
                        resampling=measurement.get('resampling_method', 'nearest'),
                        fuse_func=fuse_func,
                        skip_broken_datasets=skip_broken_datasets)

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -332,9 +332,12 @@ class Datacube(object):
             return None if stack else xarray.Dataset()
 
         if like:
-            assert output_crs is None, "'like' and 'output_crs' are not supported together"
-            assert resolution is None, "'like' and 'resolution' are not supported together"
-            assert align is None, "'like' and 'align' are not supported together"
+            if output_crs is not None:
+                raise RuntimeError("'like' and 'output_crs' are not supported together")
+            if resolution is not None:
+                raise RuntimeError("'like' and 'resolution' are not supported together")
+            if align is not None:
+                raise RuntimeError("'like' and 'align' are not supported together")
             geobox = like.geobox
         else:
             if output_crs:
@@ -370,17 +373,17 @@ class Datacube(object):
                 stack = 'measurement'
             return result.to_array(dim=stack)
 
-    def find_datasets(self, **kwargs):
+    def find_datasets(self, **search_terms):
         """
-        Find datasets for a product.
+        Search the index and return all datasets for a product matching the search terms.
 
-        :param kwargs: see :class:`datacube.api.query.Query`
+        :param search_terms: see :class:`datacube.api.query.Query`
         :return: list of datasets
         :rtype: list[:class:`datacube.model.Dataset`]
 
         .. seealso:: :meth:`group_datasets` :meth:`load_data`
         """
-        query = Query(self.index, **kwargs)
+        query = Query(self.index, **search_terms)
         if not query.product:
             raise RuntimeError('must specify a product')
 

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -370,11 +370,6 @@ class Datacube(object):
                 stack = 'measurement'
             return result.to_array(dim=stack)
 
-    def product_observations(self, **kwargs):
-        warnings.warn("product_observations() has been renamed to find_datasets() and will eventually be removed",
-                      DeprecationWarning)
-        return self.find_datasets(**kwargs)
-
     def find_datasets(self, **kwargs):
         """
         Find datasets for a product.
@@ -396,12 +391,6 @@ class Datacube(object):
             # Check against the bounding box of the original scene, can throw away some portions
 
         return datasets
-
-    @staticmethod
-    def product_sources(datasets, group_by):
-        warnings.warn("product_sources() has been renamed to group_datasets() and will eventually be removed",
-                      DeprecationWarning)
-        return Datacube.group_datasets(datasets, group_by)
 
     @staticmethod
     def group_datasets(datasets, group_by):
@@ -502,12 +491,6 @@ class Datacube(object):
             result[measurement['name']] = (dims, data, attrs)
 
         return result
-
-    @staticmethod
-    def product_data(*args, **kwargs):
-        warnings.warn("product_data() has been renamed to load_data() and will eventually be removed",
-                      DeprecationWarning)
-        return Datacube.load_data(*args, **kwargs)
 
     @staticmethod
     def load_data(sources, geobox, measurements, fuse_func=None, dask_chunks=None, skip_broken_datasets=False,

--- a/datacube/api/grid_workflow.py
+++ b/datacube/api/grid_workflow.py
@@ -373,6 +373,9 @@ class GridWorkflow(object):
 
             Defaults to ``'nearest'``.
 
+        :param bool skip_broken_datasets: If True, ignore broken datasets and continue processing with the data
+            that can be loaded. If False, an exception will be raised on a broken dataset. Defaults to False.
+
         :param DriverManager driver_manager: The driver manager to
           use. If not specified, an new manager will be created using
           the index if specified, or the default configuration

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -50,8 +50,9 @@ class Query(object):
 
     Use by accessing :attr:`search_terms`.
 
-    >>> query.search_terms
-    {'time': Range(begin=datetime.datetime(2001, 1, 1, 0, 0, tzinfo=<UTC>), end=datetime.datetime(2002, 1, 1, 0, 0, tzinfo=<UTC>)), 'product': 'ls5_nbar_albers'}
+    >>> query.search_terms  # doctest: +NORMALIZE_WHITESPACE
+    {'time': Range(begin=datetime.datetime(2001, 1, 1, 0, 0, tzinfo=<UTC>), \
+    end=datetime.datetime(2002, 1, 1, 0, 0, tzinfo=<UTC>)), 'product': 'ls5_nbar_albers'}
 
     By passing in an ``index``, the search parameters will be validated as existing on the ``product``.
 

--- a/datacube/drivers/datasource.py
+++ b/datacube/drivers/datasource.py
@@ -19,6 +19,10 @@ class DataSource(object):
         return None
 
     @abstractmethod
+    def get_bandnumber(self):
+        pass
+
+    @abstractmethod
     def get_transform(self, shape):
         return None
 

--- a/datacube/drivers/manager.py
+++ b/datacube/drivers/manager.py
@@ -60,14 +60,14 @@ class DriverManager(object):
 
         self._orig = {'index': dumps(index), 'index_args': index_args, 'index_kargs': index_kargs}
 
+        #: Data Cube Index
         self.__index = None
-        '''Generic index.'''
 
+        #: Current driver
         self.__driver = None
-        '''Current driver.'''
 
+        #: List of all available drivers, indexed by name.
         self.__drivers = None
-        '''List of all available drivers, indexed by name.'''
 
         self.logger = logging.getLogger(self.__class__.__name__)
         self.is_clone = False
@@ -117,11 +117,11 @@ class DriverManager(object):
           `index._db` variable is used, and is passed to the index
           initialisation method, that should basically replace the
           existing DB connection with that variable.
-        :param args: Optional positional arguments to be passed to the
+        :param index_args: Optional positional arguments to be passed to the
           index on initialisation. Caution: In the current
           implementation all parameters get passed to all available
           indexes.
-        :param args: Optional keyword arguments to be passed to the
+        :param index_kargs: Optional keyword arguments to be passed to the
           index on initialisation. Caution: In the current
           implementation all parameters get passed to all available
           indexes.
@@ -141,11 +141,11 @@ class DriverManager(object):
           `index._db` variable is used, and is passed to the index
           initialisation method, that should basically replace the
           existing DB connection with that variable.
-        :param args: Optional positional arguments to be passed to the
+        :param index_args: Optional positional arguments to be passed to the
           index on initialisation. Caution: In the current
           implementation all parameters get passed to all available
           indexes.
-        :param args: Optional keyword arguments to be passed to the
+        :param index_kargs: Optional keyword arguments to be passed to the
           index on initialisation. Caution: In the current
           implementation all parameters get passed to all available
           indexes.
@@ -203,7 +203,7 @@ class DriverManager(object):
 
     @property
     def index(self):
-        """Generic index.
+        """Data Cube index.
         """
         return self.__index
 

--- a/datacube/drivers/manager.py
+++ b/datacube/drivers/manager.py
@@ -36,7 +36,7 @@ class DriverManager(object):
     def __init__(self, index=None, *index_args, **index_kargs):
         """Initialise the manager.
 
-        Each driver get initialised during instantiation, including
+        Each driver is initialised during instantiation, including
         the initialisation of their index, using the `index_args` and
         `index_kargs` optional arguments. If `index` is specified, it
         is passed to the driver for its DB connection to be used
@@ -48,10 +48,12 @@ class DriverManager(object):
           `index._db` variable is used, and is passed to the index
           initialisation method, that should basically replace the
           existing DB connection with that variable.
+
         :param args: Optional positional arguments to be passed to the
           index on initialisation. Caution: In the current
           implementation all parameters get passed to all available
           indexes.
+
         :param args: Optional keyword arguments to be passed to the
           index on initialisation. Caution: In the current
           implementation all parameters get passed to all available

--- a/datacube/drivers/netcdf/__init__.py
+++ b/datacube/drivers/netcdf/__init__.py
@@ -1,2 +1,3 @@
+
+#: Driver specs: (<name>, <class_name>, <filepath>).
 DRIVER_SPEC = ('NetCDF CF', 'NetCDFDriver', './driver.py')
-'''Driver specs: (<name>, <class_name>, <filepath>).'''

--- a/datacube/drivers/netcdf/driver.py
+++ b/datacube/drivers/netcdf/driver.py
@@ -2,9 +2,13 @@
 """
 from __future__ import absolute_import
 
+from pathlib import Path
+
 from datacube.drivers.driver import Driver
-from datacube.storage.storage import write_dataset_to_netcdf, RasterDatasetSource
+from datacube.storage import netcdf_writer
+from datacube.storage.storage import DatacubeRasterSource, _LOG
 from datacube.drivers.netcdf.index import Index
+from datacube.utils import DatacubeException
 
 
 class NetCDFDriver(Driver):
@@ -32,4 +36,92 @@ class NetCDFDriver(Driver):
 
     def get_datasource(self, dataset, measurement_id):
         """See :meth:`datacube.drivers.driver.get_datasource`"""
-        return RasterDatasetSource(dataset, measurement_id)
+        return DatacubeRasterSource(dataset, measurement_id)
+
+
+def create_netcdf_storage_unit(filename,
+                               crs, coordinates, variables, variable_params, global_attributes=None,
+                               netcdfparams=None):
+    """
+    Create a NetCDF file on disk.
+
+    :param pathlib.Path filename: filename to write to
+    :param datacube.utils.geometry.CRS crs: Datacube CRS object defining the spatial projection
+    :param dict coordinates: Dict of named `datacube.model.Coordinate`s to create
+    :param dict variables: Dict of named `datacube.model.Variable`s to create
+    :param dict variable_params:
+        Dict of dicts, with keys matching variable names, of extra parameters for variables
+    :param dict global_attributes: named global attributes to add to output file
+    :param dict netcdfparams: Extra parameters to use when creating netcdf file
+    :return: open :class:`netCDF4.Dataset` object, ready for writing to
+    """
+    filename = Path(filename)
+    if filename.exists():
+        raise RuntimeError('Storage Unit already exists: %s' % filename)
+
+    try:
+        filename.parent.mkdir(parents=True)
+    except OSError:
+        pass
+
+    _LOG.info('Creating storage unit: %s', filename)
+
+    nco = netcdf_writer.create_netcdf(str(filename), **(netcdfparams or {}))
+
+    for name, coord in coordinates.items():
+        netcdf_writer.create_coordinate(nco, name, coord.values, coord.units)
+
+    netcdf_writer.create_grid_mapping_variable(nco, crs)
+
+    for name, variable in variables.items():
+        set_crs = all(dim in variable.dims for dim in crs.dimensions)
+        var_params = variable_params.get(name, {})
+        data_var = netcdf_writer.create_variable(nco, name, variable, set_crs=set_crs, **var_params)
+
+        for key, value in var_params.get('attrs', {}).items():
+            setattr(data_var, key, value)
+
+    for key, value in (global_attributes or {}).items():
+        setattr(nco, key, value)
+
+    return nco
+
+
+def write_dataset_to_netcdf(dataset, filename, global_attributes=None, variable_params=None,
+                            netcdfparams=None):
+    """
+    Write a Data Cube style xarray Dataset to a NetCDF file
+
+    Requires a spatial Dataset, with attached coordinates and global crs attribute.
+
+    :param `xarray.Dataset` dataset:
+    :param filename: Output filename
+    :param global_attributes: Global file attributes. dict of attr_name: attr_value
+    :param variable_params: dict of variable_name: {param_name: param_value, [...]}
+                            Allows setting storage and compression options per variable.
+                            See the `netCDF4.Dataset.createVariable` for available
+                            parameters.
+    :param netcdfparams: Optional params affecting netCDF file creation
+    """
+    global_attributes = global_attributes or {}
+    variable_params = variable_params or {}
+    filename = Path(filename)
+
+    if not dataset.data_vars.keys():
+        raise DatacubeException('Cannot save empty dataset to disk.')
+
+    if not hasattr(dataset, 'crs'):
+        raise DatacubeException('Dataset does not contain CRS, cannot write to NetCDF file.')
+
+    nco = create_netcdf_storage_unit(filename,
+                                     dataset.crs,
+                                     dataset.coords,
+                                     dataset.data_vars,
+                                     variable_params,
+                                     global_attributes,
+                                     netcdfparams)
+
+    for name, variable in dataset.data_vars.items():
+        nco[name][:] = netcdf_writer.netcdfy_data(variable.values)
+
+    nco.close()

--- a/datacube/drivers/s3/__init__.py
+++ b/datacube/drivers/s3/__init__.py
@@ -1,2 +1,3 @@
+
+#: Driver specs: (<name>, <class_name>, <filepath>).
 DRIVER_SPEC = ('s3', 'S3Driver', './driver.py')
-'''Driver specs: (<name>, <class_name>, <filepath>).'''

--- a/datacube/drivers/s3/datasource.py
+++ b/datacube/drivers/s3/datasource.py
@@ -10,7 +10,7 @@ from affine import Affine
 from numpy import dtype
 
 from datacube.drivers.datasource import DataSource
-from datacube.storage.storage import OverrideBandDataSource
+from datacube.storage.storage import OverrideBandSource
 from datacube.utils import datetime_to_seconds_since_1970
 from datacube.drivers.utils import DriverUtils
 
@@ -119,10 +119,10 @@ class S3DataSource(DataSource):
         """
         self.source.bidx = self.get_bandnumber()
 
-        yield OverrideBandDataSource(self.source,
-                                     nodata=self.nodata,
-                                     crs=self.get_crs(),
-                                     transform=self.get_transform(self.macro_shape))
+        yield OverrideBandSource(self.source,
+                                 nodata=self.nodata,
+                                 crs=self.get_crs(),
+                                 transform=self.get_transform(self.macro_shape))
 
     def get_bandnumber(self):
         time = self._dataset.center_time

--- a/datacube/drivers/s3/datasource.py
+++ b/datacube/drivers/s3/datasource.py
@@ -18,12 +18,12 @@ from datacube.drivers.utils import DriverUtils
 class S3Source(object):
     """A data reader class, with an API similar to rasterio so it can be
     used without modification as a source in
-    :class:`datacube.storage.storage.OverrideBandDataSource`.
+    :class:`OverrideBandDataSource`.
     """
 
     class S3DS(object):
         """An inner reader class, mimicking the `source.ds` within
-        :class:`datacube.storage.storage.OverrideBandDataSource`.
+        :class:`OverrideBandDataSource`.
         """
 
         def __init__(self, parent):

--- a/datacube/drivers/s3_test/__init__.py
+++ b/datacube/drivers/s3_test/__init__.py
@@ -1,2 +1,3 @@
+
+#: Driver specs: (<name>, <class_name>, <filepath>).
 DRIVER_SPEC = ('s3-test', 'S3TestDriver', './driver.py')
-'''Driver specs: (<name>, <class_name>, <filepath>).'''

--- a/datacube/drivers/utils.py
+++ b/datacube/drivers/utils.py
@@ -6,17 +6,16 @@ from __future__ import absolute_import
 class DriverUtils(object):
     """Constants shared by all drivers."""
 
+    #: Precision margins allowed when comparing coord or time
+    #: intervals. For example, to determine whether a coord is regular,
+    #: or to determine an irregular index from its timestamp. Access them
+    #: through the :meth:`epsilon` property.
     EPSILON = {
         'x': 0.00000001,
         'y': 0.00000001,
         'time': 0.00000001,
         'default': 0.00000001
     }
-    '''Precision margins allowed when comparing coord or time
-    intervals. For example, to determine whether a coord is regular,
-    or to determine an irregular index from its timestamp. Access them
-    through the :meth:`epsilon` property.
-    '''
 
     @staticmethod
     def epsilon(dimension):
@@ -31,5 +30,7 @@ class DriverUtils(object):
         :return: Float value, presumably small. A default value is
           returned if the dimension is unknown.
         """
-        return DriverUtils.EPSILON[dimension] if dimension in DriverUtils.EPSILON \
-            else DriverUtils.EPSILON['default']
+        if dimension in DriverUtils.EPSILON:
+            return DriverUtils.EPSILON[dimension]
+        else:
+            return DriverUtils.EPSILON['default']

--- a/datacube/storage/storage.py
+++ b/datacube/storage/storage.py
@@ -89,12 +89,18 @@ def read_from_source(source, dest, dst_transform, dst_nodata, dst_projection, re
         if dest.dtype == numpy.dtype('int8'):
             dest = dest.view(dtype='uint8')
             dst_nodata = dst_nodata.astype('uint8')
+
+        num_threads = OPTIONS['reproject_threads']
+        # A bug in rasterio or GDAL causes data reads to fail if only a single row is requested and num_threads > 1
+        if dest.shape[0] == 1:
+            num_threads = 1
+
         src.reproject(dest,
                       dst_transform=dst_transform,
                       dst_crs=str(dst_projection),
                       dst_nodata=dst_nodata,
                       resampling=resampling,
-                      NUM_THREADS=OPTIONS['reproject_threads'])
+                      num_threads=num_threads)
 
 
 def reproject_and_fuse(sources, destination, dst_transform, dst_projection, dst_nodata,

--- a/datacube/storage/storage.py
+++ b/datacube/storage/storage.py
@@ -13,8 +13,6 @@ from __future__ import absolute_import, division, print_function
 import logging
 from contextlib import contextmanager
 from pathlib import Path
-from abc import ABCMeta, abstractmethod
-from six import add_metaclass
 
 from datacube.compat import urlparse, urljoin, url_parse_module
 from datacube.config import OPTIONS
@@ -310,7 +308,7 @@ class OverrideBandDataSource(object):
                                        **kwargs)
 
 
-class RasterioDataSource(DataSource):
+class RasterioDataSource(object):
     """
     Abstract class used by fuse_sources and :func:`read_from_source`
 

--- a/datacube/storage/storage.py
+++ b/datacube/storage/storage.py
@@ -76,31 +76,6 @@ else:
         return src.affine
 
 
-def read_from_source(source, dest, dst_transform, dst_nodata, dst_projection, resampling):
-    """
-    Read from `source` into `dest`, reprojecting if necessary.
-
-    :param RasterioDataSource source: Data source
-    :param numpy.ndarray dest: Data destination
-    """
-    with source.open() as src:
-        if dest.dtype == numpy.dtype('int8'):
-            dest = dest.view(dtype='uint8')
-            dst_nodata = dst_nodata.astype('uint8')
-
-        num_threads = OPTIONS['reproject_threads']
-        # A bug in rasterio or GDAL causes data reads to fail if only a single row is requested and num_threads > 1
-        if dest.shape[0] == 1:
-            num_threads = 1
-
-        src.reproject(dest,
-                      dst_transform=dst_transform,
-                      dst_crs=str(dst_projection),
-                      dst_nodata=dst_nodata,
-                      resampling=resampling,
-                      num_threads=num_threads)
-
-
 def reproject_and_fuse(sources, destination, dst_transform, dst_projection, dst_nodata,
                        resampling='nearest', fuse_func=None, skip_broken_datasets=False):
     """
@@ -141,6 +116,31 @@ def reproject_and_fuse(sources, destination, dst_transform, dst_projection, dst_
                 fuse_func(destination, buffer_)
 
         return destination
+
+
+def read_from_source(source, dest, dst_transform, dst_nodata, dst_projection, resampling):
+    """
+    Read from `source` into `dest`, reprojecting if necessary.
+
+    :param RasterioDataSource source: Data source
+    :param numpy.ndarray dest: Data destination
+    """
+    with source.open() as src:
+        if dest.dtype == numpy.dtype('int8'):
+            dest = dest.view(dtype='uint8')
+            dst_nodata = dst_nodata.astype('uint8')
+
+        num_threads = OPTIONS['reproject_threads']
+        # A bug in rasterio or GDAL causes data reads to fail if only a single row is requested and num_threads > 1
+        if dest.shape[0] == 1:
+            num_threads = 1
+
+        src.reproject(dest,
+                      dst_transform=dst_transform,
+                      dst_crs=str(dst_projection),
+                      dst_nodata=dst_nodata,
+                      resampling=resampling,
+                      num_threads=num_threads)
 
 
 class BandDataSource(object):

--- a/datacube/storage/storage.py
+++ b/datacube/storage/storage.py
@@ -189,6 +189,12 @@ class BandDataSource(object):
                                 resampling=resampling,
                                 **kwargs)
 
+    def __repr__(self):
+        return "BandDataSource(source={!r},...)".format(self.source)
+
+    def __str__(self):
+        return self.__repr__()
+
 
 # class NetCDFDataSource(object):
 #     def __init__(self, dataset, variable, slab=None, nodata=None):
@@ -517,6 +523,12 @@ class RasterDatasetSource(RasterioDataSource):
 
     def get_crs(self):
         return self._dataset.crs
+
+    def __repr__(self):
+        return "DatasetSource(dataset={!r},measurement={!r})".format(self._dataset, self._measurement)
+
+    def __str__(self):
+        return self.__repr__()
 
 
 def create_netcdf_storage_unit(filename,

--- a/datacube_apps/stacker/fixer.py
+++ b/datacube_apps/stacker/fixer.py
@@ -28,7 +28,7 @@ import datacube
 from datacube.model import Dataset
 from datacube.model.utils import xr_apply, datasets_to_doc
 from datacube.storage import netcdf_writer
-from datacube.storage.storage import create_netcdf_storage_unit
+from datacube.drivers.netcdf.driver import create_netcdf_storage_unit
 from datacube.ui import task_app
 from datacube.ui.click import to_pathlib
 

--- a/datacube_apps/stacker/stacker.py
+++ b/datacube_apps/stacker/stacker.py
@@ -24,7 +24,7 @@ from datacube.api import Tile
 from datacube.model import Dataset
 from datacube.model.utils import xr_apply, datasets_to_doc
 from datacube.storage import netcdf_writer
-from datacube.storage.storage import create_netcdf_storage_unit
+from datacube.drivers.netcdf.driver import create_netcdf_storage_unit
 from datacube.ui import task_app
 from datacube.ui.click import to_pathlib
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -177,5 +177,5 @@ pseudoxml:
 	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."
 
 livehtml:
-	sphinx-autobuild -b html -p 8123 --ignore "*_tmp_*" --ignore "*_old_*" $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	sphinx-autobuild -b html -p 8123 --ignore "*_tmp_*" --ignore "*_old_*" -z ../datacube $(ALLSPHINXOPTS) $(BUILDDIR)/html 
 

--- a/docs/click_utils.py
+++ b/docs/click_utils.py
@@ -1,7 +1,7 @@
 import pkg_resources
 from docutils.nodes import literal_block, section, title, make_id
 from sphinx.domains import Domain
-from sphinx.util.compat import Directive
+from docutils.parsers.rst import Directive
 import importlib
 
 import click

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -306,46 +306,41 @@ texinfo_documents = [
 
 
 # Mock modules that need native libraries.
-# See: http://read-the-docs.readthedocs.org/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules
-NATIVE_MODULES = [
+
+autodoc_mock_imports = [
     'rasterio',
     'netcdf4',
     'pypeg2',
     'osgeo',
-    'rasterio.warp',
     'numexpr',
-    'rasterio.coords',
     'netCDF4',
-    'netCDF4.Dataset',
     'jsonschema',
     'xarray',
     'dask',
-    'dask.array',
     'pandas',
-    'rasterio.crs',
-    'gdal', 'osgeo.gdal',
+    'gdal',
+    'osgeo',
     'osr',
-    'numpy', 'numpy.core.multiarray',
+    'numpy',
     'matplotlib',
-    'matplotlib.pyplot',
-    'scipy', 'scipy.io',
+    'scipy',
     'SharedArray',
     'paramiko',
     'sshtunnel',
     'tqdm',
 ]
 
-from mock import Mock as MagicMock
-
-
-class Mock(MagicMock):
-    @classmethod
-    def __getattr__(cls, name):
-        return Mock()
-
-
-sys.modules.update((mod_name, Mock()) for mod_name in NATIVE_MODULES)
-sys.modules['rasterio.coords'].BoundingBox = Mock
+# from mock import Mock as MagicMock
+#
+#
+# class Mock(MagicMock):
+#     @classmethod
+#     def __getattr__(cls, name):
+#         return Mock()
+#
+#
+# sys.modules.update((mod_name, Mock()) for mod_name in NATIVE_MODULES)
+# sys.modules['rasterio.coords'].BoundingBox = Mock
 
 
 # Clean up generated documentation files that RTD seems to be having trouble with

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -232,20 +232,20 @@ htmlhelp_basename = 'ODCdoc'
 
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
-    #'papersize': 'letterpaper',
+    'papersize': 'a4paper',
 
     # The font size ('10pt', '11pt' or '12pt').
-    #'pointsize': '10pt',
+    'pointsize': '10pt',
 
     # Additional stuff for the LaTeX preamble.
-    #'preamble': '',
+    'preamble': '',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    ('index', 'ODC.tex', u'Open Data Cube Documentation')
+    ('index', 'ODC.tex', 'Open Data Cube Documentation', 'ODC Members', 'manual')
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -123,6 +123,8 @@ pygments_style = 'friendly'
 
 autosummary_generate = True
 
+autodoc_default_flags = ['members']
+
 extlinks = {'issue': ('https://github.com/opendatacube/datacube-core/issues/%s', 'GH')}
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3.5/', None),
@@ -190,10 +192,6 @@ html_static_path = ['_static']
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
 #html_last_updated_fmt = '%b %d, %Y'
-
-# If true, SmartyPants will be used to convert quotes and dashes to
-# typographically correct entities.
-html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
 #html_sidebars = {}

--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import shutil
-from subprocess import call
 
 import numpy
 import rasterio

--- a/tests/storage/test_netcdfwriter.py
+++ b/tests/storage/test_netcdfwriter.py
@@ -12,7 +12,7 @@ import string
 from datacube.model import Variable
 from datacube.storage.netcdf_writer import create_netcdf, create_coordinate, create_variable, netcdfy_data, \
     create_grid_mapping_variable, flag_mask_meanings
-from datacube.storage.storage import write_dataset_to_netcdf
+from datacube.drivers.netcdf.driver import write_dataset_to_netcdf
 from datacube.utils import geometry, DatacubeException, read_strings_from_netcdf
 
 GEO_PROJ = geometry.CRS("""GEOGCS["WGS 84",

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -157,9 +157,9 @@ def _mock_datasetsource(value, crs=None, shape=(2, 2)):
     rio_reader.read.return_value = np.array(value)
 
     # Use the following if a reproject were to be required
-    # def fill_array(dest, *args, **kwargs):
-    #     dest[:] = value
-    # rio_reader.reproject.side_effect = fill_array
+    def fill_array(dest, *args, **kwargs):
+        dest[:] = value
+    rio_reader.reproject.side_effect = fill_array
     return dataset_source
 
 
@@ -173,7 +173,7 @@ def test_read_from_broken_source():
     sources = [source1, source2]
 
     rio_reader = source1.open.return_value.__enter__.return_value
-    rio_reader.read.side_effect = OSError('Read or write failed')
+    rio_reader.reproject.side_effect = OSError('Read or write failed')
 
     output_data = np.full(shape, fill_value=no_data, dtype='int16')
 

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -12,9 +12,10 @@ from affine import Affine, identity
 
 import datacube
 from datacube.model import Dataset, DatasetType, MetadataType
-from datacube.storage.storage import OverrideBandDataSource, RasterFileDataSource
-from datacube.storage.storage import write_dataset_to_netcdf, reproject_and_fuse, read_from_source, Resampling, \
-    RasterDatasetSource
+from datacube.storage.storage import OverrideBandSource, RasterFileDataSource
+from datacube.storage.storage import reproject_and_fuse, read_from_source, Resampling, \
+    DatacubeRasterSource
+from datacube.drivers.netcdf.driver import write_dataset_to_netcdf
 from datacube.utils import geometry
 
 GEO_PROJ = 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],' \
@@ -428,7 +429,7 @@ def test_read_raster_with_custom_crs_and_transform(example_gdal_path):
                            0.0, -25.0, -900000.0)
 
         # Read all raw data from source file
-        band_data_source = OverrideBandDataSource(band, nodata, crs, transform)
+        band_data_source = OverrideBandSource(band, nodata, crs, transform)
         dest1 = band_data_source.read()
         assert dest1.shape
 
@@ -511,7 +512,7 @@ def test_multiband_support_in_datasetsource():
     # Without new band attribute, default to band number 1
     d = Dataset(_EXAMPLE_DATASET_TYPE, defn, uris=['file:///tmp'])
 
-    ds = RasterDatasetSource(d, measurement_id='green')
+    ds = DatacubeRasterSource(d, measurement_id='green')
 
     bandnum = ds.get_bandnumber(None)
 
@@ -523,6 +524,6 @@ def test_multiband_support_in_datasetsource():
     defn['image']['bands']['green']['band'] = band_num
     d = Dataset(_EXAMPLE_DATASET_TYPE, defn, uris=['file:///tmp'])
 
-    ds = RasterDatasetSource(d, measurement_id='green')
+    ds = DatacubeRasterSource(d, measurement_id='green')
 
     assert ds.get_bandnumber(None) == band_num


### PR DESCRIPTION
### Reason for this pull request
The decimated read code was causing exceptions to be thrown when the list of data sources to read from wasn't carefully filter to exclude sources outside the target region. It was used when 1:1 or Nearest Neighbour reads were possible.

This resulted in __datacube-stats__ and __dask__ sometimes throwing can't read from negative window errors.

The removed code isn't well understood or supported, and is a low level performance optimisation, that we're not even sure we need. This change makes the code more reliable and maintainable, but with an unknown potential to be slower, probably not by much, but we're not sure.

### Proposed changes
- Remove decimated read from data load function.


 - [x] Tests added / passed

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
