### PR TITLE
Mock cloudpickle for docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -335,6 +335,7 @@ NATIVE_MODULES = [
     'paramiko',
     'sshtunnel',
     'tqdm',
+    'cloudpickle',
 ]
 
 from mock import Mock as MagicMock


### PR DESCRIPTION
The read the docs build is failing, with an import error of cloudpickle.
See: https://readthedocs.org/projects/datacube-core/builds/5748075/