### PR TITLE
Re-add @pass_index convenience decorator

### DIFF
--- a/datacube/drivers/manager.py
+++ b/datacube/drivers/manager.py
@@ -23,7 +23,7 @@ class DriverManager(object):
     retrieve the actual data.
 
     A 'current' driver can be set in the manager and which can be used
-    to handle datasets which don't specifiy a storage driver in their
+    to handle datasets which don't specify a storage driver in their
     metadata.
     """
 
@@ -287,3 +287,9 @@ class DriverManager(object):
           data.
         """
         return self.get_driver_by_scheme(dataset.uris).index.add_specifics(dataset)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type_, value, traceback):
+        self.close()

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -161,9 +161,8 @@ def parse_match_rules_options(index, match_rules, dtype, auto_match):
 @click.option('--dry-run', help='Check if everything is ok', is_flag=True, default=False)
 @click.argument('dataset-paths',
                 type=click.Path(exists=True, readable=True, writable=False), nargs=-1)
-@ui.pass_driver_manager()
-def index_cmd(driver_manager, match_rules, dtype, auto_match, sources_policy, dry_run, dataset_paths):
-    index = driver_manager.index
+@ui.pass_index()
+def index_cmd(index, match_rules, dtype, auto_match, sources_policy, dry_run, dataset_paths):
     rules = parse_match_rules_options(index, match_rules, dtype, auto_match)
     if rules is None:
         return
@@ -203,9 +202,8 @@ def parse_update_rules(allow_any):
 @click.option('--dry-run', help='Check if everything is ok', is_flag=True, default=False)
 @click.argument('datasets',
                 type=click.Path(exists=True, readable=True, writable=False), nargs=-1)
-@ui.pass_driver_manager()
-def update_cmd(driver_manager, allow_any, match_rules, dtype, auto_match, dry_run, datasets):
-    index = driver_manager.index
+@ui.pass_index()
+def update_cmd(index, allow_any, match_rules, dtype, auto_match, dry_run, datasets):
     rules = parse_match_rules_options(index, match_rules, dtype, auto_match)
     if rules is None:
         return
@@ -362,11 +360,10 @@ _OUTPUT_WRITERS = {
               # Unlikely to be hit, but will avoid total-death by circular-references.
               default=99)
 @click.argument('ids', nargs=-1)
-@ui.pass_driver_manager()
-def info_cmd(driver_manager, show_sources, show_derived, f, max_depth, ids):
-    # type: (DriverManager, bool, bool, Iterable[str]) -> None
+@ui.pass_index()
+def info_cmd(index, show_sources, show_derived, f, max_depth, ids):
+    # type: (Index, bool, bool, Iterable[str]) -> None
 
-    index = driver_manager.index
     # Using an array wrapper to get around the lack of "nonlocal" in py2
     missing_datasets = [0]
 
@@ -394,12 +391,11 @@ def info_cmd(driver_manager, show_sources, show_derived, f, max_depth, ids):
 @click.option('-f', help='Output format',
               type=click.Choice(_OUTPUT_WRITERS.keys()), default='yaml', show_default=True)
 @ui.parsed_search_expressions
-@ui.pass_driver_manager()
-def search_cmd(driver_manager, f, expressions):
+@ui.pass_index()
+def search_cmd(index, f, expressions):
     """
     Search available Datasets
     """
-    index = driver_manager.index
     datasets = index.datasets.search(**expressions)
     _OUTPUT_WRITERS[f](
         build_dataset_info(index, dataset)
@@ -426,9 +422,8 @@ def _get_derived_set(index, id_):
 @click.option('--dry-run', help="Don't archive. Display datasets that would get archived",
               is_flag=True, default=False)
 @click.argument('ids', nargs=-1)
-@ui.pass_driver_manager()
-def archive_cmd(driver_manager, archive_derived, dry_run, ids):
-    index = driver_manager.index
+@ui.pass_index()
+def archive_cmd(index, archive_derived, dry_run, ids):
     for id_ in ids:
         to_process = _get_derived_set(index, id_) if archive_derived else [index.datasets.get(id_)]
         for d in to_process:
@@ -446,9 +441,8 @@ def archive_cmd(driver_manager, archive_derived, dry_run, ids):
                    "this recently to the original dataset",
               default=10 * 60)
 @click.argument('ids', nargs=-1)
-@ui.pass_driver_manager()
-def restore_cmd(driver_manager, restore_derived, derived_tolerance_seconds, dry_run, ids):
-    index = driver_manager.index
+@ui.pass_index()
+def restore_cmd(index, restore_derived, derived_tolerance_seconds, dry_run, ids):
     tolerance = datetime.timedelta(seconds=derived_tolerance_seconds)
 
     for id_ in ids:

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -174,7 +174,6 @@ def index_cmd(driver_manager, match_rules, dtype, auto_match, sources_policy, dr
             index_dataset_paths(sources_policy, dry_run, index, rules, dataset_path_iter)
     else:
         index_dataset_paths(sources_policy, dry_run, index, rules, dataset_paths)
-    driver_manager.close()
 
 
 def index_dataset_paths(sources_policy, dry_run, index, rules, dataset_paths):
@@ -231,7 +230,6 @@ def update_cmd(driver_manager, allow_any, match_rules, dtype, auto_match, dry_ru
             else:
                 fail += 1
     echo('%d successful, %d failed' % (success, fail))
-    driver_manager.close()
 
 
 def update_dry_run(index, updates, dataset):
@@ -389,7 +387,6 @@ def info_cmd(driver_manager, show_sources, show_derived, f, max_depth, ids):
                            max_depth=max_depth)
         for dataset in get_datasets(ids)
     )
-    driver_manager.close()
     sys.exit(missing_datasets[0])
 
 
@@ -408,7 +405,6 @@ def search_cmd(driver_manager, f, expressions):
         build_dataset_info(index, dataset)
         for dataset in datasets
     )
-    driver_manager.close()
 
 
 def _get_derived_set(index, id_):
@@ -439,7 +435,6 @@ def archive_cmd(driver_manager, archive_derived, dry_run, ids):
             click.echo('archiving %s %s %s' % (d.type.name, d.id, d.local_uri))
         if not dry_run:
             index.datasets.archive(d.id for d in to_process)
-    driver_manager.close()
 
 
 @dataset_cmd.command('restore', help="Restore datasets")
@@ -458,7 +453,6 @@ def restore_cmd(driver_manager, restore_derived, derived_tolerance_seconds, dry_
 
     for id_ in ids:
         _restore_one(dry_run, id_, index, restore_derived, tolerance)
-    driver_manager.close()
 
 
 def _restore_one(dry_run, id_, index, restore_derived, tolerance):

--- a/datacube/scripts/ingest.py
+++ b/datacube/scripts/ingest.py
@@ -294,9 +294,6 @@ def _index_datasets(driver_manager, results):
 
 
 def process_tasks(driver_manager, config, source_type, output_type, tasks, queue_size, executor):
-    index = driver_manager.index
-
-    # driver_manager_dump = dumps(driver_manager)
 
     def submit_task(task):
         _LOG.info('Submitting task: %s', task['tile_index'])

--- a/datacube/scripts/ingest.py
+++ b/datacube/scripts/ingest.py
@@ -393,5 +393,5 @@ def ingest_cmd(driver_manager, config_file, year, queue_size, save_tasks, load_t
 
     successful, failed = process_tasks(driver_manager, config, source_type, output_type, tasks, queue_size, executor)
     click.echo('%d successful, %d failed' % (successful, failed))
-    driver_manager.close()
+
     return 0

--- a/datacube/scripts/metadata_type.py
+++ b/datacube/scripts/metadata_type.py
@@ -26,13 +26,12 @@ def metadata_type():
 @click.argument('files',
                 type=click.Path(exists=True, readable=True, writable=False),
                 nargs=-1)
-@ui.pass_driver_manager()
-def add_metadata_types(driver_manager, allow_exclusive_lock, files):
-    # type: (DriverManager, bool, list) -> None
+@ui.pass_index()
+def add_metadata_types(index, allow_exclusive_lock, files):
+    # type: (Index, bool, list) -> None
     """
     Add or update metadata types in the index
     """
-    index = driver_manager.index
     for descriptor_path, parsed_doc in read_documents(*(Path(f) for f in files)):
         try:
             type_ = index.metadata_types.from_doc(parsed_doc)
@@ -55,9 +54,9 @@ def add_metadata_types(driver_manager, allow_exclusive_lock, files):
 @click.argument('files',
                 type=click.Path(exists=True, readable=True, writable=False),
                 nargs=-1)
-@ui.pass_driver_manager()
-def update_metadata_types(driver_manager, allow_unsafe, allow_exclusive_lock, dry_run, files):
-    # type: (DriverManager, bool, bool, bool, list) -> None
+@ui.pass_index()
+def update_metadata_types(index, allow_unsafe, allow_exclusive_lock, dry_run, files):
+    # type: (Index, bool, bool, bool, list) -> None
     """
     Update existing metadata types.
 
@@ -66,7 +65,6 @@ def update_metadata_types(driver_manager, allow_unsafe, allow_exclusive_lock, dr
     (An unsafe change is anything that may potentially make the metadata type
     incompatible with existing ones of the same name)
     """
-    index = driver_manager.index
     for descriptor_path, parsed_doc in read_documents(*(Path(f) for f in files)):
         try:
             type_ = index.metadata_types.from_doc(parsed_doc)
@@ -99,12 +97,11 @@ def update_metadata_types(driver_manager, allow_unsafe, allow_exclusive_lock, dr
 @metadata_type.command('show')
 @click.option('-v', '--verbose', is_flag=True)
 @click.argument('metadata_type_name', nargs=1)
-@ui.pass_driver_manager()
-def show_metadata_type(driver_manager, metadata_type_name, verbose):
+@ui.pass_index()
+def show_metadata_type(index, metadata_type_name, verbose):
     """
     Show information about a metadata type.
     """
-    index = driver_manager.index
     metadata_type_obj = index.metadata_types.get_by_name(metadata_type_name)
     print(metadata_type_obj.description)
     print('Search fields: %s' % ', '.join(sorted(metadata_type_obj.dataset_fields.keys())))
@@ -113,12 +110,11 @@ def show_metadata_type(driver_manager, metadata_type_name, verbose):
 
 
 @metadata_type.command('list')
-@ui.pass_driver_manager()
-def list_metadata_types(driver_manager):
+@ui.pass_index()
+def list_metadata_types(index):
     """
     List metadata types that are defined in the generic index.
     """
-    index = driver_manager.index
     metadata_types = list(index.metadata_types.get_all())
 
     if not metadata_types:

--- a/datacube/scripts/metadata_type.py
+++ b/datacube/scripts/metadata_type.py
@@ -41,7 +41,6 @@ def add_metadata_types(driver_manager, allow_exclusive_lock, files):
             _LOG.exception(e)
             _LOG.error('Invalid metadata type definition: %s', descriptor_path)
             continue
-    driver_manager.close()
 
 
 @metadata_type.command('update')
@@ -95,7 +94,6 @@ def update_metadata_types(driver_manager, allow_unsafe, allow_exclusive_lock, dr
                 echo('Cannot update "%s": %s unsafe changes, %s safe changes' % (type_.name,
                                                                                  len(unsafe_changes),
                                                                                  len(safe_changes)))
-    driver_manager.close()
 
 
 @metadata_type.command('show')
@@ -113,8 +111,6 @@ def show_metadata_type(driver_manager, metadata_type_name, verbose):
     if verbose:
         echo(json.dumps(metadata_type_obj.definition, indent=4))
 
-    driver_manager.close()
-
 
 @metadata_type.command('list')
 @ui.pass_driver_manager()
@@ -131,4 +127,3 @@ def list_metadata_types(driver_manager):
 
     for m in metadata_types:
         echo(m)
-    driver_manager.close()

--- a/datacube/scripts/product.py
+++ b/datacube/scripts/product.py
@@ -43,7 +43,6 @@ def add_dataset_types(driver_manager, allow_exclusive_lock, files):
             _LOG.exception(e)
             _LOG.error('Invalid product definition: %s', descriptor_path)
             continue
-    driver_manager.close()
 
 
 @product.command('update')
@@ -126,7 +125,6 @@ def list_products(driver_manager):
     echo(products.to_string(columns=('name', 'description', 'product_type', 'instrument',
                                      'format', 'platform'),
                             justify='left'))
-    driver_manager.close()
 
 
 @product.command('show')
@@ -139,4 +137,3 @@ def show_product(driver_manager, product_name):
     index = driver_manager.index
     product_def = index.products.get_by_name(product_name)
     click.echo_via_pager(json.dumps(product_def.definition, indent=4))
-    driver_manager.close()

--- a/datacube/scripts/product.py
+++ b/datacube/scripts/product.py
@@ -27,13 +27,12 @@ def product():
 @click.argument('files',
                 type=click.Path(exists=True, readable=True, writable=False),
                 nargs=-1)
-@ui.pass_driver_manager()
-def add_dataset_types(driver_manager, allow_exclusive_lock, files):
+@ui.pass_index()
+def add_dataset_types(index, allow_exclusive_lock, files):
     # type: (DriverManager, bool, list) -> None
     """
     Add or update products in the generic index.
     """
-    index = driver_manager.index
     for descriptor_path, parsed_doc in read_documents(*(Path(f) for f in files)):
         try:
             type_ = index.products.from_doc(parsed_doc)
@@ -57,9 +56,9 @@ def add_dataset_types(driver_manager, allow_exclusive_lock, files):
 @click.argument('files',
                 type=click.Path(exists=True, readable=True, writable=False),
                 nargs=-1)
-@ui.pass_driver_manager()
-def update_dataset_types(driver_manager, allow_unsafe, allow_exclusive_lock, dry_run, files):
-    # type: (DriverManager, bool, bool, bool, list) -> None
+@ui.pass_index()
+def update_dataset_types(index, allow_unsafe, allow_exclusive_lock, dry_run, files):
+    # type: (Index, bool, bool, bool, list) -> None
     """
     Update existing products.
 
@@ -68,7 +67,6 @@ def update_dataset_types(driver_manager, allow_unsafe, allow_exclusive_lock, dry
     (An unsafe change is anything that may potentially make the product
     incompatible with existing datasets of that type)
     """
-    index = driver_manager.index
     for descriptor_path, parsed_doc in read_documents(*(Path(f) for f in files)):
         try:
             type_ = index.products.from_doc(parsed_doc)
@@ -105,17 +103,14 @@ def update_dataset_types(driver_manager, allow_unsafe, allow_exclusive_lock, dry
                 echo('Cannot update "%s": %s unsafe changes, %s safe changes' % (type_.name,
                                                                                  len(unsafe_changes),
                                                                                  len(safe_changes)))
-    driver_manager.close()
 
 
 @product.command('list')
-@ui.pass_driver_manager()
-def list_products(driver_manager):
+@ui.pass_datacube()
+def list_products(dc):
     """
     List products that are defined in the generic index.
     """
-    index = driver_manager.index
-    dc = Datacube(index)
     products = dc.list_products()
 
     if products.empty:
@@ -129,11 +124,10 @@ def list_products(driver_manager):
 
 @product.command('show')
 @click.argument('product_name', nargs=1)
-@ui.pass_driver_manager()
-def show_product(driver_manager, product_name):
+@ui.pass_index()
+def show_product(index, product_name):
     """
     Show details about a product in the generic index.
     """
-    index = driver_manager.index
     product_def = index.products.get_by_name(product_name)
     click.echo_via_pager(json.dumps(product_def.definition, indent=4))

--- a/datacube/scripts/search_tool.py
+++ b/datacube/scripts/search_tool.py
@@ -95,7 +95,6 @@ def datasets(ctx, driver_manager, expressions):
         sorted(index.datasets.get_field_names()),
         index.datasets.search_summaries(**expressions)
     )
-    driver_manager.close()
 
 
 @cli.command('product-counts')
@@ -114,7 +113,6 @@ def product_counts(driver_manager, period, expressions):
         for timerange, count in series:
             formatted_dt = _assume_utc(timerange[0]).strftime("%Y-%m-%d")
             click.echo('    {}: {}'.format(formatted_dt, count))
-    driver_manager.close()
 
 
 @singledispatch

--- a/datacube/scripts/search_tool.py
+++ b/datacube/scripts/search_tool.py
@@ -20,7 +20,7 @@ from datacube.ui import click as ui
 from datacube.ui.click import CLICK_SETTINGS
 from datacube.ui.expression import parse_expressions
 
-PASS_DRIVER_MANAGER = ui.pass_driver_manager('datacube-search')
+PASS_INDEX = ui.pass_index('datacube-search')
 
 
 def printable_values(d):
@@ -84,13 +84,12 @@ def cli(ctx, f):
 
 @cli.command()
 @ui.parsed_search_expressions
-@PASS_DRIVER_MANAGER
+@PASS_INDEX
 @click.pass_context
-def datasets(ctx, driver_manager, expressions):
+def datasets(ctx, index, expressions):
     """
     Search available Datasets
     """
-    index = driver_manager.index
     ctx.obj['write_results'](
         sorted(index.datasets.get_field_names()),
         index.datasets.search_summaries(**expressions)
@@ -100,14 +99,13 @@ def datasets(ctx, driver_manager, expressions):
 @cli.command('product-counts')
 @click.argument('period', nargs=1)
 @ui.parsed_search_expressions
-@PASS_DRIVER_MANAGER
-def product_counts(driver_manager, period, expressions):
+@PASS_INDEX
+def product_counts(index, period, expressions):
     """
     Count product Datasets available by period
 
     PERIOD: eg. 1 month, 6 months, 1 year
     """
-    index = driver_manager.index
     for product, series in index.datasets.count_by_product_through_time(period, **expressions):
         click.echo(product.name)
         for timerange, count in series:

--- a/datacube/scripts/system.py
+++ b/datacube/scripts/system.py
@@ -66,7 +66,6 @@ def database_init(driver_manager, default_types, init_users, recreate_views, reb
         rebuild_views=recreate_views or rebuild,
     )
     echo('Done.')
-    driver_manager.close()
 
 
 @system.command('check', help='Check and display current configuration')

--- a/datacube/scripts/system.py
+++ b/datacube/scripts/system.py
@@ -45,10 +45,9 @@ def system():
     '--create-s3-tables', '-s3', is_flag=True, default=False,
     help="Create S3 datables."
 )
-@ui.pass_driver_manager(expect_initialised=False)
-def database_init(driver_manager, default_types, init_users, recreate_views, rebuild, lock_table, create_s3_tables):
+@ui.pass_index(expect_initialised=False)
+def database_init(index, default_types, init_users, recreate_views, rebuild, lock_table, create_s3_tables):
     echo('Initialising database...')
-    index = driver_manager.index
 
     was_created = index.init_db(with_default_types=default_types,
                                 with_permissions=init_users,

--- a/datacube/scripts/user.py
+++ b/datacube/scripts/user.py
@@ -29,7 +29,6 @@ def list_users(driver_manager):
     index = driver_manager.index
     for role, user, description in index.users.list_users():
         click.echo('{0:6}\t{1:15}\t{2}'.format(role, user, description if description else ''))
-    driver_manager.close()
 
 
 @user_cmd.command('grant')
@@ -44,7 +43,6 @@ def grant(driver_manager, role, users):
     """
     index = driver_manager.index
     index.users.grant_role(role, *users)
-    driver_manager.close()
 
 
 @user_cmd.command('create')
@@ -69,7 +67,6 @@ def create_user(config, driver_manager, role, user, description):
         username=user,
         password=password
     ))
-    driver_manager.close()
 
 
 @user_cmd.command('delete')
@@ -82,4 +79,3 @@ def delete_user(config, driver_manager, users):
     """
     index = driver_manager.index
     index.users.delete_user(*users)
-    driver_manager.close()

--- a/datacube/scripts/user.py
+++ b/datacube/scripts/user.py
@@ -10,7 +10,6 @@ from datacube.index._api import Index
 from datacube.ui import click as ui
 from datacube.ui.click import cli
 
-
 _LOG = logging.getLogger('datacube-user')
 USER_ROLES = ('user', 'ingest', 'manage', 'admin')
 
@@ -21,12 +20,11 @@ def user_cmd():
 
 
 @user_cmd.command('list')
-@ui.pass_driver_manager()
-def list_users(driver_manager):
+@ui.pass_index()
+def list_users(index):
     """
     List users
     """
-    index = driver_manager.index
     for role, user, description in index.users.list_users():
         click.echo('{0:6}\t{1:15}\t{2}'.format(role, user, description if description else ''))
 
@@ -36,12 +34,11 @@ def list_users(driver_manager):
                 type=click.Choice(USER_ROLES),
                 nargs=1)
 @click.argument('users', nargs=-1)
-@ui.pass_driver_manager()
-def grant(driver_manager, role, users):
+@ui.pass_index()
+def grant(index, role, users):
     """
     Grant a role to users
     """
-    index = driver_manager.index
     index.users.grant_role(role, *users)
 
 
@@ -50,14 +47,13 @@ def grant(driver_manager, role, users):
                 type=click.Choice(USER_ROLES), nargs=1)
 @click.argument('user', nargs=1)
 @click.option('--description')
-@ui.pass_driver_manager()
+@ui.pass_index()
 @ui.pass_config
-def create_user(config, driver_manager, role, user, description):
-    # type: (LocalConfig, DriverManager, str, str, str) -> None
+def create_user(config, index, role, user, description):
+    # type: (LocalConfig, Index, str, str, str) -> None
     """
     Create a User
     """
-    index = driver_manager.index
     password = gen_password(12)
     index.users.create_user(user, password, role, description=description)
 
@@ -71,11 +67,10 @@ def create_user(config, driver_manager, role, user, description):
 
 @user_cmd.command('delete')
 @click.argument('users', nargs=-1)
-@ui.pass_driver_manager()
+@ui.pass_index()
 @ui.pass_config
-def delete_user(config, driver_manager, users):
+def delete_user(config, index, users):
     """
     Delete a User
     """
-    index = driver_manager.index
     index.users.delete_user(*users)

--- a/datacube/ui/click.py
+++ b/datacube/ui/click.py
@@ -13,6 +13,7 @@ import sys
 import click
 
 from datacube import config, __version__
+from datacube.api.core import Datacube
 
 from datacube.executor import get_executor, mk_celery_executor
 
@@ -215,6 +216,50 @@ def pass_driver_manager(app_name=None, expect_initialised=True):
                 handle_exception('Error Connecting to database: %s', e)
 
         return functools.update_wrapper(with_driver_manager, f)
+
+    return decorate
+
+
+def pass_index(app_name=None, expect_initialised=True):
+    """
+    Get an index from the current or default local settings.
+
+    :param str app_name:
+        A short name of the application for logging purposes.
+    :param bool expect_initialised:
+        Whether to connect immediately on startup. Useful to catch connection config issues immediately,
+        but if you're planning to fork before any usage (such as in the case of some web servers),
+        you may not want this. For More information on thread/process usage, see datacube.index._api.Index
+    """
+
+    def decorate(f):
+        @pass_driver_manager(app_name=app_name, expect_initialised=expect_initialised)
+        def with_index(driver_manager, *args, **kwargs):
+            return f(driver_manager.index, *args, **kwargs)
+
+        return functools.update_wrapper(with_index, f)
+
+    return decorate
+
+
+def pass_datacube(app_name=None, expect_initialised=True):
+    """
+    Get a DataCube from the current or default local settings.
+
+    :param str app_name:
+        A short name of the application for logging purposes.
+    :param bool expect_initialised:
+        Whether to connect immediately on startup. Useful to catch connection config issues immediately,
+        but if you're planning to fork before any usage (such as in the case of some web servers),
+        you may not want this. For More information on thread/process usage, see datacube.index._api.Index
+    """
+
+    def decorate(f):
+        @pass_driver_manager(app_name=app_name, expect_initialised=expect_initialised)
+        def with_index(driver_manager, *args, **kwargs):
+            return f(Datacube(driver_manager=driver_manager), *args, **kwargs)
+
+        return functools.update_wrapper(with_index, f)
 
     return decorate
 

--- a/datacube_apps/ncml.py
+++ b/datacube_apps/ncml.py
@@ -18,9 +18,7 @@ import datacube
 from datacube.ui import task_app
 from datacube.ui.click import to_pathlib
 
-
 _LOG = logging.getLogger(__name__)
-
 
 APP_NAME = 'datacube-ncml'
 
@@ -185,7 +183,6 @@ def full(driver_manager, config, tasks, executor, queue_size, **kwargs):
 
     task_func = partial(do_ncml_task, config)
     task_app.run_tasks(tasks, executor, task_func, None, queue_size)
-    driver_manager.close()
 
 
 @ncml_app.command(short_help='Create a full ncml file with nested ncml files for particular years')
@@ -206,7 +203,6 @@ def nest(driver_manager, config, tasks, executor, queue_size, **kwargs):
 
     task_func = partial(do_ncml_task, config)
     task_app.run_tasks(tasks, executor, task_func, None, queue_size)
-    driver_manager.close()
 
 
 @ncml_app.command(short_help='Update a single year ncml file')
@@ -226,7 +222,6 @@ def update(driver_manager, config, tasks, executor, queue_size, **kwargs):
 
     task_func = partial(do_ncml_task, config)
     task_app.run_tasks(tasks, executor, task_func, None, queue_size)
-    driver_manager.close()
 
 
 if __name__ == '__main__':

--- a/datacube_apps/stacker/fixer.py
+++ b/datacube_apps/stacker/fixer.py
@@ -32,9 +32,7 @@ from datacube.storage.storage import create_netcdf_storage_unit
 from datacube.ui import task_app
 from datacube.ui.click import to_pathlib
 
-
 _LOG = logging.getLogger(__name__)
-
 
 APP_NAME = 'datacube-fixer'
 
@@ -269,7 +267,6 @@ def fixer(driver_manager, config, tasks, executor, queue_size, **kwargs):
     task_func = partial(do_fixer_task, config)
     process_func = partial(process_result, index) if config['index_datasets'] else None
     task_app.run_tasks(tasks, executor, task_func, process_func, queue_size)
-    driver_manager.close()
 
 
 if __name__ == '__main__':

--- a/datacube_apps/stacker/stacker.py
+++ b/datacube_apps/stacker/stacker.py
@@ -237,7 +237,6 @@ def main(driver_manager, config, tasks, executor, queue_size, **kwargs):
     task_func = partial(do_stack_task, config)
     process_func = partial(process_result, index) if config['index_datasets'] else None
     task_app.run_tasks(tasks, executor, task_func, process_func, queue_size)
-    driver_manager.close()
 
 
 if __name__ == '__main__':

--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -75,7 +75,7 @@ def test_end_to_end(global_integration_cli_args, driver_manager, testdata_dir):
     The input dataset should be recorded in the index, and two sets of storage units
     should be created on disk and recorded in the index.
     """
-    index = driver_manager.index
+
     lbg_nbar = testdata_dir / 'lbg' / LBG_NBAR
     lbg_pq = testdata_dir / 'lbg' / LBG_PQ
     ls5_nbar_albers_ingest_config = testdata_dir / LS5_NBAR_ALBERS
@@ -132,7 +132,7 @@ def run_click_command(command, args):
 
 def check_open_with_api(driver_manager):
     from datacube.api import API
-    index = driver_manager.index
+
     api = API(driver_manager=driver_manager)
 
     # fields = api.list_fields()
@@ -239,9 +239,9 @@ def check_open_with_dc(driver_manager):
 
 
 def check_open_with_grid_workflow(driver_manager):
-    index = driver_manager.index
+
     type_name = 'ls5_nbar_albers'
-    dt = index.products.get_by_name(type_name)
+    dt = driver_manager.index.products.get_by_name(type_name)
 
     from datacube.api.grid_workflow import GridWorkflow
     gw = GridWorkflow(None, dt.grid_spec, driver_manager=driver_manager)


### PR DESCRIPTION
The `@pass_index` decorator for cli scripts was recently replaced with `@pass_driver_manager`. I think we should include both.

- It makes API usage simpler for simple tasks: if the script only uses an index, give it just an index. The users of the scripts still have cli options for choosing/configuring the driver.
- Minimise the breakage of backwards compatibility with existing scripts -- `@pass_index` is used, for example, in the DEA repository scripts.

Other changes:
- Update the scripts in the core repo to use `@pass_index` again where it's simpler
- Change `@pass_driver_manager` to have similar close behaviour: auto-close after use rather than require a `.close()` manually in every script.
- Changes `DriverManager` to support `with` statement usage to auto close, as `Index` and `Datacube` already do.

--- 

I haven't added a release notes change, as this isn't changing or adding behaviour from the last release.
