### PR TITLE
Product update improvements

### DIFF
--- a/datacube/drivers/manager.py
+++ b/datacube/drivers/manager.py
@@ -204,6 +204,8 @@ class DriverManager(object):
     @property
     def index(self):
         """Generic index.
+
+        :rtype: Index
         """
         return self.__index
 

--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -387,17 +387,22 @@ class ProductResource(object):
             _LOG.info("No changes detected for product %s", product.name)
             return self.get_by_name(product.name)
 
+        for offset, old_val, new_val in safe_changes:
+            _LOG.info("Safe change in %s from %r to %r", _readable_offset(offset), old_val, new_val)
+
+        for offset, old_val, new_val in unsafe_changes:
+            _LOG.info("Unsafe change in %s from %r to %r", _readable_offset(offset), old_val, new_val)
+
         if not can_update:
-            full_message = "Unsafe changes at " + ", ".join(".".join(offset) for offset, _, _ in unsafe_changes)
+            full_message = "Unsafe changes at " + (
+                ", ".join(
+                    _readable_offset(offset)
+                    for offset, _, _ in unsafe_changes
+                )
+            )
             raise ValueError(full_message)
 
         _LOG.info("Updating product %s", product.name)
-
-        for offset, old_val, new_val in safe_changes:
-            _LOG.info("Safe change from %r to %r", old_val, new_val)
-
-        for offset, old_val, new_val in unsafe_changes:
-            _LOG.info("Unsafe change from %r to %r", old_val, new_val)
 
         existing = self.get_by_name(product.name)
         changing_metadata_type = product.metadata_type.name != existing.metadata_type.name
@@ -595,6 +600,10 @@ class ProductResource(object):
             metadata_type=self.metadata_type_resource.get(query_row['metadata_type_ref']),
             id_=query_row['id'],
         )
+
+
+def _readable_offset(offset):
+    return '.'.join(map(str, offset))
 
 
 class DatasetResource(object):

--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -356,7 +356,12 @@ class ProductResource(object):
             # You can safely make the match rules looser but not tighter.
             # Tightening them could exclude datasets already matched to the product.
             # (which would make search results wrong)
-            ('metadata',): changes.allow_truncation
+            ('metadata',): changes.allow_truncation,
+
+            # Some old storage fields should not be in the product definition any more: allow removal.
+            ('storage', 'chunking'): changes.allow_removal,
+            ('storage', 'driver'): changes.allow_removal,
+            ('storage', 'dimension_order'): changes.allow_removal,
         }
 
         doc_changes = get_doc_changes(existing.definition, jsonify_document(product.definition))

--- a/datacube/scripts/ingest.py
+++ b/datacube/scripts/ingest.py
@@ -165,7 +165,6 @@ def make_output_type(driver_manager, config):
     if existing and backwards_compatible_fields:
         updates_allowed = {
             ('description',): changes.allow_any,
-            ('metadata_type',): changes.allow_any,
             ('storage', 'chunking'): changes.allow_any,
             ('storage', 'driver'): changes.allow_any,
             ('storage', 'dimension_order'): changes.allow_any,

--- a/datacube/scripts/ingest.py
+++ b/datacube/scripts/ingest.py
@@ -6,6 +6,8 @@ import click
 import cachetools
 import itertools
 
+from datacube.drivers.manager import DriverManager
+
 try:
     import cPickle as pickle
 except ImportError:
@@ -148,6 +150,8 @@ def get_namemap(config):
 
 
 def make_output_type(driver_manager, config):
+    # type: (DriverManager, dict) -> (DatasetType, DatasetType)
+
     index = driver_manager.index
     source_type = index.products.get_by_name(config['source_type'])
     if not source_type:
@@ -157,31 +161,9 @@ def make_output_type(driver_manager, config):
     output_type = morph_dataset_type(source_type, config, driver_manager.driver.format)
     _LOG.info('Created DatasetType %s', output_type.name)
 
-    # Some storage fields should not be in the product definition, and should be removed.
-    # To handle backwards compatibility for now, ignore them with custom rules,
-    # rather than using the default checks done by index.products.add
     existing = index.products.get_by_name(output_type.name)
-    backwards_compatible_fields = True
-    if existing and backwards_compatible_fields:
-        updates_allowed = {
-            ('description',): changes.allow_any,
-            ('storage', 'chunking'): changes.allow_any,
-            ('storage', 'driver'): changes.allow_any,
-            ('storage', 'dimension_order'): changes.allow_any,
-            ('metadata',): changes.allow_truncation
-        }
-
-        doc_changes = changes.get_doc_changes(output_type.definition,
-                                              datacube.utils.jsonify_document(existing.definition))
-        good_changes, bad_changes = changes.classify_changes(doc_changes, updates_allowed)
-        if bad_changes:
-            raise ValueError(
-                '{} differs from stored ({})'.format(
-                    output_type.name,
-                    ', '.join(['{}: {!r}!={!r}'.format('.'.join(offset), v1, v2) for offset, v1, v2 in bad_changes])
-                )
-            )
-        output_type = index.products.update(output_type, allow_unsafe_updates=True)
+    if existing:
+        output_type = index.products.update(output_type)
     else:
         output_type = index.products.add(output_type)
 

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -5,13 +5,19 @@ Module
 from __future__ import absolute_import
 
 import copy
+import json
 
 import pytest
+import yaml
+from click.testing import CliRunner
 
+from datacube.index._api import Index
 from datacube.index.postgres._fields import NumericRangeDocField, PgField
-from datacube.model import MetadataType
+from datacube.model import MetadataType, DatasetType
 from datacube.model import Range, Dataset
 from datacube.utils import changes
+import datacube.scripts.cli_app
+from tests.util import write_file
 
 _DATASET_METADATA = {
     'id': 'f7018d80-8807-11e5-aeaa-1040f381a756',
@@ -326,6 +332,74 @@ def test_update_dataset_type(index, ls5_telem_type, ls5_telem_doc, ga_metadata_t
     index.products.update_document(different_telemetry_type, allow_unsafe_updates=True)
     updated_type = index.products.get_by_name(ls5_telem_type.name)
     assert updated_type.definition['metadata']['ga_label'] == 'something'
+
+
+def test_dataset_update_cli(index, global_integration_cli_args, ls5_telem_type, ls5_telem_doc, ga_metadata_type):
+    # type: (Index, list, DatasetType, dict, MetadataType) -> None
+    """
+    Test updating products via cli
+    """
+
+    def run_update_product(file_path, allow_unsafe=False):
+        opts = list(global_integration_cli_args)
+        opts.extend(
+            [
+                '-v', 'product', 'update', str(file_path)
+            ]
+        )
+
+        if allow_unsafe:
+            opts.append('--allow-unsafe')
+
+        runner = CliRunner()
+        result = runner.invoke(
+            datacube.scripts.cli_app.cli,
+            opts,
+            catch_exceptions=False
+        )
+        return result
+
+    def get_current(index, product_doc):
+        return index.products.get_by_name(product_doc['name']).definition
+
+    # Update an unchanged file, should be unchanged.
+    file_path = write_file('product.yaml', yaml.dump(ls5_telem_doc))
+    result = run_update_product(file_path)
+    assert str('Updated "ls5_telem_test"') in result.output
+    assert get_current(index, ls5_telem_doc) == ls5_telem_doc
+    assert result.exit_code == 0
+
+    # Try to add an unknown property: this should be forbidden by validation of dataset-type-schema.yaml
+    modified_doc = copy.deepcopy(ls5_telem_doc)
+    modified_doc['extra'] = {}
+    file_path = write_file('product.yaml', yaml.dump(modified_doc))
+    result = run_update_product(file_path)
+    assert str('Additional properties are not allowed') in result.output
+    # Return error code for failure!
+    assert result.exit_code == 1
+    assert get_current(index, ls5_telem_doc) == ls5_telem_doc
+
+    # Use of a numeric key in the document
+    # (This has thrown errors in the past. all dict keys are strings after json conversion, but some old docs use
+    # numbers as keys in yaml)
+    modified_doc = copy.deepcopy(ls5_telem_doc)
+    modified_doc['metadata'][42] = 'hello'
+    file_path = write_file('product.yaml', yaml.dump(modified_doc))
+    result = run_update_product(file_path)
+    assert "Unsafe change in metadata.42 from missing to 'hello'" in result.output
+    # Return error code for failure!
+    assert result.exit_code == 1
+    # Unchanged
+    assert get_current(index, ls5_telem_doc) == ls5_telem_doc
+
+    # But if we set allow-unsafe==True, this one will work.
+    result = run_update_product(file_path, allow_unsafe=True)
+    assert "Unsafe change in metadata.42 from missing to 'hello'" in result.output
+    assert result.exit_code == 0
+    # Has changed, and our key is now a string (json only allows string keys)
+    modified_doc = copy.deepcopy(ls5_telem_doc)
+    modified_doc['metadata']['42'] = 'hello'
+    assert get_current(index, ls5_telem_doc) == modified_doc
 
 
 def test_update_metadata_type(index, default_metadata_type_docs, default_metadata_type):

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -17,7 +17,6 @@ from datacube.model import MetadataType, DatasetType
 from datacube.model import Range, Dataset
 from datacube.utils import changes
 import datacube.scripts.cli_app
-from tests.util import write_file
 
 _DATASET_METADATA = {
     'id': 'f7018d80-8807-11e5-aeaa-1040f381a756',

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -334,7 +334,12 @@ def test_update_dataset_type(index, ls5_telem_type, ls5_telem_doc, ga_metadata_t
     assert updated_type.definition['metadata']['ga_label'] == 'something'
 
 
-def test_dataset_update_cli(index, global_integration_cli_args, ls5_telem_type, ls5_telem_doc, ga_metadata_type):
+def test_product_update_cli(index,
+                            global_integration_cli_args,
+                            ls5_telem_type,
+                            ls5_telem_doc,
+                            ga_metadata_type,
+                            tmpdir):
     # type: (Index, list, DatasetType, dict, MetadataType) -> None
     """
     Test updating products via cli
@@ -363,7 +368,8 @@ def test_dataset_update_cli(index, global_integration_cli_args, ls5_telem_type, 
         return index.products.get_by_name(product_doc['name']).definition
 
     # Update an unchanged file, should be unchanged.
-    file_path = write_file('product.yaml', yaml.dump(ls5_telem_doc))
+    file_path = tmpdir.join('unmodified-product.yaml')
+    file_path.write(_to_yaml(ls5_telem_doc))
     result = run_update_product(file_path)
     assert str('Updated "ls5_telem_test"') in result.output
     assert get_current(index, ls5_telem_doc) == ls5_telem_doc
@@ -372,7 +378,8 @@ def test_dataset_update_cli(index, global_integration_cli_args, ls5_telem_type, 
     # Try to add an unknown property: this should be forbidden by validation of dataset-type-schema.yaml
     modified_doc = copy.deepcopy(ls5_telem_doc)
     modified_doc['extra'] = {}
-    file_path = write_file('product.yaml', yaml.dump(modified_doc))
+    file_path = tmpdir.join('invalid-product.yaml')
+    file_path.write(_to_yaml(modified_doc))
     result = run_update_product(file_path)
     assert str('Additional properties are not allowed') in result.output
     # Return error code for failure!
@@ -384,7 +391,8 @@ def test_dataset_update_cli(index, global_integration_cli_args, ls5_telem_type, 
     # numbers as keys in yaml)
     modified_doc = copy.deepcopy(ls5_telem_doc)
     modified_doc['metadata'][42] = 'hello'
-    file_path = write_file('product.yaml', yaml.dump(modified_doc))
+    file_path = tmpdir.join('unsafe-change-to-product.yaml')
+    file_path.write(_to_yaml(modified_doc))
     result = run_update_product(file_path)
     assert "Unsafe change in metadata.42 from missing to 'hello'" in result.output
     # Return error code for failure!
@@ -400,6 +408,11 @@ def test_dataset_update_cli(index, global_integration_cli_args, ls5_telem_type, 
     modified_doc = copy.deepcopy(ls5_telem_doc)
     modified_doc['metadata']['42'] = 'hello'
     assert get_current(index, ls5_telem_doc) == modified_doc
+
+
+def _to_yaml(ls5_telem_doc):
+    # Need to explicitly allow unicode in Py2
+    return yaml.safe_dump(ls5_telem_doc, allow_unicode=True)
 
 
 def test_update_metadata_type(index, default_metadata_type_docs, default_metadata_type):

--- a/tests/util.py
+++ b/tests/util.py
@@ -92,16 +92,6 @@ def _write_files_to_dir(directory_path, file_dict):
                     raise Exception('Unexpected file contents: %s' % type(contents))
 
 
-def write_file(name, contents):
-    # type: (str, str) -> pathlib.Path
-    """
-    Write a single file to an automatically-deleted temporary directory
-
-    """
-    d = write_files({name: contents})
-    return d.joinpath(name)
-
-
 def temp_dir():
     """
     Create and return a temporary directory that will be deleted automatically on exit.

--- a/tests/util.py
+++ b/tests/util.py
@@ -92,6 +92,16 @@ def _write_files_to_dir(directory_path, file_dict):
                     raise Exception('Unexpected file contents: %s' % type(contents))
 
 
+def write_file(name, contents):
+    # type: (str, str) -> pathlib.Path
+    """
+    Write a single file to an automatically-deleted temporary directory
+
+    """
+    d = write_files({name: contents})
+    return d.joinpath(name)
+
+
 def temp_dir():
     """
     Create and return a temporary directory that will be deleted automatically on exit.
@@ -157,4 +167,4 @@ def isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
     Testing aproximate equality for floats
     See https://docs.python.org/3/whatsnew/3.5.html#pep-485-a-function-for-testing-approximate-equality
     """
-    return abs(a-b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
+    return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)


### PR DESCRIPTION
See commit messages: fixes several safety and user-level bugs related to updating products.

It also modifies the allowed changes of the storage fields from `allow_any` to `allow_removal`, as the comment above them says that was the intention. Does that sound sensible, @andrewdhicks?