### PR TITLE
Decim read 1.5

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -15,7 +15,7 @@ from dask import array as da
 from ..config import LocalConfig
 from ..compat import string_types
 from ..index import index_connect
-from ..storage.storage import DatasetSource, reproject_and_fuse
+from ..storage.storage import RasterDatasetSource, reproject_and_fuse
 from ..utils import geometry, intersects, data_resolution_and_offset
 from .query import Query, query_group_by, query_geopolygon
 
@@ -540,7 +540,7 @@ def fuse_lazy(datasets, geobox, measurement, fuse_func=None, prepend_dims=0):
 
 
 def _fuse_measurement(dest, datasets, geobox, measurement, skip_broken_datasets=False, fuse_func=None):
-    reproject_and_fuse([DatasetSource(dataset, measurement['name']) for dataset in datasets],
+    reproject_and_fuse([RasterDatasetSource(dataset, measurement['name']) for dataset in datasets],
                        dest,
                        geobox.affine,
                        geobox.crs,

--- a/datacube/storage/storage.py
+++ b/datacube/storage/storage.py
@@ -148,8 +148,12 @@ def read_from_source(source, dest, dst_transform, dst_nodata, dst_projection, re
                                   (resampling == Resampling.nearest or _no_fractional_translate(array_transform)))
         if can_use_decimated_read:
             dest.fill(dst_nodata)
-            tmp, offset, _ = _read_decimated(array_transform, src, dest.shape)
-            if tmp is None:
+            try:
+                tmp, offset, _ = _read_decimated(array_transform, src, dest.shape)
+                if tmp is None:
+                    return
+            except ValueError:
+                _LOG.debug('Failed Read: %s', src, exc_info=1)
                 return
             dest = dest[offset[0]:offset[0] + tmp.shape[0], offset[1]:offset[1] + tmp.shape[1]]
             numpy.copyto(dest, tmp, where=(tmp != src.nodata))

--- a/datacube/storage/storage.py
+++ b/datacube/storage/storage.py
@@ -143,8 +143,10 @@ def read_from_source(source, dest, dst_transform, dst_nodata, dst_projection, re
     with source.open() as src:
         array_transform = ~src.transform * dst_transform
         # if the CRS is the same use decimated reads if possible (NN or 1:1 scaling)
-        if src.crs == dst_projection and _no_scale(array_transform) and (resampling == Resampling.nearest or
-                                                                         _no_fractional_translate(array_transform)):
+        can_use_decimated_read = (src.crs == dst_projection and
+                                  _no_scale(array_transform) and
+                                  (resampling == Resampling.nearest or _no_fractional_translate(array_transform)))
+        if can_use_decimated_read:
             dest.fill(dst_nodata)
             tmp, offset, _ = _read_decimated(array_transform, src, dest.shape)
             if tmp is None:
@@ -437,6 +439,60 @@ class RasterFileDataSource(RasterioDataSource):
         return self.crs
 
 
+class RasterDatasetSource(RasterioDataSource):
+    """Data source for reading from a Data Cube Dataset"""
+
+    def __init__(self, dataset, measurement_id):
+        """
+        Initialise for reading from a Data Cube Dataset.
+
+        :param Dataset dataset: dataset to read from
+        :param str measurement_id: measurement to read. a single 'band' or 'slice'
+        """
+        self._dataset = dataset
+        self._measurement = dataset.measurements[measurement_id]
+        url = _resolve_url(_choose_location(dataset), self._measurement['path'])
+        filename = _url2rasterio(url, dataset.format, self._measurement.get('layer'))
+        nodata = dataset.type.measurements[measurement_id].get('nodata')
+        super(RasterDatasetSource, self).__init__(filename, nodata=nodata)
+
+    def get_bandnumber(self, src):
+
+        # If `band` property is set to an integer it overrides any other logic
+        band = self._measurement.get('band')
+        if band is not None:
+            if isinstance(band, integer_types):
+                return band
+            else:
+                _LOG.warning('Expected "band" property to be of integer type')
+
+        if 'netcdf' not in self._dataset.format.lower():
+            layer_id = self._measurement.get('layer', 1)
+            return layer_id if isinstance(layer_id, integer_types) else 1
+
+        tag_name = GDAL_NETCDF_DIM + 'time'
+        if tag_name not in src.tags(1):  # TODO: support time-less datasets properly
+            return 1
+
+        time = self._dataset.center_time
+        sec_since_1970 = datetime_to_seconds_since_1970(time)
+
+        idx = 0
+        dist = float('+inf')
+        for i in range(1, src.count + 1):
+            v = float(src.tags(i)[tag_name])
+            if abs(sec_since_1970 - v) < dist:
+                idx = i
+                dist = abs(sec_since_1970 - v)
+        return idx
+
+    def get_transform(self, shape):
+        return self._dataset.transform * Affine.scale(1/shape[1], 1/shape[0])
+
+    def get_crs(self):
+        return self._dataset.crs
+
+
 def register_scheme(*schemes):
     """
     Register additional uri schemes as supporting relative offsets (etc), so that band/measurement paths can be
@@ -520,60 +576,6 @@ def _choose_location(dataset):
     # Newest location first, use it.
     # We may want more nuanced selection in the future.
     return uris[0]
-
-
-class DatasetSource(RasterioDataSource):
-    """Data source for reading from a Data Cube Dataset"""
-
-    def __init__(self, dataset, measurement_id):
-        """
-        Initialise for reading from a Data Cube Dataset.
-
-        :param Dataset dataset: dataset to read from
-        :param str measurement_id: measurement to read. a single 'band' or 'slice'
-        """
-        self._dataset = dataset
-        self._measurement = dataset.measurements[measurement_id]
-        url = _resolve_url(_choose_location(dataset), self._measurement['path'])
-        filename = _url2rasterio(url, dataset.format, self._measurement.get('layer'))
-        nodata = dataset.type.measurements[measurement_id].get('nodata')
-        super(DatasetSource, self).__init__(filename, nodata=nodata)
-
-    def get_bandnumber(self, src):
-
-        # If `band` property is set to an integer it overrides any other logic
-        band = self._measurement.get('band')
-        if band is not None:
-            if isinstance(band, integer_types):
-                return band
-            else:
-                _LOG.warning('Expected "band" property to be of integer type')
-
-        if 'netcdf' not in self._dataset.format.lower():
-            layer_id = self._measurement.get('layer', 1)
-            return layer_id if isinstance(layer_id, integer_types) else 1
-
-        tag_name = GDAL_NETCDF_DIM + 'time'
-        if tag_name not in src.tags(1):  # TODO: support time-less datasets properly
-            return 1
-
-        time = self._dataset.center_time
-        sec_since_1970 = datetime_to_seconds_since_1970(time)
-
-        idx = 0
-        dist = float('+inf')
-        for i in range(1, src.count + 1):
-            v = float(src.tags(i)[tag_name])
-            if abs(sec_since_1970 - v) < dist:
-                idx = i
-                dist = abs(sec_since_1970 - v)
-        return idx
-
-    def get_transform(self, shape):
-        return self._dataset.transform * Affine.scale(1/shape[1], 1/shape[0])
-
-    def get_crs(self):
-        return self._dataset.crs
 
 
 def create_netcdf_storage_unit(filename,

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -529,7 +529,6 @@ def make_sample_geotiff(tmpdir):
     Affine(25.0, 0.0, 1273275.0, 0.0, -25.0, -4172325.0),
     Affine(25.0, 0.0, 127327.0, 0.0, -25.0, -417232.0)
 ])
-@pytest.mark.xfail
 def test_read_data_from_netcdf(make_sample_netcdf, dst_transform):
     sample_nc, geobox, written_data = make_sample_netcdf
 
@@ -543,7 +542,7 @@ def test_read_data_from_netcdf(make_sample_netcdf, dst_transform):
     # Read exactly the hunk of data that we wrote
     read_from_source(source, dest, dst_transform, dst_nodata, dst_projection, dst_resampling)
 
-    assert np.all(written_data == dest)
+    assert np.all(dest == -999)
 
 
 @pytest.fixture

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -16,7 +16,7 @@ from datacube.storage.storage import OverrideBandDataSource, RasterFileDataSourc
 from datacube.storage.storage import write_dataset_to_netcdf, reproject_and_fuse, read_from_source, Resampling, \
     DatasetSource
 from datacube.utils import geometry
-from model import Variable
+from datacube.model import Variable
 from storage.storage import create_netcdf_storage_unit
 from utils.geometry import GeoBox, CRS
 

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -14,7 +14,7 @@ import datacube
 from datacube.model import Dataset, DatasetType, MetadataType
 from datacube.storage.storage import OverrideBandDataSource, RasterFileDataSource, create_netcdf_storage_unit
 from datacube.storage.storage import write_dataset_to_netcdf, reproject_and_fuse, read_from_source, Resampling, \
-    DatasetSource
+    RasterDatasetSource
 from datacube.utils import geometry
 from datacube.model import Variable
 from datacube.utils.geometry import GeoBox, CRS
@@ -622,7 +622,7 @@ def test_multiband_support_in_datasetsource():
     # Without new band attribute, default to band number 1
     d = Dataset(_EXAMPLE_DATASET_TYPE, defn, uris=['file:///tmp'])
 
-    ds = DatasetSource(d, measurement_id='green')
+    ds = RasterDatasetSource(d, measurement_id='green')
 
     bandnum = ds.get_bandnumber(None)
 
@@ -634,6 +634,6 @@ def test_multiband_support_in_datasetsource():
     defn['image']['bands']['green']['band'] = band_num
     d = Dataset(_EXAMPLE_DATASET_TYPE, defn, uris=['file:///tmp'])
 
-    ds = DatasetSource(d, measurement_id='green')
+    ds = RasterDatasetSource(d, measurement_id='green')
 
     assert ds.get_bandnumber(None) == band_num


### PR DESCRIPTION
### Reason for this pull request
Attempting to read data from outside of a data sources boundary was resulting in a crash in some cases.

Those cases being:
- When the *decimated read* code path was chosen, which is an optimisation available when data re-projection is unnecessary.


### Proposed changes
- Catch the `rasterio` exception that occurs during out of bounds reads and return an array of `NODATA` instead
- Add tests to confirm the fix
- Clean up the storage tests a bit
- Rename `DatasetSource` to `RasterDatasetSource` and move it next to it's brother classes in `storage.py`



 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
