### PR TITLE
Test DriverManager serialization with logging

### DIFF
--- a/tests/drivers/test_drivers.py
+++ b/tests/drivers/test_drivers.py
@@ -23,3 +23,16 @@ def test_can_import_s3testdriver():
     pytest.importorskip('SharedArray')
     from datacube.drivers.s3_test.driver import S3TestDriver
     assert S3TestDriver is not None
+
+
+def test_can_initialize_drivermanager_with_logging():
+    from logging import getLogger, StreamHandler
+
+    from datacube import Datacube
+    from datacube.drivers.manager import DriverManager
+
+    logger = getLogger(__name__)
+    logger.addHandler(StreamHandler())
+
+    dc = Datacube(app='test')
+    dm = DriverManager(index=dc.index)


### PR DESCRIPTION
`DriverManager` tries to serialize the given `Index`. When
the `Index` has a thread lock somewhere inside it, the program
crashes. One way to keep the lock alive is to turn logging on.
Although, nobody knows how that works yet. Need to find a simpler
way to ensure the existence of that lock.