### PR TITLE
Merge 1.5.2 release notes changes, fix formatting/consistency

### DIFF
--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -4,12 +4,6 @@
 
 What's New
 ==========
-(03 Aug 2017)utils/ls_usgs_prepare.py
--------------------------------------
--New file added under utils for USGS prepare script for Collection 1 data.
--Dataset path is given as a folder in directory after downloading data.
--Take cares bands of Landsat5/Landsat7/Landsat8 in one file
-
 
 
 v1.6.0 ??????? (?? ??????? 2017)
@@ -19,6 +13,8 @@ v1.6.0 ??????? (?? ??????? 2017)
    or a _GDAL_ based comparison. (Closed #243)
 
  - Allow creation of :class:`Geometry` objects from 3d representations. The Z axis is simply thrown away.
+
+ - Added example prepare script for Collection 1 USGS data; improved band handling and downloads.
 
 
 v1.5.2 Purpler Unicorn with Stars (28 August 2017)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -21,6 +21,16 @@ v1.6.0 ??????? (?? ??????? 2017)
  - Allow creation of :class:`Geometry` objects from 3d representations. The Z axis is simply thrown away.
 
 
+v1.5.2 Purpler Unicorn with Stars (28 August 2017)
+--------------------------------------------------
+
+ - Fix bug when reading data in native projection, but outside `source` area. Often hit when running `datacube-stats`
+
+ - Fix error loading and fusing data using `dask`. (Fixes #276)
+
+ - When reading data, implement `skip_broken_datasets` for the `dask` case too
+
+
 v1.5.1 Purpler Unicorn (13 July 2017)
 -------------------------------------
 


### PR DESCRIPTION
`develop`'s release notes are the most prominently displayed, so it's worth keeping them in sync.
