### PR TITLE
Product changes should be opt-in during ingestion

### DIFF
--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -102,6 +102,12 @@ class MetadataTypeResource(object):
         doc_changes = get_doc_changes(existing.definition, jsonify_document(metadata_type.definition))
         good_changes, bad_changes = changes.classify_changes(doc_changes, updates_allowed)
 
+        for offset, old_val, new_val in good_changes:
+            _LOG.info("Safe change in %s from %r to %r", _readable_offset(offset), old_val, new_val)
+
+        for offset, old_val, new_val in bad_changes:
+            _LOG.info("Unsafe change in %s from %r to %r", _readable_offset(offset), old_val, new_val)
+
         return allow_unsafe_updates or not bad_changes, good_changes, bad_changes
 
     def update(self, metadata_type, allow_unsafe_updates=False, allow_table_lock=False):
@@ -132,11 +138,6 @@ class MetadataTypeResource(object):
 
         _LOG.info("Updating metadata type %s", metadata_type.name)
 
-        for offset, old_val, new_val in safe_changes:
-            _LOG.info("Safe change from %r to %r", old_val, new_val)
-
-        for offset, old_val, new_val in unsafe_changes:
-            _LOG.info("Unsafe change from %r to %r", old_val, new_val)
 
         with self._db.connect() as connection:
             connection.update_metadata_type(
@@ -367,6 +368,12 @@ class ProductResource(object):
         doc_changes = get_doc_changes(existing.definition, jsonify_document(product.definition))
         good_changes, bad_changes = changes.classify_changes(doc_changes, updates_allowed)
 
+        for offset, old_val, new_val in good_changes:
+            _LOG.info("Safe change in %s from %r to %r", _readable_offset(offset), old_val, new_val)
+
+        for offset, old_val, new_val in bad_changes:
+            _LOG.info("Unsafe change in %s from %r to %r", _readable_offset(offset), old_val, new_val)
+
         return allow_unsafe_updates or not bad_changes, good_changes, bad_changes
 
     def update(self, product, allow_unsafe_updates=False, allow_table_lock=False):
@@ -391,12 +398,6 @@ class ProductResource(object):
         if not safe_changes and not unsafe_changes:
             _LOG.info("No changes detected for product %s", product.name)
             return self.get_by_name(product.name)
-
-        for offset, old_val, new_val in safe_changes:
-            _LOG.info("Safe change in %s from %r to %r", _readable_offset(offset), old_val, new_val)
-
-        for offset, old_val, new_val in unsafe_changes:
-            _LOG.info("Unsafe change in %s from %r to %r", _readable_offset(offset), old_val, new_val)
 
         if not can_update:
             full_message = "Unsafe changes at " + (

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -237,12 +237,6 @@ def update_dry_run(index, updates, dataset):
         echo('Cannot update %s: %s' % (dataset.id, e))
         return False
 
-    for offset, old_val, new_val in safe_changes:
-        echo('Safe change in %s:%s from %r to %r' % (dataset.id, '.'.join(offset), old_val, new_val))
-
-    for offset, old_val, new_val in unsafe_changes:
-        echo('Unsafe change in %s:%s from %r to %r' % (dataset.id, '.'.join(offset), old_val, new_val))
-
     if can_update:
         echo('Can update %s: %s unsafe changes, %s safe changes' % (dataset.id,
                                                                     len(unsafe_changes),

--- a/datacube/scripts/product.py
+++ b/datacube/scripts/product.py
@@ -90,14 +90,10 @@ def update_dataset_types(index, allow_unsafe, allow_exclusive_lock, dry_run, fil
                 echo('Failed to update "%s": %s' % (type_.name, e))
                 failures += 1
         else:
-            can_update, safe_changes, unsafe_changes = index.products.can_update(type_,
-                                                                                 allow_unsafe_updates=allow_unsafe)
-
-            for offset, old_val, new_val in safe_changes:
-                echo('Safe change in %r %s from %r to %r' % (type_.name, _readable_offset(offset), old_val, new_val))
-
-            for offset, old_val, new_val in unsafe_changes:
-                echo('Unsafe change in %r %s from %r to %r' % (type_.name, _readable_offset(offset), old_val, new_val))
+            can_update, safe_changes, unsafe_changes = index.products.can_update(
+                type_,
+                allow_unsafe_updates=allow_unsafe
+            )
 
             if can_update:
                 echo('Can update "%s": %s unsafe changes, %s safe changes' % (type_.name,
@@ -108,10 +104,6 @@ def update_dataset_types(index, allow_unsafe, allow_exclusive_lock, dry_run, fil
                                                                                  len(unsafe_changes),
                                                                                  len(safe_changes)))
     sys.exit(failures)
-
-
-def _readable_offset(offset):
-    return '.'.join(map(str, offset))
 
 
 @product.command('list')


### PR DESCRIPTION
(these are some older commits from the 1.5 branch)

The primary change is throwing an error by default if the ingester needs to change a product definition. The user must explicitly pass `--allow-product-changes` to allow it. On previous versions this was potentially dangerous as changes could be made accidentally (and very rarely need to be actually done).

The other change is to make `--dry-run`'s and normal runs to output similar information: telling the user which fields are actually changing.