### PR TITLE
Update link to build release notes

### DIFF
--- a/docs/about/release_process.rst
+++ b/docs/about/release_process.rst
@@ -47,14 +47,15 @@ stable version.
 #. Update conda-forge recipe
     Follow the instrucions under **Updating datacube-feedstock** in the `Datcube Feedstock`_ repository.
     
-    It should involve modifying the version number in the `recipe <https://github.com/conda-forge/datacube-feedstock/blob/master/recipe/meta.yaml>`_ and updating the SHA hash.    
+    It should involve modifying the version number in the
+    `recipe <https://github.com/conda-forge/datacube-feedstock/blob/master/recipe/meta.yaml>`_ and updating the SHA hash.    
     The hash should be generated from the ``.tar.gz`` mentioned in the ``source`` of the recipe.
     
-    .. code-block::bash
-        
-        openssl sha256 <downloaded-datacube-source.tar.gz>
+    .. code-block:: bash
     
-
+        openssl sha256 <downloaded-datacube-source.tar.gz>
+        
+    
 #. Update the default version on `raijin`
     Follow the instructions under **Update default version** in the `Datacube Environment`_ repository.
 
@@ -74,4 +75,3 @@ stable version.
 .. _Datacube Environment: https://github.com/GeoscienceAustralia/digitalearthau/tree/develop/modules
 
 .. _Datcube Feedstock: https://github.com/conda-forge/datacube-feedstock#updating-datacube-feedstock
-

--- a/docs/about/release_process.rst
+++ b/docs/about/release_process.rst
@@ -34,7 +34,8 @@ stable version.
 #. Merge changes leading up to the release into the `stable` branch
     This will also update the `stable` docs
 
-#. Upload the build to PyPi.
+#. Upload the build to PyPi
+    You might need a PyPI_ account with appropriate authorization.
 
     .. code-block:: bash
 
@@ -42,14 +43,17 @@ stable version.
         twine upload dist/*
 
 #. Update conda-forge recipe
-    Follow the instrucions under **Updating datacube-feedstock** in the `Datcube Feedstock`_ repository
+    Follow the instrucions under **Updating datacube-feedstock** in the `Datcube Feedstock`_ repository.
+    It should involve modifying the version number in the `recipe <https://github.com/conda-forge/datacube-feedstock/blob/master/recipe/meta.yaml>`_ and updating the SHA hash.
+    The hash should be generated from the ``.tar.gz`` mentioned in the ``source`` of the recipe.
 
 #. Update the default version on `raijin`
-    Follow the instructions under **Update default version** in the `Datacube Environment`_ repository
+    Follow the instructions under **Update default version** in the `Datacube Environment`_ repository.
 
 #. Notify the community of the release using the Datacube Central mailing list
     Ask Simon Oliver for the MailChimp details.
 
+.. _PyPI: https://pypi.python.org/pypi
 
 .. _Travis: https://travis-ci.org/opendatacube/datacube-core
 
@@ -62,3 +66,4 @@ stable version.
 .. _Datacube Environment: https://github.com/GeoscienceAustralia/digitalearthau/tree/develop/modules
 
 .. _Datcube Feedstock: https://github.com/conda-forge/datacube-feedstock#updating-datacube-feedstock
+

--- a/docs/about/release_process.rst
+++ b/docs/about/release_process.rst
@@ -32,7 +32,7 @@ Once/if a built version has been tested on Raijin, found to be stable, and the t
 stable version.
 
 #. Merge changes leading up to the release into the `stable` branch
-    This will also update the `stable` docs
+    This will also update the `stable` docs.
 
 #. Upload the build to PyPi
     You might need a PyPI_ account with appropriate authorization.
@@ -41,11 +41,19 @@ stable version.
 
         python setup.py sdist bdist_wheel
         twine upload dist/*
+        
+    This should upload the project to https://pypi.python.org/pypi/datacube/.
 
 #. Update conda-forge recipe
     Follow the instrucions under **Updating datacube-feedstock** in the `Datcube Feedstock`_ repository.
-    It should involve modifying the version number in the `recipe <https://github.com/conda-forge/datacube-feedstock/blob/master/recipe/meta.yaml>`_ and updating the SHA hash.
+    
+    It should involve modifying the version number in the `recipe <https://github.com/conda-forge/datacube-feedstock/blob/master/recipe/meta.yaml>`_ and updating the SHA hash.    
     The hash should be generated from the ``.tar.gz`` mentioned in the ``source`` of the recipe.
+    
+    .. code-block::bash
+        
+        openssl sha256 <downloaded-datacube-source.tar.gz>
+    
 
 #. Update the default version on `raijin`
     Follow the instructions under **Update default version** in the `Datacube Environment`_ repository.

--- a/docs/about/release_process.rst
+++ b/docs/about/release_process.rst
@@ -59,6 +59,6 @@ stable version.
 
 .. _Jira: https://gaautobots.atlassian.net/projects/ACDD?selectedItem=com.atlassian.jira.jira-projects-plugin%3Arelease-page&status=unreleased
 
-.. _Datacube Environment: https://github.com/GeoscienceAustralia/ga-datacube-env#building-a-release
+.. _Datacube Environment: https://github.com/GeoscienceAustralia/digitalearthau/tree/develop/modules
 
 .. _Datcube Feedstock: https://github.com/conda-forge/datacube-feedstock#updating-datacube-feedstock


### PR DESCRIPTION
Update link to the build release notes under the `digitalearthau` repository.

### Reason for this pull request
The old link does not exist anymore.