### PR TITLE
Support multiple instance configurations

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -69,7 +69,7 @@ class Datacube(object):
     :type index: datacube.index._api.Index
     """
 
-    def __init__(self, index=None, config=None, app=None, driver_manager=None):
+    def __init__(self, index=None, config=None, app=None, env=None, driver_manager=None):
         """
         Create the interface for the query and storage access.
 
@@ -89,6 +89,13 @@ class Datacube(object):
             The application name is used to track down problems with database queries, so it is strongly
             advised that be used.  Required if an index is not supplied, otherwise ignored.
 
+        :param str env: Name of the datacube environment to use.
+            ie. the section name in any config files. Defaults to 'datacube' for backwards
+            compatibility with old config files.
+
+            Allows you to have multiple datacube instances in one configuration, specified on load,
+            eg. 'dev', 'test' or 'landsat', 'modis' etc.
+
         :param DriverManager driver_manager: The driver manager to
           use. If not specified, an new manager will be created using
           the index if specified, or the default configuration
@@ -99,10 +106,9 @@ class Datacube(object):
         """
         self._to_close = None
 
-        # Backwards compatibility: users previously may have passed an index alone.
         if not driver_manager:
             if isinstance(config, string_types):
-                config = LocalConfig.find([config])
+                config = LocalConfig.find([config], env=env)
 
             driver_manager = DriverManager(index=index, local_config=config, application_name=app)
             self._to_close = driver_manager

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -8,6 +8,7 @@ import warnings
 from collections import namedtuple, OrderedDict
 from itertools import groupby, repeat
 from math import ceil
+from pathlib import PurePath
 
 import numpy
 import pandas
@@ -116,7 +117,7 @@ class Datacube(object):
             if not config:
                 config = LocalConfig.find(env=env)
             # The 'config' parameter could be a string path
-            elif isinstance(config, string_types):
+            elif isinstance(config, (string_types, PurePath)):
                 config = LocalConfig.find(paths=[config], env=env)
 
             driver_manager = DriverManager(index=index,

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -107,8 +107,11 @@ class Datacube(object):
         self._to_close = None
 
         if not driver_manager:
-            if isinstance(config, string_types):
-                config = LocalConfig.find([config], env=env)
+            if not config:
+                config = LocalConfig.find(env=env)
+            # The 'config' parameter could be a string path
+            elif isinstance(config, string_types):
+                config = LocalConfig.find(paths=[config], env=env)
 
             driver_manager = DriverManager(index=index, local_config=config, application_name=app)
             self._to_close = driver_manager

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -69,7 +69,13 @@ class Datacube(object):
     :type index: datacube.index._api.Index
     """
 
-    def __init__(self, index=None, config=None, app=None, env=None, driver_manager=None):
+    def __init__(self,
+                 index=None,
+                 config=None,
+                 app=None,
+                 env=None,
+                 driver_manager=None,
+                 validate_connection=None):
         """
         Create the interface for the query and storage access.
 
@@ -113,7 +119,10 @@ class Datacube(object):
             elif isinstance(config, string_types):
                 config = LocalConfig.find(paths=[config], env=env)
 
-            driver_manager = DriverManager(index=index, local_config=config, application_name=app)
+            driver_manager = DriverManager(index=index,
+                                           local_config=config,
+                                           application_name=app,
+                                           validate_connection=validate_connection)
             self._to_close = driver_manager
 
         self.driver_manager = driver_manager

--- a/datacube/config.py
+++ b/datacube/config.py
@@ -81,7 +81,7 @@ class LocalConfig(object):
         """
 
         config = compat.read_config(_DEFAULT_CONF)
-        files_loaded = config.read(p for p in paths if p)
+        files_loaded = config.read(str(p) for p in paths if p)
 
         return LocalConfig(
             config,

--- a/datacube/config.py
+++ b/datacube/config.py
@@ -144,10 +144,11 @@ class LocalConfig(object):
         return self._environment_prop('db_port') or '5432'
 
     def __str__(self):
-        return "LocalConfig<loaded_from={}, config={}, environment={})".format(
+        return "LocalConfig<loaded_from={}, environment={!r}, driver={!r}, config={}>".format(
             self.files_loaded or 'defaults',
+            self.environment,
+            self.default_driver,
             dict(self._config[self.environment]),
-            self.environment
         )
 
     def __repr__(self):

--- a/datacube/config.py
+++ b/datacube/config.py
@@ -35,10 +35,12 @@ default_driver: NetCDF CF
 
 
 [user]
-# This was the section name before we had environments, so it's backwards compatible with old configs.
+# Which environment to use when none is specified explicitly.
+# 'datacube' was the config section name before we had environments; it's used here to be backwards compatible.
 default_environment: datacube
 
 [datacube]
+# Inherit all defaults.
 """
 
 

--- a/datacube/drivers/manager.py
+++ b/datacube/drivers/manager.py
@@ -169,9 +169,13 @@ class DriverManager(object):
                 driver_cls = getattr(driver_module, spec[1])
                 if issubclass(driver_cls, Driver):
                     driver = driver_cls(weakref.ref(self)(), spec[0], index, *index_args, **index_kargs)
-                    if not driver.requirements_satisfied():
+
+                    validate_connection = index_kargs['validate_connection'] \
+                        if 'validate_connection' in index_kargs else True
+                    if validate_connection and not driver.requirements_satisfied():
                         self.logger.info('Driver plugin "%s" failed requirements check, skipping.', spec[1])
                         continue
+
                     self.__drivers[driver.name] = driver
                 else:
                     self.logger.info('Driver plugin "%s" is not a subclass of the abstract Driver class.',

--- a/datacube/drivers/manager.py
+++ b/datacube/drivers/manager.py
@@ -33,7 +33,7 @@ class DriverManager(object):
     #: Attribue name where driver information is stored in `__init__.py`.
     _DRIVER_SPEC = 'DRIVER_SPEC'
 
-    def __init__(self, index=None, *index_args, **index_kargs):
+    def __init__(self, index=None, default_driver_name=None, *index_args, **index_kargs):
         """Initialise the manager.
 
         Each driver get initialised during instantiation, including
@@ -75,7 +75,7 @@ class DriverManager(object):
         # pylint: disable=protected-access
         self.set_index(index, *index_args, **index_kargs)
         self.reload_drivers(index, *index_args, **index_kargs)
-        self.set_current_driver(DriverManager._DEFAULT_DRIVER)
+        self.set_current_driver(default_driver_name or self._DEFAULT_DRIVER)
         self.logger.debug('Ready. %s', self)
 
     def __getstate__(self):

--- a/datacube/index/_api.py
+++ b/datacube/index/_api.py
@@ -7,8 +7,9 @@ from __future__ import absolute_import
 import logging
 from pathlib import Path
 
+from sqlalchemy.engine.url import URL
+
 import datacube.utils
-from datacube.config import LocalConfig
 from ._datasets import DatasetResource, ProductResource, MetadataTypeResource
 from .postgres import PostgresDb
 
@@ -48,6 +49,7 @@ class Index(object):
 
     @property
     def url(self):
+        # type: () -> URL
         return self._db.url
 
     def init_db(self, with_default_types=True, with_permissions=True, with_s3_tables=False):

--- a/datacube/index/postgres/_connections.py
+++ b/datacube/index/postgres/_connections.py
@@ -62,6 +62,7 @@ class PostgresDb(object):
 
     @property
     def url(self):
+        # type: () -> URL
         return self._engine.url
 
     @staticmethod

--- a/datacube/scripts/system.py
+++ b/datacube/scripts/system.py
@@ -76,19 +76,24 @@ def check(
     """
     Verify & view current configuration
     """
-    echo('Version:\t' + style(str(datacube.__version__), bold=True))
-    echo('Config files:\t' + style(','.join(local_config.files_loaded), bold=True))
-    echo('Host:\t\t' +
-         style('{}:{}'.format(local_config.db_hostname or 'localhost',
-                              local_config.db_port or '5432'), bold=True))
-    echo('Database:\t' + style('{}'.format(local_config.db_database), bold=True))
-    echo('User:\t\t' + style('{}'.format(local_config.db_username), bold=True))
-    echo('Environment:\t' + style('{}'.format(local_config.environment), bold=True))
+
+    def echo_field(name, value):
+        echo('{:<15}'.format(name + ':') + style(str(value), bold=True))
+
+    echo_field('Version', datacube.__version__)
+    echo_field('Config files', ','.join(local_config.files_loaded))
+    echo_field('Host',
+               '{}:{}'.format(local_config.db_hostname or 'localhost', local_config.db_port or '5432'))
+
+    echo_field('Database', local_config.db_database)
+    echo_field('User', local_config.db_username)
+    echo_field('Environment', local_config.environment)
 
     echo()
     echo('Valid connection:\t', nl=False)
     try:
-        with DriverManager(default_driver_name=local_config.default_driver, local_config=local_config) as driver_manager:
+        with DriverManager(default_driver_name=local_config.default_driver,
+                           local_config=local_config) as driver_manager:
             index = driver_manager.index
             echo(style('YES', bold=True))
             for role, user, description in index.users.list_users():

--- a/datacube/scripts/system.py
+++ b/datacube/scripts/system.py
@@ -83,6 +83,7 @@ def check(
                               local_config.db_port or '5432'), bold=True))
     echo('Database:\t' + style('{}'.format(local_config.db_database), bold=True))
     echo('User:\t\t' + style('{}'.format(local_config.db_username), bold=True))
+    echo('Environment:\t' + style('{}'.format(local_config.environment), bold=True))
 
     echo()
     echo('Valid connection:\t', nl=False)

--- a/datacube/ui/click.py
+++ b/datacube/ui/click.py
@@ -121,12 +121,10 @@ def _set_config(ctx, param, value):
         if not any(os.path.exists(p) for p in value):
             raise ValueError('No specified config paths exist: {}' % value)
 
+        if not ctx.obj:
+            ctx.obj = {}
         paths = value
-
-    if not ctx.obj:
-        ctx.obj = {}
-
-    ctx.obj['config_files'] = paths
+        ctx.obj['config_files'] = paths
 
 
 def _set_driver(ctx, param, value):

--- a/datacube/ui/click.py
+++ b/datacube/ui/click.py
@@ -122,23 +122,23 @@ def _set_config(ctx, param, value):
             raise ValueError('No specified config paths exist: {}' % value)
 
         paths = value
-    else:
-        paths = config.DEFAULT_CONF_PATHS
-
-    parsed_config = config.LocalConfig.find(paths=paths)
-
-    _LOG.debug("Loaded datacube config files: %s", parsed_config.files_loaded)
 
     if not ctx.obj:
         ctx.obj = {}
 
-    ctx.obj['config_file'] = parsed_config
+    ctx.obj['config_files'] = paths
 
 
 def _set_driver(ctx, param, value):
     if not ctx.obj:
         ctx.obj = {}
     ctx.obj['driver'] = value
+
+
+def _set_environment(ctx, param, value):
+    if not ctx.obj:
+        ctx.obj = {}
+    ctx.obj['config_environment'] = value
 
 
 #: pylint: disable=invalid-name
@@ -153,8 +153,14 @@ logfile_option = click.option('--log-file', multiple=True, callback=_add_logfile
 #: pylint: disable=invalid-name
 config_option = click.option('--config_file', '-C', multiple=True, default='', callback=_set_config,
                              expose_value=False)
+
 #: pylint: disable=invalid-name
-driver_option = click.option('--driver', '-D', default='NetCDF CF', callback=_set_driver,
+environment_option = click.option('--env', '-E', callback=_set_environment,
+                                  expose_value=False)
+
+#: pylint: disable=invalid-name
+DEFAULT_DRIVER = 'NetCDF CF'
+driver_option = click.option('--driver', '-D', default=DEFAULT_DRIVER, callback=_set_driver,
                              expose_value=False)
 #: pylint: disable=invalid-name
 log_queries_option = click.option('--log-queries', is_flag=True, callback=_log_queries,
@@ -167,6 +173,7 @@ global_cli_options = compose(
     verbose_option,
     logfile_option,
     driver_option,
+    environment_option,
     config_option,
     log_queries_option
 )
@@ -182,8 +189,14 @@ def pass_config(f):
     """Get a datacube config as the first argument. """
 
     def new_func(*args, **kwargs):
-        config_ = click.get_current_context().obj['config_file']
-        return f(config_, *args, **kwargs)
+        obj = click.get_current_context().obj
+
+        paths = obj.get('config_files') or config.DEFAULT_CONF_PATHS
+        environment = obj.get('config_environment')
+
+        parsed_config = config.LocalConfig.find(paths=paths, env=environment)
+        _LOG.debug("Loaded datacube config: %r", parsed_config)
+        return f(parsed_config, *args, **kwargs)
 
     return functools.update_wrapper(new_func, f)
 
@@ -200,14 +213,15 @@ def pass_driver_manager(app_name=None, expect_initialised=True):
     """
 
     def decorate(f):
-        def with_driver_manager(*args, **kwargs):
+        @pass_config
+        def with_driver_manager(local_config, *args, **kwargs):
             ctx = click.get_current_context()
             try:
                 with DriverManager(index=None,
-                                   local_config=ctx.obj['config_file'],
+                                   local_config=local_config,
                                    application_name=app_name or ctx.command_path,
                                    validate_connection=expect_initialised) as driver_manager:
-                    driver_manager.set_current_driver(ctx.obj['driver'])
+                    driver_manager.set_current_driver(ctx.obj.get('driver') or DEFAULT_DRIVER)
                     ctx.obj['index'] = driver_manager.index
                     _LOG.debug("Driver manager ready. Connected to index: %s",
                                driver_manager.index)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -16,6 +16,10 @@ v1.6.0 ??????? (?? ??????? 2017)
 
  - Added example prepare script for Collection 1 USGS data; improved band handling and downloads.
 
+ - Multiple environments can now be specified in one datacube config. See `#298`_ and the `config docs`_
+
+.. _#298: https://github.com/opendatacube/datacube-core/pull/298
+.. _config docs: https://datacube-core.readthedocs.io/en/latest/ops/config.html#runtime-config-doc
 
 v1.5.2 Purpler Unicorn with Stars (28 August 2017)
 --------------------------------------------------

--- a/docs/ops/config.rst
+++ b/docs/ops/config.rst
@@ -331,19 +331,29 @@ measurements
 Runtime Config
 --------------
 
-Runtime Config document specifies database connection configuration options:
+The runtime config specifies configuration options for the current user, such as
+available datacube instances and which to use by default.
 
 This is loaded from the following locations in order, if they exist, with properties from latter files
 overriding those in earlier ones:
 
- * /etc/datacube.conf
- * $DATACUBE_CONFIG_PATH
- * ~/.datacube.conf
- * datacube.conf
+ * ``/etc/datacube.conf``
+ * ``$DATACUBE_CONFIG_PATH``
+ * ``~/.datacube.conf``
+ * ``datacube.conf``
+
+Example:
 
 .. code-block:: text
+    [user]
+    # This should correspond to a section name in your config.
+    default_environment: dev
 
-    [datacube]
+    ## Development environment ##
+
+    [dev]
+    # These fields are all the defaults, so they could be omitted, but are here for reference
+
     db_database: datacube
 
     # A blank host will use a local socket. Specify a hostname (such as localhost) to use TCP.
@@ -354,4 +364,23 @@ overriding those in earlier ones:
     # db_username:
     # A blank password will fall back to default postgres driver authentication, such as reading your ~/.pgpass file.
     # db_password:
+
+    ## Staging environment ##
+
+    [staging]
+    db_hostname: staging.dea.ga.gov.au
+
+Note that the staging environment only specifies the hostname, all other fields will use default values (dbname
+datacube, current username, password loaded from ``~/.pgpass``)
+
+When using the datacube, it will use your default environment unless you specify one explicitly
+
+eg.
+
+    with Datacube(env='staging') as dc:
+        ...
+
+or for cli commmands ``-E <name>``:
+
+    datacube -E staging system check
 

--- a/integration_tests/agdcintegration.conf
+++ b/integration_tests/agdcintegration.conf
@@ -1,11 +1,3 @@
 [datacube]
 db_hostname: localhost
 db_database: agdcintegration
-
-[locations]
-# Where to reach storage locations from the current machine.
-#  -> Location names (here 'eotiles') are arbitrary, but correspond to names used in the
-#     storage type files.
-#  -> We may eventually support remote protocols (http, S3, etc) to lazily fetch remote data.
-# Define these in your own datacube.conf file.
-eotiles: file:///tmp

--- a/integration_tests/test_config_tool.py
+++ b/integration_tests/test_config_tool.py
@@ -235,14 +235,14 @@ def test_multiple_environment_config(tmpdir):
     config_path = tmpdir.join('second.conf')
 
     config_path.write("""
-    [user]
-    default_environment: test_default
+[user]
+default_environment: test_default
 
-    [test_default]
-    db_hostname: db.opendatacube.test
+[test_default]
+db_hostname: db.opendatacube.test
 
-    [test_alt]
-    db_hostname: alt-db.opendatacube.test
+[test_alt]
+db_hostname: alt-db.opendatacube.test
     """)
 
     config_path = str(config_path)


### PR DESCRIPTION
### Reason for this pull request

* We'd like to able to use mulitple datacube environments without manually managing separate config files.
* GA would prefer to only deploy and manage one `dea` module on NCI, instead of three (`-prod`, `-staging`, `dev`)
* It would be nice if users could more "effortlessly" use their own custom dea instances (eg. `WOfSCube`) without the pain of interference with existing prod config.
* The current config setup makes it easier than it should be to accidentally use the wrong instance. We'd to allow code to be explicit ("do this in prod" / "do this in staging") without users manually writing and managing their own separate config files everywhere.

### Proposed changes

This extends the LocalConfig classes to allow the user to specify multiple datacube environments in one config file

eg.

    [user]
    default_environment: dev

    [dev]
    db_hostname: localhost
    db_database: dev

    [staging]
    db_database: staging

Then 'dev' is used by default, but staging can be specified during any setup:

eg.

```
$ datacube -E staging system check
Version:       1.5.1+176.gaf2c2fee
Config files:  /home/jez/.datacube.conf
Host:          localhost:5432
Database:      staging
User:          jez
Environment:   staging
$
```

or

```
with Datacube(env='staging') as dc:
    ...
```

Note that this change is backwards compatible with all existing user configs: if not specified, the default environment is `datacube`, which is the config section name used on previous config files.
