### PR TITLE
add gdal version peg to resolve build dependencies on travis

### DIFF
--- a/.travis/environment.yaml
+++ b/.travis/environment.yaml
@@ -17,7 +17,8 @@ dependencies:
 - singledispatch
 - netcdf4
 - psycopg2
-- gdal = 2.1.*  # fiona requires 2.1 libgdal, doesn't trigger gdal 2.1
+- gdal = 2.1.*        # [py27]
+- gdal                # [not py27]
 - dask
 - xarray
 - redis-py # redis client lib, used by celery
@@ -47,3 +48,6 @@ dependencies:
   - pytest-faulthandler
   - SharedArray
   - yamllint # testing
+
+# [py27] is a preprocessing-selector
+# https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#preprocessing-selectors

--- a/.travis/environment.yaml
+++ b/.travis/environment.yaml
@@ -17,7 +17,7 @@ dependencies:
 - singledispatch
 - netcdf4
 - psycopg2
-- gdal
+- gdal = 2.1.*  # fiona requires 2.1 libgdal, doesn't trigger gdal 2.1
 - dask
 - xarray
 - redis-py # redis client lib, used by celery

--- a/integration_tests/test_config_tool.py
+++ b/integration_tests/test_config_tool.py
@@ -235,14 +235,14 @@ def test_multiple_environment_config(tmpdir):
     config_path = tmpdir.join('second.conf')
 
     config_path.write("""
-    [user]
-    default_environment: test_default
+[user]
+default_environment: test_default
 
-    [test_default]
-    db_hostname: db.opendatacube.test
+[test_default]
+db_hostname: db.opendatacube.test
 
-    [test_alt]
-    db_hostname: alt-db.opendatacube.test
+[test_alt]
+db_hostname: alt-db.opendatacube.test
     """)
 
     config_path = str(config_path)


### PR DESCRIPTION
### Reason for this pull request

Travis builds for python2.7 were broken due to a discrepancy between gdal and libgdal

### Proposed changes
To peg the gdal version to 2.1 in the travis build configuration
 - [x] Closes #303