### PR TITLE
Add limit to datacube dataset search

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -429,13 +429,13 @@ class Datacube(object):
                                               **query.search_terms)
 
         polygon = query.geopolygon
-        if polygon:
-            for dataset in datasets:
+        for dataset in datasets:
+            if polygon:
                 # Check against the bounding box of the original scene, can throw away some portions
                 if intersects(polygon.to_crs(dataset.crs), dataset.extent):
                     yield dataset
-        else:
-            yield from datasets
+            else:
+                yield dataset
 
     @staticmethod
     def product_sources(datasets, group_by):

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -214,7 +214,7 @@ class Datacube(object):
             If not provided, all measurements for the product will be returned.
             ::
 
-                measurements=['red', 'nir', swir2']
+                measurements=['red', 'nir', 'swir2']
 
         **Dimensions**
             Spatial dimensions can specified using the ``longitude``/``latitude`` and ``x``/``y`` fields.
@@ -271,9 +271,10 @@ class Datacube(object):
         :param str product: the product to be included.
 
         :param measurements:
-            measurements name or list of names to be included, as listed in :meth:`list_measurements`.
-                If a list is specified, the measurements will be returned in the order requested.
-                By default all available measurements are included.
+            Measurements name or list of names to be included, as listed in :meth:`list_measurements`.
+
+            If a list is specified, the measurements will be returned in the order requested.
+            By default all available measurements are included.
 
         :type measurements: list(str), optional
 
@@ -340,6 +341,10 @@ class Datacube(object):
 
             Default is False.
 
+        :param int limit:
+            Optional. If provided, limit the maximum number of datasets
+            returned. Useful for testing and debugging.
+
         :return: Requested data in a :class:`xarray.Dataset`.
             As a :class:`xarray.DataArray` if the ``stack`` variable is supplied.
 
@@ -401,19 +406,36 @@ class Datacube(object):
         :return: list of datasets
         :rtype: list[:class:`datacube.model.Dataset`]
 
-        .. seealso:: :meth:`group_datasets` :meth:`load_data`
+        .. seealso:: :meth:`group_datasets` :meth:`load_data` :meth:`find_datasets_lazy`
+        """
+        return list(self.find_datasets_lazy(**kwargs))
+
+    def find_datasets_lazy(self, limit=None, **kwargs):
+        """
+        Find datasets matching query.
+
+        :param kwargs: see :class:`datacube.api.query.Query`
+        :param limit: if provided, limit the maximum number of datasets returned
+        :return: iterator of datasets
+        :rtype: __generator[:class:`datacube.model.Dataset`]
+
+        .. seealso:: :meth:`group_datasets` :meth:`load_data` :meth:`find_datasets`
         """
         query = Query(self.index, **kwargs)
         if not query.product:
-            raise RuntimeError('must specify a product')
+            raise ValueError("must specify a product")
 
-        datasets = self.index.datasets.search_eager(**query.search_terms)
-        if query.geopolygon:
-            datasets = [dataset for dataset in datasets
-                        if intersects(query.geopolygon.to_crs(dataset.crs), dataset.extent)]
-            # Check against the bounding box of the original scene, can throw away some portions
+        datasets = self.index.datasets.search(limit=limit,
+                                              **query.search_terms)
 
-        return datasets
+        polygon = query.geopolygon
+        if polygon:
+            for dataset in datasets:
+                # Check against the bounding box of the original scene, can throw away some portions
+                if intersects(polygon.to_crs(dataset.crs), dataset.extent):
+                    yield dataset
+        else:
+            yield from datasets
 
     @staticmethod
     def product_sources(datasets, group_by):

--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -1179,6 +1179,7 @@ class DatasetResource(object):
             q['dataset_type_id'] = product.id
             yield q, product
 
+    # pylint: disable=too-many-locals
     def _do_search_by_product(self, query, return_fields=False, select_field_names=None,
                               with_source_ids=False, source_filter=None,
                               limit=None):

--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -138,7 +138,6 @@ class MetadataTypeResource(object):
 
         _LOG.info("Updating metadata type %s", metadata_type.name)
 
-
         with self._db.connect() as connection:
             connection.update_metadata_type(
                 name=metadata_type.name,
@@ -1041,15 +1040,18 @@ class DatasetResource(object):
             for dataset in self._make_many(connection.search_datasets_by_metadata(metadata)):
                 yield dataset
 
-    def search(self, **query):
+    def search(self, limit=None, **query):
         """
         Perform a search, returning results as Dataset objects.
 
         :param dict[str,str|float|Range] query:
+        :param int limit:
         :rtype: __generator[Dataset]
         """
         source_filter = query.pop('source_filter', None)
-        for _, datasets in self._do_search_by_product(query, source_filter=source_filter):
+        for _, datasets in self._do_search_by_product(query,
+                                                      source_filter=source_filter,
+                                                      limit=limit):
             for dataset in self._make_many(datasets):
                 yield dataset
 
@@ -1178,7 +1180,9 @@ class DatasetResource(object):
             yield q, product
 
     def _do_search_by_product(self, query, return_fields=False, select_field_names=None,
-                              with_source_ids=False, source_filter=None):
+                              with_source_ids=False, source_filter=None,
+                              limit=None):
+
         if source_filter:
             product_queries = list(self._get_product_queries(source_filter))
             if not product_queries:
@@ -1213,6 +1217,7 @@ class DatasetResource(object):
                            query_exprs,
                            source_exprs,
                            select_fields=select_fields,
+                           limit=limit,
                            with_source_ids=with_source_ids
                        ))
 

--- a/datacube/index/postgres/_api.py
+++ b/datacube/index/postgres/_api.py
@@ -415,16 +415,17 @@ class PostgresDbAPI(object):
         where_expr = and_(DATASET.c.archived == None, *raw_expressions)
 
         if not source_exprs:
-            return select(
-                       select_columns
-                   ).select_from(
-                       from_expression
-                   ).where(
-                       where_expr
-                   ).limit(
-                       limit
-                   )
-
+            return (
+                select(
+                    select_columns
+                ).select_from(
+                    from_expression
+                ).where(
+                    where_expr
+                ).limit(
+                    limit
+                )
+            )
         base_query = (
             select(
                 select_columns + (DATASET_SOURCE.c.source_dataset_ref,
@@ -450,17 +451,19 @@ class PostgresDbAPI(object):
             )
         )
 
-        return select(
-                   [distinct(recursive_query.c.id)] +
-                   [col for col in recursive_query.columns
-                    if col.name not in ['id', 'source_dataset_ref', 'distance', 'path']]
-               ).select_from(
-                   recursive_query.join(DATASET, DATASET.c.id == recursive_query.c.source_dataset_ref)
-               ).where(
-                   and_(DATASET.c.archived == None, *PostgresDbAPI._alchemify_expressions(source_exprs))
-               ).limit(
-                   limit
-               )
+        return (
+            select(
+                [distinct(recursive_query.c.id)] +
+                [col for col in recursive_query.columns
+                 if col.name not in ['id', 'source_dataset_ref', 'distance', 'path']]
+            ).select_from(
+                recursive_query.join(DATASET, DATASET.c.id == recursive_query.c.source_dataset_ref)
+            ).where(
+                and_(DATASET.c.archived == None, *PostgresDbAPI._alchemify_expressions(source_exprs))
+            ).limit(
+                limit
+            )
+        )
 
     def search_datasets(self, expressions,
                         source_exprs=None, select_fields=None,

--- a/datacube/index/postgres/_api.py
+++ b/datacube/index/postgres/_api.py
@@ -378,8 +378,16 @@ class PostgresDbAPI(object):
         return [raw_expr(expression) for expression in expressions]
 
     @staticmethod
-    def search_datasets_query(expressions, source_exprs=None, select_fields=None, with_source_ids=False):
-        # type: (Tuple[Expression], Tuple[Expression], Iterable[PgField], bool) -> sqlalchemy.Expression
+    def search_datasets_query(expressions, source_exprs=None,
+                              select_fields=None, with_source_ids=False, limit=None):
+        """
+        :type expressions: Tuple[Expression]
+        :type source_exprs: Tuple[Expression]
+        :type select_fields: Iterable[PgField]
+        :type with_source_ids: bool
+        :type limit: int
+        :rtype: sqlalchemy.Expression
+        """
         if select_fields:
             select_columns = tuple(
                 f.alchemy_expression.label(f.name)
@@ -407,15 +415,15 @@ class PostgresDbAPI(object):
         where_expr = and_(DATASET.c.archived == None, *raw_expressions)
 
         if not source_exprs:
-            return (
-                select(
-                    select_columns
-                ).select_from(
-                    from_expression
-                ).where(
-                    where_expr
-                )
-            )
+            return select(
+                       select_columns
+                   ).select_from(
+                       from_expression
+                   ).where(
+                       where_expr
+                   ).limit(
+                       limit
+                   )
 
         base_query = (
             select(
@@ -442,25 +450,28 @@ class PostgresDbAPI(object):
             )
         )
 
-        return (
-            select(
-                [distinct(recursive_query.c.id)] +
-                [col for col in recursive_query.columns
-                 if col.name not in ['id', 'source_dataset_ref', 'distance', 'path']]
-            ).select_from(
-                recursive_query.join(DATASET, DATASET.c.id == recursive_query.c.source_dataset_ref)
-            ).where(
-                and_(DATASET.c.archived == None, *PostgresDbAPI._alchemify_expressions(source_exprs))
-            )
-        )
+        return select(
+                   [distinct(recursive_query.c.id)] +
+                   [col for col in recursive_query.columns
+                    if col.name not in ['id', 'source_dataset_ref', 'distance', 'path']]
+               ).select_from(
+                   recursive_query.join(DATASET, DATASET.c.id == recursive_query.c.source_dataset_ref)
+               ).where(
+                   and_(DATASET.c.archived == None, *PostgresDbAPI._alchemify_expressions(source_exprs))
+               ).limit(
+                   limit
+               )
 
-    def search_datasets(self, expressions, source_exprs=None, select_fields=None, with_source_ids=False):
+    def search_datasets(self, expressions,
+                        source_exprs=None, select_fields=None,
+                        with_source_ids=False, limit=None):
         """
         :type with_source_ids: bool
         :type select_fields: tuple[datacube.index.postgres._fields.PgField]
         :type expressions: tuple[datacube.index.postgres._fields.PgExpression]
         """
-        select_query = self.search_datasets_query(expressions, source_exprs, select_fields, with_source_ids)
+        select_query = self.search_datasets_query(expressions, source_exprs,
+                                                  select_fields, with_source_ids, limit)
         return self._connection.execute(select_query)
 
     def get_duplicates(self, match_fields, expressions):

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -382,15 +382,17 @@ def info_cmd(index, show_sources, show_derived, f, max_depth, ids):
 
 
 @dataset_cmd.command('search')
+@click.option('--limit', help='Limit the number of results',
+              type=int, default=None)
 @click.option('-f', help='Output format',
               type=click.Choice(_OUTPUT_WRITERS.keys()), default='yaml', show_default=True)
 @ui.parsed_search_expressions
 @ui.pass_index()
-def search_cmd(index, f, expressions):
+def search_cmd(index, limit, f, expressions):
     """
     Search available Datasets
     """
-    datasets = index.datasets.search(**expressions)
+    datasets = index.datasets.search(**expressions, limit=limit)
     _OUTPUT_WRITERS[f](
         build_dataset_info(index, dataset)
         for dataset in datasets

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -392,7 +392,7 @@ def search_cmd(index, limit, f, expressions):
     """
     Search available Datasets
     """
-    datasets = index.datasets.search(**expressions, limit=limit)
+    datasets = index.datasets.search(limit=limit, **expressions)
     _OUTPUT_WRITERS[f](
         build_dataset_info(index, dataset)
         for dataset in datasets

--- a/docs/ops/config.rst
+++ b/docs/ops/config.rst
@@ -345,6 +345,7 @@ overriding those in earlier ones:
 Example:
 
 .. code-block:: text
+
     [user]
     # This should correspond to a section name in your config.
     default_environment: dev
@@ -376,6 +377,8 @@ datacube, current username, password loaded from ``~/.pgpass``)
 When using the datacube, it will use your default environment unless you specify one explicitly
 
 eg.
+
+.. code-block:: python
 
     with Datacube(env='staging') as dc:
         ...

--- a/integration_tests/index/test_search.py
+++ b/integration_tests/index/test_search.py
@@ -413,6 +413,17 @@ def test_search_by_product(index, pseudo_ls8_type, pseudo_ls8_dataset, indexed_l
     assert next(datasets).id == pseudo_ls8_dataset.id
 
 
+def test_search_limit(index, pseudo_ls8_dataset, pseudo_ls8_dataset2):
+    datasets = list(index.datasets.search())
+    assert len(datasets) == 2
+    datasets = list(index.datasets.search(limit=1))
+    assert len(datasets) == 1
+    datasets = list(index.datasets.search(limit=0))
+    assert len(datasets) == 0
+    datasets = list(index.datasets.search(limit=5))
+    assert len(datasets) == 2
+
+
 def test_search_or_expressions(index,
                                pseudo_ls8_type, pseudo_ls8_dataset,
                                ls5_dataset_nbar_type, ls5_dataset_w_children,

--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -156,11 +156,6 @@ def check_open_with_dc(driver_manager):
     from datacube.api.core import Datacube
     dc = Datacube(driver_manager=driver_manager)
 
-    datasets = dc.find_datasets(product='ls5_nbar_albers')
-    assert len(datasets) == 1
-    datasets = dc.find_datasets(product='ls5_nbar_albers', limit=0)
-    assert len(datasets) == 0
-
     data_array = dc.load(product='ls5_nbar_albers', measurements=['blue'], stack='variable')
     assert data_array.shape
     assert (data_array != -999).any()

--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -156,6 +156,11 @@ def check_open_with_dc(driver_manager):
     from datacube.api.core import Datacube
     dc = Datacube(driver_manager=driver_manager)
 
+    datasets = dc.find_datasets(product='ls5_nbar_albers')
+    assert len(datasets) == 1
+    datasets = dc.find_datasets(product='ls5_nbar_albers', limit=0)
+    assert len(datasets) == 0
+
     data_array = dc.load(product='ls5_nbar_albers', measurements=['blue'], stack='variable')
     assert data_array.shape
     assert (data_array != -999).any()


### PR DESCRIPTION
The `datacube dataset search` command is often invoked to find
sample datasets for testing purposes.

- Add `--limit INTEGER` option to limit number of results
- Partially fix issue #191
- Add `find_datasets_lazy` to `datacube.Datacube` that returns
  an iterator over the search results
- Add test for `find_datasets` with `limit` keyword argument