### PR TITLE
Add limit to datacube dataset search

### DIFF
--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -138,7 +138,6 @@ class MetadataTypeResource(object):
 
         _LOG.info("Updating metadata type %s", metadata_type.name)
 
-
         with self._db.connect() as connection:
             connection.update_metadata_type(
                 name=metadata_type.name,
@@ -1038,15 +1037,18 @@ class DatasetResource(object):
             for dataset in self._make_many(connection.search_datasets_by_metadata(metadata)):
                 yield dataset
 
-    def search(self, **query):
+    def search(self, limit=None, **query):
         """
         Perform a search, returning results as Dataset objects.
 
         :param dict[str,str|float|Range] query:
+        :param int limit:
         :rtype: __generator[Dataset]
         """
         source_filter = query.pop('source_filter', None)
-        for _, datasets in self._do_search_by_product(query, source_filter=source_filter):
+        for _, datasets in self._do_search_by_product(query,
+                                                      source_filter=source_filter,
+                                                      limit=limit):
             for dataset in self._make_many(datasets):
                 yield dataset
 
@@ -1175,7 +1177,9 @@ class DatasetResource(object):
             yield q, product
 
     def _do_search_by_product(self, query, return_fields=False, select_field_names=None,
-                              with_source_ids=False, source_filter=None):
+                              with_source_ids=False, source_filter=None,
+                              limit=None):
+
         if source_filter:
             product_queries = list(self._get_product_queries(source_filter))
             if not product_queries:
@@ -1210,6 +1214,7 @@ class DatasetResource(object):
                            query_exprs,
                            source_exprs,
                            select_fields=select_fields,
+                           limit=limit,
                            with_source_ids=with_source_ids
                        ))
 

--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -1176,6 +1176,7 @@ class DatasetResource(object):
             q['dataset_type_id'] = product.id
             yield q, product
 
+    # pylint: disable=too-many-locals
     def _do_search_by_product(self, query, return_fields=False, select_field_names=None,
                               with_source_ids=False, source_filter=None,
                               limit=None):

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -393,7 +393,7 @@ def search_cmd(index, limit, f, expressions):
     """
     Search available Datasets
     """
-    datasets = index.datasets.search(**expressions, limit=limit)
+    datasets = index.datasets.search(limit=limit, **expressions)
     _OUTPUT_WRITERS[f](
         build_dataset_info(index, dataset)
         for dataset in datasets

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -383,15 +383,17 @@ def info_cmd(index, show_sources, show_derived, f, max_depth, ids):
 
 
 @dataset_cmd.command('search')
+@click.option('--limit', help='Limit the number of results',
+              type=int, default=None)
 @click.option('-f', help='Output format',
               type=click.Choice(_OUTPUT_WRITERS.keys()), default='yaml', show_default=True)
 @ui.parsed_search_expressions
 @ui.pass_index()
-def search_cmd(index, f, expressions):
+def search_cmd(index, limit, f, expressions):
     """
     Search available Datasets
     """
-    datasets = index.datasets.search(**expressions)
+    datasets = index.datasets.search(**expressions, limit=limit)
     _OUTPUT_WRITERS[f](
         build_dataset_info(index, dataset)
         for dataset in datasets

--- a/integration_tests/index/test_search.py
+++ b/integration_tests/index/test_search.py
@@ -413,6 +413,17 @@ def test_search_by_product(index, pseudo_ls8_type, pseudo_ls8_dataset, indexed_l
     assert next(datasets).id == pseudo_ls8_dataset.id
 
 
+def test_search_limit(index, pseudo_ls8_dataset, pseudo_ls8_dataset2):
+    datasets = list(index.datasets.search())
+    assert len(datasets) == 2
+    datasets = list(index.datasets.search(limit=1))
+    assert len(datasets) == 1
+    datasets = list(index.datasets.search(limit=0))
+    assert len(datasets) == 0
+    datasets = list(index.datasets.search(limit=5))
+    assert len(datasets) == 2
+
+
 def test_search_or_expressions(index,
                                pseudo_ls8_type, pseudo_ls8_dataset,
                                ls5_dataset_nbar_type, ls5_dataset_w_children,


### PR DESCRIPTION
The `datacube dataset search` command is often invoked to find
sample datasets for testing purposes.

- Add `--limit INTEGER` option to limit number of results
- Partially fix issue #191
- Add `find_datasets_lazy` to `datacube.Datacube` that returns
  an iterator over the search results
- Add test for `find_datasets` with `limit` keyword argument