### PR TITLE
Connection should not be held out of the pool between product searches

### DIFF
--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -1200,19 +1200,19 @@ class DatasetResource(object):
             source_exprs = None
 
         product_queries = list(self._get_product_queries(query))
-        with self._db.connect() as connection:
-            for q, product in product_queries:
-                dataset_fields = product.metadata_type.dataset_fields
-                query_exprs = tuple(fields.to_expressions(dataset_fields.get, **q))
-                select_fields = None
-                if return_fields:
-                    # if no fields specified, select all
-                    if select_field_names is None:
-                        select_fields = tuple(field for name, field in dataset_fields.items()
-                                              if not field.affects_row_selection)
-                    else:
-                        select_fields = tuple(dataset_fields[field_name]
-                                              for field_name in select_field_names)
+        for q, product in product_queries:
+            dataset_fields = product.metadata_type.dataset_fields
+            query_exprs = tuple(fields.to_expressions(dataset_fields.get, **q))
+            select_fields = None
+            if return_fields:
+                # if no fields specified, select all
+                if select_field_names is None:
+                    select_fields = tuple(field for name, field in dataset_fields.items()
+                                          if not field.affects_row_selection)
+                else:
+                    select_fields = tuple(dataset_fields[field_name]
+                                          for field_name in select_field_names)
+            with self._db.connect() as connection:
                 yield (product,
                        connection.search_datasets(
                            query_exprs,
@@ -1224,13 +1224,14 @@ class DatasetResource(object):
 
     def _do_count_by_product(self, query):
         product_queries = self._get_product_queries(query)
-        with self._db.connect() as connection:
-            for q, product in product_queries:
-                dataset_fields = product.metadata_type.dataset_fields
-                query_exprs = tuple(fields.to_expressions(dataset_fields.get, **q))
+
+        for q, product in product_queries:
+            dataset_fields = product.metadata_type.dataset_fields
+            query_exprs = tuple(fields.to_expressions(dataset_fields.get, **q))
+            with self._db.connect() as connection:
                 count = connection.count_datasets(query_exprs)
-                if count > 0:
-                    yield product, count
+            if count > 0:
+                yield product, count
 
     def _do_time_count(self, period, query, ensure_single=False):
         if 'time' not in query:
@@ -1249,10 +1250,10 @@ class DatasetResource(object):
                 raise ValueError('Multiple products match single query search: %r' %
                                  ([dt.name for q, dt in product_queries],))
 
-        with self._db.connect() as connection:
-            for q, product in product_queries:
-                dataset_fields = product.metadata_type.dataset_fields
-                query_exprs = tuple(fields.to_expressions(dataset_fields.get, **q))
+        for q, product in product_queries:
+            dataset_fields = product.metadata_type.dataset_fields
+            query_exprs = tuple(fields.to_expressions(dataset_fields.get, **q))
+            with self._db.connect() as connection:
                 yield product, list(connection.count_datasets_through_time(
                     start,
                     end,

--- a/datacube/index/postgres/_connections.py
+++ b/datacube/index/postgres/_connections.py
@@ -181,6 +181,16 @@ class PostgresDb(object):
     def connect(self):
         """
         Borrow a connection from the pool.
+
+        The name connect() is misleading: it will not create a new connection if one is already available in the pool.
+
+        Callers should minimise the amount of time they hold onto their connections. If they're doing anything between
+        calls to the DB (such as opening files, or waiting on user input), it's better to return the connection
+        to the pool beforehand.
+
+        The connection can raise errors if not following this advice ("server closed the connection unexpectedly"),
+        as some servers will aggressively close idle connections (eg. DEA's NCI servers). It also prevents the
+        connection from being reused while borrowed.
         """
         return _PostgresDbConnection(self._engine)
 


### PR DESCRIPTION
This can sometimes result in connection errors when iteratively processing search results slowly, as the connection is sitting idle while you are processing the previous search result.

By returning the connection to the pool between product searches, the connection is renewed by the pool if needed.