### PR TITLE
Fix index initialisation duplication and leak

### DIFF
--- a/.travis/environment.yaml
+++ b/.travis/environment.yaml
@@ -42,6 +42,7 @@ dependencies:
 - tqdm # for simple-replicas
 - pip:
   - celery >= 4
+  - objgraph
   - pypeg2
   - pylint == 1.7.2 # testing
   - pytest-cov # testing

--- a/datacube/drivers/manager.py
+++ b/datacube/drivers/manager.py
@@ -74,7 +74,7 @@ class DriverManager(object):
         # Initialise the generic index
         # pylint: disable=protected-access
         self.set_index(index, *index_args, **index_kargs)
-        self.reload_drivers(index, *index_args, **index_kargs)
+        self.reload_drivers(*index_args, **index_kargs)
         self.set_current_driver(default_driver_name or self._DEFAULT_DRIVER)
         self.logger.debug('Ready. %s', self)
 
@@ -131,7 +131,7 @@ class DriverManager(object):
         self.__index = Index(weakref.ref(self)(), index, *index_args, **index_kargs)
         self.logger.debug('Generic index set to %s', self.__index)
 
-    def reload_drivers(self, index=None, *index_args, **index_kargs):
+    def reload_drivers(self, *index_args, **index_kargs):
         """Load and initialise all available drivers and their indexes.
 
 
@@ -168,7 +168,7 @@ class DriverManager(object):
                     continue
                 driver_cls = getattr(driver_module, spec[1])
                 if issubclass(driver_cls, Driver):
-                    driver = driver_cls(weakref.ref(self)(), spec[0], index, *index_args, **index_kargs)
+                    driver = driver_cls(weakref.ref(self)(), spec[0], self.__index, *index_args, **index_kargs)
 
                     validate_connection = index_kargs['validate_connection'] \
                         if 'validate_connection' in index_kargs else True

--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -41,6 +41,18 @@ class MetadataTypeResource(object):
         self.get_unsafe = lru_cache()(self.get_unsafe)
         self.get_by_name_unsafe = lru_cache()(self.get_by_name_unsafe)
 
+    def __getstate__(self):
+        """
+        We define getstate/setstate to avoid pickling the caches
+        """
+        return self._db,
+
+    def __setstate__(self, state):
+        """
+        We define getstate/setstate to avoid pickling the caches
+        """
+        self.__init__(*state)
+
     def from_doc(self, definition):
         """
         :param dict definition:
@@ -274,6 +286,18 @@ class ProductResource(object):
 
         self.get_unsafe = lru_cache()(self.get_unsafe)
         self.get_by_name_unsafe = lru_cache()(self.get_by_name_unsafe)
+
+    def __getstate__(self):
+        """
+        We define getstate/setstate to avoid pickling the caches
+        """
+        return self._db, self.metadata_type_resource
+
+    def __setstate__(self, state):
+        """
+        We define getstate/setstate to avoid pickling the caches
+        """
+        self.__init__(*state)
 
     def from_doc(self, definition):
         """

--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -38,6 +38,9 @@ class MetadataTypeResource(object):
         """
         self._db = db
 
+        self.get_unsafe = lru_cache()(self.get_unsafe)
+        self.get_by_name_unsafe = lru_cache()(self.get_by_name_unsafe)
+
     def from_doc(self, definition):
         """
         :param dict definition:
@@ -179,7 +182,6 @@ class MetadataTypeResource(object):
         except KeyError:
             return None
 
-    @lru_cache()
     def get_unsafe(self, id_):
         with self._db.connect() as connection:
             record = connection.get_metadata_type(id_)
@@ -187,7 +189,6 @@ class MetadataTypeResource(object):
             raise KeyError('%s is not a valid MetadataType id')
         return self._make_from_query_row(record)
 
-    @lru_cache()
     def get_by_name_unsafe(self, name):
         with self._db.connect() as connection:
             record = connection.get_metadata_type_by_name(name)
@@ -266,6 +267,9 @@ class ProductResource(object):
         """
         self._db = db
         self.metadata_type_resource = metadata_type_resource
+
+        self.get_unsafe = lru_cache()(self.get_unsafe)
+        self.get_by_name_unsafe = lru_cache()(self.get_by_name_unsafe)
 
     def from_doc(self, definition):
         """
@@ -499,7 +503,6 @@ class ProductResource(object):
         except KeyError:
             return None
 
-    @lru_cache()
     def get_unsafe(self, id_):
         with self._db.connect() as connection:
             result = connection.get_dataset_type(id_)
@@ -507,7 +510,6 @@ class ProductResource(object):
             raise KeyError('"%s" is not a valid Product id' % id_)
         return self._make(result)
 
-    @lru_cache()
     def get_by_name_unsafe(self, name):
         with self._db.connect() as connection:
             result = connection.get_dataset_type_by_name(name)

--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -182,6 +182,8 @@ class MetadataTypeResource(object):
         except KeyError:
             return None
 
+    # This is memoized in the constructor
+    # pylint: disable=method-hidden
     def get_unsafe(self, id_):
         with self._db.connect() as connection:
             record = connection.get_metadata_type(id_)
@@ -189,6 +191,8 @@ class MetadataTypeResource(object):
             raise KeyError('%s is not a valid MetadataType id')
         return self._make_from_query_row(record)
 
+    # This is memoized in the constructor
+    # pylint: disable=method-hidden
     def get_by_name_unsafe(self, name):
         with self._db.connect() as connection:
             record = connection.get_metadata_type_by_name(name)
@@ -503,6 +507,8 @@ class ProductResource(object):
         except KeyError:
             return None
 
+    # This is memoized in the constructor
+    # pylint: disable=method-hidden
     def get_unsafe(self, id_):
         with self._db.connect() as connection:
             result = connection.get_dataset_type(id_)
@@ -510,6 +516,8 @@ class ProductResource(object):
             raise KeyError('"%s" is not a valid Product id' % id_)
         return self._make(result)
 
+    # This is memoized in the constructor
+    # pylint: disable=method-hidden
     def get_by_name_unsafe(self, name):
         with self._db.connect() as connection:
             result = connection.get_dataset_type_by_name(name)

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -364,6 +364,10 @@ def test_product_update_cli(index,
         return result
 
     def get_current(index, product_doc):
+        # It's calling out to a separate instance to update the product (through the cli),
+        # so we need to clear our local index object's cache to get the updated one.
+        index.products.get_by_name_unsafe.cache_clear()
+
         return index.products.get_by_name(product_doc['name']).definition
 
     # Update an unchanged file, should be unchanged.

--- a/integration_tests/test_model.py
+++ b/integration_tests/test_model.py
@@ -109,10 +109,14 @@ def test_single_dm_instance(driver_manager, db):
     # how many are connected to our instance of DriverManager
     references = 0
     for pg_instance in objgraph.by_type('PostgresDb'):
-        chain = objgraph.find_backref_chain(pg_instance, predicate=lambda o: isinstance(o, DriverManager))
+        chain = objgraph.find_backref_chain(
+            pg_instance,
+            max_depth=10,
+            predicate=lambda o: isinstance(o, DriverManager)
+        )
         # If the referenced DriverManager is ours
         if chain[0] is driver_manager:
-            pprint(chain)
+            print("Length {}: {}".format(len(chain), ' -> '.join(c.__class__.__name__ for c in chain)))
             references += 1
 
     assert references == 1, "Our DriverManager should only reference one PG instance"

--- a/integration_tests/test_model.py
+++ b/integration_tests/test_model.py
@@ -3,6 +3,7 @@ from pprint import pprint
 import gc
 
 import pytest
+import sys
 
 from datacube.drivers.manager import DriverManager
 from datacube.model import Dataset
@@ -94,6 +95,10 @@ def test_crs_parse(indexed_ls5_scene_dataset_types):
     assert d.crs is None
 
 
+@pytest.mark.skip(
+    sys.version_info < (3, 4),
+    reason="objgraph search is too slow on older python"
+)
 def test_single_dm_instance(driver_manager, db):
     """
     Our driver manager should only be linked to one PostgresDb instance in memory.

--- a/integration_tests/test_model.py
+++ b/integration_tests/test_model.py
@@ -94,7 +94,6 @@ def test_crs_parse(indexed_ls5_scene_dataset_types):
     assert d.crs is None
 
 
-@pytest.mark.xfail(reason="Not yet implemented")
 def test_single_dm_instance(driver_manager, db):
     """
     Our driver manager should only be linked to one PostgresDb instance in memory.

--- a/integration_tests/test_model.py
+++ b/integration_tests/test_model.py
@@ -1,5 +1,14 @@
+from pprint import pprint
+
+import gc
+
+import pytest
+
+from datacube.drivers.manager import DriverManager
 from datacube.model import Dataset
 from datacube.model import MetadataType
+
+import objgraph
 
 
 def test_crs_parse(indexed_ls5_scene_dataset_types):
@@ -83,3 +92,28 @@ def test_crs_parse(indexed_ls5_scene_dataset_types):
     # Prints warning: Can't figure out projection: possibly invalid zone (-60) for datum ('GDA94')."
     # We still return None, rather than error, as they didn't specify a CRS explicitly
     assert d.crs is None
+
+
+@pytest.mark.xfail(reason="Not yet implemented")
+def test_single_dm_instance(driver_manager, db):
+    """
+    Our driver manager should only be linked to one PostgresDb instance in memory.
+
+    Subsequent drivers should share the same instance to avoid extra connections (and cache duplication)
+    """
+
+    # There's a circular reference in DriverManager structure, so old test instances aren't cleaned up by
+    # the reference counter.
+    gc.collect()
+
+    # For all PostgresDb instances in memory (there may be others due to other pytests), count
+    # how many are connected to our instance of DriverManager
+    references = 0
+    for pg_instance in objgraph.by_type('PostgresDb'):
+        chain = objgraph.find_backref_chain(pg_instance, predicate=lambda o: isinstance(o, DriverManager))
+        # If the referenced DriverManager is ours
+        if chain[0] is driver_manager:
+            pprint(chain)
+            references += 1
+
+    assert references == 1, "Our DriverManager should only reference one PG instance"

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import versioneer
 from setuptools import setup, find_packages
 
 tests_require = [
-    'pytest', 'pytest-cov', 'mock', 'pep8', 'pylint==1.6.4', 'hypothesis', 'compliance-checker', 'objgraph'
+    'pytest', 'pytest-cov', 'mock', 'pep8', 'pylint', 'hypothesis', 'compliance-checker', 'objgraph'
 ]
 
 extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,9 @@
 import versioneer
 from setuptools import setup, find_packages
 
-tests_require = ['pytest', 'pytest-cov', 'mock', 'pep8', 'pylint==1.6.4', 'hypothesis', 'compliance-checker']
+tests_require = [
+    'pytest', 'pytest-cov', 'mock', 'pep8', 'pylint==1.6.4', 'hypothesis', 'compliance-checker', 'objgraph'
+]
 
 extras_require = {
     'performance': ['ciso8601', 'bottleneck'],


### PR DESCRIPTION
- When a user runs `DriverManager()` without passing in an existing index, it was unintentionally creating a duplicate PostgresDb instance for the NetCDF driver, resulting in duplicate connections and caches.

- Adding a test for this also found a leak in the lru_cache()'d index methods, which were holding on to old indexes when created/destroyed more than once.

- An unrelated test also failed once the cache was fixed, as it was testing its own cached copy of data, rather than the DB's own state.

(this _may_ fix the "already closed" errors from drivermanager's `__del__()` on shutdown of some scripts, whose investigation lead me to find the leaks, but I haven't reliably reproduced the issue to know for sure.)
