### PR TITLE
Disable prefetch for celery workers

### DIFF
--- a/datacube/_celery_runner.py
+++ b/datacube/_celery_runner.py
@@ -33,6 +33,7 @@ def mk_celery_app(addr=None):
     _app = Celery('datacube_task', broker=url, backend=url)
 
     _app.conf.update(
+        worker_prefetch_multiplier=1,
         task_serializer='cloudpickle',
         result_serializer='cloudpickle',
         event_serializer='cloudpickle',


### PR DESCRIPTION
By default celery worker grabs 4 times more tasks than it can run in parallel,
this is not ideal for our use-cases. Datacube tasks are long duration so
pre-fetching doesn't make sense, in the worst case where number of total tasks
is roughly the same as number of workers 75% of workers will sit idle while
other 25% do all the work.
