### PR TITLE
Trivial field updates for UIs

### DIFF
--- a/datacube/index/postgres/_api.py
+++ b/datacube/index/postgres/_api.py
@@ -90,7 +90,7 @@ def get_native_fields():
     fields = {
         'id': NativeField(
             'id',
-            None,
+            'Dataset UUID',
             DATASET.c.id
         ),
         'product': NativeField(
@@ -105,7 +105,7 @@ def get_native_fields():
         ),
         'metadata_type': NativeField(
             'metadata_type',
-            'Metadata type of dataset',
+            'Metadata type name of dataset',
             METADATA_TYPE.c.name
         ),
         'metadata_type_id': NativeField(

--- a/datacube/utils/__init__.py
+++ b/datacube/utils/__init__.py
@@ -26,6 +26,7 @@ import numpy
 import xarray
 import yaml
 from dateutil.tz import tzutc
+from decimal import Decimal
 
 try:
     from yaml import CSafeLoader as SafeLoader
@@ -443,7 +444,7 @@ def jsonify_document(doc):
     >>> sorted(jsonify_document({'a': (1.0, 2.0, 3.0), 'b': float("inf"), 'c': datetime(2016, 3, 11)}).items())
     [('a', (1.0, 2.0, 3.0)), ('b', 'Infinity'), ('c', '2016-03-11T00:00:00')]
     >>> # Converts keys to strings:
-    >>> sorted(jsonify_document({1: 'a', '2': 'b'}).items())
+    >>> sorted(jsonify_document({1: 'a', '2': Decimal('2')}).items())
     [('1', 'a'), ('2', 'b')]
     >>> jsonify_document({'k': UUID("1f231570-e777-11e6-820f-185e0f80a5c0")})
     {'k': '1f231570-e777-11e6-820f-185e0f80a5c0'}
@@ -463,6 +464,8 @@ def jsonify_document(doc):
         if isinstance(v, numpy.dtype):
             return v.name
         if isinstance(v, UUID):
+            return str(v)
+        if isinstance(v, Decimal):
             return str(v)
         return v
 

--- a/datacube/utils/__init__.py
+++ b/datacube/utils/__init__.py
@@ -445,7 +445,7 @@ def jsonify_document(doc):
     [('a', (1.0, 2.0, 3.0)), ('b', 'Infinity'), ('c', '2016-03-11T00:00:00')]
     >>> # Converts keys to strings:
     >>> sorted(jsonify_document({1: 'a', '2': Decimal('2')}).items())
-    [('1', 'a'), ('2', 'b')]
+    [('1', 'a'), ('2', '2')]
     >>> jsonify_document({'k': UUID("1f231570-e777-11e6-820f-185e0f80a5c0")})
     {'k': '1f231570-e777-11e6-820f-185e0f80a5c0'}
     """


### PR DESCRIPTION
- The field names are displayed on the cubedash ui. Make them consistent.
- Dataset fields can come back from the DB as decimals, so add support for decimals to jsonify_document