### PR TITLE
Move doc-test into proper py.test test

### DIFF
--- a/datacube/utils/geometry.py
+++ b/datacube/utils/geometry.py
@@ -701,18 +701,6 @@ class GeoBox(object):
     Defines the location and resolution of a rectangular grid of data,
     including it's :py:class:`CRS`.
 
-    >>> from affine import Affine
-    >>> t = GeoBox(4000, 4000, Affine(0.00025, 0.0, 151.0, 0.0, -0.00025, -29.0), CRS('EPSG:4326'))
-    >>> t.coordinates['latitude'].values
-    array([-29.000125, -29.000375, -29.000625, ..., -29.999375, -29.999625,
-           -29.999875])
-    >>> t.coordinates['longitude'].values
-    array([ 151.000125,  151.000375,  151.000625, ...,  151.999375,
-            151.999625,  151.999875])
-    >>> t.resolution
-    (-0.00025, 0.00025)
-
-
     :param geometry.CRS crs: Coordinate Reference System
     :param affine.Affine affine: Affine transformation defining the location of the geobox
     """

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import numpy as np
 import osgeo
 import pytest
 
@@ -16,6 +17,26 @@ def test_pickleable():
     pickled = pickle.dumps(poly, pickle.HIGHEST_PROTOCOL)
     unpickled = pickle.loads(pickled)
     assert poly == unpickled
+
+
+def test_geobox_simple():
+    from affine import Affine
+    t = geometry.GeoBox(4000, 4000,
+                        Affine(0.00025, 0.0, 151.0, 0.0, -0.00025, -29.0),
+                        geometry.CRS('EPSG:4326'))
+
+    expect_lon = np.asarray([151.000125,  151.000375,  151.000625,  151.000875,  151.001125,
+                             151.001375,  151.001625,  151.001875,  151.002125,  151.002375])
+
+    expect_lat = np.asarray([-29.000125, -29.000375, -29.000625, -29.000875, -29.001125,
+                             -29.001375, -29.001625, -29.001875, -29.002125, -29.002375])
+    expect_resolution = np.asarray([-0.00025, 0.00025])
+
+    assert (np.abs(np.r_[t.resolution] - expect_resolution) < 1e-6).all()
+    assert t.coordinates['latitude'].values.shape == (4000,)
+    assert t.coordinates['longitude'].values.shape == (4000,)
+    assert (np.abs(t.coords['latitude'].values[:10] - expect_lat) < 1e-6).all()
+    assert (np.abs(t.coords['longitude'].values[:10] - expect_lon) < 1e-6).all()
 
 
 def test_props():


### PR DESCRIPTION
### Reason for this pull request

Doc test started failing because numpy changed string representation of the
arrays. 

### Proposed changes

Making a more robust test that checks roughly the same thing.



 - [ ] Closes #xxxx
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes
