### PR TITLE
Provide --config as an alternative to --config_file cli option

### DIFF
--- a/datacube/ui/click.py
+++ b/datacube/ui/click.py
@@ -150,7 +150,7 @@ verbose_option = click.option('--verbose', '-v', count=True, callback=_init_logg
 logfile_option = click.option('--log-file', multiple=True, callback=_add_logfile,
                               is_eager=True, expose_value=False, help="Specify log file")
 #: pylint: disable=invalid-name
-config_option = click.option('--config_file', '-C', multiple=True, default='', callback=_set_config,
+config_option = click.option('--config', '--config_file', '-C', multiple=True, default='', callback=_set_config,
                              expose_value=False)
 
 #: pylint: disable=invalid-name

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -18,6 +18,9 @@ Next release
 
  - Multiple environments can now be specified in one datacube config. See `#298`_ and the `config docs`_
 
+ - The :option:`--config_file` option to :program:`datacube` has been renamed to :option:`--config`, which is
+   shorter and more consistent with the other options. The old name can still be used for now.
+
 .. _#298: https://github.com/opendatacube/datacube-core/pull/298
 .. _config docs: https://datacube-core.readthedocs.io/en/latest/ops/config.html#runtime-config-doc
 

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -124,7 +124,7 @@ def global_integration_cli_args(integration_config_paths):
     The first arguments to pass to a cli command for integration test configuration.
     """
     # List of a config files in order.
-    return list(itertools.chain(*(('--config_file', f) for f in integration_config_paths)))
+    return list(itertools.chain(*(('--config', f) for f in integration_config_paths)))
 
 
 @pytest.fixture


### PR DESCRIPTION
We don't like --config_file since it uses an underscore, which is
inconsistent with everything, and hard to type to boot. No one likes using the
shift key when they don't need to.

 - [x] Closes #334 
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
