### PR TITLE
Only depend on pathlib when running on python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         'jsonschema',
         'netcdf4',
         'numpy',
-        'pathlib',
+        'pathlib;python_version<"3"',
         'psycopg2',
         'pypeg2',
         'python-dateutil',


### PR DESCRIPTION


### Reason for this pull request
We shouldn't require `pathlib` when running on python 3.

 - [x] Closes #347
 - [ ] Tests added / passed

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
