### PR TITLE
Travis without conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ git:
 
 language: python
 python:
-# We don't use the travis python, but we will use it for the build matrix
   - "2.7"
   - "3.5"
   - "3.6"
@@ -19,55 +18,49 @@ cache:
 
 # Install required packages
 addons:
+  # We typically use postgres 9.6, but Travis has 9.5 pre-installed, so the build goes a little faster
   postgresql: "9.5"
   services:
     - postgresql
     - redis-server
+  apt:
+    sources:
+      - sourceline: ppa:nextgis/ppa
+    packages:
+      - gdal-bin
+      - libgdal-dev
+      - libgdal20
 
 before_install:
-  # Create a database for the integration tests.
+# Create a database for the integration tests.
   - createdb agdcintegration
+
+# Check disk usage
   - df -h
   - df -i
 
+# Set paths for building python-gdal
+  - export CPLUS_INCLUDE_PATH=/usr/include/gdal
+  - export C_INCLUDE_PATH=/usr/include/gdal
+
+
 install:
-  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-  - bash miniconda.sh -f -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
+# Install datacube
+  - pip install '.[test,analytics,celery,s3]' --upgrade
 
-  # travis specific goo
-  - conda config --set always_yes yes --set changeps1 no
-  - conda config --show-sources
-  - conda config --show
-
-  - conda config --prepend channels conda-forge
-  - conda config --prepend channels conda-forge/label/dev
-  - conda update --all
-
-  # Useful for debugging any issues with conda
-  - conda info -a
-
-  - conda create -n agdc python=$TRAVIS_PYTHON_VERSION
-  - conda env update -n agdc --file .travis/environment.yaml
-
-  # try to reclaim some space -- delete downloaded packages
-  - conda clean --tarballs --yes
-
-  - source activate agdc
-  - pip install . --no-deps --upgrade
-
+# Print installed packages in case we need to debug them
   - pip freeze
+
+# Check disk usage
   - df -h
   - df -i
 
 script:
-  # Ensure we are running against the correct python version
+# Ensure we are running against the correct python version
   - '[[ $(python --version 2>&1) == *"$TRAVIS_PYTHON_VERSION"* ]]'
-  - conda clean --all --yes
+
+# Run all the linting and tests
   - ./check-code.sh integration_tests
-  # Take extra steps to minimise disk space. We have run out a few times.
-  - conda clean --all --yes
 
 after_success:
   - test $TRAVIS_PYTHON_VERSION = "3.6" && coveralls

--- a/.travis/environment.yaml
+++ b/.travis/environment.yaml
@@ -5,41 +5,41 @@ channels:
 - defaults
 - nodefaults
 dependencies:
-- pyyaml
-- sqlalchemy
-- python-dateutil
-- jsonschema
+- boto3 = 1.4.3
 - cachetools
 - cloudpickle >= 0.4.0 # pickle logger objects
-- coveralls
-- numpy
-- numexpr # For AE/EE
-- rasterio >= 0.9 # to handle weird 1.0a ordering...
-- singledispatch
-- netcdf4
-- psycopg2
-- gdal = 2.1.*        # [py27]
-- gdal                # [not py27]
-- dask
-- xarray
-- redis-py # redis client lib, used by celery
-- redis # redis server
-- pep8 # testing
-- fiona # movie generator app
-- mock # testing
-- hypothesis # testing
-- matplotlib # pixel drill app
-- pathlib
 - compliance-checker
-- boto3 = 1.4.3
-- pathos
-- zstandard
 - compliance-checker = 3.0.3
+- coveralls
 - cython # used by netcdf4 at compile only, but needed for compliance checker to load plugins
-- pygeoif = 0.6 # compliance-checker 3.0.3 fails with 0.7
+- dask
+- fiona # movie generator app
+- gdal                # [not py27]
+- gdal = 2.1.*        # [py27]
+- hypothesis # testing
+- jsonschema
+- matplotlib # pixel drill app
+- mock # testing
+- netcdf4
+- numexpr # For AE/EE
+- numpy
 - paramiko # for simple-replicas
+- pathlib
+- pathos
+- pep8 # testing
+- psycopg2
+- pygeoif = 0.6 # compliance-checker 3.0.3 fails with 0.7
+- python-dateutil
+- pyyaml
+- rasterio >= 0.9 # to handle weird 1.0a ordering...
+- redis # redis server
+- redis-py # redis client lib, used by celery
+- singledispatch
+- sqlalchemy
 - sshtunnel # for simple-replicas
 - tqdm # for simple-replicas
+- xarray
+- zstandard
 - pip:
   - celery >= 4
   - objgraph

--- a/check-code.sh
+++ b/check-code.sh
@@ -10,7 +10,7 @@ pylint -j 2 --reports no datacube datacube_apps
 
 # Run tests, taking coverage.
 # Users can specify extra folders as arguments.
-pytest -r sx --cov datacube --doctest-ignore-import-errors --durations=5 datacube tests datacube_apps $@
+pytest -r a --cov datacube --doctest-ignore-import-errors --durations=5 datacube tests datacube_apps $@
 
 set +x
 

--- a/datacube/analytics/analytics_engine.py
+++ b/datacube/analytics/analytics_engine.py
@@ -417,14 +417,14 @@ class AnalyticsEngine(object):
             self.api_products = self.api.list_products()
         for product in self.api_products:
             storage_type = str(product['name'])
-            if storage_type not in self.api_descriptors.keys():
+            if storage_type not in self.api_descriptors:
                 continue
             items[storage_type]['platform'] = str(product['platform'])
             items[storage_type]['product_type'] = str(product['product_type'])
             items[storage_type]['instrument'] = str(product['instrument'])
         for variable in self.api.list_variables():
             storage_type = str(variable['product'])
-            if storage_type not in self.api_descriptors.keys():
+            if storage_type not in self.api_descriptors:
                 continue
             if 'bands' not in items[storage_type]:
                 items[storage_type]['bands'] = []

--- a/datacube/index/postgres/_fields.py
+++ b/datacube/index/postgres/_fields.py
@@ -190,8 +190,7 @@ class SimpleDocField(PgDocField):
         self.offset = offset
         if selection not in SELECTION_TYPES:
             raise ValueError(
-                "Unknown field selection type %s. Expected one of: %r" % (
-                    selection, (SELECTION_TYPES.keys(),),)
+                "Unknown field selection type %s. Expected one of: %r" % (selection, (SELECTION_TYPES,),)
             )
         self.aggregation = SELECTION_TYPES[selection]
 

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -347,7 +347,7 @@ _OUTPUT_WRITERS = {
 @click.option('--show-sources', help='Also show source datasets', is_flag=True, default=False)
 @click.option('--show-derived', help='Also show derived datasets', is_flag=True, default=False)
 @click.option('-f', help='Output format',
-              type=click.Choice(_OUTPUT_WRITERS.keys()), default='yaml', show_default=True)
+              type=click.Choice(list(_OUTPUT_WRITERS)), default='yaml', show_default=True)
 @click.option('--max-depth',
               help='Maximum sources/derived depth to travel',
               type=int,
@@ -385,7 +385,7 @@ def info_cmd(index, show_sources, show_derived, f, max_depth, ids):
 @click.option('--limit', help='Limit the number of results',
               type=int, default=None)
 @click.option('-f', help='Output format',
-              type=click.Choice(_OUTPUT_WRITERS.keys()), default='yaml', show_default=True)
+              type=click.Choice(list(_OUTPUT_WRITERS)), default='yaml', show_default=True)
 @ui.parsed_search_expressions
 @ui.pass_index()
 def search_cmd(index, limit, f, expressions):

--- a/datacube/scripts/search_tool.py
+++ b/datacube/scripts/search_tool.py
@@ -74,7 +74,7 @@ OUTPUT_FORMATS = {
 @click.group(help="Search the Data Cube", context_settings=CLICK_SETTINGS)
 @ui.global_cli_options
 @click.option('-f',
-              type=click.Choice(OUTPUT_FORMATS.keys()),
+              type=click.Choice(list(OUTPUT_FORMATS)),
               default='pretty', show_default=True,
               help='Output format')
 @click.pass_context

--- a/datacube/ui/click.py
+++ b/datacube/ui/click.py
@@ -303,7 +303,7 @@ def _setup_executor(ctx, param, value):
 
 
 executor_cli_options = click.option('--executor',
-                                    type=(click.Choice(EXECUTOR_TYPES.keys()), str),
+                                    type=(click.Choice(list(EXECUTOR_TYPES)), str),
                                     default=('serial', None),
                                     help="Run parallelized, either locally or distributed. eg:\n"
                                          "--executor multiproc 4 (OR)\n"

--- a/datacube/utils/__init__.py
+++ b/datacube/utils/__init__.py
@@ -664,7 +664,7 @@ class DocReader(object):
         return fields
 
     def __dir__(self):
-        return self.fields.keys()
+        return list(self.fields)
 
 
 def import_function(func_ref):

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         'pypeg2',
         'python-dateutil',
         'pyyaml',
-        'rasterio>=0.9',  # required for zip reading, 0.9 gets around 1.0a ordering problems
+        'rasterio>=0.9a10',  # required for zip reading, 0.9 gets around 1.0a ordering problems
         'singledispatch',
         'sqlalchemy',
         'xarray>=0.9',  # >0.9 fixes most problems with `crs` attributes being lost

--- a/setup.py
+++ b/setup.py
@@ -91,15 +91,15 @@ setup(
 
     entry_points={
         'console_scripts': [
-            'datacube-search = datacube.scripts.search_tool:cli',
             'datacube = datacube.scripts.cli_app:cli',
+            'datacube-search = datacube.scripts.search_tool:cli',
             'datacube-stacker = datacube_apps.stacker:main',
             'datacube-worker = datacube.execution.worker:main',
             'datacube-fixer = datacube_apps.stacker:fixer_main',
             'datacube-ncml = datacube_apps.ncml:ncml_app',
             'pixeldrill = datacube_apps.pixeldrill:main [interactive]',
             'movie_generator = datacube_apps.movie_generator:main',
-            'datacube-simple-replica = datacube_apps.simple_replica:replicate'
+            'datacube-simple-replica = datacube_apps.simple_replica:replicate [replicas]'
         ]
     },
 )


### PR DESCRIPTION
### Reason for this pull request
The Travis CI build broke recently due to broken dependencies in `conda-forge`. This isn't the first time this has happened. All the packages in `conda-forge` are maintained by volunteers and while the quality is pretty good considering, it's far from perfect.

### Proposed changes

Since it's it's no longer particularly difficult to install all the datacube dependencies with standard python, instead of relying on conda + conda-forge, lets do that in Travis. That we we only care about `PyPI` packages, which is only one layer of brokenness to contend with.

We can move to pinning specific versions later...

 - [x] Tests added / passed
