### PR TITLE
Don't fail trying to show a debug message

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -137,7 +137,8 @@ class Datacube(object):
                 self._to_close.close()
             # pylint: disable=bare-except
             except:
-                self.logger.debug('Connections already closed')
+                if hasattr(self, 'logger'):
+                    self.logger.debug('Connections already closed')
 
     def list_products(self, show_archived=False, with_pandas=True):
         """


### PR DESCRIPTION
### Reason for this pull request
I have seen it fail enough times writing to a
non-existent logger to make this pull request.

### Proposed changes
- Check if logger exists before sending a message to it
  when a `Datacube` object is being deleted
 
