### PR TITLE
Set 3.5.2 as earliest supported python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     name='datacube',
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
-    python_requires='>3.5.2',
+    python_requires='>=3.5.2',
 
     url='https://github.com/opendatacube/datacube-core',
     author='AGDC Collaboration',


### PR DESCRIPTION

### Reason for this pull request

Ubuntu LTS (16.04) has 3.5.2 python, we should probably support at least this
version for another few months until 18.04 comes out.


### Proposed changes

-  bump down earliest supported python version to one available in Ubuntu 16.04 LTS
