### PR TITLE
Fix ReadTheDocs build

### DIFF
--- a/rtd-environment.yml
+++ b/rtd-environment.yml
@@ -22,5 +22,7 @@ dependencies:
 - xarray
 - matplotlib # pixel drill app
 - pathlib
+- sphinx
+- sphinx_rtd_theme
 - pip:
     - sphinxcontrib-plantuml


### PR DESCRIPTION
### Reason for this pull request
Read the Docs builds are failing.

Change the condo environment install to include `sphinx` and `sphinx_rtd_theme` so
that we end up with a valid sphinx install.

See [this valid build result from this branch](https://readthedocs.org/projects/datacube-core/builds/6772266/) for validation.
