### PR TITLE
Load one observation at a time

### DIFF
--- a/datacube/virtual/impl.py
+++ b/datacube/virtual/impl.py
@@ -297,12 +297,12 @@ def transform(child, data_transform=None, measurement_transform=None, raster_tra
 
 
 class Collate(VirtualProduct):
-    def __init__(self, *children, **kwargs):
+    def __init__(self, *children, index_measurement_name=None):
         if len(children) == 0:
             raise VirtualProductException("No children for collate node")
 
         self.children = children
-        self.index_measurement_name = kwargs.get('index_measurement_name')
+        self.index_measurement_name = index_measurement_name
 
         name = self.index_measurement_name
         if name is not None:
@@ -393,8 +393,8 @@ class Collate(VirtualProduct):
         return xarray.concat(rasters, dim='time')
 
 
-def collate(*children, **kwargs):
-    return Collate(*children, **kwargs)
+def collate(*children, index_measurement_name=None):
+    return Collate(*children, index_measurement_name=index_measurement_name)
 
 
 class Juxtapose(VirtualProduct):

--- a/datacube/virtual/impl.py
+++ b/datacube/virtual/impl.py
@@ -1,4 +1,7 @@
 # Warning: this is a WIP
+
+# TODO: fix juxtapose collate bug
+# TODO: needs an aggregation phase
 """
 Implementation of virtual products.
 Provides an interface to the products in the database

--- a/datacube/virtual/utils.py
+++ b/datacube/virtual/utils.py
@@ -1,5 +1,5 @@
 """
-Utility functions that mimic existing functionality in the core api.
+Utility functions that mimic existing functionality in the core API.
 Perhaps core can be refactored to use these to reduce code duplication.
 """
 from __future__ import absolute_import
@@ -19,7 +19,7 @@ def select_datasets_inside_polygon(datasets, polygon):
 def output_geobox(datasets, grid_spec,
                   like=None, output_crs=None, resolution=None, align=None,
                   **query):
-    # figure out output geobox as in `datacube.Datacube.load`
+    # configure output geobox as in `datacube.Datacube.load`
 
     if like is not None:
         assert output_crs is None, "'like' and 'output_crs' are not supported together"
@@ -48,5 +48,5 @@ def output_geobox(datasets, grid_spec,
 
 
 def product_definitions_from_index(index):
-    return dict((product.name, product.definition)
-                for product in index.products.get_all())
+    return {product.name: product.definition
+            for product in index.products.get_all()}


### PR DESCRIPTION
- Modify the API to take a `Datacube` instance as input rather than an `Index`
- Naive loading one observation at a time
  (to be replaced with proper chunking later)
- Take syntactic advantages of Python 2.7 not being supported any more