### PR TITLE
datacube.index._api.Index -> datacube.index.Index

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -83,7 +83,7 @@ class Datacube(object):
         If no index or config is given, the default configuration is used for database connection.
 
         :param Index index: The database index to use.
-        :type index: :py:class:`datacube.index._api.Index` or None.
+        :type index: :py:class:`datacube.index.Index` or None.
 
         :param Union[LocalConfig|str] config: A config object or a path to a config file that defines the connection.
 

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -60,7 +60,7 @@ class Query(object):
 
         Used by :meth:`datacube.Datacube.find_datasets` and :meth:`datacube.Datacube.load`.
 
-        :param datacube.index._api.Index index: An optional `index` object, if checking of field names is desired.
+        :param datacube.index.Index index: An optional `index` object, if checking of field names is desired.
         :param str product: name of product
         :param geopolygon: spatial bounds of the search
         :type geopolygon: geometry.Geometry or None

--- a/datacube/index/__init__.py
+++ b/datacube/index/__init__.py
@@ -5,6 +5,7 @@ Modules for interfacing with the index/database.
 from __future__ import absolute_import
 
 from ._api import index_connect as index_connect
+from .index import Index
 from .fields import UnknownFieldError
 from .exceptions import DuplicateRecordError, MissingRecordError
 

--- a/datacube/ui/click.py
+++ b/datacube/ui/click.py
@@ -202,7 +202,7 @@ def pass_index(app_name=None, expect_initialised=True):
     :param bool expect_initialised:
         Whether to connect immediately on startup. Useful to catch connection config issues immediately,
         but if you're planning to fork before any usage (such as in the case of some web servers),
-        you may not want this. For more information on thread/process usage, see datacube.index._api.Index
+        you may not want this. For more information on thread/process usage, see datacube.index.Index
     """
 
     def decorate(f):
@@ -235,7 +235,7 @@ def pass_datacube(app_name=None, expect_initialised=True):
     :param bool expect_initialised:
         Whether to connect immediately on startup. Useful to catch connection config issues immediately,
         but if you're planning to fork before any usage (such as in the case of some web servers),
-        you may not want this. For More information on thread/process usage, see datacube.index._api.Index
+        you may not want this. For More information on thread/process usage, see datacube.index.Index
     """
 
     def decorate(f):

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -159,7 +159,7 @@ def _object_exists(db, index_name):
 def test_idempotent_add_dataset_type(index, ls5_telem_type, ls5_telem_doc):
     """
     :type ls5_telem_type: datacube.model.DatasetType
-    :type index: datacube.index._api.Index
+    :type index: datacube.index.Index
     """
     assert index.products.get_by_name(ls5_telem_type.name) is not None
 
@@ -177,7 +177,7 @@ def test_idempotent_add_dataset_type(index, ls5_telem_type, ls5_telem_doc):
 
 def test_update_dataset(index, ls5_telem_doc, example_ls5_nbar_metadata_doc):
     """
-    :type index: datacube.index._api.Index
+    :type index: datacube.index.Index
     """
     ls5_telem_type = index.products.add_document(ls5_telem_doc)
     assert ls5_telem_type
@@ -257,7 +257,7 @@ def test_update_dataset(index, ls5_telem_doc, example_ls5_nbar_metadata_doc):
 def test_update_dataset_type(index, ls5_telem_type, ls5_telem_doc, ga_metadata_type_doc):
     """
     :type ls5_telem_type: datacube.model.DatasetType
-    :type index: datacube.index._api.Index
+    :type index: datacube.index.Index
     """
     assert index.products.get_by_name(ls5_telem_type.name) is not None
 
@@ -390,7 +390,7 @@ def _to_yaml(ls5_telem_doc):
 def test_update_metadata_type(index, default_metadata_type):
     """
     :type default_metadata_type_docs: list[dict]
-    :type index: datacube.index._api.Index
+    :type index: datacube.index.Index
     """
     mt_doc = [d for d in default_metadata_type_docs() if d['name'] == default_metadata_type.name][0]
 
@@ -429,7 +429,7 @@ def test_update_metadata_type(index, default_metadata_type):
 def test_filter_types_by_fields(index, ls5_telem_type):
     """
     :type ls5_telem_type: datacube.model.DatasetType
-    :type index: datacube.index._api.Index
+    :type index: datacube.index.Index
     """
     assert index.products
     res = list(index.products.get_with_fields(['sat_path', 'sat_row', 'platform']))
@@ -442,7 +442,7 @@ def test_filter_types_by_fields(index, ls5_telem_type):
 def test_filter_types_by_search(index, ls5_telem_type):
     """
     :type ls5_telem_type: datacube.model.DatasetType
-    :type index: datacube.index._api.Index
+    :type index: datacube.index.Index
     """
     assert index.products
 

--- a/integration_tests/index/test_search.py
+++ b/integration_tests/index/test_search.py
@@ -241,7 +241,7 @@ def ls5_dataset_nbar_type(ls5_dataset_w_children, indexed_ls5_scene_products):
 
 def test_search_dataset_equals(index, pseudo_ls8_dataset):
     """
-    :type index: datacube.index._api.Index
+    :type index: datacube.index.Index
     :type pseudo_ls8_dataset: datacube.model.Dataset
     """
     datasets = index.datasets.search_eager(
@@ -267,7 +267,7 @@ def test_search_dataset_equals(index, pseudo_ls8_dataset):
 
 def test_search_dataset_by_metadata(index, pseudo_ls8_dataset):
     """
-    :type index: datacube.index._api.Index
+    :type index: datacube.index.Index
     :type pseudo_ls8_dataset: datacube.model.Dataset
     """
     datasets = index.datasets.search_by_metadata(
@@ -303,7 +303,7 @@ def test_search_day(index, pseudo_ls8_dataset):
 
 def test_search_dataset_ranges(index, pseudo_ls8_dataset):
     """
-    :type index: datacube.index._api.Index
+    :type index: datacube.index.Index
     :type pseudo_ls8_dataset: datacube.model.Dataset
     """
 
@@ -384,7 +384,7 @@ def test_search_dataset_ranges(index, pseudo_ls8_dataset):
 
 def test_search_globally(index, pseudo_ls8_dataset):
     """
-    :type index: datacube.index._api.Index
+    :type index: datacube.index.Index
     :type pseudo_ls8_dataset: datacube.model.Dataset
     """
     # Insert dataset. It should be matched to the telemetry collection.
@@ -399,7 +399,7 @@ def test_search_globally(index, pseudo_ls8_dataset):
 def test_search_by_product(index, pseudo_ls8_type, pseudo_ls8_dataset, indexed_ls5_scene_products,
                            ls5_dataset_w_children):
     """
-    :type index: datacube.index._api.Index
+    :type index: datacube.index.Index
     """
     # Expect one product with our one dataset.
     products = list(index.datasets.search_by_product(
@@ -490,7 +490,7 @@ def test_search_or_expressions(index,
 def test_search_returning(index, pseudo_ls8_type, pseudo_ls8_dataset, indexed_ls5_scene_products):
     # type: (Index, DatasetType, Dataset, list) -> None
     """
-    :type index: datacube.index._api.Index
+    :type index: datacube.index.Index
     """
 
     # Expect one product with our one dataset.
@@ -576,7 +576,7 @@ def test_search_returning_rows(index, pseudo_ls8_type,
 
 def test_searches_only_type(index, pseudo_ls8_type, pseudo_ls8_dataset, ls5_telem_type):
     """
-    :type index: datacube.index._api.Index
+    :type index: datacube.index.Index
     :type pseudo_ls8_type: datacube.model.DatasetType
     :type pseudo_ls8_dataset: datacube.model.Dataset
     """
@@ -630,7 +630,7 @@ def test_searches_only_type(index, pseudo_ls8_type, pseudo_ls8_dataset, ls5_tele
 def test_search_special_fields(index, pseudo_ls8_type, pseudo_ls8_dataset,
                                ls5_dataset_w_children):
     """
-    :type index: datacube.index._api.Index
+    :type index: datacube.index.Index
     :type pseudo_ls8_type: datacube.model.DatasetType
     :type pseudo_ls8_dataset: datacube.model.Dataset
     """
@@ -923,7 +923,7 @@ def test_cli_info(index, clirunner, pseudo_ls8_dataset, pseudo_ls8_dataset2):
     # type: (Index, callable, Dataset, Dataset) -> None
     """
     Search datasets using the cli.
-    :type index: datacube.index._api.Index
+    :type index: datacube.index.Index
     :type pseudo_ls8_dataset: datacube.model.Dataset
     """
     index.datasets.add_location(pseudo_ls8_dataset.id, 'file:///tmp/location1')


### PR DESCRIPTION
### Reason for this pull request
The `Index` class does not reside in `datacube.index._api` anymore.
This breaks any code that imports it from there.


### Proposed changes
The new location for the class is `datacube.index.index`. But it does
not help readability:
```
from datacube.index.index import Index
```
is odd, given its frequency.

- Make `datacube.index.index.Index` also available as `datacube.index.Index`
- Remove all references to the old location
