### PR TITLE
purge datacube.index._api.Index references in comments

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -83,7 +83,7 @@ class Datacube(object):
         If no index or config is given, the default configuration is used for database connection.
 
         :param Index index: The database index to use.
-        :type index: :py:class:`datacube.index._api.Index` or None.
+        :type index: :py:class:`datacube.index.Index` or None.
 
         :param Union[LocalConfig|str] config: A config object or a path to a config file that defines the connection.
 

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -60,7 +60,7 @@ class Query(object):
 
         Used by :meth:`datacube.Datacube.find_datasets` and :meth:`datacube.Datacube.load`.
 
-        :param datacube.index._api.Index index: An optional `index` object, if checking of field names is desired.
+        :param datacube.index.Index index: An optional `index` object, if checking of field names is desired.
         :param str product: name of product
         :param geopolygon: spatial bounds of the search
         :type geopolygon: geometry.Geometry or None

--- a/datacube/ui/click.py
+++ b/datacube/ui/click.py
@@ -202,7 +202,7 @@ def pass_index(app_name=None, expect_initialised=True):
     :param bool expect_initialised:
         Whether to connect immediately on startup. Useful to catch connection config issues immediately,
         but if you're planning to fork before any usage (such as in the case of some web servers),
-        you may not want this. For more information on thread/process usage, see datacube.index._api.Index
+        you may not want this. For more information on thread/process usage, see datacube.index.Index
     """
 
     def decorate(f):
@@ -235,7 +235,7 @@ def pass_datacube(app_name=None, expect_initialised=True):
     :param bool expect_initialised:
         Whether to connect immediately on startup. Useful to catch connection config issues immediately,
         but if you're planning to fork before any usage (such as in the case of some web servers),
-        you may not want this. For More information on thread/process usage, see datacube.index._api.Index
+        you may not want this. For More information on thread/process usage, see datacube.index.Index
     """
 
     def decorate(f):


### PR DESCRIPTION
Caught a couple more referring to the non-existent `Index`.