### PR TITLE
Remove unnecessary code from load_data

### DIFF
--- a/datacube/api/grid_workflow.py
+++ b/datacube/api/grid_workflow.py
@@ -371,10 +371,6 @@ class GridWorkflow(object):
         .. seealso::
             :meth:`list_tiles` :meth:`list_cells`
         """
-        observations = []
-        for dataset in tile.sources.values:
-            observations += dataset
-
         measurements = tile.product.lookup_measurements(measurements)
         measurements = set_resampling_method(measurements, resampling)
 


### PR DESCRIPTION
### Reason for this pull request
In `GridWorkflow.load_data`, a few lines of code (vestiges of some other time) remains
that currently do nothing of consequence.

### Proposed changes
Remove those lines.