### PR TITLE
Clean up in entry point handling 

### DIFF
--- a/datacube/drivers/driver_cache.py
+++ b/datacube/drivers/driver_cache.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, print_function
 
 import logging
 
-from pkg_resources import iter_entry_points
+from pkg_resources import iter_entry_points, DistributionNotFound
 
 _LOG = logging.getLogger(__name__)
 
@@ -27,7 +27,11 @@ def load_drivers(group):
     def safe_load(ep):
         # pylint: disable=bare-except
         try:
-            driver_init = ep.resolve()
+            driver_init = ep.load()
+        except DistributionNotFound:
+            # This happens when entry points were marked with extra features,
+            # but extra feature were not requested for installation
+            return None
         except:
             _LOG.warning('Failed to resolve driver %s::%s', group, ep.name)
             return None

--- a/datacube/drivers/indexes.py
+++ b/datacube/drivers/indexes.py
@@ -7,6 +7,10 @@ class IndexDriverCache(object):
     def __init__(self, group):
         self._drivers = load_drivers(group)
 
+        if len(self._drivers) == 0:
+            from datacube.index.index import index_driver_init
+            self._drivers = dict(default=index_driver_init())
+
         for driver in list(self._drivers.values()):
             if hasattr(driver, 'aliases'):
                 for alias in driver.aliases:

--- a/datacube/drivers/indexes.py
+++ b/datacube/drivers/indexes.py
@@ -17,8 +17,7 @@ class IndexDriverCache(object):
         :returns: None if driver with a given name is not found
 
         :param str name: Driver name
-        :param str fmt: Dataset format
-        :return: Returns WriterDriver
+        :return: Returns IndexDriver
         """
         return self._drivers.get(name, None)
 
@@ -29,7 +28,7 @@ class IndexDriverCache(object):
 
 
 def index_cache():
-    """ Singleton for WriterDriverCache
+    """ Singleton for IndexDriverCache
     """
     # pylint: disable=protected-access
     if not hasattr(index_cache, '_instance'):

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 import versioneer
 from setuptools import setup, find_packages
+import os
 
 tests_require = [
     'compliance-checker',
@@ -28,6 +29,22 @@ extras_require = {
 }
 # An 'all' option, following ipython naming conventions.
 extras_require['all'] = sorted(set(sum(extras_require.values(), [])))
+
+extra_plugins = dict(read=[], write=[], index=[])
+
+if os.name != 'nt':
+    extra_plugins['read'].extend([
+        's3aio = datacube.drivers.s3.driver:reader_driver_init [s3]',
+        's3aio_test = datacube.drivers.s3.driver:reader_test_driver_init [s3]',
+    ])
+    extra_plugins['write'].extend([
+        's3aio = datacube.drivers.s3.driver:writer_driver_init [s3]',
+        's3aio_test = datacube.drivers.s3.driver:writer_test_driver_init [s3]',
+    ])
+
+    extra_plugins['index'].extend([
+        's3aio_index = datacube.drivers.s3aio_index:index_driver_init [s3]',
+    ])
 
 setup(
     name='datacube',
@@ -110,17 +127,15 @@ setup(
         ],
         'datacube.plugins.io.read': [
             'netcdf = datacube.drivers.netcdf.driver:reader_driver_init',
-            's3aio = datacube.drivers.s3.driver:reader_driver_init',
-            's3aio_test = datacube.drivers.s3.driver:reader_test_driver_init'
+            *extra_plugins['read'],
         ],
         'datacube.plugins.io.write': [
             'netcdf = datacube.drivers.netcdf.driver:writer_driver_init',
-            's3aio = datacube.drivers.s3.driver:writer_driver_init',
-            's3aio_test = datacube.drivers.s3.driver:writer_test_driver_init',
+            *extra_plugins['write'],
         ],
         'datacube.plugins.index': [
             'default = datacube.index.index:index_driver_init',
-            's3aio_index = datacube.drivers.s3aio_index:index_driver_init',
+            *extra_plugins['index'],
         ],
     },
 )

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -4,6 +4,7 @@ import pytest
 from collections import namedtuple
 
 from datacube.drivers import new_datasource, reader_drivers, writer_drivers, index_drivers
+from datacube.drivers.indexes import IndexDriverCache
 from datacube.storage.storage import RasterDatasetDataSource
 from .util import mk_sample_dataset
 
@@ -60,6 +61,11 @@ def test_index_drivers():
     available_drivers = index_drivers()
     assert 'default' in available_drivers
     assert 's3aio_index' in available_drivers
+
+
+def test_default_injection():
+    cache = IndexDriverCache('datacube.plugins.index-no-such-prefix')
+    assert cache.drivers() == ['default']
 
 
 def test_netcdf_driver_import():


### PR DESCRIPTION
### Reason for this pull request

- s3 plugins are not available on Windows machine
- s3 plugins should be registered if they were not requested to be installed by the user
- default index driver should be available even when running datacube without installation

### Proposed changes

- Do not register s3 plugins on windows platform
- Mark s3 entry points with `[s3]` extra flag
- Detect `DistributionNotFound` exception and silently ignore it when loading drivers
- Detect that index driver cache is empty and replace it with single element cache containing default driver



 - [x] Closes #384 
 - [x] Tests added / passed
 