### PR TITLE
Minor tweaks to improve index-driver agnosticism

### DIFF
--- a/datacube/index/fields.py
+++ b/datacube/index/fields.py
@@ -15,18 +15,43 @@ class UnknownFieldError(Exception):
     pass
 
 
+# Allowed values for field 'type' (specified in a metadata type docuemnt)
+_AVAILABLE_TYPE_NAMES = (
+    'numeric-range',
+    'double-range',
+    'integer-range',
+    'datetime-range',
+
+    'string',
+    'numeric',
+    'double',
+    'integer',
+    'datetime',
+
+    # For backwards compatibility (alias for numeric-range)
+    'float-range',
+)
+
+
 class Field(object):
     """
     A searchable field within a dataset/storage metadata document.
     """
+    # type of field.
+    # If type is not specified, the field is a string
+    # This should always be one of _AVAILABLE_TYPE_NAMES
+    type_name = 'string'
 
-    def __init__(self, name, description):
+    def __init__(self, name: str, description: str):
         self.name = name
+
         self.description = description
 
         # Does selecting this affect the output rows?
         # (eg. Does this join other tables that aren't 1:1 with datasets.)
         self.affects_row_selection = False
+
+        assert self.type_name in _AVAILABLE_TYPE_NAMES, "Invalid type name %r" % (self.type_name,)
 
     def __eq__(self, value):
         """


### PR DESCRIPTION
- When an interface (such as cubedash) needs to know the type of a field, it currently has to run `instanceof` against the postgres-driver-specific field classes. Add a `field.type_name` attribute to the base `Field` class so that we can find this out without using PG-driver-specific code.
     - It's exposing the name from the `metadata_type` configs: 'integer-range' etc.
     - Fields possibly wont be separate classes on future driver implementations, so it's a lowercase variable that could be set by the constructor.
- Remove a few instances where we've hard-coded the inner document structure of datasets.