### PR TITLE
Script consistency

### DIFF
--- a/datacube/api/_api.py
+++ b/datacube/api/_api.py
@@ -22,7 +22,7 @@ from itertools import chain, groupby
 import numpy
 
 from ..utils import geometry
-from .core import Datacube, Group, get_bounds, datatset_type_to_row
+from .core import Datacube, Group, get_bounds, dataset_type_to_row
 from .query import DescriptorQuery
 
 _LOG = logging.getLogger(__name__)
@@ -411,7 +411,7 @@ class API(object):
 
         :return: list of dictionaries describing the products
         """
-        return [datatset_type_to_row(dataset_type) for dataset_type in self.datacube.index.products.get_all()]
+        return [dataset_type_to_row(dataset_type) for dataset_type in self.datacube.index.products.get_all()]
 
     def list_variables(self):
         """

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -103,7 +103,7 @@ class Datacube(object):
         :param with_pandas: return the list as a Pandas DataFrame, otherwise as a list of dict.
         :rtype: pandas.DataFrame or list(dict)
         """
-        rows = [datatset_type_to_row(dataset_type) for dataset_type in self.index.products.get_all()]
+        rows = [dataset_type_to_row(dataset_type) for dataset_type in self.index.products.get_all()]
         if not with_pandas:
             return rows
 
@@ -661,7 +661,7 @@ def set_resampling_method(measurements, resampling=None):
     return measurements
 
 
-def datatset_type_to_row(dt):
+def dataset_type_to_row(dt):
     row = {
         'id': dt.id,
         'name': dt.name,
@@ -670,7 +670,7 @@ def datatset_type_to_row(dt):
     row.update(dt.fields)
     if dt.grid_spec is not None:
         row.update({
-            'crs': dt.grid_spec.crs,
+            'crs': str(dt.grid_spec.crs),
             'spatial_dimensions': dt.grid_spec.dimensions,
             'tile_size': dt.grid_spec.tile_size,
             'resolution': dt.grid_spec.resolution,

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -22,7 +22,7 @@ from datacube.model import Range
 from datacube.ui import click as ui
 from datacube.ui.click import cli
 from datacube.ui.common import get_metadata_path
-from datacube.utils import read_documents, changes, InvalidDocException 
+from datacube.utils import read_documents, changes, InvalidDocException
 from datacube.utils.serialise import SafeDatacubeDumper
 
 try:

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -22,7 +22,8 @@ from datacube.model import Range
 from datacube.ui import click as ui
 from datacube.ui.click import cli
 from datacube.ui.common import get_metadata_path
-from datacube.utils import read_documents, changes, InvalidDocException, SafeDatacubeDumper
+from datacube.utils import read_documents, changes, InvalidDocException 
+from datacube.utils.serialise import SafeDatacubeDumper
 
 try:
     from typing import Iterable

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -22,7 +22,7 @@ from datacube.model import Range
 from datacube.ui import click as ui
 from datacube.ui.click import cli
 from datacube.ui.common import get_metadata_path
-from datacube.utils import read_documents, changes, InvalidDocException
+from datacube.utils import read_documents, changes, InvalidDocException, SafeDatacubeDumper
 
 try:
     from typing import Iterable
@@ -279,7 +279,6 @@ def build_dataset_info(index, dataset, show_sources=False, show_derived=False, d
 
     return info
 
-
 def _write_csv(infos):
     writer = csv.DictWriter(sys.stdout, ['id', 'status', 'product', 'location'], extrasaction='ignore')
     writer.writeheader()
@@ -291,7 +290,6 @@ def _write_csv(infos):
 
     writer.writerows(add_first_location(row) for row in infos)
 
-
 def _write_yaml(infos):
     """
     Dump yaml data with support for OrderedDicts.
@@ -301,47 +299,12 @@ def _write_yaml(infos):
     (Ordered dicts are output identically to normal yaml dicts: their order is purely for readability)
     """
 
-    # We can't control how many ancestors this dumper API uses.
-    # pylint: disable=too-many-ancestors
-    class OrderedDumper(yaml.SafeDumper):
-        pass
-
-    def _dict_representer(dumper, data):
-        return dumper.represent_mapping(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, data.items())
-
-    def _range_representer(dumper, data):
-        # type: (yaml.Dumper, Range) -> Node
-        begin, end = data
-
-        # pyyaml doesn't output timestamps in flow style as timestamps(?)
-        if isinstance(begin, datetime.datetime):
-            begin = begin.isoformat()
-        if isinstance(end, datetime.datetime):
-            end = end.isoformat()
-
-        return dumper.represent_mapping(
-            yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
-            (('begin', begin), ('end', end)),
-            flow_style=True
-        )
-
-    def _reduced_accuracy_decimal_representer(dumper, data):
-        # type: (yaml.Dumper, Decimal) -> Node
-        return dumper.represent_float(
-            float(data)
-        )
-
-    OrderedDumper.add_representer(OrderedDict, _dict_representer)
-    OrderedDumper.add_representer(Range, _range_representer)
-    OrderedDumper.add_representer(Decimal, _reduced_accuracy_decimal_representer)
-    return yaml.dump_all(infos, sys.stdout, OrderedDumper, default_flow_style=False, indent=4)
-
+    return yaml.dump_all(infos, sys.stdout, SafeDatacubeDumper, default_flow_style=False, indent=4)
 
 _OUTPUT_WRITERS = {
     'csv': _write_csv,
     'yaml': _write_yaml,
 }
-
 
 @dataset_cmd.command('info', help="Display dataset information")
 @click.option('--show-sources', help='Also show source datasets', is_flag=True, default=False)

--- a/datacube/scripts/product.py
+++ b/datacube/scripts/product.py
@@ -19,7 +19,8 @@ import pandas as pd
 from datacube.index.index import Index
 from datacube.ui import click as ui
 from datacube.ui.click import cli
-from datacube.utils import read_documents, InvalidDocException, SafeDatacubeDumper
+from datacube.utils import read_documents, InvalidDocException
+from datacube.utils.serialise import SafeDatacubeDumper
 
 _LOG = logging.getLogger('datacube-product')
 

--- a/datacube/scripts/product.py
+++ b/datacube/scripts/product.py
@@ -114,20 +114,26 @@ def update_products(index, allow_unsafe, allow_exclusive_lock, dry_run, files):
 
 def build_product_list(index):
     lstdct = []
-    for product in index.products.search():
-        info = dataset_type_to_row(product)
+    for line in index.products.search():
+        info = dataset_type_to_row(line)
         lstdct.append(info)
     return lstdct
 
 def _write_csv(index):
-    writer = csv.DictWriter(sys.stdout, ['id', 'name', 'description', 'ancillary_quality', 'latgqa_cep90', 'product_type', 'gqa_abs_iterative_mean_xy', 'gqa_ref_source', 'sat_path', 'gqa_iterative_stddev_xy', 'time', 'sat_row', 'orbit', 'gqa', 'instrument', 'gqa_abs_xy', 'crs', 'resolution', 'tile_size', 'spatial_dimensions'], extrasaction='ignore')
+    writer = csv.DictWriter(sys.stdout, ['id', 'name', 'description',\
+                            'ancillary_quality', 'latgqa_cep90', 'product_type',\
+                            'gqa_abs_iterative_mean_xy', 'gqa_ref_source', 'sat_path',\
+                            'gqa_iterative_stddev_xy', 'time', 'sat_row', 'orbit', 'gqa',\
+                            'instrument', 'gqa_abs_xy', 'crs', 'resolution', 'tile_size',\
+                            'spatial_dimensions'], extrasaction='ignore')
     writer.writeheader()
 
     def add_first_name(row):
         names_ = row['name']
         row['name'] = names_ if names_ else None
         return row
-        writer.writerows(add_first_name(row) for row in index)
+
+    writer.writerows(add_first_name(row) for row in index)
 
 def _write_yaml(index):
     """
@@ -159,7 +165,12 @@ def _write_tab(products):
         echo('No products discovered :(')
         return
 
-    echo(products.to_string(columns=('id', 'name', 'description', 'ancillary_quality', 'product_type', 'gqa_abs_iterative_mean_xy', 'gqa_ref_source', 'sat_path', 'gqa_iterative_stddev_xy', 'time', 'sat_row', 'orbit', 'gqa', 'instrument', 'gqa_abs_xy', 'crs', 'resolution', 'tile_size', 'spatial_dimensions'),
+    echo(products.to_string(columns=('id', 'name', 'description', 'ancillary_quality',\
+                                     'product_type', 'gqa_abs_iterative_mean_xy',\
+                                     'gqa_ref_source', 'sat_path',\
+                                     'gqa_iterative_stddev_xy', 'time', 'sat_row',\
+                                     'orbit', 'gqa', 'instrument', 'gqa_abs_xy', 'crs',\
+                                     'resolution', 'tile_size', 'spatial_dimensions'),
                             justify='left'))
 
 LIST_OUTPUT_WRITERS = {
@@ -204,4 +215,3 @@ def show_product(dc, product_name, f):
     """
     SHOW_OUTPUT_WRITERS[f]((build_product_show(dc.index, product_name)
                            ))
-

--- a/datacube/scripts/user.py
+++ b/datacube/scripts/user.py
@@ -108,12 +108,12 @@ _OUTPUT_WRITERS = {
 @ui.pass_index()
 
 
-def list_users(index,f):
+def list_users(index, f):
     """
     List users
     """
     _OUTPUT_WRITERS[f]((build_user_list(index)
-    ))
+                       ))
 
 @user_cmd.command('grant')
 @click.argument('role',

--- a/datacube/scripts/user.py
+++ b/datacube/scripts/user.py
@@ -2,12 +2,21 @@ from __future__ import absolute_import
 
 import logging
 import click
+import csv
+import sys
+import yaml
+import yaml.resolver
+from yaml import Node
+from decimal import Decimal
+
+from collections import OrderedDict
 
 from datacube.utils import gen_password
 from datacube.config import LocalConfig
 from datacube.index.index import Index
 from datacube.ui import click as ui
 from datacube.ui.click import cli
+from datacube.model import Range
 
 _LOG = logging.getLogger('datacube-user')
 USER_ROLES = ('user', 'ingest', 'manage', 'admin')
@@ -17,16 +26,94 @@ USER_ROLES = ('user', 'ingest', 'manage', 'admin')
 def user_cmd():
     pass
 
+def build_user_list(index):
+    lstdct = []
+    for role, user, description in index.users.list_users():
+        info = OrderedDict((
+            ('role', role),
+            ('user', user),
+            ('description', description)
+        ))
+        lstdct.append(info)
+    return lstdct
+
+def _write_csv(index):
+    writer = csv.DictWriter(sys.stdout, ['role', 'user', 'description'], extrasaction='ignore')
+    writer.writeheader()
+
+    #for role, user, description in index:
+        #click.echo('{0:6}\t{1:15}\t{2}'.format(role, user, description if description else ''))
+        #writer.writerow('role':role, 'user':user,'description':description})
+    def add_first_role(row):
+        roles_ = row['role']
+        row['role'] = roles_ if roles_ else None
+        return row
+
+    writer.writerows(add_first_role(row) for row in index)
+
+
+def _write_yaml(index):
+    """
+    Dump yaml data with support for OrderedDicts.
+
+    Allows for better human-readability of output: such as dataset ID field first, sources last.
+
+    (Ordered dicts are output identically to normal yaml dicts: their order is purely for readability)
+    """
+
+    # We can't control how many ancestors this dumper API uses.
+    # pylint: disable=too-many-ancestors
+    class OrderedDumper(yaml.SafeDumper):
+        pass
+
+    def _dict_representer(dumper, data):
+        return dumper.represent_mapping(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, data.items())
+
+#    def _range_representer(dumper, data):
+#        # type: (yaml.Dumper, Range) -> Node
+#        begin, end = data
+#
+#        # pyyaml doesn't output timestamps in flow style as timestamps(?)
+#        if isinstance(begin, datetime.datetime):
+#            begin = begin.isoformat()
+#        if isinstance(end, datetime.datetime):
+#            end = end.isoformat()
+#
+#        return dumper.represent_mapping(
+#            yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+#            (('begin', begin), ('end', end)),
+#            flow_style=True
+#        )
+#
+#    def _reduced_accuracy_decimal_representer(dumper, data):
+#        # type: (yaml.Dumper, Decimal) -> Node
+#        return dumper.represent_float(
+#            float(data)
+#        )
+#
+    OrderedDumper.add_representer(OrderedDict, _dict_representer)
+#    OrderedDumper.add_representer(Range, _range_representer)
+#    OrderedDumper.add_representer(Decimal, _reduced_accuracy_decimal_representer)
+    return yaml.dump_all(index, sys.stdout, OrderedDumper, default_flow_style=False, indent=4)
+
+_OUTPUT_WRITERS = {
+    'csv': _write_csv,
+    'yaml': _write_yaml,
+}
+
 
 @user_cmd.command('list')
+@click.option('-f', help='Output format',
+              type=click.Choice(list(_OUTPUT_WRITERS)), default='yaml', show_default=True)
 @ui.pass_index()
-def list_users(index):
+
+
+def list_users(index,f):
     """
     List users
     """
-    for role, user, description in index.users.list_users():
-        click.echo('{0:6}\t{1:15}\t{2}'.format(role, user, description if description else ''))
-
+    _OUTPUT_WRITERS[f]((build_user_list(index)
+    ))
 
 @user_cmd.command('grant')
 @click.argument('role',

--- a/datacube/scripts/user.py
+++ b/datacube/scripts/user.py
@@ -11,7 +11,7 @@ from decimal import Decimal
 
 from collections import OrderedDict
 
-from datacube.utils import gen_password
+from datacube.utils import gen_password, SafeDatacubeDumper
 from datacube.config import LocalConfig
 from datacube.index.index import Index
 from datacube.ui import click as ui
@@ -41,9 +41,6 @@ def _write_csv(index):
     writer = csv.DictWriter(sys.stdout, ['role', 'user', 'description'], extrasaction='ignore')
     writer.writeheader()
 
-    #for role, user, description in index:
-        #click.echo('{0:6}\t{1:15}\t{2}'.format(role, user, description if description else ''))
-        #writer.writerow('role':role, 'user':user,'description':description})
     def add_first_role(row):
         roles_ = row['role']
         row['role'] = roles_ if roles_ else None
@@ -61,40 +58,7 @@ def _write_yaml(index):
     (Ordered dicts are output identically to normal yaml dicts: their order is purely for readability)
     """
 
-    # We can't control how many ancestors this dumper API uses.
-    # pylint: disable=too-many-ancestors
-    class OrderedDumper(yaml.SafeDumper):
-        pass
-
-    def _dict_representer(dumper, data):
-        return dumper.represent_mapping(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, data.items())
-
-#    def _range_representer(dumper, data):
-#        # type: (yaml.Dumper, Range) -> Node
-#        begin, end = data
-#
-#        # pyyaml doesn't output timestamps in flow style as timestamps(?)
-#        if isinstance(begin, datetime.datetime):
-#            begin = begin.isoformat()
-#        if isinstance(end, datetime.datetime):
-#            end = end.isoformat()
-#
-#        return dumper.represent_mapping(
-#            yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
-#            (('begin', begin), ('end', end)),
-#            flow_style=True
-#        )
-#
-#    def _reduced_accuracy_decimal_representer(dumper, data):
-#        # type: (yaml.Dumper, Decimal) -> Node
-#        return dumper.represent_float(
-#            float(data)
-#        )
-#
-    OrderedDumper.add_representer(OrderedDict, _dict_representer)
-#    OrderedDumper.add_representer(Range, _range_representer)
-#    OrderedDumper.add_representer(Decimal, _reduced_accuracy_decimal_representer)
-    return yaml.dump_all(index, sys.stdout, OrderedDumper, default_flow_style=False, indent=4)
+    return yaml.dump_all(index, sys.stdout, SafeDatacubeDumper, default_flow_style=False, indent=4)
 
 _OUTPUT_WRITERS = {
     'csv': _write_csv,
@@ -112,8 +76,7 @@ def list_users(index, f):
     """
     List users
     """
-    _OUTPUT_WRITERS[f]((build_user_list(index)
-                       ))
+    _OUTPUT_WRITERS[f](build_user_list(index))
 
 @user_cmd.command('grant')
 @click.argument('role',

--- a/datacube/scripts/user.py
+++ b/datacube/scripts/user.py
@@ -11,12 +11,13 @@ from decimal import Decimal
 
 from collections import OrderedDict
 
-from datacube.utils import gen_password, SafeDatacubeDumper
+from datacube.utils import gen_password
 from datacube.config import LocalConfig
 from datacube.index.index import Index
 from datacube.ui import click as ui
 from datacube.ui.click import cli
 from datacube.model import Range
+from datacube.utils.serialise import SafeDatacubeDumper
 
 _LOG = logging.getLogger('datacube-user')
 USER_ROLES = ('user', 'ingest', 'manage', 'admin')

--- a/datacube/utils/__init__.py
+++ b/datacube/utils/__init__.py
@@ -18,6 +18,7 @@ from datetime import datetime, date
 from itertools import chain
 from math import ceil
 from uuid import UUID
+from decimal import Decimal
 
 import dateutil.parser
 import jsonschema
@@ -759,3 +760,35 @@ def ignore_exceptions_if(ignore_errors):
 
 def _readable_offset(offset):
     return '.'.join(map(str, offset))
+
+from datacube.model import Range
+
+class SafeDatacubeDumper(yaml.SafeDumper):
+    pass
+def _dict_representer(dumper, data):
+    return dumper.represent_mapping(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, data.items())
+
+def _range_representer(dumper, data):
+    # type: (yaml.Dumper, Range) -> Node
+    begin, end = data
+
+    # pyyaml doesn't output timestamps in flow style as timestamps(?)
+    if isinstance(begin, datetime):
+        begin = begin.isoformat()
+    if isinstance(end, datetime):
+        end = end.isoformat()
+
+    return dumper.represent_mapping(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+        (('begin', begin), ('end', end)),
+        flow_style=True
+    )
+
+def _reduced_accuracy_decimal_representer(dumper, data):
+    # type: (yaml.Dumper, Decimal) -> Node
+    return dumper.represent_float(
+        float(data)
+    )
+SafeDatacubeDumper.add_representer(OrderedDict, _dict_representer)
+SafeDatacubeDumper.add_representer(Range, _range_representer)
+SafeDatacubeDumper.add_representer(Decimal, _reduced_accuracy_decimal_representer)

--- a/datacube/utils/__init__.py
+++ b/datacube/utils/__init__.py
@@ -18,7 +18,6 @@ from datetime import datetime, date
 from itertools import chain
 from math import ceil
 from uuid import UUID
-from decimal import Decimal
 
 import dateutil.parser
 import jsonschema
@@ -760,35 +759,3 @@ def ignore_exceptions_if(ignore_errors):
 
 def _readable_offset(offset):
     return '.'.join(map(str, offset))
-
-from datacube.model import Range
-
-class SafeDatacubeDumper(yaml.SafeDumper):
-    pass
-def _dict_representer(dumper, data):
-    return dumper.represent_mapping(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, data.items())
-
-def _range_representer(dumper, data):
-    # type: (yaml.Dumper, Range) -> Node
-    begin, end = data
-
-    # pyyaml doesn't output timestamps in flow style as timestamps(?)
-    if isinstance(begin, datetime):
-        begin = begin.isoformat()
-    if isinstance(end, datetime):
-        end = end.isoformat()
-
-    return dumper.represent_mapping(
-        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
-        (('begin', begin), ('end', end)),
-        flow_style=True
-    )
-
-def _reduced_accuracy_decimal_representer(dumper, data):
-    # type: (yaml.Dumper, Decimal) -> Node
-    return dumper.represent_float(
-        float(data)
-    )
-SafeDatacubeDumper.add_representer(OrderedDict, _dict_representer)
-SafeDatacubeDumper.add_representer(Range, _range_representer)
-SafeDatacubeDumper.add_representer(Decimal, _reduced_accuracy_decimal_representer)

--- a/datacube/utils/serialise.py
+++ b/datacube/utils/serialise.py
@@ -12,7 +12,7 @@ from decimal import Decimal
 import yaml
 from datacube.model import Range
 
-class SafeDatacubeDumper(yaml.SafeDumper):
+class SafeDatacubeDumper(yaml.SafeDumper): # pylint: disable=too-many-ancestors
     pass
 def _dict_representer(dumper, data):
     return dumper.represent_mapping(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, data.items())

--- a/datacube/utils/serialise.py
+++ b/datacube/utils/serialise.py
@@ -1,0 +1,43 @@
+# coding=utf-8
+"""
+Serialise function used in YAML output
+"""
+from __future__ import absolute_import, division, print_function
+
+import os
+from collections import OrderedDict
+from datetime import datetime, date
+from decimal import Decimal
+
+import yaml
+from datacube.model import Range
+
+class SafeDatacubeDumper(yaml.SafeDumper):
+    pass
+def _dict_representer(dumper, data):
+    return dumper.represent_mapping(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, data.items())
+
+def _range_representer(dumper, data):
+    # type: (yaml.Dumper, Range) -> Node
+    begin, end = data
+
+    # pyyaml doesn't output timestamps in flow style as timestamps(?)
+    if isinstance(begin, datetime):
+        begin = begin.isoformat()
+    if isinstance(end, datetime):
+        end = end.isoformat()
+
+    return dumper.represent_mapping(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+        (('begin', begin), ('end', end)),
+        flow_style=True
+    )
+
+def _reduced_accuracy_decimal_representer(dumper, data):
+    # type: (yaml.Dumper, Decimal) -> Node
+    return dumper.represent_float(
+        float(data)
+    )
+SafeDatacubeDumper.add_representer(OrderedDict, _dict_representer)
+SafeDatacubeDumper.add_representer(Range, _range_representer)
+SafeDatacubeDumper.add_representer(Decimal, _reduced_accuracy_decimal_representer)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -49,6 +49,8 @@ Next release
 
  - Added Dockerfile to enable with automated builds for a reference Docker image.
 
+ - Command line tools can now output CSV or YAML. (Issue #206, PR 390)
+
 .. _#298: https://github.com/opendatacube/datacube-core/pull/298
 .. _config docs: https://datacube-core.readthedocs.io/en/latest/ops/config.html#runtime-config-doc
 

--- a/integration_tests/test_config_tool.py
+++ b/integration_tests/test_config_tool.py
@@ -204,9 +204,9 @@ def test_user_creation(clirunner, example_user):
     assert_no_user(clirunner, username)
 
 
-def assert_user_with_role(clirunner, role, user_name, description):
-    result = clirunner(['user', 'list', '-f', 'csv'])
-    assert '{},{},{}'.format(role, user_name, description) in result.output
+def assert_user_with_role(clirunner, role, user_name):
+    result = clirunner(['user', 'list'])
+    assert '{}{}'.format('user: ', user_name) in result.output
 
 
 def assert_no_user(clirunner, username):

--- a/integration_tests/test_config_tool.py
+++ b/integration_tests/test_config_tool.py
@@ -205,8 +205,8 @@ def test_user_creation(clirunner, example_user):
 
 
 def assert_user_with_role(clirunner, role, user_name):
-    result = clirunner(['user', 'list'])
-    assert '{}\t{}'.format(role, user_name) in result.output
+    result = clirunner(['user', 'list', '-f', 'csv'])
+    assert '{},{}'.format(role, user_name) in result.output
 
 
 def assert_no_user(clirunner, username):

--- a/integration_tests/test_config_tool.py
+++ b/integration_tests/test_config_tool.py
@@ -204,9 +204,9 @@ def test_user_creation(clirunner, example_user):
     assert_no_user(clirunner, username)
 
 
-def assert_user_with_role(clirunner, role, user_name):
+def assert_user_with_role(clirunner, role, user_name, description):
     result = clirunner(['user', 'list', '-f', 'csv'])
-    assert '{},{}'.format(role, user_name) in result.output
+    assert '{},{},{}'.format(role, user_name, description) in result.output
 
 
 def assert_no_user(clirunner, username):

--- a/utils/nbartprepare.py
+++ b/utils/nbartprepare.py
@@ -35,7 +35,7 @@ def main(datasets):
         with open(str(path)) as stream:
             documents = list(yaml.load_all(stream))
 
-        documents = [prepare_dataset(datatset) for datatset in documents]
+        documents = [prepare_dataset(dataset) for dataset in documents]
         if documents:
             yaml_path = str(path.parent.joinpath('agdc-metadata.yaml'))
             logging.info("Writing %s dataset(s) into %s", len(documents), yaml_path)


### PR DESCRIPTION
### Reason for this pull request
Add options for formatted output for product list/show and user list. This includes yaml as default, as well as csv and plain table formats. Formatting is only applied to the outputs as appropriate.
...


### Proposed changes

- Add yaml, csv, table format to product/list.
-  Add yaml, csv, json format to product/show
- Add yaml, csv format to user/list
- Resolve minor formatting errors in api/core.py and utils/nbartprepare.py


 - [x] Closes #206
 - [x] Tests passing
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

