### PR TITLE
Per-band image URI in metadata

### DIFF
--- a/datacube/model/utils.py
+++ b/datacube/model/utils.py
@@ -83,10 +83,14 @@ def new_dataset_info():
     }
 
 
-def band_info(band_names):
+def band_info(band_names, uri=None, band_uris=None):
+    if band_uris is None:
+        band_uris = {name: uri if uri is not None else ''
+                     for name in band_names}
+
     return {
         'image': {
-            'bands': {name: {'path': '', 'layer': name} for name in band_names}
+            'bands': {name: {'path': band_uris[name], 'layer': name} for name in band_names}
         }
     }
 
@@ -166,7 +170,8 @@ def xr_apply(data_array, func, dtype):
     return xarray.DataArray(data, coords=data_array.coords, dims=data_array.dims)
 
 
-def make_dataset(product, sources, extent, center_time, valid_data=None, uri=None, app_info=None):
+def make_dataset(product, sources, extent, center_time,
+                 valid_data=None, uri=None, app_info=None, band_uris=None):
     """
     Create :class:`datacube.model.Dataset` for the data
 
@@ -177,13 +182,14 @@ def make_dataset(product, sources, extent, center_time, valid_data=None, uri=Non
     :param center_time: time of the central point of the dataset
     :param str uri: The uri of the dataset
     :param dict app_info: Additional metadata to be stored about the generation of the product
+    :param dict band_uris: band name to uri mapping
     :rtype: class:`Dataset`
     """
     document = {}
     merge(document, product.metadata_doc)
     merge(document, new_dataset_info())
     merge(document, machine_info())
-    merge(document, band_info(product.measurements.keys()))
+    merge(document, band_info(product.measurements.keys(), uri=uri, band_uris=band_uris))
     merge(document, source_info(sources))
     merge(document, geobox_info(extent, valid_data))
     merge(document, time_info(center_time))

--- a/datacube/model/utils.py
+++ b/datacube/model/utils.py
@@ -85,8 +85,10 @@ def new_dataset_info():
 
 def band_info(band_names, uri=None, band_uris=None):
     if band_uris is None:
-        band_uris = {name: uri if uri is not None else ''
-                     for name in band_names}
+        band_uris = {name: '' for name in band_names}
+    elif band_uris == uri:
+        # multiband
+        band_uris = {name: uri for name in band_names}
 
     return {
         'image': {
@@ -182,7 +184,7 @@ def make_dataset(product, sources, extent, center_time,
     :param center_time: time of the central point of the dataset
     :param str uri: The uri of the dataset
     :param dict app_info: Additional metadata to be stored about the generation of the product
-    :param dict band_uris: band name to uri mapping
+    :param dict band_uris: band name to uri mapping (or just the uri for multiband datasets)
     :rtype: class:`Dataset`
     """
     document = {}


### PR DESCRIPTION
### Reason for this pull request
The metadata generated by `datacube-stats` is missing band-to-path mapping.

### Proposed changes
- Allow specifying band-to-uri mapping in `make_dataset`
  (that currently sets the paths to empty strings)
