### PR TITLE
Enable band info override

### DIFF
--- a/datacube/model/utils.py
+++ b/datacube/model/utils.py
@@ -83,16 +83,17 @@ def new_dataset_info():
     }
 
 
-def band_info(band_names, uri=None, band_uris=None):
+def band_info(band_names, band_uris=None):
+    """
+    :param list band_names: names of the bands
+    :param dict band_uris: mapping from names to dicts with 'path' and 'layer' specs
+    """
     if band_uris is None:
-        band_uris = {name: '' for name in band_names}
-    elif band_uris == uri:
-        # multiband
-        band_uris = {name: uri for name in band_names}
+        band_uris = {name: {'path': '', 'layer': name} for name in band_names}
 
     return {
         'image': {
-            'bands': {name: {'path': band_uris[name], 'layer': name} for name in band_names}
+            'bands': {name: band_uris[name] for name in band_names}
         }
     }
 
@@ -184,14 +185,14 @@ def make_dataset(product, sources, extent, center_time,
     :param center_time: time of the central point of the dataset
     :param str uri: The uri of the dataset
     :param dict app_info: Additional metadata to be stored about the generation of the product
-    :param dict band_uris: band name to uri mapping (or just the uri for multiband datasets)
+    :param dict band_uris: band name to uri mapping
     :rtype: class:`Dataset`
     """
     document = {}
     merge(document, product.metadata_doc)
     merge(document, new_dataset_info())
     merge(document, machine_info())
-    merge(document, band_info(product.measurements.keys(), uri=uri, band_uris=band_uris))
+    merge(document, band_info(product.measurements.keys(), band_uris=band_uris))
     merge(document, source_info(sources))
     merge(document, geobox_info(extent, valid_data))
     merge(document, time_info(center_time))


### PR DESCRIPTION
### Reason for this pull request
Turns out the previous pull request #399 was a bit premature in that the
band metadata needs the band number in the GeoTiff in addition to the
name of the band. It is perhaps easier to let the caller of `make_dataset`
construct this metadata.

### Proposed changes
Get rid of the half-hearted attempt at supporting GeoTiff metadata
and enable overriding band metadata by simply providing it.
Preserves old behaviour of constructing dataset with empty band
paths if band info not supplied.