### PR TITLE
Make dc.load raise error on invalid product request

### DIFF
--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -601,15 +601,11 @@ class DatasetResource(object):
     def _do_search_by_product(self, query, return_fields=False, select_field_names=None,
                               with_source_ids=False, source_filter=None,
                               limit=None):
-        #if not product:
-        #    raise ValueError('No valid product was specified.')
-
         if source_filter:
             product_queries = list(self._get_product_queries(source_filter))
             if not product_queries:
                 # No products match our source filter, so there will be no search results regardless.
-                _LOG.info("No products match source filter")
-                return
+                raise ValueError('No products match source filter: ' % source_filter)
             if len(product_queries) > 1:
                 raise RuntimeError("Multi-product source filters are not supported. Try adding 'product' field")
 

--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -601,6 +601,8 @@ class DatasetResource(object):
     def _do_search_by_product(self, query, return_fields=False, select_field_names=None,
                               with_source_ids=False, source_filter=None,
                               limit=None):
+        #if not product:
+        #    raise ValueError('No valid product was specified.')
 
         if source_filter:
             product_queries = list(self._get_product_queries(source_filter))

--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -619,7 +619,7 @@ class DatasetResource(object):
 
         product_queries = list(self._get_product_queries(query))
         if not product_queries:
-            raise ValueError('No valid product was specified.')         
+            raise ValueError('No valid product was specified.')
 
         for q, product in product_queries:
             dataset_fields = product.metadata_type.dataset_fields

--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -618,6 +618,9 @@ class DatasetResource(object):
             source_exprs = None
 
         product_queries = list(self._get_product_queries(query))
+        if not product_queries:
+            raise ValueError('No valid product was specified.')         
+
         for q, product in product_queries:
             dataset_fields = product.metadata_type.dataset_fields
             query_exprs = tuple(fields.to_expressions(dataset_fields.get, **q))

--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -619,7 +619,7 @@ class DatasetResource(object):
 
         product_queries = list(self._get_product_queries(query))
         if not product_queries:
-            raise ValueError('No valid product was specified.')
+            raise ValueError('No products match search terms: %r' % query)
 
         for q, product in product_queries:
             dataset_fields = product.metadata_type.dataset_fields

--- a/datacube/scripts/product.py
+++ b/datacube/scripts/product.py
@@ -26,11 +26,11 @@ _LOG = logging.getLogger('datacube-product')
 
 
 @cli.group(name='product', help='Product commands')
-def product():
+def product_cli():
     pass
 
 
-@product.command('add')
+@product_cli.command('add')
 @click.option('--allow-exclusive-lock/--forbid-exclusive-lock', is_flag=True, default=False,
               help='Allow index to be locked from other users while updating (default: false)')
 @click.argument('files',
@@ -53,7 +53,7 @@ def add_dataset_types(index, allow_exclusive_lock, files):
             continue
 
 
-@product.command('update')
+@product_cli.command('update')
 @click.option(
     '--allow-unsafe/--forbid-unsafe', is_flag=True, default=False,
     help="Allow unsafe updates (default: false)"
@@ -171,7 +171,7 @@ LIST_OUTPUT_WRITERS = {
     'tab': _write_tab,
 }
 
-@product.command('list')
+@product_cli.command('list')
 @click.option('-f', help='Output format',
               type=click.Choice(list(LIST_OUTPUT_WRITERS)), default='yaml', show_default=True)
 @ui.pass_datacube()
@@ -194,7 +194,7 @@ SHOW_OUTPUT_WRITERS = {
     'json': _write_json,
 }
 
-@product.command('show')
+@product_cli.command('show')
 @click.option('-f', help='Output format',
               type=click.Choice(list(SHOW_OUTPUT_WRITERS)), default='yaml', show_default=True)
 @click.argument('product_name', nargs=1)

--- a/datacube/scripts/product.py
+++ b/datacube/scripts/product.py
@@ -115,8 +115,8 @@ def update_products(index, allow_unsafe, allow_exclusive_lock, dry_run, files):
 
 def build_product_list(index):
     lstdct = []
-    for line in index.products.search():
-        info = dataset_type_to_row(line)
+    for product in index.products.search():
+        info = dataset_type_to_row(product)
         lstdct.append(info)
     return lstdct
 

--- a/integration_tests/index/test_search.py
+++ b/integration_tests/index/test_search.py
@@ -1107,7 +1107,11 @@ def test_csv_search_via_cli(clirunner, pseudo_ls8_type, pseudo_ls8_dataset, pseu
 
     def matches_none(*args):
         rows = _cli_csv_search(('datasets',) + args, clirunner)
-        assert len(lines) == 1
+        assert len(rows) == 0
+
+    def no_such_product(*args):
+        with pytest.raises(ValueError):
+            rows = _cli_csv_search(('datasets',) + args, clirunner)
 
     matches_both(' -40 < lat < -10')
     matches_both('product=' + pseudo_ls8_type.name)
@@ -1119,7 +1123,7 @@ def test_csv_search_via_cli(clirunner, pseudo_ls8_type, pseudo_ls8_dataset, pseu
     matches_1('platform=LANDSAT_8', '2014-07-24<time<2014-07-27')
 
     # One matching field, one non-matching
-    matches_none('2014-07-24<time<2014-07-27', 'platform=LANDSAT_5')
+    no_such_product('2014-07-24<time<2014-07-27', 'platform=LANDSAT_5')
 
     # Test date shorthand
     matches_both('2014-7 < time < 2014-8')

--- a/integration_tests/index/test_search.py
+++ b/integration_tests/index/test_search.py
@@ -603,12 +603,12 @@ def test_searches_only_type(index, pseudo_ls8_type, pseudo_ls8_dataset, ls5_tele
     assert datasets[0].id == pseudo_ls8_dataset.id
 
     # No results when searching for a different dataset type.
-    datasets = index.datasets.search_eager(
-        product=ls5_telem_type.name,
-        platform='LANDSAT_8',
-        instrument='OLI_TIRS'
-    )
-    assert len(datasets) == 0
+    with pytest.raises(ValueError):
+        datasets = index.datasets.search_eager(
+            product=ls5_telem_type.name,
+            platform='LANDSAT_8',
+            instrument='OLI_TIRS'
+        )
 
     # One result when no types specified.
     datasets = index.datasets.search_eager(
@@ -643,11 +643,11 @@ def test_search_special_fields(index, pseudo_ls8_type, pseudo_ls8_dataset,
     assert datasets[0].id == pseudo_ls8_dataset.id
 
     # Unknown field: no results
-    datasets = index.datasets.search_eager(
-        platform='LANDSAT_8',
-        flavour='chocolate',
-    )
-    assert len(datasets) == 0
+    with pytest.raises(ValueError):
+        datasets = index.datasets.search_eager(
+            platform='LANDSAT_8',
+            flavour='chocolate',
+        )
 
 
 def test_search_by_uri(index, ls5_dataset_w_children):
@@ -662,12 +662,12 @@ def test_search_by_uri(index, ls5_dataset_w_children):
 
 def test_search_conflicting_types(index, pseudo_ls8_dataset, pseudo_ls8_type):
     # Should return no results.
-    datasets = index.datasets.search_eager(
-        product=pseudo_ls8_type.name,
-        # The telemetry type is not of type storage_unit.
-        metadata_type='storage_unit'
-    )
-    assert len(datasets) == 0
+    with pytest.raises(ValueError):
+        datasets = index.datasets.search_eager(
+            product=pseudo_ls8_type.name,
+            # The telemetry type is not of type storage_unit.
+            metadata_type='storage_unit'
+        )
 
 
 def test_fetch_all_of_md_type(index, pseudo_ls8_dataset):
@@ -687,10 +687,10 @@ def test_fetch_all_of_md_type(index, pseudo_ls8_dataset):
     assert results[0].id == pseudo_ls8_dataset.id
 
     # No results for another.
-    results = index.datasets.search_eager(
-        metadata_type='telemetry'
-    )
-    assert len(results) == 0
+    with pytest.raises(ValueError):
+        results = index.datasets.search_eager(
+            metadata_type='telemetry'
+        )
 
 
 def test_count_searches(index, pseudo_ls8_type, pseudo_ls8_dataset, ls5_telem_type):

--- a/integration_tests/index/test_search.py
+++ b/integration_tests/index/test_search.py
@@ -258,11 +258,11 @@ def test_search_dataset_equals(index, pseudo_ls8_dataset):
     assert datasets[0].id == pseudo_ls8_dataset.id
 
     # Wrong sensor name
-    datasets = index.datasets.search_eager(
-        platform='LANDSAT-8',
-        instrument='TM',
-    )
-    assert len(datasets) == 0
+    with pytest.raises(ValueError):
+        datasets = index.datasets.search_eager(
+            platform='LANDSAT-8',
+            instrument='TM',
+        )
 
 
 def test_search_dataset_by_metadata(index, pseudo_ls8_dataset):

--- a/integration_tests/index/test_search.py
+++ b/integration_tests/index/test_search.py
@@ -1107,7 +1107,7 @@ def test_csv_search_via_cli(clirunner, pseudo_ls8_type, pseudo_ls8_dataset, pseu
 
     def matches_none(*args):
         rows = _cli_csv_search(('datasets',) + args, clirunner)
-        assert len(rows) == 0
+        assert len(lines) == 1
 
     matches_both(' -40 < lat < -10')
     matches_both('product=' + pseudo_ls8_type.name)

--- a/integration_tests/index/test_search.py
+++ b/integration_tests/index/test_search.py
@@ -619,12 +619,12 @@ def test_searches_only_type(index, pseudo_ls8_type, pseudo_ls8_dataset, ls5_tele
     assert datasets[0].id == pseudo_ls8_dataset.id
 
     # No results for different metadata type.
-    datasets = index.datasets.search_eager(
-        metadata_type='telemetry',
-        platform='LANDSAT_8',
-        instrument='OLI_TIRS'
-    )
-    assert len(datasets) == 0
+    with pytest.raises(ValueError):
+        datasets = index.datasets.search_eager(
+            metadata_type='telemetry',
+            platform='LANDSAT_8',
+            instrument='OLI_TIRS'
+        )
 
 
 def test_search_special_fields(index, pseudo_ls8_type, pseudo_ls8_dataset,


### PR DESCRIPTION
### Reason for this pull request

...When loading a non-existent product, dc.load will not give an error but return an empty xarray.


### Proposed changes

- Add value error when loading a non-existent product to explicitly fail.
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
