### PR TITLE
Remove the test fail_drivers from the Docker install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN pip3 install '.[test,celery,s3]' --upgrade \
     && rm -rf $HOME/.cache/pip
 
 # Install ODC
-RUN python3 setup.py develop
+RUN python3 setup.py install
 
 # Move docs and utils somewhere else, and remove the temp folder
 RUN mkdir -p /opt/odc \

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ENV C_INCLUDE_PATH=/usr/include/gdal
 RUN pip3 install --upgrade pip setuptools wheel \
     && rm -rf $HOME/.cache/pip
 
-# Install psychopg2 as a special case, to quiet the warning message 
+# Install psycopg2 as a special case, to quiet the warning message 
 RUN pip3 install --no-cache --no-binary :all: psycopg2 \
     && rm -rf $HOME/.cache/pip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,6 @@ RUN pip3 install --no-cache --no-binary :all: psycopg2 \
 # Now use the setup.py file to identify dependencies
 RUN pip3 install '.[test,celery,s3]' --upgrade \
     && rm -rf $HOME/.cache/pip
-RUN pip3 install ./tests/drivers/fail_drivers --no-deps --upgrade \
-    && rm -rf $HOME/.cache/pip
 
 # Install ODC
 RUN python3 setup.py develop


### PR DESCRIPTION
### Reason for this pull request

Fixing an issue with the image caused by including the install of fail_drivers, which raises warnings when importing data.


### Proposed changes

- Remove the pip install fail_drivers step
- Included changing the setup.py develop to setup.py install



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
