### PR TITLE
Datacube.load logic refactor

### DIFF
--- a/docs/config_samples/dataset_types/ls_usgs_sr_scene.yaml
+++ b/docs/config_samples/dataset_types/ls_usgs_sr_scene.yaml
@@ -240,4 +240,3 @@ measurements:
             32: Land/Water
             64: Unused
             128: Unused
-


### PR DESCRIPTION
### Reason for this pull request
- Prettier `Datacube.load`
- Virtual product uses these functionalities as well, so avoid code duplication

### Proposed changes
- Refactor relevant pieces of code into separate methods
- More rigorous checks against `None` instead of Python truthiness
- Replace `RuntimeError`s with more appropriate `ValueError`s
- Fix `align` initialization
  + I think the overall intention of the code in the branch marked `# specification from grid_spec`
    is to get the parameters from the `grid_spec` if not overridden by the user
  + The proposed logic achieves that
  + The old logic deviates from that specification in the special case where:
     - if the user has specified a resolution but has not specified an alignment then the alignment
       is not taken from the `grid_spec`
     - that is, whether or not the alignment is inherited from the `grid_spec` depends on
       whether or not the user has specified a resolution
  + I do not find this behaviour intuitive