### PR TITLE
Set date for release and auto release from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ git:
   # we can reach the last tagged version.
   depth: 99999
 
+env:
+  global:
+    - CC_TEST_REPORTER_ID=56b5f09a9339c3ada591c94a6430823aee15e426fbcd9990e04fe936e40c8582
+
 language: python
 python:
   - "3.5"
@@ -57,12 +61,20 @@ install:
   - df -h
   - df -i
 
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+
 script:
 # Ensure we are running against the correct python version
   - '[[ $(python --version 2>&1) == *"$TRAVIS_PYTHON_VERSION"* ]]'
 
 # Run all the linting and tests
   - ./check-code.sh integration_tests
+
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 
 after_success:
   - test $TRAVIS_PYTHON_VERSION = "3.6" && coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,16 @@ deploy:
       condition: $TRAVIS_BRANCH = "develop" || ! -z "${TRAVIS_TAG}"  # develop branch or tags
       repo: opendatacube/datacube-core
       python: "3.6"
+  - provider: pypi
+    user: damien.ayers
+    password:
+      secure: "D868pBc2xCF67O2MjLc+OeuIJjIFxSOEhmm7D7lmWqqkJPf+af8qmIBmjJQoyegpiI0n6wwORG65V7E0rCvJlcNtbDwcCYNbGYoFqptZ1OjRedSjr72Vn+45hkgXcyqCyuNf9kikCZv3VkR4yLvput5j9glHAESarrKAQahLdObzJ1cHdPokEPYD1ibyT+wM5jmQJx5Q1Cp3P+c7EE7DTm/g1HL9g4vAx/b729dMVodGrly0gRzH99ivKDMUaUcMRlIABFJvl4qxNn6O7X3SUaEzqKy2gqMzCcjlqwU4rrfTizy5fxPD7r2RJ3RZFv1iPMGF1qLCutN6JzBZltKHVcObUXmm+5ZEGcarpzllkp4gmFcSI47TLLMgQ2nn9UVfmeYqAnbBkjNLZS4/8CfhZFn/QY0gqmZUSo8sdwSqOgACbMwUN5F0qdm/Cq66kS/0iTM4WeShYrhkDX5txFQM11DVPC3fuxs2PhastnwBMPybhEqj0dhCOS1u4bStJN2vAygFTkuHWEZYsI4tyyXb6q1rtx6palbKgTS1UI/+HCh0fhdBPMTjciFldWxkf9ZyVMMcxKSEavqfan78OMfXo2xnn3HgsyiOXtKzrIngPt/8amKIQ7L2cjdG/bGxE9TtH2wU9hLk4g7BQDR13lv8s3l4DsW/6B5lO2lodZ14nfE="
+    distributions: sdist bdist_wheel
+    on:
+      branch: stable
+      tags: true
+      python: 3.6
+      repo: opendatacube/datacube-core
 
 notifications:
   slack:

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -6,12 +6,11 @@ What's New
 **********
 
 
-v1.6rc1 Easter Bilby
-====================
+v1.6rc1 Easter Bilby (10 April 2018)
+====================================
 
 This is the first release in a while, and so there's a lot of changes, including
 some significant refactoring, with the potential having issues when upgrading.
-
 
 
 Backwards Incompatible Fixes


### PR DESCRIPTION
### Proposed changes
- Upload code coverage to [codeclimate](https://codeclimate.com/github/opendatacube/datacube-core) from Travis CI
- Set a release date for the release candidate
- Attempt to upload to PyPI automatically for Tagged Releases from the `stable` branch.
