### PR TITLE
Provide default spatial dimensions to Products

### DIFF
--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -29,6 +29,7 @@ CellIndex = namedtuple('CellIndex', ('x', 'y'))
 
 NETCDF_VAR_OPTIONS = {'zlib', 'complevel', 'shuffle', 'fletcher32', 'contiguous'}
 VALID_VARIABLE_ATTRS = {'standard_name', 'long_name', 'units', 'flags_definition'}
+DEFAULT_SPATIAL_DIMS = ('y', 'x')  # Used when product lacks grid_spec
 
 SCHEMA_PATH = Path(__file__).parent / 'schema'
 
@@ -420,7 +421,12 @@ class DatasetType(object):
         :type: tuple[str]
         """
         assert self.metadata_type.name == 'eo'
-        return ('time',) + self.grid_spec.dimensions
+        if self.grid_spec is not None:
+            spatial_dims = self.grid_spec.dimensions
+        else:
+            spatial_dims = DEFAULT_SPATIAL_DIMS
+
+        return ('time',) + spatial_dims
 
     @cached_property
     def grid_spec(self):

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -5,6 +5,13 @@
 What's New
 **********
 
+Bug Fixes
+~~~~~~~~~
+
+- `.dimensions` property of a product no longer crashes when product is missing
+  a `grid_spec`, instead defaults to `time,y,x`
+
+
 
 v1.6rc1 Easter Bilby (10 April 2018)
 ====================================

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 
 import numpy
-from .util import mk_sample_dataset
+from .util import mk_sample_dataset, mk_sample_product
 from datacube.model import GridSpec
 from datacube.utils import geometry
 from datacube.storage.storage import measurement_paths
@@ -53,3 +53,13 @@ def test_dataset_measurement_paths():
 
     for k, v in paths.items():
         assert v == 'file:///tmp/' + k + '.tiff'
+
+
+def test_product_dimensions():
+    product = mk_sample_product('test_product')
+    assert product.grid_spec is None
+    assert product.dimensions == ('time', 'y', 'x')
+
+    product = mk_sample_product('test_product', with_grid_spec=True)
+    assert product.grid_spec is not None
+    assert product.dimensions == ('time', 'y', 'x')

--- a/tests/util.py
+++ b/tests/util.py
@@ -166,7 +166,14 @@ def isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
 
 def mk_sample_product(name,
                       description='Sample',
-                      measurements=['red', 'green', 'blue']):
+                      measurements=['red', 'green', 'blue'],
+                      with_grid_spec=False,
+                      storage=None):
+
+    if storage is None and with_grid_spec is True:
+        storage = {'crs': 'EPSG:3577',
+                   'resolution': {'x': 25, 'y': -25},
+                   'tile_size': {'x': 100000.0, 'y': 100000.0}}
 
     eo_type = MetadataType({
         'name': 'eo',
@@ -203,13 +210,18 @@ def mk_sample_product(name,
 
     measurements = [mk_measurement(m) for m in measurements]
 
-    return DatasetType(eo_type, dict(
+    definition = dict(
         name=name,
         description=description,
         metadata_type='eo',
         metadata={},
         measurements=measurements
-    ))
+    )
+
+    if storage is not None:
+        definition['storage'] = storage
+
+    return DatasetType(eo_type, definition)
 
 
 def mk_sample_dataset(bands,


### PR DESCRIPTION
### Reason for this pull request

Fixing bug reported in issue #406. Code assumed that `grid_spec` is not `None`.


### Proposed changes

- Default to `time,y,x` when `grid_spec` is missing in the product

 - [x] Closes #406
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes