### PR TITLE
Time stamps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ addons:
     - redis-server
   apt:
     sources:
-      - sourceline: ppa:nextgis/ppa
+      - sourceline: ppa:ubuntugis/ubuntugis-unstable
     packages:
       - gdal-bin
       - libgdal-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,11 @@ addons:
     - redis-server
   apt:
     sources:
-      - sourceline: ppa:ubuntugis/ppa
+      - sourceline: ppa:nextgis/ppa
     packages:
-      - gdal-bin
-      - libgdal-dev
-      - libgdal20
+      - gdal-bin=2.2.4
+      - libgdal-dev=2.2.4
+      - libgdal20=2.2.4
       - libudunits2-0
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,10 @@ addons:
     sources:
       - sourceline: ppa:nextgis/ppa
     packages:
-      - gdal-bin
-      - libgdal-dev
-      - libgdal20
-      - libudunits2-0
+      - gdal-bin=2.2.4+1-0trusty1
+      - libgdal-dev=2.2.4+1-0trusty1
+      - libgdal20=2.2.4+1-0trusty1
+      - libudunits2-0=2.2.4+1-0trusty1
 
 before_install:
 # Create a database for the integration tests.

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ addons:
     - redis-server
   apt:
     sources:
-      - sourceline: ppa:nextgis/ppa
+      - sourceline: ppa:ubuntugis/ppa
     packages:
       - gdal-bin
       - libgdal-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ addons:
     - redis-server
   apt:
     sources:
-      - sourceline: ppa:ubuntugis/unstable
+      - sourceline: ppa:ubuntugis/ubuntugis-unstable
     packages:
       - gdal-bin
       - libgdal-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ addons:
       - sourceline: ppa:nextgis/ppa
     packages:
       - gdal-bin=2.2.4
-      - libgdal-dev
-      - libgdal20
+      - libgdal-dev=2.2.4
+      - libgdal20=2.2.4
       - libudunits2-0
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ addons:
     - redis-server
   apt:
     sources:
-      - sourceline: ppa:ubuntugis/ubuntugis-unstable
+      - sourceline: ppa:nextgis/ppa
     packages:
       - gdal-bin
       - libgdal-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ addons:
     sources:
       - sourceline: ppa:nextgis/ppa
     packages:
-      - gdal-bin=2.2.4
-      - libgdal-dev=2.2.4
-      - libgdal20=2.2.4 
+      - gdal-bin
+      - libgdal-dev
+      - libgdal20
       - libudunits2-0
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ addons:
     - redis-server
   apt:
     sources:
-      - sourceline: ppa:ubuntugis/ppa
+      - sourceline: ppa:ubuntugis-unstable/ppa
     packages:
       - gdal-bin
       - libgdal-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ addons:
     - redis-server
   apt:
     sources:
-      - sourceline: ppa:ubuntugis-unstable/ppa 
+      - sourceline: ppa:ubuntugis/unstable
     packages:
       - gdal-bin
       - libgdal-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,10 @@ addons:
     sources:
       - sourceline: ppa:nextgis/ppa
     packages:
-      - gdal-bin=2.2.4+1-0trusty1
-      - libgdal-dev=2.2.4+1-0trusty1
-      - libgdal20=2.2.4+1-0trusty1
-      - libudunits2-0=2.2.4+1-0trusty1
+      - gdal-bin=2.2.4+1
+      - libgdal-dev=2.2.4+1
+      - libgdal20=2.2.4+1
+      - libudunits2-0
 
 before_install:
 # Create a database for the integration tests.

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ addons:
     - redis-server
   apt:
     sources:
-      - sourceline: ppa:ubuntugis-unstable/ppa
+      - sourceline: ppa:ubuntugis-unstable/ppa 
     packages:
       - gdal-bin
       - libgdal-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,11 @@ addons:
     - redis-server
   apt:
     sources:
-      - sourceline: ppa:nextgis/ppa
+      - sourceline: ppa:ubuntugis/ppa
     packages:
-      - gdal-bin=2.2.4
-      - libgdal-dev=2.2.4
-      - libgdal20=2.2.4
+      - gdal-bin
+      - libgdal-dev
+      - libgdal20
       - libudunits2-0
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ addons:
     packages:
       - gdal-bin=2.2.4
       - libgdal-dev=2.2.4
-      - libgdal20=2.2.4
+      - libgdal20=2.2.4 
       - libudunits2-0
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ addons:
     sources:
       - sourceline: ppa:nextgis/ppa
     packages:
-      - gdal-bin=2.2.4+1
+      - gdal-bin=2.2.4
       - libgdal-dev
       - libgdal20
       - libudunits2-0

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ addons:
       - sourceline: ppa:nextgis/ppa
     packages:
       - gdal-bin=2.2.4+1
-      - libgdal-dev=2.2.4+1
-      - libgdal20=2.2.4+1
+      - libgdal-dev
+      - libgdal20
       - libudunits2-0
 
 before_install:

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -291,7 +291,7 @@ def fill_end_time(time_range):
     except IndexError:
         mins = 59
     try:
-        secs = float(break_time[5])+0.999
+        secs = int(break_time[5])+0.999
     except IndexError:
         secs = 59.999
 

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -307,7 +307,7 @@ def _time_to_search_dims(time_range):
         return time_range
 
     elif isinstance(time_range, str):
-        time_range = (time_range,time_range)
+        time_range = (time_range, time_range)
         time_range = Range(_to_datetime(time_range[0]), _to_datetime(fill_end_time(time_range)))
         if time_range[0] == time_range[1]:
             return time_range[0]

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -57,7 +57,7 @@ class Query(object):
 
         >>> query.search_terms['time']  # doctest: +NORMALIZE_WHITESPACE
         Range(begin=datetime.datetime(2001, 1, 1, 0, 0, tzinfo=<UTC>), \
-        end=datetime.datetime(2002, 1, 1, 0, 0, tzinfo=<UTC>))
+        end=datetime.datetime(2002, 1, 1, 23, 59, 59, 999000, tzinfo=<UTC>))
 
         By passing in an ``index``, the search parameters will be validated as existing on the ``product``.
 

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -102,7 +102,7 @@ class Query(object):
                     self.search['time'] = _time_to_search_dims(
                         (pandas_to_datetime(time_coord.values[0]).to_pydatetime(),
                          pandas_to_datetime(time_coord.values[-1]).to_pydatetime()
-                         )#+ datetime.timedelta(milliseconds=1))  # TODO: inclusive time searches
+                         + datetime.timedelta(milliseconds=1))
                     )
 
     @property
@@ -272,7 +272,8 @@ def last_day_of_month(year, month):
     return last_day
 
 def fill_end_time(time_range):
-    print('timer1=',time_range[1])
+    if isinstance(time_range[1], datetime.datetime):
+        return time_range[1]
     break_time = re.findall(r"[\w]+", time_range[1])
     year = int(break_time[0])
     try:

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -102,7 +102,7 @@ class Query(object):
                     self.search['time'] = _time_to_search_dims(
                         (pandas_to_datetime(time_coord.values[0]).to_pydatetime(),
                          pandas_to_datetime(time_coord.values[-1]).to_pydatetime()
-                         + datetime.timedelta(milliseconds=1))  # TODO: inclusive time searches
+                         )#+ datetime.timedelta(milliseconds=1))  # TODO: inclusive time searches
                     )
 
     @property
@@ -272,7 +272,8 @@ def last_day_of_month(year, month):
     return last_day
 
 def fill_end_time(time_range):
-    break_time = re.findall(r"[\w']+", time_range[1])
+    print('timer1=',time_range[1])
+    break_time = re.findall(r"[\w]+", time_range[1])
     year = int(break_time[0])
     try:
         month = int(break_time[1])

--- a/datacube/storage/masking.py
+++ b/datacube/storage/masking.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import
 
 import collections
 import warnings
+import pandas
 
 from datacube.utils import generate_table
 
@@ -26,12 +27,13 @@ def list_flag_names(variable):
     return sorted(list(flags_def.keys()))
 
 
-def describe_variable_flags(variable):
+def describe_variable_flags(variable, with_pandas=True):
     """
-    Returns a string describing the available flags for a masking variable
+    Returns either a Pandas Dataframe (with_pandas=True - default) or a string
+    (with_pandas=False) describing the available flags for a masking variable
 
-    Interprets the `flags_definition` attribute on the provided variable and returns
-    a string like::
+    Interprets the `flags_definition` attribute on the provided variable and
+    returns a Pandas Dataframe or string like::
 
         Bits are listed from the MSB (bit 13) to the LSB (bit 0)
         Bit     Value   Flag Name            Description
@@ -41,11 +43,14 @@ def describe_variable_flags(variable):
         10      0       cloud_acca           Cloud (ACCA)
 
     :param variable: Masking xarray.Dataset or xarray.DataArray
-    :return: str
+    :return: Pandas Dataframe or str
     """
     flags_def = get_flags_def(variable)
 
-    return describe_flags_def(flags_def)
+    if not with_pandas:
+        return describe_flags_def(flags_def)
+
+    return pandas.DataFrame.from_dict(flags_def, orient='index')
 
 
 def describe_flags_def(flags_def):
@@ -128,7 +133,7 @@ def mask_invalid_data(data, keep_attrs=True):
     """
     Sets all `nodata` values to ``nan``.
 
-    This will convert converts numeric data to type `float`.
+    This will convert numeric data to type `float`.
 
     :param Dataset or DataArray data:
     :param bool keep_attrs: If the attributes of the data should be included in the returned .

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -5,6 +5,31 @@
 What's New
 **********
 
+v1.7 (26 April 2018)
+====================
+
+Enhancements
+~~~~~~~~~~~~
+
+When loading data, the behaviour of the time range query has changed to be
+compatible with standard Python searches (eg. time slice an xarray). Now the time range selection is inclusive of any unspecified time units.
+
+Examples:
+time=('2008-01', '2008-03') previously would have returned all data between
+midnight on 1st January, 2008 and midnight on 1st of March, 2008. Now, this
+query will return all data between midnight on 1st January, 2008 and
+23:59:59.999 on 31st of March, 2008. 
+
+To specify a search time between 1st of January and 29th of February, 2008
+(inclusive), use a search query like time=('2008-01', '2008-02'). This query
+is equivalent to using any of the following in the second time stamp:
+('2008-02-29')
+('2008-02-29 23')
+('2008-02-29 23:59')
+('2008-02-29 23:59:59')
+('2008-02-29 23:59:59.999')
+
+
 Bug Fixes
 ~~~~~~~~~
 

--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -99,7 +99,7 @@ def check_open_with_dc(index):
     assert data_array.shape
     assert (data_array != -999).any()
 
-    data_array = dc.load(product='ls5_nbar_albers', measurements=['blue'], time='1992-03-23T23:14:25.500000')
+    data_array = dc.load(product='ls5_nbar_albers', measurements=['blue'], time='1992-03-23 23:14:25.500000')
     assert data_array['blue'].shape[0] == 1
     assert (data_array.blue != -999).any()
 

--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -99,7 +99,7 @@ def check_open_with_dc(index):
     assert data_array.shape
     assert (data_array != -999).any()
 
-    data_array = dc.load(product='ls5_nbar_albers', measurements=['blue'], time='2007-02-13 23:45:40')
+    data_array = dc.load(product='ls5_nbar_albers', measurements=['blue'], time='2007-02-13 23:45:40.0')
     assert data_array['blue'].shape[0] == 1
     assert (data_array.blue != -999).any()
 

--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -206,7 +206,7 @@ def check_open_with_grid_workflow(index):
     dataset_cell = gw.load(tile)
     assert all(m in dataset_cell for m in ['blue', 'green', 'red', 'nir', 'swir1', 'swir2'])
 
-    ts = numpy.datetime64('1992-03-23T23:14:25.500000000')
+    ts = numpy.datetime64('1992-03-23T23:14:25')
     tile_key = LBG_CELL + (ts,)
     tiles = gw.list_tiles(product=type_name)
     assert tiles

--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -99,7 +99,7 @@ def check_open_with_dc(index):
     assert data_array.shape
     assert (data_array != -999).any()
 
-    data_array = dc.load(product='ls5_nbar_albers', measurements=['blue'], time='1992-03-23 23:14:25.500000')
+    data_array = dc.load(product='ls5_nbar_albers', measurements=['blue'], time='1992-03-23 23:14:25')
     assert data_array['blue'].shape[0] == 1
     assert (data_array.blue != -999).any()
 

--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -99,7 +99,7 @@ def check_open_with_dc(index):
     assert data_array.shape
     assert (data_array != -999).any()
 
-    data_array = dc.load(product='ls5_nbar_albers', measurements=['blue'], time='2008-11-14 23:33:57')
+    data_array = dc.load(product='ls5_nbar_albers', measurements=['blue'], time='2008-11-30 23:34:29')
     assert data_array['blue'].shape[0] == 1
     assert (data_array.blue != -999).any()
 

--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -99,7 +99,7 @@ def check_open_with_dc(index):
     assert data_array.shape
     assert (data_array != -999).any()
 
-    data_array = dc.load(product='ls5_nbar_albers', measurements=['blue'], time='2008-11-30 23:34:29')
+    data_array = dc.load(product='ls5_nbar_albers', measurements=['blue'], time='2008-11-14 23:33:57')
     assert data_array['blue'].shape[0] == 1
     assert (data_array.blue != -999).any()
 

--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -99,7 +99,7 @@ def check_open_with_dc(index):
     assert data_array.shape
     assert (data_array != -999).any()
 
-    data_array = dc.load(product='ls5_nbar_albers', measurements=['blue'], time='2008-11-14 23:33:57')
+    data_array = dc.load(product='ls5_nbar_albers', measurements=['blue'], time='2007-02-13 23:45:40')
     assert data_array['blue'].shape[0] == 1
     assert (data_array.blue != -999).any()
 

--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -99,7 +99,7 @@ def check_open_with_dc(index):
     assert data_array.shape
     assert (data_array != -999).any()
 
-    data_array = dc.load(product='ls5_nbar_albers', measurements=['blue'], time='2007-02-13 23:45:40.0')
+    data_array = dc.load(product='ls5_nbar_albers', measurements=['blue'], time='1992-03-23 23:14:25.5')
     assert data_array['blue'].shape[0] == 1
     assert (data_array.blue != -999).any()
 
@@ -206,7 +206,7 @@ def check_open_with_grid_workflow(index):
     dataset_cell = gw.load(tile)
     assert all(m in dataset_cell for m in ['blue', 'green', 'red', 'nir', 'swir1', 'swir2'])
 
-    ts = numpy.datetime64('1992-03-23T23:14:25')
+    ts = numpy.datetime64('1992-03-23T23:14:25.500000000')
     tile_key = LBG_CELL + (ts,)
     tiles = gw.list_tiles(product=type_name)
     assert tiles

--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -99,7 +99,7 @@ def check_open_with_dc(index):
     assert data_array.shape
     assert (data_array != -999).any()
 
-    data_array = dc.load(product='ls5_nbar_albers', measurements=['blue'], time='1992-03-23 23:14:25')
+    data_array = dc.load(product='ls5_nbar_albers', measurements=['blue'], time='2008-11-14 23:33:57')
     assert data_array['blue'].shape[0] == 1
     assert (data_array.blue != -999).any()
 

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -86,3 +86,80 @@ def test_query_kwargs():
 
     with pytest.raises(LookupError):
         query_group_by(group_by='magic')
+
+import pytest
+
+from datacube.api.query import Query, _datetime_to_timestamp, query_group_by
+from datacube.model import Range
+from datetime import timezone
+
+testdata = [
+    (('2018-04-05', '2018-04-06'), Range(begin=datetime.datetime(2018, 4, 5, 0, 0, tzinfo=timezone.utc),
+                                         end=datetime.datetime(2018, 4, 6, 0, 0, tzinfo=timezone.utc))),
+    ('2008', datetime.datetime(2008, 1, 1, 0, 0, tzinfo=timezone.utc)),
+    (('2008', '2008'), datetime.datetime(2008, 1, 1, 0, 0, tzinfo=timezone.utc)),
+    (('2008', '2009'), Range(begin=datetime.datetime(2008, 1, 1, 0, 0, tzinfo=timezone.utc),
+                             end=datetime.datetime(2009, 1, 1, 0, 0, tzinfo=timezone.utc))),
+    (('2008-03', '2009'), Range(begin=datetime.datetime(2008, 3, 1, 0, 0, tzinfo=timezone.utc),
+                             end=datetime.datetime(2009, 1, 1, 0, 0, tzinfo=timezone.utc))),
+    (('2008-03', '2009-10'), Range(begin=datetime.datetime(2008, 3, 1, 0, 0, tzinfo=timezone.utc),
+                             end=datetime.datetime(2009, 10, 1, 0, 0, tzinfo=timezone.utc))),
+    (('2008', '2009-10'), Range(begin=datetime.datetime(2008, 1, 1, 0, 0, tzinfo=timezone.utc),
+                             end=datetime.datetime(2009, 10, 1, 0, 0, tzinfo=timezone.utc))),
+    (('2008-03-03', '2008-11'), Range(begin=datetime.datetime(2008, 3, 3, 0, 0, tzinfo=timezone.utc),
+                             end=datetime.datetime(2008, 11, 1, 0, 0, tzinfo=timezone.utc))),
+    (('2008-11-14', '2008-11-30'), Range(begin=datetime.datetime(2008, 11, 14, 0, 0, tzinfo=timezone.utc),
+                             end=datetime.datetime(2008, 11, 30, 0, 0, tzinfo=timezone.utc))),
+    (('2008-11-14', '2008-11-29'), Range(begin=datetime.datetime(2008, 11, 14, 0, 0, tzinfo=timezone.utc),
+                             end=datetime.datetime(2008, 11, 29, 0, 0, tzinfo=timezone.utc))),
+    (('2008-11-14', '2008-11'), Range(begin=datetime.datetime(2008, 11, 14, 0, 0, tzinfo=timezone.utc),
+                             end=datetime.datetime(2008, 11,  1, 0, 0, tzinfo=timezone.utc))),
+    (('2008-11-14', '2008'), Range(begin=datetime.datetime(2008, 11, 14, 0, 0, tzinfo=timezone.utc),
+                             end=datetime.datetime(2008,  1,  1, 0, 0, tzinfo=timezone.utc))),
+    (('2008-11-14'), datetime.datetime(2008, 11, 14, 0, 0, tzinfo=timezone.utc)),
+]
+
+newtestdata = [
+    (('2018-04-05', '2018-04-06'), Range(begin=datetime.datetime(2018, 4, 5, 0, 0, 0, tzinfo=timezone.utc),
+                                         end=datetime.datetime(2018, 4, 6, 23, 59, 59, 999000, tzinfo=timezone.utc))),
+    ('2008', Range(begin=datetime.datetime(2008, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+                                         end=datetime.datetime(2008, 12, 31, 23, 59, 59, 999000, tzinfo=timezone.utc))),
+    (('2008', '2008'), Range(begin=datetime.datetime(2008, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+                                         end=datetime.datetime(2008, 12, 31, 23, 59, 59, 999000, tzinfo=timezone.utc))),
+    (('2008', '2009'), Range(begin=datetime.datetime(2008, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+                             end=datetime.datetime(2009, 12, 31, 23, 59, 59, 999000, tzinfo=timezone.utc))),
+    (('2008-03', '2009'), Range(begin=datetime.datetime(2008, 3, 1, 0, 0, tzinfo=timezone.utc),
+                             end=datetime.datetime(2009, 12, 31, 23, 59, 59, 999000, tzinfo=timezone.utc))),
+    (('2008-03', '2009-10'), Range(begin=datetime.datetime(2008, 3, 1, 0, 0, tzinfo=timezone.utc),
+                             end=datetime.datetime(2009, 10, 31, 23, 59, 59, 999000, tzinfo=timezone.utc))),
+    (('2008', '2009-10'), Range(begin=datetime.datetime(2008, 1, 1, 0, 0, tzinfo=timezone.utc),
+                             end=datetime.datetime(2009, 10, 31, 23, 59, 59, 999000, tzinfo=timezone.utc))),
+    (('2008-03-03', '2008-11'), Range(begin=datetime.datetime(2008, 3, 3, 0, 0, 0, tzinfo=timezone.utc),
+                             end=datetime.datetime(2008, 11, 30, 23, 59, 59, 999000, tzinfo=timezone.utc))),
+    (('2008-11-14', '2008-11-30'), Range(begin=datetime.datetime(2008, 11, 14, 0, 0, 0, tzinfo=timezone.utc),
+                             end=datetime.datetime(2008, 11, 30, 23, 59, 59, 999000, tzinfo=timezone.utc))),
+    (('2008-11-14', '2008-11-29'), Range(begin=datetime.datetime(2008, 11, 14, 0, 0, 0, tzinfo=timezone.utc),
+                             end=datetime.datetime(2008, 11, 29, 23, 59, 59, 999000, tzinfo=timezone.utc))),
+    (('2008-11-14', '2008-11'), Range(begin=datetime.datetime(2008, 11, 14, 0, 0, 0, tzinfo=timezone.utc),
+                             end=datetime.datetime(2008, 11,  30, 23, 59, 59, 999000, tzinfo=timezone.utc))),
+    (('2008-11-14', '2008'), Range(begin=datetime.datetime(2008, 11, 14, 0, 0, 0, tzinfo=timezone.utc),
+                             end=datetime.datetime(2008,  12,  31, 23, 59, 59, 999000, tzinfo=timezone.utc))),
+    (('2008-11-14'), Range(begin=datetime.datetime(2008, 11, 14, 0, 0, 0, tzinfo=timezone.utc),
+                             end=datetime.datetime(2008,  11,  14, 23, 59, 59, 999000, tzinfo=timezone.utc))),
+    (('2008-11-14', '2009-02-02'), Range(begin=datetime.datetime(2008, 11, 14, 0, 0, 0, tzinfo=timezone.utc),
+                             end=datetime.datetime(2009, 2,  2, 23, 59, 59, 999000, tzinfo=timezone.utc))),
+    (('2008-11-14 23:33:57', '2008-11-14 23:33:57'), Range(begin=datetime.datetime(2008, 11, 14, 23, 33, 57, tzinfo=timezone.utc),
+                             end=datetime.datetime(2008, 11, 14, 23, 33, 57, 999000, tzinfo=timezone.utc))),
+    (('2008-11-14 23:33', '2008-11-14 23:34'), Range(begin=datetime.datetime(2008, 11, 14, 23, 33, 0, tzinfo=timezone.utc),
+                             end=datetime.datetime(2008, 11, 14, 23, 34, 59, 999000, tzinfo=timezone.utc))),
+    (('2008-11-14 23:00:00', '2008-11-14 23:35'), Range(begin=datetime.datetime(2008, 11, 14, 23, 0, tzinfo=timezone.utc),
+                             end=datetime.datetime(2008, 11, 14, 23, 35, 59, 999000, tzinfo=timezone.utc))),
+    (('2008-11-10 11', '2008-11-16 14:01'), Range(begin=datetime.datetime(2008, 11, 10, 11, 0, tzinfo=timezone.utc),
+                             end=datetime.datetime(2008, 11, 16, 14, 1, 59, 999000, tzinfo=timezone.utc))),
+]
+
+@pytest.mark.parametrize('time_param,expected', newtestdata)
+def test_time_handling(time_param, expected):
+    query = Query(time=time_param)
+    assert 'time' in query.search_terms
+    assert query.search_terms['time'] == expected

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -23,6 +23,8 @@ from ..util import isclose
 
 from datacube.api.query import Query, _datetime_to_timestamp, query_group_by
 from datacube.model import Range
+from datetime import timezone
+
 
 
 def test_datetime_to_timestamp():
@@ -87,78 +89,52 @@ def test_query_kwargs():
     with pytest.raises(LookupError):
         query_group_by(group_by='magic')
 
-import pytest
-
-from datacube.api.query import Query, _datetime_to_timestamp, query_group_by
-from datacube.model import Range
-from datetime import timezone
 
 testdata = [
-    (('2018-04-05', '2018-04-06'), Range(begin=datetime.datetime(2018, 4, 5, 0, 0, tzinfo=timezone.utc),
-                                         end=datetime.datetime(2018, 4, 6, 0, 0, tzinfo=timezone.utc))),
-    ('2008', datetime.datetime(2008, 1, 1, 0, 0, tzinfo=timezone.utc)),
-    (('2008', '2008'), datetime.datetime(2008, 1, 1, 0, 0, tzinfo=timezone.utc)),
-    (('2008', '2009'), Range(begin=datetime.datetime(2008, 1, 1, 0, 0, tzinfo=timezone.utc),
-                             end=datetime.datetime(2009, 1, 1, 0, 0, tzinfo=timezone.utc))),
-    (('2008-03', '2009'), Range(begin=datetime.datetime(2008, 3, 1, 0, 0, tzinfo=timezone.utc),
-                             end=datetime.datetime(2009, 1, 1, 0, 0, tzinfo=timezone.utc))),
-    (('2008-03', '2009-10'), Range(begin=datetime.datetime(2008, 3, 1, 0, 0, tzinfo=timezone.utc),
-                             end=datetime.datetime(2009, 10, 1, 0, 0, tzinfo=timezone.utc))),
-    (('2008', '2009-10'), Range(begin=datetime.datetime(2008, 1, 1, 0, 0, tzinfo=timezone.utc),
-                             end=datetime.datetime(2009, 10, 1, 0, 0, tzinfo=timezone.utc))),
-    (('2008-03-03', '2008-11'), Range(begin=datetime.datetime(2008, 3, 3, 0, 0, tzinfo=timezone.utc),
-                             end=datetime.datetime(2008, 11, 1, 0, 0, tzinfo=timezone.utc))),
-    (('2008-11-14', '2008-11-30'), Range(begin=datetime.datetime(2008, 11, 14, 0, 0, tzinfo=timezone.utc),
-                             end=datetime.datetime(2008, 11, 30, 0, 0, tzinfo=timezone.utc))),
-    (('2008-11-14', '2008-11-29'), Range(begin=datetime.datetime(2008, 11, 14, 0, 0, tzinfo=timezone.utc),
-                             end=datetime.datetime(2008, 11, 29, 0, 0, tzinfo=timezone.utc))),
-    (('2008-11-14', '2008-11'), Range(begin=datetime.datetime(2008, 11, 14, 0, 0, tzinfo=timezone.utc),
-                             end=datetime.datetime(2008, 11,  1, 0, 0, tzinfo=timezone.utc))),
-    (('2008-11-14', '2008'), Range(begin=datetime.datetime(2008, 11, 14, 0, 0, tzinfo=timezone.utc),
-                             end=datetime.datetime(2008,  1,  1, 0, 0, tzinfo=timezone.utc))),
-    (('2008-11-14'), datetime.datetime(2008, 11, 14, 0, 0, tzinfo=timezone.utc)),
-]
-
-newtestdata = [
     (('2018-04-05', '2018-04-06'), Range(begin=datetime.datetime(2018, 4, 5, 0, 0, 0, tzinfo=timezone.utc),
                                          end=datetime.datetime(2018, 4, 6, 23, 59, 59, 999000, tzinfo=timezone.utc))),
     ('2008', Range(begin=datetime.datetime(2008, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
-                                         end=datetime.datetime(2008, 12, 31, 23, 59, 59, 999000, tzinfo=timezone.utc))),
+                   end=datetime.datetime(2008, 12, 31, 23, 59, 59, 999000, tzinfo=timezone.utc))),
     (('2008', '2008'), Range(begin=datetime.datetime(2008, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
-                                         end=datetime.datetime(2008, 12, 31, 23, 59, 59, 999000, tzinfo=timezone.utc))),
+                             end=datetime.datetime(2008, 12, 31, 23, 59, 59, 999000, tzinfo=timezone.utc))),
     (('2008', '2009'), Range(begin=datetime.datetime(2008, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
                              end=datetime.datetime(2009, 12, 31, 23, 59, 59, 999000, tzinfo=timezone.utc))),
     (('2008-03', '2009'), Range(begin=datetime.datetime(2008, 3, 1, 0, 0, tzinfo=timezone.utc),
-                             end=datetime.datetime(2009, 12, 31, 23, 59, 59, 999000, tzinfo=timezone.utc))),
+                                end=datetime.datetime(2009, 12, 31, 23, 59, 59, 999000, tzinfo=timezone.utc))),
     (('2008-03', '2009-10'), Range(begin=datetime.datetime(2008, 3, 1, 0, 0, tzinfo=timezone.utc),
-                             end=datetime.datetime(2009, 10, 31, 23, 59, 59, 999000, tzinfo=timezone.utc))),
+                                   end=datetime.datetime(2009, 10, 31, 23, 59, 59, 999000, tzinfo=timezone.utc))),
     (('2008', '2009-10'), Range(begin=datetime.datetime(2008, 1, 1, 0, 0, tzinfo=timezone.utc),
-                             end=datetime.datetime(2009, 10, 31, 23, 59, 59, 999000, tzinfo=timezone.utc))),
+                                end=datetime.datetime(2009, 10, 31, 23, 59, 59, 999000, tzinfo=timezone.utc))),
     (('2008-03-03', '2008-11'), Range(begin=datetime.datetime(2008, 3, 3, 0, 0, 0, tzinfo=timezone.utc),
-                             end=datetime.datetime(2008, 11, 30, 23, 59, 59, 999000, tzinfo=timezone.utc))),
+                                      end=datetime.datetime(2008, 11, 30, 23, 59, 59, 999000, tzinfo=timezone.utc))),
     (('2008-11-14', '2008-11-30'), Range(begin=datetime.datetime(2008, 11, 14, 0, 0, 0, tzinfo=timezone.utc),
-                             end=datetime.datetime(2008, 11, 30, 23, 59, 59, 999000, tzinfo=timezone.utc))),
+                                         end=datetime.datetime(2008, 11, 30, 23, 59, 59, 999000, tzinfo=timezone.utc))),
     (('2008-11-14', '2008-11-29'), Range(begin=datetime.datetime(2008, 11, 14, 0, 0, 0, tzinfo=timezone.utc),
-                             end=datetime.datetime(2008, 11, 29, 23, 59, 59, 999000, tzinfo=timezone.utc))),
+                                         end=datetime.datetime(2008, 11, 29, 23, 59, 59, 999000, tzinfo=timezone.utc))),
     (('2008-11-14', '2008-11'), Range(begin=datetime.datetime(2008, 11, 14, 0, 0, 0, tzinfo=timezone.utc),
-                             end=datetime.datetime(2008, 11,  30, 23, 59, 59, 999000, tzinfo=timezone.utc))),
+                                      end=datetime.datetime(2008, 11,  30, 23, 59, 59, 999000, tzinfo=timezone.utc))),
     (('2008-11-14', '2008'), Range(begin=datetime.datetime(2008, 11, 14, 0, 0, 0, tzinfo=timezone.utc),
-                             end=datetime.datetime(2008,  12,  31, 23, 59, 59, 999000, tzinfo=timezone.utc))),
+                                   end=datetime.datetime(2008,  12,  31, 23, 59, 59, 999000, tzinfo=timezone.utc))),
     (('2008-11-14'), Range(begin=datetime.datetime(2008, 11, 14, 0, 0, 0, tzinfo=timezone.utc),
-                             end=datetime.datetime(2008,  11,  14, 23, 59, 59, 999000, tzinfo=timezone.utc))),
+                           end=datetime.datetime(2008,  11,  14, 23, 59, 59, 999000, tzinfo=timezone.utc))),
     (('2008-11-14', '2009-02-02'), Range(begin=datetime.datetime(2008, 11, 14, 0, 0, 0, tzinfo=timezone.utc),
-                             end=datetime.datetime(2009, 2,  2, 23, 59, 59, 999000, tzinfo=timezone.utc))),
-    (('2008-11-14 23:33:57', '2008-11-14 23:33:57'), Range(begin=datetime.datetime(2008, 11, 14, 23, 33, 57, tzinfo=timezone.utc),
-                             end=datetime.datetime(2008, 11, 14, 23, 33, 57, 999000, tzinfo=timezone.utc))),
-    (('2008-11-14 23:33', '2008-11-14 23:34'), Range(begin=datetime.datetime(2008, 11, 14, 23, 33, 0, tzinfo=timezone.utc),
-                             end=datetime.datetime(2008, 11, 14, 23, 34, 59, 999000, tzinfo=timezone.utc))),
-    (('2008-11-14 23:00:00', '2008-11-14 23:35'), Range(begin=datetime.datetime(2008, 11, 14, 23, 0, tzinfo=timezone.utc),
-                             end=datetime.datetime(2008, 11, 14, 23, 35, 59, 999000, tzinfo=timezone.utc))),
+                                         end=datetime.datetime(2009, 2,  2, 23, 59, 59, 999000, tzinfo=timezone.utc))),
+    (('2008-11-14 23:33:57', '2008-11-14 23:33:57'), Range(begin=datetime.datetime(2008, 11, 14, 23, 33, 57,
+                                                           tzinfo=timezone.utc), end=datetime.datetime(2008, 11, 14,
+                                                           23, 33, 57, 999000, tzinfo=timezone.utc))),
+    (('2008-11-14 23:33', '2008-11-14 23:34'), Range(begin=datetime.datetime(2008, 11, 14, 23, 33, 0,
+                                                     tzinfo=timezone.utc), end=datetime.datetime(2008, 11, 14, 23,
+                                                     34, 59, 999000, tzinfo=timezone.utc))),
+    (('2008-11-14 23:00:00', '2008-11-14 23:35'), Range(begin=datetime.datetime(2008, 11, 14, 23, 0,
+                                                        tzinfo=timezone.utc), end=datetime.datetime(2008, 11, 14, 23,
+                                                        35, 59, 999000, tzinfo=timezone.utc))),
     (('2008-11-10 11', '2008-11-16 14:01'), Range(begin=datetime.datetime(2008, 11, 10, 11, 0, tzinfo=timezone.utc),
-                             end=datetime.datetime(2008, 11, 16, 14, 1, 59, 999000, tzinfo=timezone.utc))),
+                                                  end=datetime.datetime(2008, 11, 16, 14, 1, 59, 999000,
+                                                  tzinfo=timezone.utc))),
 ]
 
-@pytest.mark.parametrize('time_param,expected', newtestdata)
+
+@pytest.mark.parametrize('time_param,expected', testdata)
 def test_time_handling(time_param, expected):
     query = Query(time=time_param)
     assert 'time' in query.search_terms

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -26,7 +26,6 @@ from datacube.model import Range
 from datetime import timezone
 
 
-
 def test_datetime_to_timestamp():
     assert _datetime_to_timestamp((1990, 1, 7)) == 631670400
     assert _datetime_to_timestamp(datetime.datetime(1990, 1, 7)) == 631670400


### PR DESCRIPTION
### Reason for this pull request

... Behaviour of dc.load was inconsistent with xarray when selecting data based on time


### Proposed changes

- `dc.load()` will now be inclusive of all time up to the end of the specified smallest time unit.
- eg. `time=('2008-01', '2008-03')` will retrieve all data between the start of 2008 and 31st of March, 2008 at 23:59:59.999
- eg. `time=('2008-01', '2008-03-12 23:00')` will retrieve all data from the start of 2008 to 12th of March, 2008 at 23:00:59.999.



 - [ ] Closes #184 
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
