### PR TITLE
Fix Broken Travis-CI Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ addons:
     - redis-server
   apt:
     sources:
-      - sourceline: ppa:nextgis/ppa
+      - sourceline: ppa:ubuntugis/ubuntugis-unstable
     packages:
       - gdal-bin
       - libgdal-dev


### PR DESCRIPTION
### Reason for this pull request

The Travis-CI build has been failing. This is due to our usage of the NextGIS Ubuntu GDAL package being broken last week.

They still have the latest ~and greatest~ builds of GDAL, but for now we'll switch to UbuntuGIS-Unstable since they have a *working* build.


### Proposed changes

change `ppa:nextgis/ppa` to `ppa:ubuntugis/ubuntugis-unstable`





<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
