### PR TITLE
Little geotiff write fix

### DIFF
--- a/datacube/helpers.py
+++ b/datacube/helpers.py
@@ -4,8 +4,9 @@ Useful functions for Datacube users
 Not used internally, those should go in `utils.py`
 """
 from __future__ import absolute_import
-import rasterio
+
 import numpy as np
+import rasterio
 
 DEFAULT_PROFILE = {
     'blockxsize': 256,
@@ -18,13 +19,12 @@ DEFAULT_PROFILE = {
     'tiled': True}
 
 
-def write_geotiff(filename, dataset, time_index=None, profile_override=None):
+def write_geotiff(filename, dataset, profile_override=None):
     """
-    Write an xarray dataset to a geotiff
+    Write an ODC style xarray.Dataset to a GeoTIFF file.
 
     :param filename: Output filename
     :attr dataset: xarray dataset containing multiple bands to write to file
-    :attr time_index: time index to write to file
     :attr profile_override: option dict, overrides rasterio file creation options.
     """
     profile_override = profile_override or {}
@@ -39,19 +39,35 @@ def write_geotiff(filename, dataset, time_index=None, profile_override=None):
     profile.update({
         'width': dataset.dims[dataset.crs.dimensions[1]],
         'height': dataset.dims[dataset.crs.dimensions[0]],
-        'affine': dataset.affine,
+        'transform': dataset.affine,
         'crs': dataset.crs.crs_str,
         'count': len(dataset.data_vars),
         'dtype': str(dtypes.pop())
     })
     profile.update(profile_override)
 
+    _calculate_blocksize(profile)
+
     with rasterio.open(str(filename), 'w', **profile) as dest:
         if hasattr(dataset, 'data_vars'):
             for bandnum, data in enumerate(dataset.data_vars.values(), start=1):
-                dest.write(data.isel(time=time_index).data, bandnum)
-        else:  # Assume that we have a DataArray
-            dest.write(dataset.isel(time=time_index).data, 1)
+                dest.write(data.data, bandnum)
+
+
+def _calculate_blocksize(profile):
+    # Block size must be smaller than the image size, and for geotiffs must be divisible by 16
+    # Fix for small images.
+    if profile['blockxsize'] > profile['width']:
+        if profile['width'] % 16 == 0 or profile['width'] < 16:
+            profile['blockxsize'] = profile['width']
+        else:
+            profile['blockxsize'] = 16
+
+    if profile['blockysize'] > profile['height']:
+        if profile['height'] % 16 == 0 or profile['height'] < 16:
+            profile['blockysize'] = profile['height']
+        else:
+            profile['blockysize'] = 16
 
 
 def ga_pq_fuser(dest, src):

--- a/datacube/helpers.py
+++ b/datacube/helpers.py
@@ -19,15 +19,21 @@ DEFAULT_PROFILE = {
     'tiled': True}
 
 
-def write_geotiff(filename, dataset, profile_override=None):
+def write_geotiff(filename, dataset, profile_override=None, time_index=None):
     """
     Write an ODC style xarray.Dataset to a GeoTIFF file.
 
     :param filename: Output filename
-    :attr dataset: xarray dataset containing multiple bands to write to file
-    :attr profile_override: option dict, overrides rasterio file creation options.
+    :param dataset: xarray dataset containing one or more bands to write to a file.
+    :param profile_override: option dict, overrides rasterio file creation options.
+    :param time_index: DEPRECATED
     """
     profile_override = profile_override or {}
+
+    if time_index is not None:
+        raise ValueError('''The write_geotiff function no longer supports passing in `time_index`.
+        The same function can be achieved by calling `dataset.isel(time=<time_index>)` before passing
+        in your dataset. It was removed because it made the function much less useful for more advanced cases.''')
 
     try:
         dtypes = {val.dtype for val in dataset.data_vars.values()}

--- a/datacube/helpers.py
+++ b/datacube/helpers.py
@@ -51,7 +51,7 @@ def write_geotiff(filename, dataset, time_index=None, profile_override=None):
             for bandnum, data in enumerate(dataset.data_vars.values(), start=1):
                 dest.write(data.isel(time=time_index).data, bandnum)
         else:  # Assume that we have a DataArray
-            dest.write(dataset.isel(time=time_index).data, 0)
+            dest.write(dataset.isel(time=time_index).data, 1)
 
 
 def ga_pq_fuser(dest, src):

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -5,6 +5,16 @@
 What's New
 **********
 
+v1.6rc2 (Maybe v1.6 proper) (?? May 2018)
+=========================================
+
+Backwards Incompatible Changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- The `helpers.write_geotiff()` function has been updated to support files smaller
+  than 256x256. It also no longer supports specifying the time index. Before passing
+  data in, use `xarray_data.isel(time=<my_time_index>)`. (#277)
+
 Changes
 ~~~~~~~
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,13 @@ tests in this and sub packages.
 from __future__ import print_function, absolute_import
 
 import os
+
+import numpy as np
 import pytest
+import xarray
+from affine import Affine
+
+from datacube.utils import geometry
 
 
 @pytest.fixture
@@ -28,11 +34,13 @@ def no_crs_gdal_path(data_folder):
 
 @pytest.fixture
 def data_folder():
+    """Return a string path to the location `test/data`"""
     return os.path.join(os.path.split(os.path.realpath(__file__))[0], 'data')
 
 
 @pytest.fixture
 def example_netcdf_path(request):
+    """Return a string path to `sample_tile.nc` in the test data dir"""
     return str(request.fspath.dirpath('data/sample_tile.nc'))
 
 
@@ -41,7 +49,34 @@ netcdf_num = 1
 
 @pytest.fixture
 def tmpnetcdf_filename(tmpdir):
+    """Return a generated filename for a non-existant netcdf file"""
     global netcdf_num
     filename = str(tmpdir.join('testfile_np_%s.nc' % netcdf_num))
     netcdf_num += 1
     return filename
+
+
+@pytest.fixture
+def odc_style_xr_dataset():
+    """An xarray.Dataset with ODC style coordinates and CRS, and no time dimension.
+
+    Contains an EPSG:4326, single variable 'B10' of 100x100 int16 pixels."""
+    affine = Affine.scale(0.1, 0.1) * Affine.translation(20, 30)
+    geobox = geometry.GeoBox(100, 100, affine, geometry.CRS(GEO_PROJ))
+    dataset = xarray.Dataset(attrs={'extent': geobox.extent, 'crs': geobox.crs})
+    for name, coord in geobox.coordinates.items():
+        dataset[name] = (name, coord.values, {'units': coord.units, 'crs': geobox.crs})
+    dataset['B10'] = (geobox.dimensions,
+                      np.arange(10000, dtype='int16').reshape(geobox.shape),
+                      {'nodata': 0, 'units': '1', 'crs': geobox.crs})
+
+    # To include a time dimension:
+    # dataset['B10'] = (('time', 'latitude', 'longitude'), np.arange(10000, dtype='int16').reshape((1, 100, 100)),
+    #  {'nodata': 0, 'units': '1', 'crs': geobox.crs})
+
+    return dataset
+
+
+GEO_PROJ = 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],' \
+           'AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433],' \
+           'AUTHORITY["EPSG","4326"]]'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,11 +7,13 @@ import os
 import string
 
 import pytest
+import rasterio
 from dateutil.parser import parse
-from pandas import to_datetime
 from hypothesis import given
 from hypothesis.strategies import integers, text
+from pandas import to_datetime
 
+from datacube.helpers import write_geotiff
 from datacube.utils import uri_to_local_path, clamp, gen_password, write_user_secret_file, slurp
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes, MISSING, DocumentMismatchError
 from datacube.utils.dates import date_sequence
@@ -157,3 +159,16 @@ def test_more_check_doc_unchanged():
 
     with pytest.raises(DocumentMismatchError, message='Letters differs from stored (a.b: 1!=2)'):
         check_doc_unchanged({'a': {'b': 1}}, {'a': {'b': 2}}, 'Letters')
+
+
+def test_write_geotiff(tmpdir, odc_style_xr_dataset):
+    filename = tmpdir + '/test.tif'
+
+    write_geotiff(filename, odc_style_xr_dataset)
+
+    assert filename.exists()
+
+    with rasterio.open(str(filename)) as src:
+        written_data = src.read(1)
+
+        assert (written_data == odc_style_xr_dataset['B10']).all()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -162,7 +162,10 @@ def test_more_check_doc_unchanged():
 
 
 def test_write_geotiff(tmpdir, odc_style_xr_dataset):
+    """Ensure the geotiff helper writer works, and supports datasets smaller than 256x256."""
     filename = tmpdir + '/test.tif'
+
+    assert len(odc_style_xr_dataset.latitude) < 256
 
     write_geotiff(filename, odc_style_xr_dataset)
 
@@ -172,3 +175,10 @@ def test_write_geotiff(tmpdir, odc_style_xr_dataset):
         written_data = src.read(1)
 
         assert (written_data == odc_style_xr_dataset['B10']).all()
+
+
+def test_write_geotiff_time_index_deprecated():
+    """The `time_index` parameter to `write_geotiff()` was a poorly thought out addition and is now deprecated."""
+
+    with pytest.raises(ValueError):
+        write_geotiff("", None, time_index=1)


### PR DESCRIPTION
### Reason for this pull request

The _helper_ function for writing an ODC style `xarray.Dataset` was unable to write raster arrays smaller than 256x256, as mentioned in #277 .

In addition, an off by 1 bug was introduced, due to GDAL using 1-based indexing, it wasn't being tested, and required the supplied `Dataset` to have a time dimension, which wasn't always the case.


### Proposed changes
- Allow GeoTIFFs smaller than 256x256 to be written
- Fix the 1-based indexing bug
- Deprecate the `time_index` option, and make it raise an Exception with a description of how to update user code
- Add a test which writes a small TIFF file
- Add a fixture for getting an ODC style `xarray.Dataset` for testing 



 - [x] Closes #277
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
