### PR TITLE
Don't copy `storage.driver` into the Product defn on ingest

### DIFF
--- a/datacube/scripts/ingest.py
+++ b/datacube/scripts/ingest.py
@@ -49,7 +49,7 @@ def morph_dataset_type(source_type, config, index, storage_format):
     output_type.definition['managed'] = True
     output_type.definition['description'] = config['description']
     output_type.definition['storage'] = {k: v for (k, v) in config['storage'].items()
-                                         if k in ('crs', 'driver', 'tile_size', 'resolution', 'origin')}
+                                         if k in ('crs', 'tile_size', 'resolution', 'origin')}
 
     output_type.metadata_doc['format'] = {'name': storage_format}
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -29,6 +29,9 @@ Bug Fixes
 - `.dimensions` property of a product no longer crashes when product is missing
   a `grid_spec`, instead defaults to `time,y,x`
 
+- Fix a regression in v1.6rc1 whereby it was impossible to run ``datacube ingest``
+  to create products which were defined in 1.5.5 and earlier versions of ODC. (:issue:`432`, :pull:`436`)
+
 
 
 v1.6rc1 Easter Bilby (10 April 2018)


### PR DESCRIPTION
### Reason for this pull request
See #423 and #293 for more details, but in the recent churn of adding support for defining _drivers_ for reading and writing data, and change crept into **ingester** which caused it to change the `Ingest Config -> Product` step. This meant it was not possible to run `datacube ingest` against an existing products from an old DataCube install without adding an `--allow-product-updates` flag.

### Proposed changes
- Don't copy the `storage.driver` value into the database from an ingestion configuration file.



 - [x] Closes #423
 - [x] Tests passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
