### PR TITLE
Update ubuntu version and add gdal-data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 # This Dockerfile should follow the Travis configuration process
 # available here: https://github.com/opendatacube/datacube-core/blob/develop/.travis.yml
 
 # First add the NextGIS repo
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python-software-properties \
     software-properties-common \
     && rm -rf /var/lib/apt/lists/*
 
@@ -13,7 +12,7 @@ RUN add-apt-repository ppa:nextgis/ppa
 # And now install apt dependencies, including a few of the heavy Python projects
 RUN apt-get update && apt-get install -y --no-install-recommends \
     # Core requirements from travis.yml
-    gdal-bin libgdal-dev libgdal20 libudunits2-0 \
+    gdal-bin gdal-data libgdal-dev libgdal20 libudunits2-0 \
     # Extra python components, to speed things up
     python3 python3-setuptools python3-dev \
     python3-numpy python3-netcdf4 python3-gdal \


### PR DESCRIPTION
### Reason for this pull request
This fixes an issue where the `gdal-data` package is not installed. Seems to have been a change in the NextGIS PPA, I think, removing it as a dependency of `gdal-bin`, which is a bit foolish on their part!

### Proposed changes
- Upgraded to Ubuntu 18.04, which is the latest LTS
- Changed packages to support use of PPA to what 18.04 needs
- Added `gdal-bin` package

 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes
