### PR TITLE
Include latest GDAL builds in Travis-CI (again)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,10 @@ addons:
     - redis-server
   apt:
     sources:
-      - sourceline: ppa:ubuntugis/ubuntugis-unstable
+      - sourceline: ppa:nextgis/ppa
     packages:
       - gdal-bin
+      - gdal-data
       - libgdal-dev
       - libgdal20
       - libudunits2-0


### PR DESCRIPTION
We switched to the UbuntuGIS PPA since the NextGIS ones seemed to be
broken. But it turns out they simply changed their packaging structure.
They now require both `gdal-bin` and `gdal-data` to be installed.

We want to use the nextgis/ppa because it has more up to date versions
of GDAL, and we want to catch breakages with modern GDAL early.