### PR TITLE
Remove the 'stack' keyword argument to 'Datacube.load'

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -144,7 +144,7 @@ class Datacube(object):
         return measurements
 
     #: pylint: disable=too-many-arguments, too-many-locals
-    def load(self, product=None, measurements=None, output_crs=None, resolution=None, resampling=None, stack=False,
+    def load(self, product=None, measurements=None, output_crs=None, resolution=None, resampling=None,
              dask_chunks=None, like=None, fuse_func=None, align=None, datasets=None, use_threads=False, **query):
         """
         Load data as an ``xarray`` object.  Each measurement will be a data variable in the :class:`xarray.Dataset`.
@@ -205,10 +205,6 @@ class Datacube(object):
 
 
         **Output**
-            If the `stack` argument is supplied, the returned data is stacked in a single ``DataArray``.
-            A new dimension is created with the name supplied.
-            This requires all of the data to be of the same datatype.
-
             To reproject or resample the data, supply the ``output_crs``, ``resolution``, ``resampling`` and ``align``
             fields.
 
@@ -252,13 +248,6 @@ class Datacube(object):
 
             Default is (0,0)
 
-        :param stack: The name of the new dimension used to stack the measurements.
-            If provided, the data is returned as a :class:`xarray.DataArray` rather than a :class:`xarray.Dataset`.
-
-            If only one measurement is returned, the dimension name is not used and the dimension is dropped.
-
-        :type stack: str or bool
-
         :param dict dask_chunks:
             If the data should be lazily loaded using :class:`dask.array.Array`,
             specify the chunking size in each output dimension.
@@ -294,14 +283,16 @@ class Datacube(object):
             Optional. If provided, limit the maximum number of datasets
             returned. Useful for testing and debugging.
 
-        :return: Requested data in a :class:`xarray.Dataset`, or
-            as a :class:`xarray.DataArray` if the ``stack`` variable is supplied.
-
-        :rtype: :class:`xarray.Dataset` or :class:`xarray.DataArray`
+        :return: Requested data in a :class:`xarray.Dataset`
+        :rtype: :class:`xarray.Dataset`
         """
+        if 'stack' in query:
+            raise DeprecationWarning("the `stack` keyword argument is not supported anymore, "
+                                     "please apply `xarray.Dataset.to_array()` to the result instead")
+
         observations = datasets or self.find_datasets(product=product, like=like, **query)
         if not observations:
-            return None if stack else xarray.Dataset()
+            return xarray.Dataset()
 
         geobox = output_geobox(like=like, output_crs=output_crs, resolution=resolution, align=align,
                                grid_spec=self.index.products.get_by_name(product).grid_spec,
@@ -317,12 +308,7 @@ class Datacube(object):
                                 fuse_func=fuse_func,
                                 dask_chunks=dask_chunks,
                                 use_threads=use_threads)
-        if not stack:
-            return result
-        else:
-            if not isinstance(stack, string_types):
-                stack = 'measurement'
-            return result.to_array(dim=stack)
+        return result
 
     def product_observations(self, **kwargs):
         warnings.warn("product_observations() has been renamed to find_datasets() and will eventually be removed",

--- a/datacube_apps/pixeldrill.py
+++ b/datacube_apps/pixeldrill.py
@@ -504,16 +504,16 @@ def run(latrange=None, lonrange=None, timerange=None, measurements=None,
                          time=timerange,
                          latitude=latrange,
                          longitude=lonrange,
-                         group_by=groupby,
-                         stack='band')
+                         group_by=groupby)
 
         # Check that we have data returned
 
-        if dcdata is None:
+        if dcdata.data_vars == {}:
             print('loading data failed, no data in that range.')
             sys.exit(1)
 
         # Extract times and band information
+        dcdata = dcdata.to_array(dim='band')
 
         times = dcdata.coords['time'].to_index().tolist()
         bands = dcdata.coords['band'].to_index().tolist()

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -15,6 +15,8 @@ Backwards Incompatible Changes
   than 256x256. It also no longer supports specifying the time index. Before passing
   data in, use `xarray_data.isel(time=<my_time_index>)`. (#277)
 
+- The seldom-used `stack` keyword argument has been removed from `Datcube.load`. (#461)
+
 Changes
 ~~~~~~~
 

--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -95,7 +95,7 @@ def check_open_with_dc(index):
     from datacube.api.core import Datacube
     dc = Datacube(index=index)
 
-    data_array = dc.load(product='ls5_nbar_albers', measurements=['blue'], stack='variable')
+    data_array = dc.load(product='ls5_nbar_albers', measurements=['blue']).to_array(dim='variable')
     assert data_array.shape
     assert (data_array != -999).any()
 
@@ -107,14 +107,15 @@ def check_open_with_dc(index):
     assert data_array['blue'].shape[1:] == (1, 1)
     assert (data_array.blue != -999).any()
 
-    data_array = dc.load(product='ls5_nbar_albers', latitude=(-35, -36), longitude=(149, 150), stack='variable')
+    data_array = dc.load(product='ls5_nbar_albers', latitude=(-35, -36), longitude=(149, 150)).to_array(dim='variable')
+
     assert data_array.ndim == 4
     assert 'variable' in data_array.dims
     assert (data_array != -999).any()
 
     with rasterio.Env():
         lazy_data_array = dc.load(product='ls5_nbar_albers', latitude=(-35, -36), longitude=(149, 150),
-                                  stack='variable', dask_chunks={'time': 1, 'x': 1000, 'y': 1000})
+                                  dask_chunks={'time': 1, 'x': 1000, 'y': 1000}).to_array(dim='variable')
         assert lazy_data_array.data.dask
         assert lazy_data_array.ndim == data_array.ndim
         assert 'variable' in lazy_data_array.dims


### PR DESCRIPTION
### Reason for this pull request
The keyword argument `stack`, when supplied, squashes all the different
data variables into one, provided they all have the same dimensions.
A handy feature which, however, is equivalent to calling
```python
data.to_array(dim=stack)
```
and has less to do with loading the data.

But the more serious objection that I have against it is that it changes the
return type of the method (from a clean `xarray.Dataset` to
`Union[xarray.Dataset, xarray.DataArray, None]` in the current implementation).

Perhaps even more confusing is that the parameter itself has type `Union[bool, str]`.

### Proposed changes
- Nuke it. Persevere through the fallout.
