### PR TITLE
Dataset move

### DIFF
--- a/datacube/storage/storage.py
+++ b/datacube/storage/storage.py
@@ -430,7 +430,7 @@ class RasterDatasetDataSource(RasterioDataSource):
         if src.count == 1:  # Single-slice netcdf file
             return 1
 
-        _LOG.warning("Encountered stacked netcdf file without recorded index\n - %s", src.name)
+        _LOG.debug("Encountered stacked netcdf file without recorded index\n - %s", src.name)
 
         # Below is backwards compatibility code
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -26,6 +26,12 @@ Backwards Incompatible Changes
 Changes
 ~~~~~~~
 
+- Add `--location-policy` to `datacube dataset update` command. Previously this
+  command would always just add a new location to the list of uris associated
+  with a given dataset, now one can specify `archive` and `forget` options,
+  which would mark previous location as archived or remove it from the index
+  altogether. The default behaviour is unchanged. (:pull:`469`)
+
 - The masking related function `describe_variable_flags()` now returns a
   pandas DataFrame by default. This will display as a table in Jupyter
   Notebooks. (:pull:`422`)

--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -87,12 +87,21 @@ def test_end_to_end(clirunner, index, testdata_dir, ingest_configs):
                str(lbg_nbar), str(lbg_pq)])
 
     # Test no-op update
-    clirunner(['-v', 'dataset', 'update', '--dry-run',
-               str(lbg_nbar), str(lbg_pq)])
+    for policy in ['archive', 'forget', 'keep']:
+        clirunner(['-v', 'dataset', 'update',
+                   '--dry-run',
+                   '--location-policy', policy,
+                   str(lbg_nbar), str(lbg_pq)])
 
-    # Test no changes needed update
-    clirunner(['-v', 'dataset', 'update',
-               str(lbg_nbar), str(lbg_pq)])
+        # Test no changes needed update
+        clirunner(['-v', 'dataset', 'update',
+                   '--location-policy', policy,
+                   str(lbg_nbar), str(lbg_pq)])
+
+    # TODO: test location update
+    # 1. Make a copy of a file
+    # 2. Call dataset update with archive/forget
+    # 3. Check location
 
     # Ingest NBAR
     clirunner(['-v', 'ingest', '-c', str(ls5_nbar_albers_ingest_config)])


### PR DESCRIPTION
### Reason for this pull request

As part of addressing #415, we need to update location uris for stacked datasets on the NCI, this adds a generally useful option to `datacube dataset update` that would allow to either archive or completely forget existing location of a dataset when calling update with a new uri. 


### Proposed changes

Add `--location-policy` to `datacube dataset update` command. Previously this command would always just add a new location to the list of uris associated with a given dataset, now one can specify `archive` and `forget` options, which would mark previous location as archived or remove it from the index altogether. The default behaviour is unchanged, and will just insert new location into a set of locations this dataset can be found at.

While I have added tests, they are fairly rudimentary.

 - [x] Closes #465 
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes