### PR TITLE
Add option to find datasets from prefix rather than exact path

### DIFF
--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -288,8 +288,11 @@ class PostgresDbAPI(object):
             ).fetchone()
         )
 
-    def get_datasets_for_location(self, uri, mode="exact"):
+    def get_datasets_for_location(self, uri, mode=None):
         scheme, body = _split_uri(uri)
+
+        if mode is None:
+            mode = 'exact' if body.count('#') > 0 else 'prefix'
 
         if mode == 'exact':
             body_query = DATASET_LOCATION.c.uri_body == body

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -288,16 +288,23 @@ class PostgresDbAPI(object):
             ).fetchone()
         )
 
-    def get_datasets_for_location(self, uri):
+    def get_datasets_for_location(self, uri, mode="exact"):
         scheme, body = _split_uri(uri)
+
+        if mode == 'exact':
+            body_query = DATASET_LOCATION.c.uri_body == body
+        elif mode == 'prefix':
+            body_query = DATASET_LOCATION.c.uri_body.startswith(body)
+        else:
+            raise ValueError('Unsupported query mode {}'.format(mode))
+
         return self._connection.execute(
             select(
                 _DATASET_SELECT_FIELDS
             ).select_from(
                 DATASET_LOCATION.join(DATASET)
             ).where(
-                and_(DATASET_LOCATION.c.uri_scheme == scheme,
-                     DATASET_LOCATION.c.uri_body == body)
+                and_(DATASET_LOCATION.c.uri_scheme == scheme, body_query)
             )
         ).fetchall()
 

--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -370,9 +370,9 @@ class DatasetResource(object):
             except DuplicateRecordError:
                 return False
 
-    def get_datasets_for_location(self, uri):
+    def get_datasets_for_location(self, uri, mode='exact'):
         with self._db.connect() as connection:
-            return (self._make(row) for row in connection.get_datasets_for_location(uri))
+            return (self._make(row) for row in connection.get_datasets_for_location(uri, mode=mode))
 
     def remove_location(self, id_, uri):
         """

--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -370,7 +370,7 @@ class DatasetResource(object):
             except DuplicateRecordError:
                 return False
 
-    def get_datasets_for_location(self, uri, mode='exact'):
+    def get_datasets_for_location(self, uri, mode=None):
         with self._db.connect() as connection:
             return (self._make(row) for row in connection.get_datasets_for_location(uri, mode=mode))
 

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -352,8 +352,9 @@ def test_index_dataset_with_location(index, default_metadata_type):
     second_ds_doc = copy.deepcopy(_telemetry_dataset)
     second_ds_doc['id'] = '366f32d8-e1f8-11e6-94b4-185e0f80a5c0'
     index.datasets.add(Dataset(type_, second_ds_doc, uris=[second_file.as_uri()], sources={}))
-    dataset_ids = [d.id for d in index.datasets.get_datasets_for_location(first_file.as_uri())]
-    assert dataset_ids == [dataset.id]
+    for mode in ('exact', 'prefix'):
+        dataset_ids = [d.id for d in index.datasets.get_datasets_for_location(first_file.as_uri(), mode=mode)]
+        assert dataset_ids == [dataset.id]
 
 
 def utc_now():

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -352,9 +352,11 @@ def test_index_dataset_with_location(index, default_metadata_type):
     second_ds_doc = copy.deepcopy(_telemetry_dataset)
     second_ds_doc['id'] = '366f32d8-e1f8-11e6-94b4-185e0f80a5c0'
     index.datasets.add(Dataset(type_, second_ds_doc, uris=[second_file.as_uri()], sources={}))
-    for mode in ('exact', 'prefix'):
+    for mode in ('exact', 'prefix', None):
         dataset_ids = [d.id for d in index.datasets.get_datasets_for_location(first_file.as_uri(), mode=mode)]
         assert dataset_ids == [dataset.id]
+
+    assert list(index.datasets.get_datasets_for_location(first_file.as_uri() + "#part=100")) == []
 
     with pytest.raises(ValueError):
         list(index.datasets.get_datasets_for_location(first_file.as_uri(), mode="nosuchmode"))

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -356,6 +356,9 @@ def test_index_dataset_with_location(index, default_metadata_type):
         dataset_ids = [d.id for d in index.datasets.get_datasets_for_location(first_file.as_uri(), mode=mode)]
         assert dataset_ids == [dataset.id]
 
+    with pytest.raises(ValueError):
+        list(index.datasets.get_datasets_for_location(first_file.as_uri(), mode="nosuchmode"))
+
 
 def utc_now():
     # utcnow() doesn't include a tzinfo.


### PR DESCRIPTION
Adding backwards compatible option to `get_datasets_for_location` called
`mode=prefix|exact|None=auto`.

Default mode is `auto` which means prefix search for uris without fragment part, and exact search if fragment part is present. This way old code that did `index. get_datasets_for_location(path.as_uri())` will still do the same thing even if db was updated with fragment information. Only thing is that this will now return results when path is a valid folder also, when in the past it wouldn't.

### Reason for this pull request

Needed for `dea-sync` to find datasets for stacked netcdfs after we update locations to include `#part=x` in the uri. 



 - [x] Closes #466
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

This is internal api as far as I can tell so no additions to `whats_new.rst`