### PR TITLE
include KeyError in exceptions for getting DEFAULT_DB_USER

### DIFF
--- a/datacube/drivers/postgres/_connections.py
+++ b/datacube/drivers/postgres/_connections.py
@@ -35,8 +35,8 @@ try:
     import pwd
 
     DEFAULT_DB_USER = pwd.getpwuid(os.geteuid()).pw_name
-except ImportError:
-    # No default on Windows
+except (ImportError, KeyError):
+    # No default on Windows and some other systems
     DEFAULT_DB_USER = None
 DEFAULT_DB_PORT = 5432
 


### PR DESCRIPTION
### Reason for this pull request

Working on Jupyterhub, by default, the user is none (somehow!), so this line of code breaks.


### Proposed changes

- Handle `KeyError` exception when trying to get the OS user for the `DEFAULT_DB_USER` variable

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.
-->
