### PR TITLE
Indexing cleanup

### DIFF
--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -354,6 +354,11 @@ class PostgresDbAPI(object):
             select(_DATASET_SELECT_FIELDS).where(DATASET.c.id == dataset_id)
         ).first()
 
+    def get_datasets(self, dataset_ids):
+        return self._connection.execute(
+            select(_DATASET_SELECT_FIELDS).where(DATASET.c.id.in_(dataset_ids))
+        ).fetchall()
+
     def get_derived_datasets(self, dataset_id):
         return self._connection.execute(
             select(

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -656,12 +656,13 @@ class PostgresDbAPI(object):
             METADATA_TYPE.select().where(METADATA_TYPE.c.name == name)
         ).first()
 
-    def add_dataset_type(self,
-                         name,
-                         metadata,
-                         metadata_type_id,
-                         search_fields,
-                         definition, concurrently=True):
+    def insert_dataset_type(self,
+                            name,
+                            metadata,
+                            metadata_type_id,
+                            search_fields,
+                            definition,
+                            concurrently=True):
 
         res = self._connection.execute(
             DATASET_TYPE.insert().values(
@@ -714,7 +715,7 @@ class PostgresDbAPI(object):
                                         rebuild_view=True)
         return type_id
 
-    def add_metadata_type(self, name, definition, concurrently=False):
+    def insert_metadata_type(self, name, definition, concurrently=False):
         res = self._connection.execute(
             METADATA_TYPE.insert().values(
                 name=name,

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -35,11 +35,7 @@ from ._schema import (
     DATASET, DATASET_SOURCE, METADATA_TYPE, DATASET_LOCATION, DATASET_TYPE
 )
 
-try:
-    from typing import Iterable
-    from typing import Tuple
-except ImportError:
-    pass
+from typing import Iterable, Tuple
 
 
 def _dataset_uri_field(table):

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -61,7 +61,8 @@ _DATASET_SELECT_FIELDS = (
                 SELECTED_DATASET_LOCATION.c.archived == None
             )
         ).order_by(
-            SELECTED_DATASET_LOCATION.c.added.desc()
+            SELECTED_DATASET_LOCATION.c.added.desc(),
+            SELECTED_DATASET_LOCATION.c.id.desc()
         ).label('uris')
     ).label('uris')
 )
@@ -834,7 +835,8 @@ class PostgresDbAPI(object):
                 ]).where(
                     and_(DATASET_LOCATION.c.dataset_ref == dataset_id, DATASET_LOCATION.c.archived == None)
                 ).order_by(
-                    DATASET_LOCATION.c.added.desc()
+                    DATASET_LOCATION.c.added.desc(),
+                    DATASET_LOCATION.c.id.desc()
                 )
             ).fetchall()
         ]

--- a/datacube/drivers/postgres/_fields.py
+++ b/datacube/drivers/postgres/_fields.py
@@ -24,10 +24,7 @@ from datacube.model import Range
 from datacube.utils import get_doc_offset_safe
 from .sql import FLOAT8RANGE
 
-try:
-    from typing import Any, Callable, Tuple, Union
-except ImportError:
-    pass
+from typing import Any, Callable, Tuple, Union
 
 
 class PgField(Field):

--- a/datacube/drivers/s3aio_index/index.py
+++ b/datacube/drivers/s3aio_index/index.py
@@ -73,15 +73,15 @@ class DatasetResource(BaseDatasetResource):
     additional s3 information to specific tables.
     """
 
-    def add(self, dataset, sources_policy='verify', **kwargs):
-        saved_dataset = super(DatasetResource, self).add(dataset, sources_policy, **kwargs)
+    def add(self, dataset, with_lineage=None, **kwargs):
+        saved_dataset = super(DatasetResource, self).add(dataset, with_lineage=with_lineage, **kwargs)
 
         if dataset.format == FORMAT:
             storage_metadata = kwargs['storage_metadata']  # It's an error to not include this
             self.add_datasets_to_s3_tables([dataset.id], storage_metadata)
         return saved_dataset
 
-    def add_multiple(self, datasets, sources_policy='verify'):
+    def add_multiple(self, datasets, with_lineage=None):
         """Index several datasets.
 
         Perform the normal indexing, followed by the s3 specific
@@ -91,7 +91,7 @@ class DatasetResource(BaseDatasetResource):
         :param datasets: The datasets to be indexed. It must contain
           an attribute named `storage_metadata` otherwise a ValueError
           is raised.
-        :param str sources_policy: The sources policy.
+        :param bool with_lineage: Whether to recursively add lineage, default: yes
         :return: The number of datasets indexed.
         :rtype: int
 
@@ -104,7 +104,7 @@ class DatasetResource(BaseDatasetResource):
         # dataset_refs = []
         # n = 0
         # for dataset in datasets.values:
-        #     self.add(dataset, sources_policy=sources_policy)
+        #     self.add(dataset, with_lineage=with_lineage)
         #     dataset_refs.append(dataset.id)
         #     n += 1
         # if n == len(datasets):

--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -117,9 +117,6 @@ class DatasetResource(object):
 
         :rtype: Dataset
         """
-        if 'skip_sources' in kwargs and kwargs['skip_sources']:
-            warnings.warn('"skip_sources" is deprecated, use "sources_policy=\'skip\'"', DeprecationWarning)
-            sources_policy = 'skip'
         self._add_sources(dataset, sources_policy)
 
         sources_tmp = dataset.metadata.sources

--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -76,6 +76,16 @@ class DatasetResource(object):
             }
         return datasets[id_][0]
 
+    def get_many(self, ids):
+        def to_uuid(x):
+            return x if isinstance(x, UUID) else UUID(x)
+
+        ids = [to_uuid(i) for i in ids]
+
+        with self._db.connect() as connection:
+            rows = connection.get_datasets(ids)
+            return [self._make(r, full_info=True) for r in rows]
+
     def get_derived(self, id_):
         """
         Get all derived datasets

--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -560,16 +560,12 @@ class DatasetResource(object):
     def _try_add(self, dataset):
         was_inserted = False
 
-        product = self.types.get_by_name(dataset.type.name)
-        if product is None:
-            _LOG.warning('Adding product "%s" as it doesn\'t exist.', dataset.type.name)
-            product = self.types.add(dataset.type)
         if dataset.sources is None:
             raise ValueError("Dataset has missing (None) sources. Was this loaded without include_sources=True?")
 
         with self._db.begin() as transaction:
             try:
-                was_inserted = transaction.insert_dataset(dataset.metadata_doc, dataset.id, product.id)
+                was_inserted = transaction.insert_dataset(dataset.metadata_doc, dataset.id, dataset.type.id)
 
                 for classifier, source_dataset in dataset.sources.items():
                     transaction.insert_dataset_source(classifier, dataset.id, source_dataset.id)

--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -8,6 +8,7 @@ import logging
 import warnings
 from collections import namedtuple
 from uuid import UUID
+from typing import Any, Iterable, Mapping, Set, Tuple, Union
 
 from datacube import compat
 from datacube.model import Dataset, DatasetType
@@ -19,10 +20,6 @@ from .exceptions import DuplicateRecordError
 
 _LOG = logging.getLogger(__name__)
 
-try:
-    from typing import Any, Iterable, Mapping, Set, Tuple, Union
-except ImportError:
-    pass
 
 
 # It's a public api, so we can't reorganise old methods.

--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -135,14 +135,6 @@ class DatasetResource(object):
                         jsonify_document(dataset.metadata_doc),
                         'Dataset {}'.format(dataset.id)
                     )
-
-                # reinsert attempt? try updating the location
-                if dataset.uris:
-                    try:
-                        with self._db.begin() as transaction:
-                            transaction.ensure_dataset_locations(dataset.id, dataset.uris)
-                    except DuplicateRecordError as e:
-                        _LOG.warning(str(e))
         finally:
             dataset.metadata.sources = sources_tmp
 

--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -72,7 +72,7 @@ class DatasetResource(object):
             }
         return datasets[id_][0]
 
-    def get_many(self, ids):
+    def bulk_get(self, ids):
         def to_uuid(x):
             return x if isinstance(x, UUID) else UUID(x)
 
@@ -105,7 +105,7 @@ class DatasetResource(object):
         with self._db.connect() as connection:
             return connection.contains_dataset(id_)
 
-    def has_many(self, ids_):
+    def bulk_has(self, ids_):
         """
         Like `has` but operates on a list of ids.
 
@@ -163,7 +163,7 @@ class DatasetResource(object):
             ds_by_uuid = flatten_datasets(dataset)
             all_uuids = list(ds_by_uuid)
 
-            present = {k: v for k, v in zip(all_uuids, self.has_many(all_uuids))}
+            present = {k: v for k, v in zip(all_uuids, self.bulk_has(all_uuids))}
 
             if present[dataset.id]:
                 _LOG.warning('Dataset %s is already in the database', dataset.id)

--- a/datacube/index/_metadata_types.py
+++ b/datacube/index/_metadata_types.py
@@ -74,7 +74,7 @@ class MetadataTypeResource(object):
             )
         else:
             with self._db.connect() as connection:
-                connection.add_metadata_type(
+                connection.insert_metadata_type(
                     name=metadata_type.name,
                     definition=metadata_type.definition,
                     concurrently=not allow_table_lock

--- a/datacube/index/_products.py
+++ b/datacube/index/_products.py
@@ -98,7 +98,7 @@ class ProductResource(object):
                 metadata_type = self.metadata_type_resource.add(product.metadata_type,
                                                                 allow_table_lock=allow_table_lock)
             with self._db.connect() as connection:
-                connection.add_dataset_type(
+                connection.insert_dataset_type(
                     name=product.name,
                     metadata=product.metadata_doc,
                     metadata_type_id=metadata_type.id,

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -14,7 +14,7 @@ from uuid import UUID
 from affine import Affine
 
 from datacube.compat import urlparse
-from datacube.utils import geometry
+from datacube.utils import geometry, without_lineage_sources
 from datacube.utils import parse_time, cached_property, uri_to_local_path, intersects, schema_validated, DocReader
 from datacube.utils.geometry import (CRS as _CRS,
                                      GeoBox as _GeoBox,
@@ -309,6 +309,11 @@ class Dataset(object):
     @property
     def metadata(self):
         return self.metadata_type.dataset_reader(self.metadata_doc)
+
+    def metadata_doc_without_lineage(self):
+        """ Return metadata document without nested lineage datasets
+        """
+        return without_lineage_sources(self.metadata_doc, self.metadata_type)
 
 
 class Measurement(object):

--- a/datacube/model/utils.py
+++ b/datacube/model/utils.py
@@ -281,3 +281,30 @@ def traverse_datasets(ds, cbk, mode='post-order', **kwargs):
         raise ValueError('Unsupported traversal mode: {}'.format(mode))
 
     proc(ds, cbk)
+
+
+def flatten_datasets(ds):
+    """Build a dictionary mapping from dataset.id to a list of datasets with that
+    id appearing in the lineage DAG. When DAG is unrolled into a tree, some
+    datasets will be reachable by multiple paths, sometimes these would be
+    exactly the same python object, other times they will be duplicate views of
+    the same "conceptual dataset object". If the same dataset is reachable by
+    three possible paths from the root, it will appear three times in the
+    flattened view.
+
+    ds could be a Dataset object read from DB with `include_sources=True`, or
+    it could be `SimpleDocNav` object created from a dataset metadata document
+    read from a file.
+
+    """
+    def proc(ds, depth=0, name=None, out=None):
+        k = ds.id
+
+        if k not in out:
+            out[k] = []
+
+        out[k].append(ds)
+
+    out = {}
+    traverse_datasets(ds, proc, out=out)
+    return out

--- a/datacube/model/utils.py
+++ b/datacube/model/utils.py
@@ -14,7 +14,7 @@ from pandas import to_datetime
 
 import datacube
 from datacube.model import Dataset
-from datacube.utils import geometry, SimpleDocNav, sorted_items
+from datacube.utils import geometry, SimpleDocNav, sorted_items, InvalidDocException
 
 try:
     from yaml import CSafeDumper as SafeDumper
@@ -375,10 +375,10 @@ def dedup_lineage(root):
             _ds, _doc, _sources = existing
 
             if not check_sources(sources, _sources):
-                raise ValueError('Inconsistent lineage for repeated dataset with _id: {}'.format(_id))
+                raise InvalidDocException('Inconsistent lineage for repeated dataset with _id: {}'.format(_id))
 
             if doc != _doc:
-                raise ValueError('Inconsistent metadata for repeated dataset with _id: {}'.format(_id))
+                raise InvalidDocException('Inconsistent metadata for repeated dataset with _id: {}'.format(_id))
 
             return _ds
 

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -22,10 +22,7 @@ from datacube.ui.common import get_metadata_path
 from datacube.utils import read_documents, changes, InvalidDocException, without_lineage_sources
 from datacube.utils.serialise import SafeDatacubeDumper
 
-try:
-    from typing import Iterable
-except ImportError:
-    pass
+from typing import Iterable
 
 _LOG = logging.getLogger('datacube-dataset')
 

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -293,13 +293,6 @@ def load_datasets_for_update(dataset_paths, index):
                 _LOG.error("Dataset %s inconsistency: %s", dataset.id, reason)
 
 
-def parse_match_rules_options(index, dtype, auto_match):
-    if auto_match is True:
-        _LOG.warning("--auto-match option is deprecated, update your scripts, behaviour is the same without it")
-
-    return load_rules_from_types(index, dtype)
-
-
 @dataset_cmd.command('add',
                      help="Add datasets to the Data Cube",
                      context_settings=dict(token_normalize_func=report_old_options({
@@ -351,7 +344,10 @@ def index_cmd(index, product_names,
 
         confirm_ignore_lineage = True
 
-    rules = parse_match_rules_options(index, product_names, auto_match)
+    if auto_match is True:
+        _LOG.warning("--auto-match option is deprecated, update your scripts, behaviour is the same without it")
+
+    rules = load_rules_from_types(index, product_names)
     if rules is None:
         sys.exit(2)
 

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -125,8 +125,16 @@ def check_dataset_consistent(dataset):
     :return: (Is consistent, [error message|None])
     :rtype: (bool, str or None)
     """
+    product_measurements = set(dataset.type.measurements.keys())
+
+    if len(product_measurements) == 0:
+        return True, None
+
+    if dataset.measurements is None:
+        return False, "No measurements defined for a dataset"
+
     # It the type expects measurements, ensure our dataset contains them all.
-    if not set(dataset.type.measurements.keys()).issubset(dataset.measurements.keys()):
+    if not product_measurements.issubset(dataset.measurements.keys()):
         return False, "measurement fields don't match type specification"
 
     return True, None

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -189,7 +189,7 @@ def dataset_resolver(index,
 
         ds_by_uuid = toolz.valmap(toolz.first, flatten_datasets(main_ds))
         all_uuid = list(ds_by_uuid)
-        db_dss = {str(ds.id): ds for ds in index.datasets.get_many(all_uuid)}
+        db_dss = {str(ds.id): ds for ds in index.datasets.bulk_get(all_uuid)}
 
         lineage_uuids = set(filter(lambda x: x != main_uuid, all_uuid))
         missing_lineage = lineage_uuids - set(db_dss)

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -316,6 +316,10 @@ def parse_match_rules_options(index, dtype, auto_match):
               help=('Default behaviour is to automatically add lineage datasets if they are missing from the database, '
                     'but this can be disabled if lineage is expected to be present in the DB, '
                     'in this case add will abort when encountering missing lineage dataset'))
+@click.option('--verify-lineage/--no-verify-lineage', is_flag=True, default=True,
+              help=('Lineage referenced in the metadata document should be the same as in DB, '
+                    'default behaviour is to skip those top-level datasets that have lineage data '
+                    'different from the version in the DB. This option allows omitting verification step.'))
 @click.option('--dry-run', help='Check if everything is ok', is_flag=True, default=False)
 @click.option('--ignore-lineage',
               help="Pretend that there is no lineage data in the datasets being indexed",
@@ -329,6 +333,7 @@ def parse_match_rules_options(index, dtype, auto_match):
 def index_cmd(index, product_names,
               auto_match,
               auto_add_lineage,
+              verify_lineage,
               dry_run,
               ignore_lineage,
               confirm_ignore_lineage,
@@ -351,8 +356,6 @@ def index_cmd(index, product_names,
         sys.exit(2)
 
     assert len(rules) > 0
-
-    verify_lineage = not confirm_ignore_lineage
 
     ds_resolve = dataset_resolver(index, rules,
                                   skip_lineage=confirm_ignore_lineage,

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -356,6 +356,7 @@ def index_cmd(index, product_names,
 
     ds_resolve = dataset_resolver(index, rules,
                                   skip_lineage=confirm_ignore_lineage,
+                                  fail_on_missing_lineage=not auto_add_lineage,
                                   verify_lineage=verify_lineage)
 
     def run_it(dataset_paths):

--- a/datacube/scripts/ingest.py
+++ b/datacube/scripts/ingest.py
@@ -266,7 +266,7 @@ def _index_datasets(index, results):
             extra_args['storage_metadata'] = datasets.attrs['storage_metadata']
 
         for dataset in datasets.values:
-            index.datasets.add(dataset, sources_policy='skip', **extra_args)
+            index.datasets.add(dataset, with_lineage=False, **extra_args)
             n += 1
     return n
 

--- a/datacube/testutils/__init__.py
+++ b/datacube/testutils/__init__.py
@@ -12,8 +12,6 @@ from datetime import datetime
 
 import pathlib
 
-from osgeo import gdal
-
 from datacube import compat
 from datacube.model import Dataset, DatasetType, MetadataType
 
@@ -95,66 +93,6 @@ def _write_files_to_dir(directory_path, file_dict):
                     f.write(contents)
                 else:
                     raise Exception('Unexpected file contents: %s' % type(contents))
-
-
-def temp_dir():
-    """
-    Create and return a temporary directory that will be deleted automatically on exit.
-
-    :rtype: pathlib.Path
-    """
-    return write_files({})
-
-
-def temp_file(suffix=""):
-    """
-    Get a temporary file path that will be cleaned up on exit.
-
-    Simpler than NamedTemporaryFile--- just a file path, no open mode or anything.
-    :return:
-    """
-    f = tempfile.mktemp(suffix=suffix)
-
-    def permissive_ignore(file_):
-        if os.path.exists(file_):
-            os.remove(file_)
-
-    atexit.register(permissive_ignore, f)
-    return f
-
-
-def file_of_size(path, size_mb):
-    """
-    Create a blank file of the given size.
-    """
-    with open(path, "wb") as f:
-        f.seek(size_mb * 1024 * 1024 - 1)
-        f.write("\0")
-
-
-def create_empty_dataset(src_filename, out_filename):
-    """
-    Create a new GDAL dataset based on an existing one, but with no data.
-
-    Will contain the same projection, extents, etc, but have a very small filesize.
-
-    These files can be used for automated testing without having to lug enormous files around.
-
-    :param src_filename: Source Filename
-    :param out_filename: Output Filename
-    """
-    inds = gdal.Open(src_filename)
-    driver = inds.GetDriver()
-    band = inds.GetRasterBand(1)
-
-    out = driver.Create(out_filename,
-                        inds.RasterXSize,
-                        inds.RasterYSize,
-                        inds.RasterCount,
-                        band.DataType)
-    out.SetGeoTransform(inds.GetGeoTransform())
-    out.SetProjection(inds.GetProjection())
-    out.FlushCache()
 
 
 def isclose(a, b, rel_tol=1e-09, abs_tol=0.0):

--- a/datacube/testutils/__init__.py
+++ b/datacube/testutils/__init__.py
@@ -14,6 +14,8 @@ import pathlib
 
 from datacube import compat
 from datacube.model import Dataset, DatasetType, MetadataType
+from datacube.ui.common import get_metadata_path
+from datacube.utils import read_documents, SimpleDocNav
 
 
 def assert_file_structure(folder, expected_structure, root=''):
@@ -236,3 +238,12 @@ def gen_dataset_test_dag(idx, t=None, force_tree=False):
 
     root, *_ = make_graph_abcde(node_maker(idx, t))
     return deref(root) if force_tree else root
+
+
+def load_dataset_definition(path):
+    if not isinstance(path, pathlib.Path):
+        path = pathlib.Path(path)
+
+    fname = get_metadata_path(path)
+    for _, doc in read_documents(fname):
+        return SimpleDocNav(doc)

--- a/datacube/testutils/__init__.py
+++ b/datacube/testutils/__init__.py
@@ -167,7 +167,7 @@ def isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
 
 def mk_sample_product(name,
                       description='Sample',
-                      measurements=['red', 'green', 'blue'],
+                      measurements=('red', 'green', 'blue'),
                       with_grid_spec=False,
                       storage=None):
 
@@ -208,6 +208,7 @@ def mk_sample_product(name,
             return m_merged
 
         assert False and 'Only support str|dict|(name, dtype, nodata)'
+        return {}
 
     measurements = [mk_measurement(m) for m in measurements]
 
@@ -230,6 +231,7 @@ def mk_sample_dataset(bands,
                       product_name='sample',
                       format='GeoTiff',
                       id='12345678123456781234567812345678'):
+    # pylint: disable=redefined-builtin
     image_bands_keys = 'path layer band'.split(' ')
     measurement_keys = 'dtype units nodata aliases name'.split(' ')
 
@@ -258,12 +260,12 @@ def make_graph_abcde(node):
       |
       +--> E
     """
-    D = node('D')
-    E = node('E')
-    C = node('C', cd=D)
-    B = node('B', bc=C)
-    A = node('A', ab=B, ac=C, ae=E)
-    return A, B, C, D, E
+    d = node('D')
+    e = node('E')
+    c = node('C', cd=d)
+    b = node('B', bc=c)
+    a = node('A', ab=b, ac=c, ae=e)
+    return a, b, c, d, e
 
 
 def gen_dataset_test_dag(idx, t=None, force_tree=False):

--- a/datacube/testutils/__init__.py
+++ b/datacube/testutils/__init__.py
@@ -17,6 +17,8 @@ from datacube.model import Dataset, DatasetType, MetadataType
 from datacube.ui.common import get_metadata_path
 from datacube.utils import read_documents, SimpleDocNav
 
+_DEFAULT = object()
+
 
 def assert_file_structure(folder, expected_structure, root=''):
     """
@@ -208,6 +210,33 @@ def make_graph_abcde(node):
     return a, b, c, d, e
 
 
+def dataset_maker(idx, t=None):
+    """ Return function that generates "dataset documents"
+
+    (name, sources={}, **kwargs) -> dict
+    """
+    ns = uuid.UUID('c0fefefe-2470-3b03-803f-e7599f39ceff')
+    postfix = '' if idx is None else '{:04d}'.format(idx)
+
+    if t is None:
+        t = datetime.fromordinal(736637 + (0 if idx is None else idx))
+
+    t = t.isoformat()
+
+    def make(name, sources=_DEFAULT, **kwargs):
+        if sources is _DEFAULT:
+            sources = {}
+
+        return dict(id=str(uuid.uuid5(ns, name + postfix)),
+                    label=name+postfix,
+                    creation_dt=t,
+                    n=idx,
+                    lineage=dict(source_datasets=sources),
+                    **kwargs)
+
+    return make
+
+
 def gen_dataset_test_dag(idx, t=None, force_tree=False):
     """Build document suitable for consumption by dataset add
 
@@ -216,25 +245,17 @@ def gen_dataset_test_dag(idx, t=None, force_tree=False):
     copies instead).
     """
     def node_maker(n, t):
-        ns = uuid.UUID('c0fefefe-2470-3b03-803f-e7599f39ceff')
-        postfix = '' if n is None else '{:04d}'.format(n)
-        t = t.isoformat()
+        mk = dataset_maker(n, t)
 
         def node(name, **kwargs):
-            return dict(id=str(uuid.uuid5(ns, name + postfix)),
-                        label=name+postfix,
-                        creation_dt=t,
-                        n=n,
-                        product_type=name,
-                        lineage=dict(source_datasets=kwargs))
+            return mk(name,
+                      product_type=name,
+                      sources=kwargs)
 
         return node
 
     def deref(a):
         return json.loads(json.dumps(a))
-
-    if t is None:
-        t = datetime.fromordinal(736637 + (0 if idx is None else idx))
 
     root, *_ = make_graph_abcde(node_maker(idx, t))
     return deref(root) if force_tree else root

--- a/datacube/ui/task_app.py
+++ b/datacube/ui/task_app.py
@@ -255,7 +255,7 @@ def check_existing_files(paths):
 
 def add_dataset_to_db(index, datasets):
     for dataset in datasets.values:
-        index.datasets.add(dataset, sources_policy='skip')
+        index.datasets.add(dataset, with_lineage=False)
         _LOG.info('Dataset added')
 
 

--- a/datacube/utils/__init__.py
+++ b/datacube/utils/__init__.py
@@ -13,6 +13,7 @@ import json
 import logging
 import pathlib
 import re
+import toolz
 from copy import deepcopy
 from collections import OrderedDict
 from contextlib import contextmanager
@@ -123,10 +124,7 @@ def get_doc_offset(offset, document):
     ...
     KeyError: 'a'
     """
-    value = document
-    for key in offset:
-        value = value[key]
-    return value
+    return toolz.get_in(offset, document, no_default=True)
 
 
 def get_doc_offset_safe(offset, document, value_if_missing=None):
@@ -145,14 +143,7 @@ def get_doc_offset_safe(offset, document, value_if_missing=None):
     >>> get_doc_offset_safe(['a', 'b', 'c'], {'a':{'b':[]}}, 11)
     11
     """
-    for k in offset:
-        if not isinstance(document, collections.Mapping):
-            return value_if_missing
-
-        document = document.get(k)
-        if document is None:
-            return value_if_missing
-    return document
+    return toolz.get_in(offset, document, default=value_if_missing)
 
 
 def _parse_time_generic(time):
@@ -811,10 +802,7 @@ class SimpleDocNav(object):
     @property
     def doc_without_lineage_sources(self):
         if self._doc_without is None:
-            doc_without = deepcopy(self._doc)
-            xx = get_doc_offset_safe(self._sources_path[:-1], doc_without, {})
-            xx[self._sources_path[-1]] = {}
-            self._doc_without = doc_without
+            self._doc_without = toolz.assoc_in(self._doc, self._sources_path, {})
 
         return self._doc_without
 

--- a/datacube/utils/__init__.py
+++ b/datacube/utils/__init__.py
@@ -791,7 +791,7 @@ class SimpleDocNav(object):
 
         self._doc = doc
         self._doc_without = None
-        self._sources_path = ['lineage', 'source_datasets']
+        self._sources_path = ('lineage', 'source_datasets')
         self._sources = None
 
     @property
@@ -815,6 +815,10 @@ class SimpleDocNav(object):
             self._sources = {k: SimpleDocNav(v)
                              for k, v in get_doc_offset_safe(self._sources_path, self._doc, {}).items()}
         return self._sources
+
+    @property
+    def sources_path(self):
+        return self._sources_path
 
 
 def import_function(func_ref):

--- a/datacube/utils/__init__.py
+++ b/datacube/utils/__init__.py
@@ -11,6 +11,7 @@ import importlib
 import itertools
 import json
 import logging
+import math
 import pathlib
 import re
 import toolz
@@ -562,13 +563,11 @@ def jsonify_document(doc):
 
     def fixup_value(v):
         if isinstance(v, float):
-            if v != v:
+            if math.isfinite(v):
+                return v
+            if math.isnan(v):
                 return "NaN"
-            if v == float("inf"):
-                return "Infinity"
-            if v == float("-inf"):
-                return "-Infinity"
-            return v
+            return "-Infinity" if v < 0 else "Infinity"
         if isinstance(v, (datetime, date)):
             return v.isoformat()
         if isinstance(v, numpy.dtype):

--- a/datacube/utils/__init__.py
+++ b/datacube/utils/__init__.py
@@ -56,6 +56,19 @@ def namedtuples2dicts(namedtuples):
     return {k: dict(v._asdict()) for k, v in namedtuples.items()}
 
 
+def sorted_items(d, key=None, reverse=False):
+    """Given a dictionary `d` return items: (k1, v1), (k2, v2)... sorted in
+    ascending order according to key.
+
+    :param dict d: dictionary
+    :param key: optional function remapping key
+    :param bool reverse: If True return in descending order instead of default ascending
+
+    """
+    key = toolz.first if key is None else toolz.comp(key, toolz.first)
+    return sorted(d.items(), key=key, reverse=reverse)
+
+
 def datetime_to_seconds_since_1970(dt):
     epoch = datetime(1970, 1, 1, 0, 0, 0, tzinfo=tzutc() if dt.tzinfo else None)
     return (dt - epoch).total_seconds()

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -5,6 +5,20 @@
 What's New
 **********
 
+Backwards Incompatible Changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Assume fixed paths for `id` and `sources` metadata fields (:issue:`482`)
+- Removed `--sources-policy=skip|verify|ensure` option of `dataset add` command,
+  instead use `--[no-]auto-add-lineage` and `--[no-]verify-lineage` (:issue:`451`)
+
+Changes
+~~~~~~~
+
+- Allow indexing without lineage `dataset add --ignore-lineage` (:pull:`485`)
+- Various improvements to indexing, mostly to do with handling of lineage (:issue:`480`)
+
+
 
 v1.6rc2 (29 June 2018)
 =========================================
@@ -36,7 +50,7 @@ Backwards Incompatible Changes
     23:59:59.999 on 31st of March, 2008.
 
   Example 2:
-    To specify a search time between 1st of January and 29th of February, 2008 
+    To specify a search time between 1st of January and 29th of February, 2008
     (inclusive), use a search query like `time=('2008-01', '2008-02')`. This query
     is equivalent to using any of the following in the second time element:
 
@@ -85,7 +99,7 @@ Changes
   -  `indexed_by` (user who indexed the dataset)
   -  `creation_time` (creation of dataset: when it was processed)
   -  `label` (the label for a dataset)
-    
+
   (See :pull:`432` for more details)
 
 Bug Fixes

--- a/docs/user/config.rst
+++ b/docs/user/config.rst
@@ -74,7 +74,7 @@ Example:
 
     [s3_test]
     db_hostname: staging.dea.ga.gov.au
-    index_driver: s3aio
+    index_driver: s3aio_index
 
 Note that the staging environment only specifies the hostname, all other fields will use default values (dbname
 datacube, current username, password loaded from ``~/.pgpass``)

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -11,6 +11,7 @@ from copy import copy, deepcopy
 from datetime import datetime, timedelta
 from pathlib import Path
 from uuid import UUID, uuid4
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -178,6 +179,16 @@ def index(local_config, uninitialised_postgres_db):
     """
     index = index_connect(local_config, validate_connection=False)
     index.init_db()
+    return index
+
+
+@pytest.fixture
+def index_empty(local_config, uninitialised_postgres_db):
+    """
+    :type initialised_postgres_db: datacube.drivers.postgres._connections.PostgresDb
+    """
+    index = index_connect(local_config, validate_connection=False)
+    index.init_db(with_default_types=False)
     return index
 
 
@@ -533,6 +544,14 @@ def clirunner(global_integration_cli_args, datacube_env_name):
         return result
 
     return _run_cli
+
+
+@pytest.fixture
+def dataset_add_configs():
+    B = INTEGRATION_TESTS_DIR/'data'/'dataset_add'
+    return SimpleNamespace(metadata=str(B/'metadata.yml'),
+                           products=str(B/'products.yml'),
+                           datasets=str(B/'datasets.yml'))
 
 
 def edit_for_fast_ingest(config):

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -551,6 +551,7 @@ def dataset_add_configs():
     B = INTEGRATION_TESTS_DIR/'data'/'dataset_add'
     return SimpleNamespace(metadata=str(B/'metadata.yml'),
                            products=str(B/'products.yml'),
+                           datasets_bad1=str(B/'datasets_bad1.yml'),
                            datasets=str(B/'datasets.yml'))
 
 

--- a/integration_tests/data/dataset_add/datasets.yml
+++ b/integration_tests/data/dataset_add/datasets.yml
@@ -1,0 +1,120 @@
+# Generated with `yaml.safe_dump_all(gen_dataset_test_dag(ii, force_tree=True) for ii in range(1,3))`
+#   A -> B
+#   |    |
+#   |    v
+#   +--> C -> D
+#   |
+#   +--> E
+#
+---
+creation_dt: '2017-11-05T00:00:00'
+id: f80c30a5-1036-5607-a62f-fde5e3fec985
+label: A0001
+lineage:
+  source_datasets:
+    ab:
+      creation_dt: '2017-11-05T00:00:00'
+      id: fb077e47-f62e-5869-9bd1-03584c2d7380
+      label: B0001
+      lineage:
+        source_datasets:
+          bc:
+            creation_dt: '2017-11-05T00:00:00'
+            id: 13d3d75a-1d90-5ec0-8b86-e8be78275660
+            label: C0001
+            lineage:
+              source_datasets:
+                cd:
+                  creation_dt: '2017-11-05T00:00:00'
+                  id: 86bafe10-d469-585a-bfe6-68ca3c5ec62d
+                  label: D0001
+                  lineage:
+                    source_datasets: {}
+                  n: 1
+                  product_type: D
+            n: 1
+            product_type: C
+      n: 1
+      product_type: B
+    ac:
+      creation_dt: '2017-11-05T00:00:00'
+      id: 13d3d75a-1d90-5ec0-8b86-e8be78275660
+      label: C0001
+      lineage:
+        source_datasets:
+          cd:
+            creation_dt: '2017-11-05T00:00:00'
+            id: 86bafe10-d469-585a-bfe6-68ca3c5ec62d
+            label: D0001
+            lineage:
+              source_datasets: {}
+            n: 1
+            product_type: D
+      n: 1
+      product_type: C
+    ae:
+      creation_dt: '2017-11-05T00:00:00'
+      id: e73de3b6-0859-5aee-a091-e1fd465c774e
+      label: E0001
+      lineage:
+        source_datasets: {}
+      n: 1
+      product_type: E
+n: 1
+product_type: A
+---
+creation_dt: '2017-11-06T00:00:00'
+id: 7a0524e2-23c3-5136-b283-ec7be47444dc
+label: A0002
+lineage:
+  source_datasets:
+    ab:
+      creation_dt: '2017-11-06T00:00:00'
+      id: ca213c03-7066-5812-b316-b39cd9b4f5d7
+      label: B0002
+      lineage:
+        source_datasets:
+          bc:
+            creation_dt: '2017-11-06T00:00:00'
+            id: f4246cae-1f3f-5629-9f03-b9beca8dfce0
+            label: C0002
+            lineage:
+              source_datasets:
+                cd:
+                  creation_dt: '2017-11-06T00:00:00'
+                  id: 604703d2-2fa6-537b-8990-57c87be03e6c
+                  label: D0002
+                  lineage:
+                    source_datasets: {}
+                  n: 2
+                  product_type: D
+            n: 2
+            product_type: C
+      n: 2
+      product_type: B
+    ac:
+      creation_dt: '2017-11-06T00:00:00'
+      id: f4246cae-1f3f-5629-9f03-b9beca8dfce0
+      label: C0002
+      lineage:
+        source_datasets:
+          cd:
+            creation_dt: '2017-11-06T00:00:00'
+            id: 604703d2-2fa6-537b-8990-57c87be03e6c
+            label: D0002
+            lineage:
+              source_datasets: {}
+            n: 2
+            product_type: D
+      n: 2
+      product_type: C
+    ae:
+      creation_dt: '2017-11-06T00:00:00'
+      id: aa547197-4bda-5352-9853-b820b16596e3
+      label: E0002
+      lineage:
+        source_datasets: {}
+      n: 2
+      product_type: E
+n: 2
+product_type: A

--- a/integration_tests/data/dataset_add/datasets_bad1.yml
+++ b/integration_tests/data/dataset_add/datasets_bad1.yml
@@ -1,0 +1,64 @@
+#   A -> B
+#   |    |
+#   |    v
+#   +--> C -> D
+#   |
+#   +--> E
+#
+#   Two views of node C are inconsistent, so should fail to add top-level A
+---
+creation_dt: '2017-11-17T00:00:00'
+id: 3c110b22-f998-5d77-9f74-f73c45ada7ac
+label: A0013
+n: 13
+product_type: A
+lineage:
+  source_datasets:
+    ab:
+      creation_dt: '2017-11-17T00:00:00'
+      id: 0d3baeb0-c597-5bcb-8876-208e357609da
+      label: B0013
+      lineage:
+        source_datasets:
+          bc:
+            creation_dt: '2017-11-17T00:00:00'
+            id: f5165c33-98af-5431-8766-8850bc862a6d
+            label: C0013
+            lineage:
+              source_datasets:
+                cd:
+                  creation_dt: '2017-11-17T00:00:00'
+                  id: 3b22ea24-2e72-5504-816d-3c5b06285980
+                  label: D0013
+                  lineage:
+                    source_datasets: {}
+                  n: 13
+                  product_type: D
+            n: 13
+            product_type: C
+      n: 13
+      product_type: B
+    ac:
+      creation_dt: '2017-11-17T00:10:00'
+      id: f5165c33-98af-5431-8766-8850bc862a6d
+      label: changed
+      lineage:
+        source_datasets:
+          cd:
+            creation_dt: '2017-11-17T00:00:00'
+            id: 3b22ea24-2e72-5504-816d-3c5b06285980
+            label: D0013
+            lineage:
+              source_datasets: {}
+            n: 13
+            product_type: D
+      n: 13
+      product_type: C
+    ae:
+      creation_dt: '2017-11-17T00:00:00'
+      id: 51b463cf-a013-5a61-8fc5-5e1caaeff8bd
+      label: E0013
+      lineage:
+        source_datasets: {}
+      n: 13
+      product_type: E

--- a/integration_tests/data/dataset_add/metadata.yml
+++ b/integration_tests/data/dataset_add/metadata.yml
@@ -1,0 +1,12 @@
+---
+name: minimal
+description: minimal metadata definition
+dataset:
+    id: [id]
+    sources: [lineage, source_datasets]
+    label: [label]
+    creation_dt: [creation_dt]
+    search_fields:
+        product_type:
+            description: Product code
+            offset: [product_type]

--- a/integration_tests/data/dataset_add/metadata.yml
+++ b/integration_tests/data/dataset_add/metadata.yml
@@ -10,3 +10,17 @@ dataset:
         product_type:
             description: Product code
             offset: [product_type]
+---
+
+name: with_measurements
+description: for testing measurement set mismatch
+dataset:
+    id: [id]
+    sources: [lineage, source_datasets]
+    label: [label]
+    creation_dt: [creation_dt]
+    measurements: [measurements]
+    search_fields:
+        product_type:
+            description: Product code
+            offset: [product_type]

--- a/integration_tests/data/dataset_add/products.yml
+++ b/integration_tests/data/dataset_add/products.yml
@@ -1,0 +1,43 @@
+##  jinja2.Template('''{% for name in products %}
+##  ---
+##  name: {{name}}
+##  description: test product {{name}}
+##  metadata_type: minimal
+##  metadata:
+##  product_type: {{name}}
+##  {% endfor %}''').render(products='ABCDE')
+##  
+---
+name: A
+description: test product A
+metadata_type: minimal
+metadata:
+    product_type: A
+
+---
+name: B
+description: test product B
+metadata_type: minimal
+metadata:
+    product_type: B
+
+---
+name: C
+description: test product C
+metadata_type: minimal
+metadata:
+    product_type: C
+
+---
+name: D
+description: test product D
+metadata_type: minimal
+metadata:
+    product_type: D
+
+---
+name: E
+description: test product E
+metadata_type: minimal
+metadata:
+    product_type: E

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -164,6 +164,23 @@ def test_has_dataset(index, telemetry_dataset):
     assert not index.datasets.has('f226a278-e422-11e6-b501-185e0f80a5c0')
 
 
+def test_get_dataset(index, telemetry_dataset):
+    # type: (Index, Dataset) -> None
+
+    assert index.datasets.has(_telemetry_uuid)
+    assert index.datasets.has(str(_telemetry_uuid))
+
+    for tr in (lambda x: x, str):
+        ds = index.datasets.get(tr(_telemetry_uuid))
+        assert ds.id == _telemetry_uuid
+
+        ds, = index.datasets.get_many([tr(_telemetry_uuid)])
+        assert ds.id == _telemetry_uuid
+
+    assert index.datasets.get_many(['f226a278-e422-11e6-b501-185e0f80a5c0',
+                                    'f226a278-e422-11e6-b501-185e0f80a5c1']) == []
+
+
 def test_transactions(index, initialised_postgres_db, local_config, default_metadata_type):
     """
     :type index: datacube.index.index.Index
@@ -226,6 +243,8 @@ def test_index_dataset_with_sources(index, default_metadata_type):
     index.datasets.add(child, sources_policy='ensure')
     assert index.datasets.get(parent.id)
     assert index.datasets.get(child.id)
+
+    assert len(index.datasets.get_many([parent.id, child.id])) == 2
 
     index.datasets.add(child, sources_policy='skip')
     index.datasets.add(child, sources_policy='ensure')

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -305,14 +305,20 @@ def test_index_dataset_with_location(index, default_metadata_type):
     locations = index.datasets.get_locations(dataset.id)
     assert len(locations) == 1
 
-    # Ingesting with a new path should add the second one too.
+    # Indexing with a new path should NOT add the second one.
     dataset.uris = [second_file.as_uri()]
     index.datasets.add(dataset)
     stored = index.datasets.get(dataset.id)
     locations = index.datasets.get_locations(dataset.id)
-    assert len(locations) == 2
+    assert len(locations) == 1
+
+    # Add location manually instead
+    index.datasets.add_location(dataset.id, second_file.as_uri())
+    stored = index.datasets.get(dataset.id)
+    assert len(stored.uris) == 2
+
     # Newest to oldest.
-    assert locations == [second_file.as_uri(), first_file.as_uri()]
+    assert stored.uris == [second_file.as_uri(), first_file.as_uri()]
     # And the second one is newer, so it should be returned as the default local path:
     assert stored.local_path == Path(second_file)
 

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -170,16 +170,16 @@ def test_get_dataset(index, telemetry_dataset):
     assert index.datasets.has(_telemetry_uuid)
     assert index.datasets.has(str(_telemetry_uuid))
 
-    assert index.datasets.has_many([_telemetry_uuid, 'f226a278-e422-11e6-b501-185e0f80a5c0']) == [True, False]
+    assert index.datasets.bulk_has([_telemetry_uuid, 'f226a278-e422-11e6-b501-185e0f80a5c0']) == [True, False]
 
     for tr in (lambda x: x, str):
         ds = index.datasets.get(tr(_telemetry_uuid))
         assert ds.id == _telemetry_uuid
 
-        ds, = index.datasets.get_many([tr(_telemetry_uuid)])
+        ds, = index.datasets.bulk_get([tr(_telemetry_uuid)])
         assert ds.id == _telemetry_uuid
 
-    assert index.datasets.get_many(['f226a278-e422-11e6-b501-185e0f80a5c0',
+    assert index.datasets.bulk_get(['f226a278-e422-11e6-b501-185e0f80a5c0',
                                     'f226a278-e422-11e6-b501-185e0f80a5c1']) == []
 
 
@@ -246,7 +246,7 @@ def test_index_dataset_with_sources(index, default_metadata_type):
     assert index.datasets.get(parent.id)
     assert index.datasets.get(child.id)
 
-    assert len(index.datasets.get_many([parent.id, child.id])) == 2
+    assert len(index.datasets.bulk_get([parent.id, child.id])) == 2
 
     index.datasets.add(child, with_lineage=False)
     index.datasets.add(child, with_lineage=True)

--- a/integration_tests/index/test_search.py
+++ b/integration_tests/index/test_search.py
@@ -29,7 +29,8 @@ from datacube.model import Dataset
 from datacube.model import DatasetType
 from datacube.model import MetadataType
 from datacube.model import Range
-from datacube.scripts import dataset as dataset_script
+
+from datacube.testutils import load_dataset_definition
 
 
 @pytest.fixture
@@ -213,18 +214,10 @@ def pseudo_ls8_dataset4(index, initialised_postgres_db, pseudo_ls8_type, pseudo_
 
 
 @pytest.fixture
-def ls5_dataset_w_children(index, example_ls5_dataset_path, indexed_ls5_scene_products):
-    # type: (Driver, Path, DatasetType) -> Dataset
-    # TODO: We need a higher-level API for indexing paths, rather than reaching inside the cli script
-    datasets = list(
-        dataset_script.load_datasets(
-            [example_ls5_dataset_path],
-            dataset_script.product_matcher(dataset_script.load_rules_from_types(index))
-        )
-    )
-    assert len(datasets) == 1
-    d = index.datasets.add(datasets[0])
-    return index.datasets.get(d.id, include_sources=True)
+def ls5_dataset_w_children(index, clirunner, example_ls5_dataset_path, indexed_ls5_scene_products):
+    clirunner(['dataset', 'add', str(example_ls5_dataset_path)])
+    doc = load_dataset_definition(example_ls5_dataset_path)
+    return index.datasets.get(doc.id, include_sources=True)
 
 
 @pytest.fixture

--- a/integration_tests/index/test_search.py
+++ b/integration_tests/index/test_search.py
@@ -219,7 +219,7 @@ def ls5_dataset_w_children(index, example_ls5_dataset_path, indexed_ls5_scene_pr
     datasets = list(
         dataset_script.load_datasets(
             [example_ls5_dataset_path],
-            dataset_script.load_rules_from_types(index)
+            dataset_script.product_matcher(dataset_script.load_rules_from_types(index))
         )
     )
     assert len(datasets) == 1

--- a/integration_tests/index/test_search.py
+++ b/integration_tests/index/test_search.py
@@ -12,6 +12,7 @@ import uuid
 from decimal import Decimal
 from pathlib import Path
 from uuid import UUID
+from typing import List, Tuple, Iterable, Dict
 
 import pytest
 import yaml
@@ -29,11 +30,6 @@ from datacube.model import DatasetType
 from datacube.model import MetadataType
 from datacube.model import Range
 from datacube.scripts import dataset as dataset_script
-
-try:
-    from typing import List, Tuple, Iterable, Dict
-except ImportError:
-    pass
 
 
 @pytest.fixture

--- a/integration_tests/test_config_tool.py
+++ b/integration_tests/test_config_tool.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 import pytest
 
-import datacube.scripts.cli_app
 from datacube.drivers.postgres import _dynamic
 from datacube.drivers.postgres._core import drop_db, has_schema, SCHEMA_NAME
 
@@ -42,6 +41,7 @@ def test_add_example_dataset_types(clirunner, initialised_postgres_db, default_m
         print('Adding mapping {}'.format(mapping_path))
 
         result = clirunner(['-v', 'product', 'add', mapping_path])
+        assert result.exit_code == 0
 
         mappings_count = _dataset_type_count(initialised_postgres_db)
         assert mappings_count > existing_mappings, "Mapping document was not added: " + str(mapping_path)
@@ -100,6 +100,7 @@ def test_list_users_does_not_fail(clirunner, local_config, initialised_postgres_
             'user', 'list'
         ]
     )
+    assert result.exit_code == 0
 
 
 def test_db_init_noop(clirunner, local_config, ls5_telem_type):

--- a/integration_tests/test_config_tool.py
+++ b/integration_tests/test_config_tool.py
@@ -152,9 +152,10 @@ def test_db_init(clirunner, initialised_postgres_db):
 
 
 def test_add_no_such_product(clirunner, initialised_postgres_db):
-    result = clirunner(['dataset', 'add', '--dtype', 'no_such_product'])
+    result = clirunner(['dataset', 'add', '--dtype', 'no_such_product'], expect_success=False)
+    assert result.exit_code != 0
     assert "DEPRECATED option detected" in result.output
-    assert "ERROR DatasetType" in result.output
+    assert "ERROR Supplied product name" in result.output
 
 
 @pytest.fixture(params=[

--- a/integration_tests/test_dataset_add.py
+++ b/integration_tests/test_dataset_add.py
@@ -4,6 +4,7 @@ from datacube.testutils import gen_dataset_test_dag
 
 def test_dataset_add(dataset_add_configs, index_empty, clirunner):
     p = dataset_add_configs
+    index = index_empty
 
     clirunner(['metadata_type', 'add', p.metadata], expect_success=True)
     clirunner(['product', 'add', p.products], expect_success=True)
@@ -17,3 +18,7 @@ def test_dataset_add(dataset_add_configs, index_empty, clirunner):
 
     ds_ = SimpleDocNav(gen_dataset_test_dag(1, force_tree=True))
     assert ds_.id == ds.id
+
+    x = index.datasets.get(ds.id, include_sources=True)
+    assert str(x.sources['ab'].id) == ds.sources['ab'].id
+    assert str(x.sources['ac'].sources['cd'].id) == ds.sources['ac'].sources['cd'].id

--- a/integration_tests/test_dataset_add.py
+++ b/integration_tests/test_dataset_add.py
@@ -5,6 +5,9 @@ from datacube.testutils import gen_dataset_test_dag
 def test_dataset_add(dataset_add_configs, index_empty, clirunner):
     p = dataset_add_configs
     index = index_empty
+    r = clirunner(['dataset', 'add', p.datasets], expect_success=False)
+    assert r.exit_code != 0
+    assert 'Found no products' in r.output
 
     clirunner(['metadata_type', 'add', p.metadata], expect_success=True)
     clirunner(['product', 'add', p.products], expect_success=True)

--- a/integration_tests/test_dataset_add.py
+++ b/integration_tests/test_dataset_add.py
@@ -1,4 +1,5 @@
 from datacube.utils import read_documents, SimpleDocNav
+from datacube.testutils import gen_dataset_test_dag
 
 
 def test_dataset_add(dataset_add_configs, index_empty, clirunner):
@@ -13,3 +14,6 @@ def test_dataset_add(dataset_add_configs, index_empty, clirunner):
     assert ds.id in r.output
     assert ds.sources['ab'].id in r.output
     assert ds.sources['ac'].sources['cd'].id in r.output
+
+    ds_ = SimpleDocNav(gen_dataset_test_dag(1, force_tree=True))
+    assert ds_.id == ds.id

--- a/integration_tests/test_dataset_add.py
+++ b/integration_tests/test_dataset_add.py
@@ -1,0 +1,15 @@
+from datacube.utils import read_documents, SimpleDocNav
+
+
+def test_dataset_add(dataset_add_configs, index_empty, clirunner):
+    p = dataset_add_configs
+
+    clirunner(['metadata_type', 'add', p.metadata], expect_success=True)
+    clirunner(['product', 'add', p.products], expect_success=True)
+    clirunner(['dataset', 'add', p.datasets], expect_success=True)
+
+    r = clirunner(['dataset', 'search'], expect_success=True)
+    ds, *_ = list(SimpleDocNav(d) for _, d in read_documents(p.datasets))
+    assert ds.id in r.output
+    assert ds.sources['ab'].id in r.output
+    assert ds.sources['ac'].sources['cd'].id in r.output

--- a/integration_tests/test_dataset_add.py
+++ b/integration_tests/test_dataset_add.py
@@ -1,5 +1,44 @@
 from datacube.utils import SimpleDocNav
-from datacube.testutils import gen_dataset_test_dag, load_dataset_definition
+from datacube.testutils import gen_dataset_test_dag, load_dataset_definition, write_files
+import yaml
+
+
+def check_skip_lineage_test(clirunner, index):
+    ds = SimpleDocNav(gen_dataset_test_dag(11, force_tree=True))
+
+    prefix = write_files({'agdc-metadata.yml': yaml.safe_dump(ds.doc)})
+
+    clirunner(['dataset', 'add', '--confirm-ignore-lineage', '--product', 'A', str(prefix)])
+
+    ds_ = index.datasets.get(ds.id, include_sources=True)
+    assert ds_ is not None
+    assert str(ds_.id) == ds.id
+    assert ds_.sources == {}
+
+    assert index.datasets.get(ds.sources['ab'].id) is None
+    assert index.datasets.get(ds.sources['ac'].id) is None
+    assert index.datasets.get(ds.sources['ae'].id) is None
+    assert index.datasets.get(ds.sources['ac'].sources['cd'].id) is None
+
+
+def check_no_product_match(clirunner, index):
+    ds = SimpleDocNav(gen_dataset_test_dag(22, force_tree=True))
+
+    prefix = write_files({'agdc-metadata.yml': yaml.safe_dump(ds.doc)})
+
+    r = clirunner(['dataset', 'add',
+                   '--product', 'A',
+                   str(prefix)])
+    assert 'ERROR Dataset metadata did not match product signature' in r.output
+
+    r = clirunner(['dataset', 'add',
+                   '--product', 'A',
+                   '--product', 'B',
+                   str(prefix)])
+    assert 'ERROR No matching Product found for dataset' in r.output
+
+    ds_ = index.datasets.get(ds.id, include_sources=True)
+    assert ds_ is None
 
 
 def test_dataset_add(dataset_add_configs, index_empty, clirunner):
@@ -29,3 +68,6 @@ def test_dataset_add(dataset_add_configs, index_empty, clirunner):
     x = index.datasets.get(ds.id, include_sources=True)
     assert str(x.sources['ab'].id) == ds.sources['ab'].id
     assert str(x.sources['ac'].sources['cd'].id) == ds.sources['ac'].sources['cd'].id
+
+    check_skip_lineage_test(clirunner, index)
+    check_no_product_match(clirunner, index)

--- a/integration_tests/test_dataset_add.py
+++ b/integration_tests/test_dataset_add.py
@@ -114,6 +114,12 @@ def check_inconsistent_lineage(clirunner, index):
     assert index.datasets.get(ds.sources['ac'].sources['cd'].id) is None
 
 
+def check_missing_metadata_doc(clirunner):
+    prefix = write_files({'im.tiff': ''})
+    r = clirunner(['dataset', 'add', str(prefix/'im.tiff')])
+    assert "ERROR No supported metadata docs found for dataset" in r.output
+
+
 def test_dataset_add(dataset_add_configs, index_empty, clirunner):
     p = dataset_add_configs
     index = index_empty
@@ -146,6 +152,7 @@ def test_dataset_add(dataset_add_configs, index_empty, clirunner):
     check_no_product_match(clirunner, index)
     check_with_existing_lineage(clirunner, index)
     check_inconsistent_lineage(clirunner, index)
+    check_missing_metadata_doc(clirunner)
 
     # check --product=nosuchproduct
     r = clirunner(['dataset', 'add', '--product', 'nosuchproduct', p.datasets],

--- a/integration_tests/test_dataset_add.py
+++ b/integration_tests/test_dataset_add.py
@@ -1,5 +1,5 @@
-from datacube.utils import read_documents, SimpleDocNav
-from datacube.testutils import gen_dataset_test_dag
+from datacube.utils import SimpleDocNav
+from datacube.testutils import gen_dataset_test_dag, load_dataset_definition
 
 
 def test_dataset_add(dataset_add_configs, index_empty, clirunner):
@@ -12,10 +12,14 @@ def test_dataset_add(dataset_add_configs, index_empty, clirunner):
     clirunner(['metadata_type', 'add', p.metadata], expect_success=True)
     clirunner(['product', 'add', p.products], expect_success=True)
     clirunner(['dataset', 'add', p.datasets], expect_success=True)
+    clirunner(['dataset', 'add', p.datasets_bad1], expect_success=False)
+
+    ds = load_dataset_definition(p.datasets)
+    ds_bad1 = load_dataset_definition(p.datasets_bad1)
 
     r = clirunner(['dataset', 'search'], expect_success=True)
-    ds, *_ = list(SimpleDocNav(d) for _, d in read_documents(p.datasets))
     assert ds.id in r.output
+    assert ds_bad1.id not in r.output
     assert ds.sources['ab'].id in r.output
     assert ds.sources['ac'].sources['cd'].id in r.output
 

--- a/integration_tests/test_dataset_add.py
+++ b/integration_tests/test_dataset_add.py
@@ -71,3 +71,10 @@ def test_dataset_add(dataset_add_configs, index_empty, clirunner):
 
     check_skip_lineage_test(clirunner, index)
     check_no_product_match(clirunner, index)
+
+    # check --product=nosuchproduct
+    r = clirunner(['dataset', 'add', '--product', 'nosuchproduct', p.datasets],
+                  expect_success=False)
+
+    assert "ERROR Supplied product name" in r.output
+    assert r.exit_code != 0

--- a/integration_tests/test_dataset_add.py
+++ b/integration_tests/test_dataset_add.py
@@ -193,10 +193,10 @@ def test_dataset_add(dataset_add_configs, index_empty, clirunner):
     assert r.exit_code != 0
     assert 'Found no products' in r.output
 
-    clirunner(['metadata_type', 'add', p.metadata], expect_success=True)
-    clirunner(['product', 'add', p.products], expect_success=True)
-    clirunner(['dataset', 'add', p.datasets], expect_success=True)
-    clirunner(['dataset', 'add', p.datasets_bad1], expect_success=False)
+    clirunner(['metadata_type', 'add', p.metadata])
+    clirunner(['product', 'add', p.products])
+    clirunner(['dataset', 'add', p.datasets])
+    clirunner(['dataset', 'add', p.datasets_bad1])
 
     ds = load_dataset_definition(p.datasets)
     ds_bad1 = load_dataset_definition(p.datasets_bad1)
@@ -238,3 +238,7 @@ def test_dataset_add(dataset_add_configs, index_empty, clirunner):
 
     assert "ERROR Supplied product name" in r.output
     assert r.exit_code != 0
+
+    # Check that deprecated option is accepted
+    r = clirunner(['dataset', 'add', '--auto-match', p.datasets])
+    assert 'WARNING --auto-match option is deprecated' in r.output

--- a/integration_tests/test_dataset_add.py
+++ b/integration_tests/test_dataset_add.py
@@ -118,10 +118,19 @@ def check_inconsistent_lineage(clirunner, index):
 
     assert 'ERROR Inconsistent lineage dataset' in r.output
 
-    assert index.datasets.get(ds.id) is None
-    assert index.datasets.get(ds.sources['ab'].id) is None
-    assert index.datasets.get(ds.sources['ac'].id) is None
-    assert index.datasets.get(ds.sources['ac'].sources['cd'].id) is None
+    assert index.datasets.has(ds.id) is False
+    assert index.datasets.has(ds.sources['ab'].id) is False
+    assert index.datasets.has(ds.sources['ac'].id) is False
+    assert index.datasets.has(ds.sources['ac'].sources['cd'].id) is False
+
+    # now again but skipping verification check
+    r = clirunner(['dataset', 'add', '--no-verify-lineage',
+                   str(prefix/'main.yml')])
+
+    assert index.datasets.has(ds.id)
+    assert index.datasets.has(ds.sources['ab'].id)
+    assert index.datasets.has(ds.sources['ac'].id)
+    assert index.datasets.has(ds.sources['ac'].sources['cd'].id)
 
 
 def check_missing_lineage(clirunner, index):

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ setup(
         'rasterio>=0.9a10',  # required for zip reading, 0.9 gets around 1.0a ordering problems
         'singledispatch',
         'sqlalchemy',
+        'toolz',
         'xarray>=0.9',  # >0.9 fixes most problems with `crs` attributes being lost
     ],
     extras_require=extras_require,

--- a/tests/api/test_geo_xarray.py
+++ b/tests/api/test_geo_xarray.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import, division, print_function
 import numpy
 import xarray as xr
 
-from ..util import isclose
+from datacube.testutils import isclose
 
 from datacube.api import geo_xarray
 

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -18,13 +18,9 @@ import datetime
 import pandas
 
 import pytest
-from dateutil import tz
-
-from ..util import isclose
 
 from datacube.api.query import Query, _datetime_to_timestamp, query_group_by
 from datacube.model import Range
-from datetime import timezone
 
 
 def test_datetime_to_timestamp():

--- a/tests/index/test_api_index_dataset.py
+++ b/tests/index/test_api_index_dataset.py
@@ -184,6 +184,9 @@ class MockDb(object):
     def get_locations(self, dataset):
         return ['file:xxx']
 
+    def datasets_intersection(self, ids):
+        return [k for k in ids if k in self.dataset]
+
     def insert_dataset_location(self, *args, **kwargs):
         return
 
@@ -235,11 +238,6 @@ def test_index_dataset():
     dataset = datasets.add(_EXAMPLE_NBAR_DATASET)
     assert len(mock_db.dataset) == 3
     assert len(mock_db.dataset_source) == 2
-
-    ds2 = deepcopy(_EXAMPLE_NBAR_DATASET)
-    ds2.metadata_doc['product_type'] = 'zzzz'
-    with pytest.raises(DocumentMismatchError):
-        dataset = datasets.add(ds2)
 
 
 def test_index_already_ingested_source_dataset():

--- a/tests/index/test_api_index_dataset.py
+++ b/tests/index/test_api_index_dataset.py
@@ -184,7 +184,7 @@ class MockDb(object):
     def get_locations(self, dataset):
         return ['file:xxx']
 
-    def ensure_dataset_locations(self, *args, **kwargs):
+    def insert_dataset_location(self, *args, **kwargs):
         return
 
     def insert_dataset(self, metadata_doc, dataset_id, dataset_type_id):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -7,11 +7,11 @@ from __future__ import absolute_import
 import pytest
 
 from datacube.ui.common import get_metadata_path, find_any_metadata_suffix
-from datacube.testutils import write_files
+from datacube.testutils import write_files, assert_file_structure
 
 
 def test_find_metadata_path():
-    files = write_files({
+    FILES = {
         'directory_dataset': {
             'file1.txt': '',
             'file2.txt': '',
@@ -21,27 +21,31 @@ def test_find_metadata_path():
         'file_dataset.tif.agdc-md.yaml': '',
         'dataset_metadata.yaml': '',
         'no_metadata.tif': '',
-    })
+    }
+
+    out_dir = write_files(FILES)
+
+    assert_file_structure(out_dir, FILES)
 
     # A metadata file can be specified directly.
-    path = get_metadata_path(files.joinpath('dataset_metadata.yaml'))
-    assert path.absolute() == files.joinpath('dataset_metadata.yaml').absolute()
+    path = get_metadata_path(out_dir.joinpath('dataset_metadata.yaml'))
+    assert path.absolute() == out_dir.joinpath('dataset_metadata.yaml').absolute()
 
     # A dataset directory will have an internal 'agdc-metadata' file.
-    path = get_metadata_path(files.joinpath('directory_dataset'))
-    assert path.absolute() == files.joinpath('directory_dataset', 'agdc-metadata.yaml.gz').absolute()
+    path = get_metadata_path(out_dir.joinpath('directory_dataset'))
+    assert path.absolute() == out_dir.joinpath('directory_dataset', 'agdc-metadata.yaml.gz').absolute()
 
-    # Other files can have a sibling file ending in 'agdc-md.yaml'
-    path = get_metadata_path(files.joinpath('file_dataset.tif'))
-    assert path.absolute() == files.joinpath('file_dataset.tif.agdc-md.yaml').absolute()
+    # Other out_dir can have a sibling file ending in 'agdc-md.yaml'
+    path = get_metadata_path(out_dir.joinpath('file_dataset.tif'))
+    assert path.absolute() == out_dir.joinpath('file_dataset.tif.agdc-md.yaml').absolute()
 
     # Lack of metadata raises an error.
     with pytest.raises(ValueError):
-        get_metadata_path(files.joinpath('no_metadata.tif'))
+        get_metadata_path(out_dir.joinpath('no_metadata.tif'))
 
     # Nonexistent dataset raises a ValueError.
     with pytest.raises(ValueError):
-        get_metadata_path(files.joinpath('missing-dataset.tif'))
+        get_metadata_path(out_dir.joinpath('missing-dataset.tif'))
 
 
 def test_find_any_metatadata_suffix():

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -7,11 +7,11 @@ from __future__ import absolute_import
 import pytest
 
 from datacube.ui.common import get_metadata_path, find_any_metadata_suffix
-from . import util
+from datacube.testutils import write_files
 
 
 def test_find_metadata_path():
-    files = util.write_files({
+    files = write_files({
         'directory_dataset': {
             'file1.txt': '',
             'file2.txt': '',
@@ -45,7 +45,7 @@ def test_find_metadata_path():
 
 
 def test_find_any_metatadata_suffix():
-    files = util.write_files({
+    files = write_files({
         'directory_dataset': {
             'file1.txt': '',
             'file2.txt': '',

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -58,6 +58,8 @@ def test_find_any_metatadata_suffix():
         'file_dataset.tif.agdc-md.yaml': '',
         'dataset_metadata.YAML': '',
         'no_metadata.tif': '',
+        'ambigous.yml': '',
+        'ambigous.yaml': '',
     })
 
     path = find_any_metadata_suffix(files.joinpath('dataset_metadata'))
@@ -72,3 +74,6 @@ def test_find_any_metatadata_suffix():
     # Returns none if none exist
     path = find_any_metadata_suffix(files.joinpath('no_metadata'))
     assert path is None
+
+    with pytest.raises(ValueError):
+        find_any_metadata_suffix(files.joinpath('ambigous'))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,11 +8,11 @@ import configparser
 from textwrap import dedent
 
 from datacube.config import LocalConfig
-from tests import util
+from datacube.testutils import write_files
 
 
 def test_find_config():
-    files = util.write_files({
+    files = write_files({
         'base.conf': dedent("""\
             [datacube]
             db_hostname: fakehost.test.lan

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 from datacube.drivers import new_datasource, reader_drivers, writer_drivers, index_drivers
 from datacube.drivers.indexes import IndexDriverCache
 from datacube.storage.storage import RasterDatasetDataSource
-from .util import mk_sample_dataset
+from datacube.testutils import mk_sample_dataset
 
 S3_dataset = namedtuple('S3_dataset', ['macro_shape'])
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 
 import numpy
-from .util import mk_sample_dataset, mk_sample_product
+from datacube.testutils import mk_sample_dataset, mk_sample_product
 from datacube.model import GridSpec
 from datacube.utils import geometry
 from datacube.storage.storage import measurement_paths

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,7 +23,7 @@ from datacube.utils import without_lineage_sources, map_with_lookahead, read_doc
 from datacube.utils import mk_part_uri, get_part_from_uri
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes, MISSING, DocumentMismatchError
 from datacube.utils.dates import date_sequence
-from datacube.model.utils import xr_apply, traverse_datasets
+from datacube.model.utils import xr_apply, traverse_datasets, flatten_datasets
 from datacube.model import MetadataType
 
 from .util import mk_sample_product
@@ -363,6 +363,13 @@ A:..:0
         traverse_datasets(A, visitor, mode=mode, out=out)
         assert '\n'.join(out) == expect
 
+    fv = flatten_datasets(A)
+
+    assert len(fv['A']) == 1
+    assert len(fv['C']) == 2
+    assert len(fv['E']) == 1
+    assert set(fv.keys()) == set('ABCDE')
+
 
 def test_simple_doc_nav():
     def node(name, **kwargs):
@@ -412,3 +419,10 @@ A:..:0
         out = []
         traverse_datasets(rdr, visitor, mode=mode, out=out)
         assert '\n'.join(out) == expect
+
+    fv = flatten_datasets(rdr)
+
+    assert len(fv['A']) == 1
+    assert len(fv['C']) == 2
+    assert len(fv['E']) == 1
+    assert set(fv.keys()) == set('ABCDE')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -390,6 +390,7 @@ def test_simple_doc_nav():
     assert rdr.sources['ab'].sources['bc'].doc == C
     assert rdr.doc_without_lineage_sources is rdr.doc_without_lineage_sources
     assert rdr.sources is rdr.sources
+    assert isinstance(rdr.sources_path, tuple)
 
     def visitor(node, name=None, depth=0, out=None):
         s = '{}:{}:{:d}'.format(node.id, name if name else '..', depth)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,7 +26,7 @@ from datacube.utils.dates import date_sequence
 from datacube.model.utils import xr_apply, traverse_datasets, flatten_datasets
 from datacube.model import MetadataType
 
-from .util import mk_sample_product, make_graph_abcde
+from datacube.testutils import mk_sample_product, make_graph_abcde
 
 
 def test_stats_dates():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -426,3 +426,21 @@ A:..:0
     assert len(fv['C']) == 2
     assert len(fv['E']) == 1
     assert set(fv.keys()) == set('ABCDE')
+
+    fv, dg = flatten_datasets(rdr, with_depth_grouping=True)
+
+    assert len(fv['A']) == 1
+    assert len(fv['C']) == 2
+    assert len(fv['E']) == 1
+    assert set(fv.keys()) == set('ABCDE')
+    assert isinstance(dg, list)
+    assert len(dg) == 4
+    assert [len(l) for l in dg] == [1, 3, 2, 1]
+
+    def to_set(xx):
+        return set(x.id for x in xx)
+
+    assert [set(s) for s in ('A',
+                             'BCE',
+                             'CD',
+                             'D')] == [to_set(xx) for xx in dg]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -377,9 +377,11 @@ def test_simple_doc_nav():
     rdr = SimpleDocNav(A)
 
     assert rdr.doc == A
-    assert rdr.doc_without_lineage_sources == {'id': 'A', 'lineage': {'source_datasets': {}}}
+    assert rdr.doc_without_lineage_sources == node('A')
     assert isinstance(rdr.sources['ae'], SimpleDocNav)
     assert rdr.sources['ab'].sources['bc'].doc == C
+    assert rdr.doc_without_lineage_sources is rdr.doc_without_lineage_sources
+    assert rdr.sources is rdr.sources
 
     def visitor(node, name=None, depth=0, out=None):
         s = '{}:{}:{:d}'.format(node.id, name if name else '..', depth)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ Test date sequence generation functions as used by statistics apps
 import os
 import string
 
+from types import SimpleNamespace
 import pytest
 import rasterio
 from dateutil.parser import parse
@@ -22,7 +23,7 @@ from datacube.utils import without_lineage_sources, map_with_lookahead, read_doc
 from datacube.utils import mk_part_uri, get_part_from_uri
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes, MISSING, DocumentMismatchError
 from datacube.utils.dates import date_sequence
-from datacube.model.utils import xr_apply
+from datacube.model.utils import xr_apply, traverse_datasets
 from datacube.model import MetadataType
 
 from .util import mk_sample_product
@@ -309,3 +310,55 @@ def test_xr_apply():
     assert dst.dtype.name == 'uint8'
     assert dst.shape == src.shape
     assert dst.values.tolist() == [0+1, 1+2, 2+3]
+
+
+def test_traverse_datasets():
+    """
+      A -> B
+      |    |
+      |    v
+      +--> C -> D
+      |
+      +--> E
+    """
+    def node(name, **kwargs):
+        return SimpleNamespace(id=name, sources=kwargs)
+
+    D = node('D')
+    E = node('E')
+    C = node('C', cd=D)
+    B = node('B', bc=C)
+    A = node('A', ab=B, ac=C, ae=E)
+
+    def visitor(node, name=None, depth=0, out=None):
+        s = '{}:{}:{:d}'.format(node.id, name if name else '..', depth)
+        out.append(s)
+
+    with pytest.raises(ValueError):
+        traverse_datasets(A, visitor, mode='not-a-real-mode')
+
+    expect_preorder = '''
+A:..:0
+B:ab:1
+C:bc:2
+D:cd:3
+C:ac:1
+D:cd:2
+E:ae:1
+'''.lstrip().rstrip()
+
+    expect_postorder = '''
+D:cd:3
+C:bc:2
+B:ab:1
+D:cd:2
+C:ac:1
+E:ae:1
+A:..:0
+'''.lstrip().rstrip()
+
+    for mode, expect in zip(['pre-order', 'post-order'],
+                            [expect_preorder, expect_postorder]):
+        out = []
+        traverse_datasets(A, visitor, mode=mode, out=out)
+        assert '\n'.join(out) == expect

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,7 +21,7 @@ import numpy as np
 from datacube.helpers import write_geotiff
 from datacube.utils import uri_to_local_path, clamp, gen_password, write_user_secret_file, slurp, SimpleDocNav
 from datacube.utils import without_lineage_sources, map_with_lookahead, read_documents, sorted_items
-from datacube.utils import mk_part_uri, get_part_from_uri
+from datacube.utils import mk_part_uri, get_part_from_uri, InvalidDocException
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes, MISSING, DocumentMismatchError
 from datacube.utils.dates import date_sequence
 from datacube.model.utils import xr_apply, traverse_datasets, flatten_datasets, dedup_lineage
@@ -482,7 +482,7 @@ def test_dedup():
     ds0 = SimpleDocNav(ds0.doc)
     assert ds0.sources['ab'].sources['bc'].doc != ds0.sources['ac'].doc
 
-    with pytest.raises(ValueError, match=r'Inconsistent metadata .*'):
+    with pytest.raises(InvalidDocException, match=r'Inconsistent metadata .*'):
         dedup_lineage(ds0)
 
     # Test that we detect inconsistent lineage subtrees for duplicate entries
@@ -495,7 +495,7 @@ def test_dedup():
     srcs['cd'] = {}
     ds0 = SimpleDocNav(ds0.doc)
 
-    with pytest.raises(ValueError, match=r'Inconsistent lineage .*'):
+    with pytest.raises(InvalidDocException, match=r'Inconsistent lineage .*'):
         dedup_lineage(ds0)
 
     # Subtest 2: different values for "child" nodes
@@ -506,7 +506,7 @@ def test_dedup():
     srcs['cd']['id'] = '7fe57724-ed44-4beb-a3ab-c275339049be'
     ds0 = SimpleDocNav(ds0.doc)
 
-    with pytest.raises(ValueError, match=r'Inconsistent lineage .*'):
+    with pytest.raises(InvalidDocException, match=r'Inconsistent lineage .*'):
         dedup_lineage(ds0)
 
     # Subtest 3: different name for child
@@ -518,5 +518,5 @@ def test_dedup():
     del srcs['cd']
     ds0 = SimpleDocNav(ds0.doc)
 
-    with pytest.raises(ValueError, match=r'Inconsistent lineage .*'):
+    with pytest.raises(InvalidDocException, match=r'Inconsistent lineage .*'):
         dedup_lineage(ds0)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,7 +19,7 @@ import numpy as np
 
 from datacube.helpers import write_geotiff
 from datacube.utils import uri_to_local_path, clamp, gen_password, write_user_secret_file, slurp, SimpleDocNav
-from datacube.utils import without_lineage_sources, map_with_lookahead, read_documents
+from datacube.utils import without_lineage_sources, map_with_lookahead, read_documents, sorted_items
 from datacube.utils import mk_part_uri, get_part_from_uri
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes, MISSING, DocumentMismatchError
 from datacube.utils.dates import date_sequence
@@ -310,6 +310,17 @@ def test_xr_apply():
     assert dst.dtype.name == 'uint8'
     assert dst.shape == src.shape
     assert dst.values.tolist() == [0+1, 1+2, 2+3]
+
+
+def test_sorted_items():
+    aa = dict(c=1, b={}, a=[])
+
+    assert ''.join(k for k, _ in sorted_items(aa)) == 'abc'
+    assert ''.join(k for k, _ in sorted_items(aa, key=lambda x: x)) == 'abc'
+    assert ''.join(k for k, _ in sorted_items(aa, reverse=True)) == 'cba'
+
+    remap = dict(c=0, a=1, b=2)
+    assert ''.join(k for k, _ in sorted_items(aa, key=lambda x: remap[x])) == 'cab'
 
 
 def test_traverse_datasets():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,7 +27,7 @@ from datacube.utils.dates import date_sequence
 from datacube.model.utils import xr_apply, traverse_datasets, flatten_datasets, dedup_lineage
 from datacube.model import MetadataType
 
-from datacube.testutils import mk_sample_product, make_graph_abcde, gen_dataset_test_dag
+from datacube.testutils import mk_sample_product, make_graph_abcde, gen_dataset_test_dag, dataset_maker
 
 
 def test_stats_dates():
@@ -322,6 +322,28 @@ def test_sorted_items():
 
     remap = dict(c=0, a=1, b=2)
     assert ''.join(k for k, _ in sorted_items(aa, key=lambda x: remap[x])) == 'cab'
+
+
+def test_dataset_maker():
+    mk = dataset_maker(0)
+    assert mk('aa') == mk('aa')
+
+    a = SimpleDocNav(mk('A'))
+    b = SimpleDocNav(mk('B'))
+
+    assert a.id != b.id
+    assert a.doc['creation_dt'] == b.doc['creation_dt']
+    assert isinstance(a.id, str)
+    assert a.sources == {}
+
+    a1, a2 = [dataset_maker(i)('A', product_type='eo') for i in (0, 1)]
+    assert a1['id'] != a2['id']
+    assert a1['creation_dt'] != a2['creation_dt']
+    assert a1['product_type'] == 'eo'
+
+    c = SimpleDocNav(mk('C', sources=dict(a=a.doc, b=b.doc)))
+    assert c.sources['a'].doc is a.doc
+    assert c.sources['b'].doc is b.doc
 
 
 def test_traverse_datasets():


### PR DESCRIPTION
### Reason for this pull request

Most are documented as separate issues and collated in #480

### Biggest Incompatible Change

We now demand that `id` and `sources` properties are at the well-known locations

- `id`
- `lineage.source_datasets` 

This allows navigation of documents without access to index see #482. This only impacts users that have defined custom metadata types and used different paths for `id` and `sources` properties.

This also means we can skip auto-match for lineage datasets that are already in the database, without hard-coding `id` and `sources` you can't know what UUIDs are being referenced in the document without first resolving `dataset<>product` relation.

### Other changes in cli behaviour

- `dataset add` on existing dataset will no longer add new location for the dataset, `dataset update` can be used for that though
- No more `--sources-policy=verify|ensure|skip`, instead
   - `--[no-]auto-add-lineage`
   - `--[no-]verify-lineage`

- Using `--product` (previously `--dtype`) option is now usable even when lineage is present, since existing lineage is no longer auto-matched.

### Major improvements

Properly handle duplicates

- Convert lineage tree into a DAG, report an error if duplicate nodes are incompatible
- Don't attempt to add duplicates twice (previous recursive solution would do that)
- Perform all additions in one transaction, so you don't end up adding some of the lineage data, but then failing to add top-level dataset for whatever reason #475

 - [x] Closes #480
 - [x] Closes #478 
 - [x] Closes #477 
 - [x] Closes #475 
 - [x] Closes #446
 - [x] Closes #450 
 - [x] Closes #451
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes