### PR TITLE
add in certificate symbolic link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,10 @@ RUN mkdir -p /opt/odc \
     && mv $APPDIR/docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh \
     && rm -rf $APPDIR
 
+# Fix an issue with libcurl...
+RUN mkdir -p /etc/pki/tls/certs \
+    && ln -s /etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt;
+
 # Set up an entrypoint that drops environment variables into the config file
 ENTRYPOINT ["docker-entrypoint.sh"]
 


### PR DESCRIPTION
### Reason for this pull request

There's been an issue where RasterIO is refusing to connect to S3, somewhat related to LibCURL. This change resolves the issue.

### Proposed changes

- Add a symbolic link to ssl certificates
