### PR TITLE
Time range query

### DIFF
--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -274,8 +274,7 @@ def _time_to_search_dims(time_range):
         if hasattr(time_range, '__iter__') and len(time_range) == 2:
             if all(isinstance(n, datetime.datetime) for n in time_range):
                 timelist = list(time_range)
-                timelist[0], timelist[1] = timelist[0].isoformat(), timelist[0].isoformat()
-                time_range = tuple(timelist)
+                time_range = timelist[0].isoformat(), timelist[1].isoformat()
             time_range = Range(_to_datetime(time_range[0]),
                                _to_datetime(pandas.Period(time_range[1]).end_time.to_pydatetime()))
             if time_range[0] == time_range[1]:
@@ -291,8 +290,7 @@ def _time_to_search_dims(time_range):
             return time_range
         else:
             timelist = list(time_range)
-            timelist[0], timelist[1] = timelist[0].isoformat(), timelist[0].isoformat()
-            time_range = tuple(timelist)
+            time_range = timelist[0].isoformat(), timelist[1].isoformat()
             time_range = Range(_to_datetime(time_range[0]),
                                _to_datetime(pandas.Period(time_range[1]).end_time.to_pydatetime()))
             return time_range

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -96,6 +96,12 @@ def format_test(start_out, end_out):
 
 
 testdata = [
+    ((datetime.datetime(2008, 1, 1), datetime.datetime(2008, 1, 10)),
+     format_test('2008-01-01T00:00:00', '2008-01-10T00:00:00.999999')),
+    ((datetime.datetime(2008, 1, 1), datetime.datetime(2008, 1, 10, 23, 0, 0)),
+     format_test('2008-01-01T00:00:00', '2008-01-10T23:00:00.999999')),
+    ((datetime.datetime(2008, 1, 1), datetime.datetime(2008, 1, 10, 23, 59, 40)),
+     format_test('2008-01-01T00:00:00', '2008-01-10T23:59:40.999999')),
     (('2008'),
      format_test('2008-01-01T00:00:00', '2008-12-31T23:59:59.999999')),
     (('2008', '2008'),


### PR DESCRIPTION
### Reason for this pull request

... Bug within the code has been corrected. The bug meant that the start timestamp was replicated in the second timestamp under some circumstances. 


### Proposed changes

- The integrity of start and finish timestamps should now be preserved, such that the second output timestamp bears no relation to the first input timestamp, where two timestamps are given to query.
- 



 - [ ] Closes #490
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
