### PR TITLE
Bump version number for release

### DIFF
--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -6,7 +6,7 @@ What's New
 **********
 
 
-v1.6rc2 (4 June 2018)
+v1.6rc2 (29 June 2018)
 =========================================
 
 Backwards Incompatible Changes


### PR DESCRIPTION
### Reason for this pull request
Bump version number on the what's new page for imminent release of a new release candidate.

v1.6rc2

With the aim to release 1.6 final early next week.


<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->