### PR TITLE
Fix indexing failure in ingestor when doing incremental ingest

### DIFF
--- a/datacube/scripts/ingest.py
+++ b/datacube/scripts/ingest.py
@@ -144,6 +144,8 @@ def ensure_output_type(index, config, storage_format, allow_product_changes=Fals
                 raise ValueError("Ingest config differs from the existing output product, "
                                  "but allow_product_changes=False")
             output_type = index.products.update(output_type)
+        else:
+            output_type = existing
     else:
         output_type = index.products.add(output_type)
 


### PR DESCRIPTION
### Reason for this pull request

Low level indexing functions now expect dataset objects that have product set to an actual object from db, not some look-alike. In the case when ingesting into existing product ingest would supply look-alike object instead of loaded from db object.

Making sure that ingest always supplies proper db version of the product.

I have added a no-op repeated ingest test, but we still need to add proper incremental ingest test, that adds new data to existing product.

 - [x] Closes #505
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes