### PR TITLE
Move dataset construction logic out of scripts into a library

### DIFF
--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -1,0 +1,187 @@
+""" High level indexing operations/utilities
+"""
+import json
+import toolz
+from types import SimpleNamespace
+
+from datacube.model import Dataset
+from datacube.utils import changes, InvalidDocException, SimpleDocNav
+from datacube.model.utils import dedup_lineage, remap_lineage_doc, flatten_datasets
+from datacube.utils.changes import get_doc_changes
+
+
+class BadMatch(Exception):
+    pass
+
+
+def load_rules_from_types(index, product_names=None):
+    products = []
+    if product_names:
+        for name in product_names:
+            product = index.products.get_by_name(name)
+            if not product:
+                return None, 'Supplied product name "%s" not present in the database' % name
+            products.append(product)
+    else:
+        products += index.products.get_all()
+
+    if len(products) == 0:
+        return None, 'Found no products in the database'
+
+    return [SimpleNamespace(product=p, signature=p.metadata_doc) for p in products], None
+
+
+def product_matcher(rules):
+    """Given product matching rules return a function mapping a document to a
+    matching product.
+
+    """
+    assert len(rules) > 0
+
+    def matches(doc, rule):
+        return changes.contains(doc, rule.signature)
+
+    def single_product_matcher(rule):
+        def match(doc):
+            if matches(doc, rule):
+                return rule.product
+
+            relevant_doc = {k: v for k, v in doc.items() if k in rule.signature}
+            raise BadMatch('Dataset metadata did not match product signature.'
+                           '\nDataset definition:\n %s\n'
+                           '\nProduct signature:\n %s\n'
+                           % (json.dumps(relevant_doc, indent=4),
+                              json.dumps(rule.signature, indent=4)))
+
+        return match
+
+    if len(rules) == 1:
+        return single_product_matcher(rules[0])
+
+    def match(doc):
+        matched = [rule.product for rule in rules if changes.contains(doc, rule.signature)]
+
+        if len(matched) == 1:
+            return matched[0]
+
+        doc_id = doc.get('id', '<missing id>')
+
+        if len(matched) == 0:
+            raise BadMatch('No matching Product found for dataset %s' % doc_id)
+        else:
+            raise BadMatch('Auto match failed, dataset %s matches several products:\n  %s' % (
+                doc_id,
+                ','.join(p.name for p in matched)))
+
+    return match
+
+
+def check_dataset_consistent(dataset):
+    """
+    :type dataset: datacube.model.Dataset
+    :return: (Is consistent, [error message|None])
+    :rtype: (bool, str or None)
+    """
+    product_measurements = set(dataset.type.measurements.keys())
+
+    if len(product_measurements) == 0:
+        return True, None
+
+    if dataset.measurements is None:
+        return False, "No measurements defined for a dataset"
+
+    # It the type expects measurements, ensure our dataset contains them all.
+    if not product_measurements.issubset(dataset.measurements.keys()):
+        return False, "measurement fields don't match type specification"
+
+    return True, None
+
+
+def check_consistent(a, b):
+    diffs = get_doc_changes(a, b)
+    if len(diffs) == 0:
+        return True, None
+
+    def render_diff(offset, a, b):
+        offset = '.'.join(map(str, offset))
+        return '{}: {!r}!={!r}'.format(offset, a, b)
+
+    return False, ", ".join([render_diff(offset, a, b) for offset, a, b in diffs])
+
+
+def dataset_resolver(index,
+                     product_matching_rules,
+                     fail_on_missing_lineage=False,
+                     verify_lineage=True,
+                     skip_lineage=False):
+    match_product = product_matcher(product_matching_rules)
+
+    def resolve_no_lineage(ds, uri):
+        doc = ds.doc_without_lineage_sources
+        try:
+            product = match_product(doc)
+        except BadMatch as e:
+            return None, e
+
+        return Dataset(product, doc, uris=[uri], sources={}), None
+
+    def resolve(main_ds, uri):
+        try:
+            main_ds = SimpleDocNav(dedup_lineage(main_ds))
+        except InvalidDocException as e:
+            return None, e
+
+        main_uuid = main_ds.id
+
+        ds_by_uuid = toolz.valmap(toolz.first, flatten_datasets(main_ds))
+        all_uuid = list(ds_by_uuid)
+        db_dss = {str(ds.id): ds for ds in index.datasets.bulk_get(all_uuid)}
+
+        lineage_uuids = set(filter(lambda x: x != main_uuid, all_uuid))
+        missing_lineage = lineage_uuids - set(db_dss)
+
+        if missing_lineage and fail_on_missing_lineage:
+            return None, "Following lineage datasets are missing from DB: %s" % (','.join(missing_lineage))
+
+        if verify_lineage:
+            bad_lineage = []
+
+            for uuid in lineage_uuids:
+                if uuid in db_dss:
+                    ok, err = check_consistent(ds_by_uuid[uuid].doc_without_lineage_sources,
+                                               db_dss[uuid].metadata_doc)
+                    if not ok:
+                        bad_lineage.append((uuid, err))
+
+            if len(bad_lineage) > 0:
+                error_report = '\n'.join('Inconsistent lineage dataset {}:\n> {}'.format(uuid, err)
+                                         for uuid, err in bad_lineage)
+                return None, error_report
+
+        def with_cache(v, k, cache):
+            cache[k] = v
+            return v
+
+        def resolve_ds(ds, sources, cache=None):
+            cached = cache.get(ds.id)
+            if cached is not None:
+                return cached
+
+            uris = [uri] if ds.id == main_uuid else []
+
+            doc = ds.doc
+
+            db_ds = db_dss.get(ds.id)
+            if db_ds:
+                product = db_ds.type
+            else:
+                product = match_product(doc)
+
+            return with_cache(Dataset(product, doc, uris=uris, sources=sources), ds.id, cache)
+
+        try:
+            return remap_lineage_doc(main_ds, resolve_ds, cache={}), None
+        except BadMatch as e:
+            return None, e
+
+    return resolve_no_lineage if skip_lineage else resolve

--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -14,7 +14,7 @@ class BadMatch(Exception):
     pass
 
 
-def load_rules_from_types(index, product_names=None):
+def load_rules_from_types(index, product_names=None, excluding=None):
     products = []
     if product_names:
         for name in product_names:
@@ -24,6 +24,10 @@ def load_rules_from_types(index, product_names=None):
             products.append(product)
     else:
         products += index.products.get_all()
+
+    if excluding is not None:
+        excluding = set(excluding)
+        products = [p for p in products if p.name not in excluding]
 
     if len(products) == 0:
         return None, 'Found no products in the database'

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -6,33 +6,25 @@ import logging
 import sys
 from collections import OrderedDict
 from pathlib import Path
-from types import SimpleNamespace
 
 import click
-import toolz
 import yaml
 import yaml.resolver
 from click import echo
-import json
 
 from datacube.index.index import Index
 from datacube.index.exceptions import MissingRecordError
 from datacube.model import Dataset
+from datacube.index.hl import load_rules_from_types, dataset_resolver, check_dataset_consistent
 from datacube.ui import click as ui
 from datacube.ui.click import cli
 from datacube.ui.common import get_metadata_path
 from datacube.utils import read_documents, changes, InvalidDocException, SimpleDocNav
 from datacube.utils.serialise import SafeDatacubeDumper
-from datacube.model.utils import dedup_lineage, remap_lineage_doc, flatten_datasets
-from datacube.utils.changes import get_doc_changes
 
 from typing import Iterable
 
 _LOG = logging.getLogger('datacube-dataset')
-
-
-class BadMatch(Exception):
-    pass
 
 
 def report_old_options(mapping):
@@ -78,179 +70,12 @@ def ui_doc_path_stream(paths):
                                on_error=on_error2, uri=True)
 
 
-def product_matcher(rules):
-    assert len(rules) > 0
+def dataset_stream(doc_stream, ds_resolve):
+    """ Convert a stream `(uri, doc)` pairs into a stream of resolved datasets
 
-    def matches(doc, rule):
-        return changes.contains(doc, rule.signature)
-
-    def single_product_matcher(rule):
-        def match(doc):
-            if matches(doc, rule):
-                return rule.product
-
-            relevant_doc = {k: v for k, v in doc.items() if k in rule.signature}
-            raise BadMatch('Dataset metadata did not match product signature.'
-                           '\nDataset definition:\n %s\n'
-                           '\nProduct signature:\n %s\n'
-                           % (json.dumps(relevant_doc, indent=4),
-                              json.dumps(rule.signature, indent=4)))
-
-        return match
-
-    if len(rules) == 1:
-        return single_product_matcher(rules[0])
-
-    def match(doc):
-        matched = [rule.product for rule in rules if changes.contains(doc, rule.signature)]
-
-        if len(matched) == 1:
-            return matched[0]
-
-        doc_id = doc.get('id', '<missing id>')
-
-        if len(matched) == 0:
-            raise BadMatch('No matching Product found for dataset %s' % doc_id)
-        else:
-            raise BadMatch('Auto match failed, dataset %s matches several products:\n  %s' % (
-                doc_id,
-                ','.join(p.name for p in matched)))
-
-    return match
-
-
-def check_dataset_consistent(dataset):
+        skips failures with logging
     """
-    :type dataset: datacube.model.Dataset
-    :return: (Is consistent, [error message|None])
-    :rtype: (bool, str or None)
-    """
-    product_measurements = set(dataset.type.measurements.keys())
-
-    if len(product_measurements) == 0:
-        return True, None
-
-    if dataset.measurements is None:
-        return False, "No measurements defined for a dataset"
-
-    # It the type expects measurements, ensure our dataset contains them all.
-    if not product_measurements.issubset(dataset.measurements.keys()):
-        return False, "measurement fields don't match type specification"
-
-    return True, None
-
-
-def load_rules_from_types(index, product_names=None):
-    products = []
-    if product_names:
-        for name in product_names:
-            product = index.products.get_by_name(name)
-            if not product:
-                _LOG.error('Supplied product name "%s" not present in the database', name)
-                return None
-            products.append(product)
-    else:
-        products += index.products.get_all()
-
-    if len(products) == 0:
-        _LOG.error('Found no products in the database')
-        return None
-
-    return [SimpleNamespace(product=p, signature=p.metadata_doc) for p in products]
-
-
-def check_consistent(a, b):
-    diffs = get_doc_changes(a, b)
-    if len(diffs) == 0:
-        return True, None
-
-    def render_diff(offset, a, b):
-        offset = '.'.join(map(str, offset))
-        return '{}: {!r}!={!r}'.format(offset, a, b)
-
-    return False, ", ".join([render_diff(offset, a, b) for offset, a, b in diffs])
-
-
-def dataset_resolver(index,
-                     product_matching_rules,
-                     fail_on_missing_lineage=False,
-                     verify_lineage=True,
-                     skip_lineage=False):
-    match_product = product_matcher(product_matching_rules)
-
-    def resolve_no_lineage(ds, uri):
-        doc = ds.doc_without_lineage_sources
-        try:
-            product = match_product(doc)
-        except BadMatch as e:
-            return None, e
-
-        return Dataset(product, doc, uris=[uri], sources={}), None
-
-    def resolve(main_ds, uri):
-        try:
-            main_ds = SimpleDocNav(dedup_lineage(main_ds))
-        except InvalidDocException as e:
-            return None, e
-
-        main_uuid = main_ds.id
-
-        ds_by_uuid = toolz.valmap(toolz.first, flatten_datasets(main_ds))
-        all_uuid = list(ds_by_uuid)
-        db_dss = {str(ds.id): ds for ds in index.datasets.bulk_get(all_uuid)}
-
-        lineage_uuids = set(filter(lambda x: x != main_uuid, all_uuid))
-        missing_lineage = lineage_uuids - set(db_dss)
-
-        if missing_lineage and fail_on_missing_lineage:
-            return None, "Following lineage datasets are missing from DB: %s" % (','.join(missing_lineage))
-
-        if verify_lineage:
-            bad_lineage = []
-
-            for uuid in lineage_uuids:
-                if uuid in db_dss:
-                    ok, err = check_consistent(ds_by_uuid[uuid].doc_without_lineage_sources,
-                                               db_dss[uuid].metadata_doc)
-                    if not ok:
-                        bad_lineage.append((uuid, err))
-
-            if len(bad_lineage) > 0:
-                error_report = '\n'.join('Inconsistent lineage dataset {}:\n> {}'.format(uuid, err)
-                                         for uuid, err in bad_lineage)
-                return None, error_report
-
-        def with_cache(v, k, cache):
-            cache[k] = v
-            return v
-
-        def resolve_ds(ds, sources, cache=None):
-            cached = cache.get(ds.id)
-            if cached is not None:
-                return cached
-
-            uris = [uri] if ds.id == main_uuid else []
-
-            doc = ds.doc
-
-            db_ds = db_dss.get(ds.id)
-            if db_ds:
-                product = db_ds.type
-            else:
-                product = match_product(doc)
-
-            return with_cache(Dataset(product, doc, uris=uris, sources=sources), ds.id, cache)
-
-        try:
-            return remap_lineage_doc(main_ds, resolve_ds, cache={}), None
-        except BadMatch as e:
-            return None, e
-
-    return resolve_no_lineage if skip_lineage else resolve
-
-
-def load_datasets(dataset_paths, ds_resolve):
-    for uri, ds in ui_doc_path_stream(dataset_paths):
+    for uri, ds in doc_stream:
         dataset, err = ds_resolve(ds, uri)
 
         if dataset is None:
@@ -265,9 +90,10 @@ def load_datasets(dataset_paths, ds_resolve):
         yield dataset
 
 
-def load_datasets_for_update(dataset_paths, index):
-    """Load datasets from disk, associate to a product by looking up existing
-    dataset in the index. Datasets not in the database will be logged.
+def load_datasets_for_update(doc_stream, index):
+    """Consume stream of dataset documents, associate each to a product by looking
+    up existing dataset in the index. Datasets not in the database will be
+    logged.
 
     Doesn't load lineage information
 
@@ -287,7 +113,7 @@ def load_datasets_for_update(dataset_paths, index):
                        ds.doc_without_lineage_sources,
                        uris=[uri]), existing, None
 
-    for uri, doc in ui_doc_path_stream(dataset_paths):
+    for uri, doc in doc_stream:
         dataset, existing, error_msg = mk_dataset(doc, uri)
 
         if dataset is None:
@@ -355,8 +181,9 @@ def index_cmd(index, product_names,
     if auto_match is True:
         _LOG.warning("--auto-match option is deprecated, update your scripts, behaviour is the same without it")
 
-    rules = load_rules_from_types(index, product_names)
+    rules, error_msg = load_rules_from_types(index, product_names)
     if rules is None:
+        _LOG.error(error_msg)
         sys.exit(2)
 
     assert len(rules) > 0
@@ -367,7 +194,8 @@ def index_cmd(index, product_names,
                                   verify_lineage=verify_lineage)
 
     def run_it(dataset_paths):
-        dss = load_datasets(dataset_paths, ds_resolve)
+        doc_stream = ui_doc_path_stream(dataset_paths)
+        dss = dataset_stream(doc_stream, ds_resolve)
         index_datasets(dss,
                        index,
                        auto_add_lineage=auto_add_lineage,
@@ -411,10 +239,10 @@ def parse_update_rules(keys_that_can_change):
 'archive' - mark as archived
 'forget' - remove from the index
 ''')
-@click.argument('datasets',
+@click.argument('dataset-paths',
                 type=click.Path(exists=True, readable=True, writable=False), nargs=-1)
 @ui.pass_index()
-def update_cmd(index, keys_that_can_change, dry_run, location_policy, datasets):
+def update_cmd(index, keys_that_can_change, dry_run, location_policy, dataset_paths):
 
     def loc_action(action, new_ds, existing_ds, action_name):
         if len(existing_ds.uris) == 0:
@@ -452,7 +280,9 @@ def update_cmd(index, keys_that_can_change, dry_run, location_policy, datasets):
     updates_allowed = parse_update_rules(keys_that_can_change)
 
     success, fail = 0, 0
-    for dataset, existing_ds in load_datasets_for_update(datasets, index):
+    doc_stream = ui_doc_path_stream(dataset_paths)
+
+    for dataset, existing_ds in load_datasets_for_update(doc_stream, index):
         _LOG.info('Matched %s', dataset)
 
         if location_policy != 'keep':

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -137,6 +137,11 @@ def load_datasets_for_update(doc_stream, index):
               help=('Only match against products specified with this option, '
                     'you can supply several by repeating this option with a new product name'),
               multiple=True)
+@click.option('--exclude-product', '-x', 'exclude_product_names',
+              help=('Attempt to match to all products in the DB except for products '
+                    'specified with this option, '
+                    'you can supply several by repeating this option with a new product name'),
+              multiple=True)
 @click.option('--auto-match', '-a', help="Deprecated don't use it, it's a no-op",
               is_flag=True, default=False)
 @click.option('--auto-add-lineage/--no-auto-add-lineage', is_flag=True, default=True,
@@ -158,6 +163,7 @@ def load_datasets_for_update(doc_stream, index):
                 type=click.Path(exists=True, readable=True, writable=False), nargs=-1)
 @ui.pass_index()
 def index_cmd(index, product_names,
+              exclude_product_names,
               auto_match,
               auto_add_lineage,
               verify_lineage,
@@ -181,7 +187,9 @@ def index_cmd(index, product_names,
     if auto_match is True:
         _LOG.warning("--auto-match option is deprecated, update your scripts, behaviour is the same without it")
 
-    rules, error_msg = load_rules_from_types(index, product_names)
+    rules, error_msg = load_rules_from_types(index,
+                                             product_names,
+                                             excluding=exclude_product_names)
     if rules is None:
         _LOG.error(error_msg)
         sys.exit(2)

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -280,9 +280,8 @@ def update_cmd(index, keys_that_can_change, dry_run, location_policy, dataset_pa
     updates_allowed = parse_update_rules(keys_that_can_change)
 
     success, fail = 0, 0
-    doc_stream = ui_doc_path_stream(dataset_paths)
 
-    for dataset, existing_ds in load_datasets_for_update(doc_stream, index):
+    for dataset, existing_ds in load_datasets_for_update(ui_doc_path_stream(dataset_paths), index):
         _LOG.info('Matched %s', dataset)
 
         if location_policy != 'keep':

--- a/datacube/ui/common.py
+++ b/datacube/ui/common.py
@@ -2,8 +2,9 @@
 """
 Common methods for UI code.
 """
-from __future__ import absolute_import
+from pathlib import Path
 
+from datacube.utils import read_documents, InvalidDocException, SimpleDocNav
 from datacube.utils import is_supported_document_type
 
 
@@ -53,3 +54,56 @@ def find_any_metadata_suffix(path):
         raise ValueError('Multiple matched metadata files: {!r}'.format(existing_paths))
 
     return existing_paths[0]
+
+
+def resolve_doc_files(paths, on_error):
+    for p in paths:
+        try:
+            yield get_metadata_path(Path(p))
+        except ValueError as e:
+            on_error(p, e)
+
+
+def path_doc_stream(files, on_error, uri=True, raw=False):
+    maybe_wrap = {True: lambda x: x,
+                  False: SimpleDocNav}[raw]
+
+    for fname in files:
+        try:
+            for p, doc in read_documents(fname, uri=uri):
+                yield p, maybe_wrap(doc)
+
+        except InvalidDocException as e:
+            on_error(fname, e)
+
+
+def ui_path_doc_stream(paths, logger=None, uri=True, raw=False):
+    """Given a stream of paths that could be directories generate a stream of
+    (path, doc) tuples.
+
+    For every path:
+    1. If directory find the metadata file or log error if not found
+
+    2. Load all documents from that path and return one at a time (parsing
+    errors are logged, but porcessing should continue)
+
+    :param paths: Filesystem paths
+
+    :param logger: Logger to use to report errors
+
+    :param uri: If True return path in uri format, else return it as filesystem path
+
+    :param raw: By default docs are wrapped in SimpleDocNav class, but you can
+    instead request them to be raw dictionaries
+
+    """
+    def on_error1(p, e):
+        if logger is not None:
+            logger.error('No supported metadata docs found for dataset %s', str(p))
+
+    def on_error2(p, e):
+        if logger is not None:
+            logger.error('Failed reading documents from %s', str(p))
+
+    yield from path_doc_stream(resolve_doc_files(paths, on_error=on_error1),
+                               on_error=on_error2, uri=uri, raw=raw)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -16,6 +16,7 @@ Changes
 ~~~~~~~
 
 - Allow indexing without lineage `dataset add --ignore-lineage` (:pull:`485`)
+- New option `dataset add --exclude-product <name>` allows excluding some products from auto-matching
 - Various improvements to indexing, mostly to do with handling of lineage (:issue:`480`)
 
 


### PR DESCRIPTION
### Reason for this pull request

Move some of the high level indexing related functionality into a lib.

Currently various scripts in `digitalearthau` and other repos reach into `datacube.scripts.dataset`, which is wrong.  


### Proposed changes

- Add class `Doc2Dataset` replaces `create_dataset, parse_match_rules_options`

 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes
