### PR TITLE
Add more thorough integration testing of ingestion

### DIFF
--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -24,6 +24,7 @@ import datacube.utils
 from datacube.drivers.postgres import _core
 from datacube.index import index_connect
 from datacube.index._metadata_types import default_metadata_type_docs
+from integration_tests.utils import limit_num_measurements
 
 try:
     from yaml import CSafeLoader as SafeLoader
@@ -403,21 +404,6 @@ def example_ls5_dataset_paths(tmpdir, geotiffs):
     return dataset_dirs
 
 
-def create_empty_geotiff(path):
-    # Example method, not used
-    metadata = {'count': 1,
-                'crs': 'EPSG:28355',
-                'driver': 'GTiff',
-                'dtype': 'int16',
-                'height': 8521,
-                'nodata': -999.0,
-                'transform': [25.0, 0.0, 638000.0, 0.0, -25.0, 6276000.0],
-                'compress': 'lzw',
-                'width': 9721}
-    with rasterio.open(path, 'w', **metadata) as dst:
-        pass
-
-
 @pytest.fixture
 def default_metadata_type_doc():
     return [doc for doc in default_metadata_type_docs() if doc['name'] == 'eo'][0]
@@ -501,15 +487,6 @@ def alter_product_for_testing(product, metadata_type=None):
     return product
 
 
-def limit_num_measurements(dataset_type):
-    if 'measurements' not in dataset_type:
-        return
-    measurements = dataset_type['measurements']
-    if len(measurements) > TEST_STORAGE_NUM_MEASUREMENTS:
-        dataset_type['measurements'] = measurements[:TEST_STORAGE_NUM_MEASUREMENTS]
-    return dataset_type
-
-
 def is_geogaphic(storage_type):
     return 'latitude' in storage_type['storage']['resolution']
 
@@ -555,50 +532,3 @@ def dataset_add_configs():
                            datasets=str(B/'datasets.yml'))
 
 
-def edit_for_fast_ingest(config):
-    config = alter_product_for_testing(config)
-    config['storage']['crs'] = 'EPSG:28355'
-    config['storage']['chunking']['time'] = 1
-    return config
-
-
-def edit_for_end2end(config):
-    storage = config.get('storage', {})
-
-    storage['crs'] = 'EPSG:3577'
-    storage['tile_size']['x'] = 100000.0
-    storage['tile_size']['y'] = 100000.0
-
-    config['storage'] = storage
-    return config
-
-
-def prepare_test_ingestion_configuration(tmpdir,
-                                         output_dir,
-                                         filename,
-                                         mode=None):
-    customizers = {
-        'fast_ingest': edit_for_fast_ingest,
-        'end2end': edit_for_end2end,
-    }
-
-    filename = Path(filename)
-    if output_dir is None:
-        output_dir = tmpdir.mkdir(filename.stem)
-    config = load_yaml_file(filename)[0]
-
-    if mode is not None:
-        if mode not in customizers:
-            raise ValueError('Wrong mode: ' + mode)
-        config = customizers[mode](config)
-
-    config['location'] = str(output_dir)
-
-    # If ingesting with the s3test driver
-    if 'bucket' in config['storage']:
-        config['storage']['bucket'] = str(output_dir)
-
-    config_path = tmpdir.join(filename.name)
-    with open(str(config_path), 'w') as stream:
-        yaml.dump(config, stream)
-    return config_path, config

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -6,16 +6,13 @@ from __future__ import absolute_import
 
 import itertools
 import os
-import shutil
 from copy import copy, deepcopy
-from datetime import datetime, timedelta
+from datetime import timedelta
 from pathlib import Path
-from uuid import UUID, uuid4
 from types import SimpleNamespace
+from uuid import uuid4
 
-import numpy as np
 import pytest
-import rasterio
 import yaml
 from click.testing import CliRunner
 
@@ -24,7 +21,8 @@ import datacube.utils
 from datacube.drivers.postgres import _core
 from datacube.index import index_connect
 from datacube.index._metadata_types import default_metadata_type_docs
-from integration_tests.utils import limit_num_measurements
+from integration_tests.utils import _make_geotiffs, _make_ls5_scene_datasets, load_yaml_file, \
+    GEOTIFF, load_test_products
 
 try:
     from yaml import CSafeLoader as SafeLoader
@@ -35,33 +33,10 @@ from datacube.config import LocalConfig
 from datacube.index.index import Index
 from datacube.drivers.postgres import PostgresDb
 
-# On Windows, symlinks are not supported in Python 2 and require
-# specific privileges otherwise, so we copy instead of linking
-if os.name == 'nt' or not hasattr(os, 'symlink'):
-    symlink = shutil.copy
-else:
-    symlink = os.symlink
-
 _SINGLE_RUN_CONFIG_TEMPLATE = """
 
 """
 
-GEOTIFF = {
-    'date': datetime(1990, 3, 2),
-    'shape': {
-        'x': 432,
-        'y': 321
-    },
-    'pixel_size': {
-        'x': 25.0,
-        'y': -25.0
-    },
-    'crs': 'EPSG:28355',  # 'EPSG:28355'
-    'ul': {
-        'x': 638000.0,  # Coords must match crs
-        'y': 6276000.0  # Coords must match crs
-    }
-}
 INTEGRATION_TESTS_DIR = Path(__file__).parent
 
 _EXAMPLE_LS5_NBAR_DATASET_FILE = INTEGRATION_TESTS_DIR / 'example-ls5-nbar.yaml'
@@ -69,35 +44,12 @@ _EXAMPLE_LS5_NBAR_DATASET_FILE = INTEGRATION_TESTS_DIR / 'example-ls5-nbar.yaml'
 #: Number of time slices to create in sample data
 NUM_TIME_SLICES = 3
 
-#: Number of bands to place in generated GeoTIFFs
-NUM_BANDS = 3
-
 PROJECT_ROOT = Path(__file__).parents[1]
 CONFIG_SAMPLES = PROJECT_ROOT / 'docs' / 'config_samples'
 
 LS5_SAMPLES = CONFIG_SAMPLES / 'storage_types' / 'ga_landsat_5'
 LS5_NBAR_STORAGE_TYPE = LS5_SAMPLES / 'ls5_geographic.yaml'
 LS5_NBAR_ALBERS_STORAGE_TYPE = LS5_SAMPLES / 'ls5_albers.yaml'
-
-# Resolution and chunking shrink factors
-TEST_STORAGE_SHRINK_FACTORS = (100, 100)
-TEST_STORAGE_NUM_MEASUREMENTS = 2
-GEOGRAPHIC_VARS = ('latitude', 'longitude')
-PROJECTED_VARS = ('x', 'y')
-
-EXAMPLE_LS5_DATASET_ID = UUID('bbf3e21c-82b0-11e5-9ba1-a0000100fe80')
-
-# def pytest_generate_tests(metafunc):
-#     if "fixture_param" in metafunc.fixturenames:
-#         metafunc.parametrize("fixture_param", ["foo"], scope="module")
-#     idlist = []
-#     argvalues = []
-#     for scenario in metafunc.cls.scenarios:
-#         idlist.append(scenario[0])
-#         items = scenario[1].items()
-#         argnames = [x[0] for x in items]
-#         argvalues.append(([x[1] for x in items]))
-#     metafunc.parametrize(argnames, argvalues, ids=idlist, scope="class")
 
 CONFIG_FILE_PATHS = [str(INTEGRATION_TESTS_DIR / 'agdcintegration.conf'),
                      os.path.expanduser('~/.datacube_integration.conf')]
@@ -204,7 +156,7 @@ def initialised_postgres_db(index):
 
 def remove_dynamic_indexes():
     """
-    Clear any dynamically created indexes from the schema.
+    Clear any dynamically created postgresql indexes from the schema.
     """
     # Our normal indexes start with "ix_", dynamic indexes with "dix_"
     for table in _core.METADATA.tables.values():
@@ -252,19 +204,26 @@ def geotiffs(tmpdir_factory):
     :ref:`GEOTIFF`.
 
     :param tmpdir_fatory: pytest tmp dir factory.
-    :return: List of dictionaries `{'day':..., 'uuid':..., 'path':...,
-      'tiffs':...}` with `day`: compact day string, e.g. `19900302`,
-      `uuid` a unique UUID for this dataset (i.e. specific day),
-      `path`: path to the yaml ingestion file, `tiffs`: list of paths
-      to the actual geotiffs in that dataset, one per band.
+    :return: List of dictionaries like::
+
+        {
+            'day':..., # compact day string, e.g. `19900302`
+            'uuid':..., # a unique UUID for this dataset (i.e. specific day)
+            'path':..., # path to the yaml ingestion file
+            'tiffs':... # list of paths to the actual geotiffs in that dataset, one per band.
+        }
 
     """
     tiffs_dir = tmpdir_factory.mktemp('tiffs')
 
     config = load_yaml_file(_EXAMPLE_LS5_NBAR_DATASET_FILE)[0]
+
     # Customise the spatial coordinates
     ul = GEOTIFF['ul']
-    lr = {dim: ul[dim] + GEOTIFF['shape'][dim] * GEOTIFF['pixel_size'][dim] for dim in ('x', 'y')}
+    lr = {
+        dim: ul[dim] + GEOTIFF['shape'][dim] * GEOTIFF['pixel_size'][dim]
+        for dim in ('x', 'y')
+    }
     config['grid_spatial']['projection']['geo_ref_points'] = {
         'ul': ul,
         'ur': {
@@ -287,11 +246,11 @@ def _make_tiffs_and_yamls(tiffs_dir, config, day_offset):
 
     :param path-like tiffs_dir: The base path to receive the tiffs.
     :param dict config: The yaml config to be cloned and altered.
-    :param int day_offset: how many days to offset the original yaml
-      by.
+    :param int day_offset: how many days to offset the original yaml by.
     """
     config = deepcopy(config)
-    # Shift dates by the specific offset
+
+    # Increment all dates by the day_offset
     delta = timedelta(days=day_offset)
     day_orig = config['acquisition']['aos'].strftime('%Y%m%d')
     config['acquisition']['aos'] += delta
@@ -328,44 +287,6 @@ def _make_tiffs_and_yamls(tiffs_dir, config, day_offset):
     }
 
 
-def _make_geotiffs(tiffs_dir, day_offset):
-    """Generate custom geotiff files, one per band."""
-    tiffs = {}
-    width = GEOTIFF['shape']['x']
-    height = GEOTIFF['shape']['y']
-    metadata = {'count': 1,
-                'crs': GEOTIFF['crs'],
-                'driver': 'GTiff',
-                'dtype': 'int16',
-                'width': width,
-                'height': height,
-                'nodata': -999.0,
-                'transform': [GEOTIFF['pixel_size']['x'],
-                              0.0,
-                              GEOTIFF['ul']['x'],
-                              0.0,
-                              GEOTIFF['pixel_size']['y'],
-                              GEOTIFF['ul']['y']]}
-
-    for band in range(NUM_BANDS):
-        path = str(tiffs_dir.join('band%02d_time%02d.tif' % ((band + 1), day_offset)))
-        with rasterio.open(path, 'w', **metadata) as dst:
-            # Write data in "corners" (rounded down by 100, for a size of 100x100)
-            data = np.zeros((height, width), dtype=np.int16)
-            data[:] = np.arange(height * width).reshape((height, width)) + 10 * band + day_offset
-            '''
-            lr = (100 * int(GEOTIFF['shape']['y'] / 100.0),
-                  100 * int(GEOTIFF['shape']['x'] / 100.0))
-            data[0:100, 0:100] = 100 + day_offset
-            data[lr[0] - 100:lr[0], 0:100] = 200 + day_offset
-            data[0:100, lr[1] - 100:lr[1]] = 300 + day_offset
-            data[lr[0] - 100:lr[0], lr[1] - 100:lr[1]] = 400 + day_offset
-            '''
-            dst.write(data, 1)
-        tiffs[band] = path
-    return tiffs
-
-
 @pytest.fixture
 def example_ls5_dataset_path(example_ls5_dataset_paths):
     """Create a single sample raw observation (dataset + geotiff)."""
@@ -387,20 +308,7 @@ def example_ls5_dataset_paths(tmpdir, geotiffs):
     :return: dict: Dict of directories containing each observation,
       indexed by dataset UUID.
     """
-    dataset_dirs = {}
-    dataset_dir = tmpdir.mkdir('ls5_dataset')
-    for geotiff in geotiffs:
-        obs_name = 'LS5_TM_NBAR_P54_GANBAR01-002_090_084_%s' % geotiff['day']
-        obs_dir = dataset_dir.mkdir(obs_name)
-        symlink(str(geotiff['path']), str(obs_dir.join('agdc-metadata.yaml')))
-
-        scene_dir = obs_dir.mkdir('scene01')
-        scene_dir.join('report.txt').write('Example')
-        geotiff_name = '%s_B{}0.tif' % obs_name
-        for band in range(NUM_BANDS):
-            path = scene_dir.join(geotiff_name.format(band + 1))
-            symlink(str(geotiff['tiffs'][band]), str(path))
-        dataset_dirs[geotiff['uuid']] = Path(str(obs_dir))
+    dataset_dirs = _make_ls5_scene_datasets(geotiffs, tmpdir)
     return dataset_dirs
 
 
@@ -466,39 +374,6 @@ def example_ls5_nbar_metadata_doc():
     return load_yaml_file(_EXAMPLE_LS5_NBAR_DATASET_FILE)[0]
 
 
-def load_test_products(filename, metadata_type=None):
-    dataset_types = load_yaml_file(filename)
-    return [alter_product_for_testing(dataset_type, metadata_type=metadata_type) for dataset_type in dataset_types]
-
-
-def load_yaml_file(filename):
-    with open(str(filename)) as f:
-        return list(yaml.load_all(f, Loader=SafeLoader))
-
-
-def alter_product_for_testing(product, metadata_type=None):
-    limit_num_measurements(product)
-    if 'storage' in product:
-        product = shrink_storage_type(product,
-                                      GEOGRAPHIC_VARS if is_geogaphic(product) else PROJECTED_VARS,
-                                      TEST_STORAGE_SHRINK_FACTORS)
-    if metadata_type:
-        product['metadata_type'] = metadata_type.name
-    return product
-
-
-def is_geogaphic(storage_type):
-    return 'latitude' in storage_type['storage']['resolution']
-
-
-def shrink_storage_type(storage_type, variables, shrink_factors):
-    storage = storage_type['storage']
-    for var in variables:
-        storage['resolution'][var] = storage['resolution'][var] * shrink_factors[0]
-        storage['chunking'][var] = storage['chunking'][var] / shrink_factors[1]
-    return storage_type
-
-
 @pytest.fixture
 def clirunner(global_integration_cli_args, datacube_env_name):
     def _run_cli(opts, catch_exceptions=False,
@@ -525,10 +400,8 @@ def clirunner(global_integration_cli_args, datacube_env_name):
 
 @pytest.fixture
 def dataset_add_configs():
-    B = INTEGRATION_TESTS_DIR/'data'/'dataset_add'
-    return SimpleNamespace(metadata=str(B/'metadata.yml'),
-                           products=str(B/'products.yml'),
-                           datasets_bad1=str(B/'datasets_bad1.yml'),
-                           datasets=str(B/'datasets.yml'))
-
-
+    B = INTEGRATION_TESTS_DIR / 'data' / 'dataset_add'
+    return SimpleNamespace(metadata=str(B / 'metadata.yml'),
+                           products=str(B / 'products.yml'),
+                           datasets_bad1=str(B / 'datasets_bad1.yml'),
+                           datasets=str(B / 'datasets.yml'))

--- a/integration_tests/data_utils.py
+++ b/integration_tests/data_utils.py
@@ -1,0 +1,199 @@
+"""
+The start of some general purpose utilities for generating test data.
+
+At the moment it's not very generic, but can continue to be extended in that fashion.
+
+Hypothesis is used for most of the data generation, which will hopefully improve the rigour
+of our tests when we can roll it into more tests.
+"""
+import string
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import numpy as np
+import rasterio
+import yaml
+from hypothesis.strategies import sampled_from, datetimes, composite, floats, lists, text, uuids
+
+from datacube.utils.geometry import CRS, point
+
+DATE_FORMAT = '%Y-%m-%d %H:%M:%S'
+
+# Bounds retrieved from http://www.epsg-registry.org
+# Code, lat_bounds, lon_bounds
+EPSG_CODES = [('EPSG:32755', (-80, 0), (144, 150))]
+crses = sampled_from(EPSG_CODES)
+REASONABLE_DATES = datetimes(min_value=datetime(1980, 1, 1), max_value=datetime(2030, 1, 1))
+
+
+@composite
+def bounds(draw, bounds):
+    return draw(
+        lists(
+            floats(*bounds), min_size=2, max_size=2
+        ).map(sorted).filter(lambda x: x[0] < x[1]))
+
+
+@composite
+def bboxes(draw, lat_bounds=(-90, 90), lon_bounds=(-180, 180)):
+    """
+    https://tools.ietf.org/html/rfc7946#section-5
+    """
+    # Use 3 dim positions even if we only need 2
+    min_lat, max_lat = draw(bounds(lat_bounds))
+    min_lon, max_lon = draw(bounds(lon_bounds))
+
+    return min_lon, min_lat, max_lon, max_lat
+
+
+@composite
+def extents(draw, lat_bounds, lon_bounds):
+    center_dt = draw(REASONABLE_DATES)
+
+    time_range = timedelta(seconds=12)
+    min_lon, min_lat, max_lon, max_lat = draw(bboxes(lat_bounds, lon_bounds))
+    return {
+        'center_dt': center_dt.strftime(DATE_FORMAT),
+        'from_dt': (center_dt - time_range).strftime(DATE_FORMAT),
+        'to_dt': (center_dt + time_range).strftime(DATE_FORMAT),
+        'coord': {
+            'll': {'lat': min_lat, 'lon': min_lon},
+            'lr': {'lat': min_lat, 'lon': max_lon},
+            'ul': {'lat': max_lat, 'lon': min_lon},
+            'ur': {'lat': max_lat, 'lon': max_lon},
+        }
+    }
+
+
+def _extent_point_projector(crs):
+    crs = CRS(crs)
+
+    def reproject_point(pos):
+        pos = point(pos['lon'], pos['lat'], CRS('EPSG:4326'))
+        coords = pos.to_crs(crs).coords[0]
+        return {'x': coords[0], 'y': coords[1]}
+
+    return reproject_point
+
+
+def extent_to_grid_spatial(extent, crs):
+    """Convert an extent in WGS84 to a grid spatial in the supplied CRS"""
+    reprojector = _extent_point_projector(crs)
+    return {
+        'projection': {
+            'geo_ref_points': {
+                corner: reprojector(pos)
+                for corner, pos in extent['coord'].items()
+            },
+            'spatial_reference': crs
+        }
+    }
+
+
+@composite
+def acquisition_details(draw):
+    return {
+        'aos': draw(REASONABLE_DATES),
+        'groundstation': {
+            'code': draw(text(alphabet=string.ascii_letters, min_size=3, max_size=5))
+        },
+        'los': draw(REASONABLE_DATES)
+    }
+
+
+@composite
+def scene_datasets(draw):
+    """
+    Generate random test Landsat 5 Scene Datasets
+    """
+    crs, lat_bounds, lon_bounds = draw(crses)
+    extent = draw(extents(lat_bounds, lon_bounds))
+    return {
+        'id': str(draw(uuids())),
+        'acquisition': draw(acquisition_details()),
+        'creation_dt': draw(REASONABLE_DATES),
+        'extent': extent,
+        'grid_spatial': extent_to_grid_spatial(extent, crs),
+        'image': {
+            'bands': {
+                '1': {
+                    'path': 'LS5_TM_NBAR_P54_GANBAR01-002_090_084_19900302_B10.tif'
+                }
+            }
+        },
+        'format': {
+            'name': 'GeoTIFF'},
+        'instrument': {
+            'name': 'TM'},
+        'lineage': {
+            'source_datasets': {}},
+        'platform': {
+            'code': 'LANDSAT_5'},
+        'processing_level': 'P54',
+        'product_type': 'nbar'
+    }
+
+
+def generate_test_scenes(tmpdir, num=2):
+    paths_to_datasets = []
+    for i in range(num):
+        ls5_dataset = scene_datasets().example()
+        dataset_file = write_test_scene_to_disk(ls5_dataset, tmpdir)
+        paths_to_datasets.append(dataset_file)
+    return paths_to_datasets
+
+
+def write_test_scene_to_disk(dataset_dict, tmpdir):
+    # Make directory name
+    dir_name = dataset_dict['platform']['code'] + dataset_dict['id'][:5]
+
+    # Create directory
+    new_dir = tmpdir.mkdir(dir_name)
+
+    _make_geotiffs(new_dir, dataset_dict)
+    dataset_file = new_dir.join('agdc-metadata.yaml')
+    dataset_file.write(yaml.safe_dump(dataset_dict))
+    return dataset_file
+
+
+def _make_geotiffs(output_dir, dataset_dict, shape=(100, 100)):
+    """
+    Generate test GeoTIFF files into ``output_dir``, one per band, from a dataset dictionary
+
+    :return: a dictionary mapping band_number to filename, eg::
+
+        {
+            0: '/tmp/tiffs/band01_time01.tif',
+            1: '/tmp/tiffs/band02_time01.tif'
+        }
+    """
+    tiffs = {}
+    width, height = shape
+    pixel_width = (dataset_dict['grid_spatial']['projection']['geo_ref_points']['ul']['x'] -
+                   dataset_dict['grid_spatial']['projection']['geo_ref_points']['ur']['x']) / width
+    pixel_height = (dataset_dict['grid_spatial']['projection']['geo_ref_points']['ul']['y'] -
+                    dataset_dict['grid_spatial']['projection']['geo_ref_points']['ll']['y']) / height
+    metadata = {'count': 1,
+                'crs': dataset_dict['grid_spatial']['projection']['spatial_reference'],
+                'driver': 'GTiff',
+                'dtype': 'int16',
+                'width': width,
+                'height': height,
+                'nodata': -999.0,
+                'transform': [pixel_width,
+                              0.0,
+                              dataset_dict['grid_spatial']['projection']['geo_ref_points']['ul']['x'],
+                              0.0,
+                              pixel_height,
+                              dataset_dict['grid_spatial']['projection']['geo_ref_points']['ul']['y']]}
+
+    for band_num, band_info in dataset_dict['image']['bands'].items():
+        path = Path(output_dir) / band_info['path']
+        with rasterio.open(path, 'w', **metadata) as dst:
+            # Write data in "corners" (rounded down by 100, for a size of 100x100)
+            data = np.zeros((height, width), dtype=np.int16)
+            data[:] = np.arange(height * width
+                                ).reshape((height, width)) + 10 * int(band_num)
+            dst.write(data, 1)
+        tiffs[band_num] = path
+    return tiffs

--- a/integration_tests/data_utils.py
+++ b/integration_tests/data_utils.py
@@ -145,15 +145,18 @@ def generate_test_scenes(tmpdir, num=2):
 
 
 def write_test_scene_to_disk(dataset_dict, tmpdir):
+    tmpdir = Path(str(tmpdir))
     # Make directory name
     dir_name = dataset_dict['platform']['code'] + dataset_dict['id'][:5]
 
     # Create directory
-    new_dir = tmpdir.mkdir(dir_name)
+    new_dir = tmpdir / dir_name
+    new_dir.mkdir()
 
     _make_geotiffs(new_dir, dataset_dict)
-    dataset_file = new_dir.join('agdc-metadata.yaml')
-    dataset_file.write(yaml.safe_dump(dataset_dict))
+    dataset_file = new_dir / 'agdc-metadata.yaml'
+    with dataset_file.open('w') as out:
+        yaml.safe_dump(dataset_dict, out)
     return dataset_file
 
 

--- a/integration_tests/data_utils.py
+++ b/integration_tests/data_utils.py
@@ -24,6 +24,7 @@ DATE_FORMAT = '%Y-%m-%d %H:%M:%S'
 EPSG_CODES = [('EPSG:32755', (-80, 0), (144, 150))]
 crses = sampled_from(EPSG_CODES)
 REASONABLE_DATES = datetimes(min_value=datetime(1980, 1, 1), max_value=datetime(2030, 1, 1))
+FILENAMES = text(alphabet=string.ascii_letters + string.digits + '-_', min_size=3)
 
 
 @composite
@@ -117,7 +118,7 @@ def scene_datasets(draw):
         'image': {
             'bands': {
                 '1': {
-                    'path': 'LS5_TM_NBAR_P54_GANBAR01-002_090_084_19900302_B10.tif'
+                    'path': draw(FILENAMES) + '.tif'
                 }
             }
         },

--- a/integration_tests/test_double_ingestion.py
+++ b/integration_tests/test_double_ingestion.py
@@ -1,217 +1,9 @@
-import string
-from datetime import datetime, timedelta
 from pathlib import Path
 
-import numpy as np
 import pytest
-import rasterio
-import yaml
-from hypothesis.strategies import (
-    composite, floats, sampled_from, lists, tuples, datetimes, uuids, text)
 
-from datacube.utils.geometry import CRS, point
+from integration_tests.data_utils import generate_test_scenes
 from integration_tests.utils import prepare_test_ingestion_configuration
-
-DATE_FORMAT = '%Y-%m-%d %H:%M:%S'
-
-# Bounds retrieved from http://www.epsg-registry.org
-# Code, lat_bounds, lon_bounds
-epsg_codes = [('EPSG:32755', (-80, 0), (144, 150))]
-crses = sampled_from(epsg_codes)
-
-reasonable_dates = datetimes(min_value=datetime(1980, 1, 1), max_value=datetime(2030, 1, 1))
-
-
-@composite
-def positions(draw, lat_bounds=(-90, 90), lon_bounds=(-180, 180)):
-    return draw(tuples(
-        floats(*lon_bounds, allow_nan=False, allow_infinity=False),
-        floats(*lat_bounds, allow_nan=False, allow_infinity=False)
-    ))
-
-
-@composite
-def bounds(draw, bounds):
-    return draw(
-        lists(
-            floats(*bounds), min_size=2, max_size=2
-        ).map(sorted).filter(lambda x: x[0] < x[1]))
-
-
-@composite
-def bboxes(draw, lat_bounds=(-90, 90), lon_bounds=(-180, 180)):
-    """
-    https://tools.ietf.org/html/rfc7946#section-5
-    """
-    # Use 3 dim positions even if we only need 2
-    min_lat, max_lat = draw(bounds(lat_bounds))
-    min_lon, max_lon = draw(bounds(lon_bounds))
-
-    return min_lon, min_lat, max_lon, max_lat
-
-
-@composite
-def image_paths(draw):
-    pass
-
-
-@composite
-def extents(draw, lat_bounds, lon_bounds):
-    center_dt = draw(reasonable_dates)
-
-    time_range = timedelta(seconds=12)
-    min_lon, min_lat, max_lon, max_lat = draw(bboxes(lat_bounds, lon_bounds))
-    return {
-        'center_dt': center_dt.strftime(DATE_FORMAT),
-        'from_dt': (center_dt - time_range).strftime(DATE_FORMAT),
-        'to_dt': (center_dt + time_range).strftime(DATE_FORMAT),
-        'coord': {
-            'll': {'lat': min_lat, 'lon': min_lon},
-            'lr': {'lat': min_lat, 'lon': max_lon},
-            'ul': {'lat': max_lat, 'lon': min_lon},
-            'ur': {'lat': max_lat, 'lon': max_lon},
-        }
-    }
-
-
-def extent_point_projector(crs):
-    crs = CRS(crs)
-
-    def reproject_point(pos):
-        pos = point(pos['lon'], pos['lat'], CRS('EPSG:4326'))
-        coords = pos.to_crs(crs).coords[0]
-        return {'x': coords[0], 'y': coords[1]}
-
-    return reproject_point
-
-
-def extent_to_grid_spatial(extent, crs):
-    """Convert an extent in WGS84 to a grid spatial in the supplied CRS"""
-    reprojector = extent_point_projector(crs)
-    return {
-        'projection': {
-            'geo_ref_points': {
-                corner: reprojector(pos)
-                for corner, pos in extent['coord'].items()
-            },
-            'spatial_reference': crs
-        }
-    }
-
-
-@composite
-def acquisition_details(draw):
-    return {
-        'aos': draw(reasonable_dates),
-        'groundstation': {
-            'code': draw(text(alphabet=string.ascii_letters, min_size=3, max_size=5))
-        },
-        'los': draw(reasonable_dates)
-    }
-
-
-def image():
-    return {
-        'bands': {
-            '1': {
-                'path': 'LS5_TM_NBAR_P54_GANBAR01-002_090_084_19900302_B10.tif'
-            }
-        }
-    }
-
-
-@composite
-def scene_datasets(draw):
-    crs, lat_bounds, lon_bounds = draw(crses)
-    extent = draw(extents(lat_bounds, lon_bounds))
-    return {
-        'id': str(draw(uuids())),
-        'acquisition': draw(acquisition_details()),
-        'creation_dt': draw(reasonable_dates),
-        'extent': extent,
-        'grid_spatial': extent_to_grid_spatial(extent, crs),
-        'image': image(),
-        'format': {
-            'name': 'GeoTIFF'},
-        'instrument': {
-            'name': 'TM'},
-        'lineage': {
-            'source_datasets': {}},
-        'platform': {
-            'code': 'LANDSAT_5'},
-        'processing_level': 'P54',
-        'product_type': 'nbar'
-    }
-
-
-def create_test_scene_datasets(tmpdir, num=2):
-    paths_to_datasets = []
-    for i in range(num):
-        ls5_dataset = scene_datasets().example()
-        dataset_file = _create_test_dataset_directory(ls5_dataset, tmpdir)
-        paths_to_datasets.append(dataset_file)
-    return paths_to_datasets
-
-
-def _create_test_dataset_directory(dataset_dict, tmpdir):
-    # Make directory name
-    dir_name = dataset_dict['platform']['code'] + dataset_dict['id'][:5]
-
-    # Create directory
-    new_dir = tmpdir.mkdir(dir_name)
-
-    _make_geotiffs(new_dir, dataset_dict)
-    dataset_file = new_dir.join('agdc-metadata.yaml')
-    dataset_file.write(yaml.safe_dump(dataset_dict))
-    return dataset_file
-
-
-def _make_geotiffs(output_dir, dataset_dict, shape=(100, 100)):
-    """
-    Generate custom geotiff files, one per band.
-
-    Create appropriate GeoTIFF files
-
-    Create ``num_bands`` TIFF files inside ``tiffs_dir``.
-
-    Return a dictionary mapping band_number to filename, eg::
-
-        {
-            0: '/tmp/tiffs/band01_time01.tif',
-            1: '/tmp/tiffs/band02_time01.tif'
-        }
-    """
-    tiffs = {}
-    width, height = shape
-    pixel_width = (dataset_dict['grid_spatial']['projection']['geo_ref_points']['ul']['x'] -
-                   dataset_dict['grid_spatial']['projection']['geo_ref_points']['ur']['x']) / width
-    pixel_height = (dataset_dict['grid_spatial']['projection']['geo_ref_points']['ul']['y'] -
-                    dataset_dict['grid_spatial']['projection']['geo_ref_points']['ll']['y']) / height
-    metadata = {'count': 1,
-                'crs': dataset_dict['grid_spatial']['projection']['spatial_reference'],
-                'driver': 'GTiff',
-                'dtype': 'int16',
-                'width': width,
-                'height': height,
-                'nodata': -999.0,
-                'transform': [pixel_width,
-                              0.0,
-                              dataset_dict['grid_spatial']['projection']['geo_ref_points']['ul']['x'],
-                              0.0,
-                              pixel_height,
-                              dataset_dict['grid_spatial']['projection']['geo_ref_points']['ul']['y']]}
-
-    for band_num, band_info in dataset_dict['image']['bands'].items():
-        path = Path(output_dir) / band_info['path']
-        with rasterio.open(path, 'w', **metadata) as dst:
-            # Write data in "corners" (rounded down by 100, for a size of 100x100)
-            data = np.zeros((height, width), dtype=np.int16)
-            data[:] = np.arange(height * width
-                                ).reshape((height, width)) + 10 * int(band_num)
-            dst.write(data, 1)
-        tiffs[band_num] = path
-    return tiffs
-
 
 PROJECT_ROOT = Path(__file__).parents[1]
 
@@ -222,6 +14,11 @@ INGESTER_CONFIGS = PROJECT_ROOT / 'docs/config_samples/' / 'ingester'
 @pytest.mark.usefixtures('default_metadata_type',
                          'indexed_ls5_scene_products')
 def test_double_ingestion(clirunner, index, tmpdir, ingest_configs):
+    """
+    Test for the case where ingestor does not need to create a new product,
+    but should re-use an existing target product.
+
+    """
     # Make a test ingestor configuration
     config = INGESTER_CONFIGS / ingest_configs['ls5_nbar_albers']
     config_path, config = prepare_test_ingestion_configuration(tmpdir, None,
@@ -230,7 +27,7 @@ def test_double_ingestion(clirunner, index, tmpdir, ingest_configs):
     index_dataset = lambda path: clirunner(['dataset', 'add', str(path)])
 
     # Create and Index some example scene datasets
-    dataset_paths = create_test_scene_datasets(tmpdir)
+    dataset_paths = generate_test_scenes(tmpdir)
     for path in dataset_paths:
         index_dataset(path)
 
@@ -242,7 +39,7 @@ def test_double_ingestion(clirunner, index, tmpdir, ingest_configs):
     ])
 
     # Create and Index some more scene datasets
-    dataset_paths = create_test_scene_datasets(tmpdir)
+    dataset_paths = generate_test_scenes(tmpdir)
     for path in dataset_paths:
         index_dataset(path)
 

--- a/integration_tests/test_double_ingestion.py
+++ b/integration_tests/test_double_ingestion.py
@@ -1,0 +1,118 @@
+import string
+from datetime import datetime, timedelta
+
+from hypothesis.strategies import (
+    composite, floats, sampled_from, lists, tuples, datetimes, uuids, text)
+
+DATE_FORMAT = '%Y-%m-%d %H:%M:%S'
+
+# Bounds retrieved from http://www.epsg-registry.org
+# Code, lat_bounds, lon_bounds
+epsg_codes = [('EPSG:32755', (-80, 0), (144, 150))]
+crses = sampled_from(epsg_codes)
+
+reasonable_dates = datetimes(min_value=datetime(1980, 1, 1), max_value=datetime(2030, 1, 1))
+
+
+@composite
+def positions(draw, lat_bounds=(-90, 90), lon_bounds=(-180, 180)):
+    return draw(tuples(
+        floats(*lon_bounds, allow_nan=False, allow_infinity=False),
+        floats(*lat_bounds, allow_nan=False, allow_infinity=False)
+    ))
+
+
+@composite
+def bounds(draw, bounds):
+    return draw(
+        lists(
+            floats(*bounds), min_size=2, max_size=2
+        ).map(sorted).filter(lambda x: x[0] < x[1]))
+
+
+@composite
+def bboxes(draw, lat_bounds=(-90, 90), lon_bounds=(-180, 180)):
+    """
+    https://tools.ietf.org/html/rfc7946#section-5
+    """
+    # Use 3 dim positions even if we only need 2
+    min_lat, max_lat = draw(bounds(lat_bounds))
+    min_lon, max_lon = draw(bounds(lon_bounds))
+
+    return min_lon, min_lat, max_lon, max_lat
+
+
+@composite
+def image_paths(draw):
+    pass
+
+
+@composite
+def extents(draw):
+    crs, lat_bounds, lon_bounds = draw(crses)
+    center_dt = draw(reasonable_dates)
+
+    time_range = timedelta(seconds=12)
+    min_lon, min_lat, max_lon, max_lat = draw(bboxes(lat_bounds, lon_bounds))
+    return {
+        'center_dt': center_dt.strftime(DATE_FORMAT),
+        'from_dt': (center_dt - time_range).strftime(DATE_FORMAT),
+        'to_dt': (center_dt + time_range).strftime(DATE_FORMAT),
+        'coord': {
+            'll': {'lat': min_lat, 'lon': min_lon},
+            'lr': {'lat': min_lat, 'lon': max_lon},
+            'ul': {'lat': max_lat, 'lon': min_lon},
+            'ur': {'lat': max_lat, 'lon': max_lon},
+        }
+
+    }
+
+
+def grid_spatial():
+    return {
+        'projection': {
+            'geo_ref_points'
+        }
+    }
+
+
+@composite
+def acquisition_details(draw):
+    return {
+        'aos': draw(reasonable_dates),
+        'groundstation': {
+            'code': draw(text(alphabet=string.ascii_letters, min_size=3, max_size=5))
+        },
+        'los': draw(reasonable_dates)
+    }
+
+
+def image():
+    return {
+        'bands': {
+            '1': {
+                'path': 'scene01/LS5_TM_NBAR_P54_GANBAR01-002_090_084_19900302_B10.tif'
+            }
+        }
+    }
+
+
+@composite
+def scene_datasets(draw):
+    return {
+        'id': draw(uuids()),
+        'acquisition': draw(acquisition_details()),
+        'creation_dt': draw(reasonable_dates),
+        'extent': draw(extents()),
+        'image': draw(image()),
+        'format': {
+            'name': 'GeoTIFF'},
+        'instrument': {
+            'name': 'TM'},
+        'lineage': {
+            'source_datasets': {}},
+        'platform': {
+            'code': 'LANDSAT_5'},
+        'processing_level': 'P54',
+        'product_type': 'nbar'
+    }

--- a/integration_tests/test_double_ingestion.py
+++ b/integration_tests/test_double_ingestion.py
@@ -24,7 +24,8 @@ def test_double_ingestion(clirunner, index, tmpdir, ingest_configs):
     config_path, config = prepare_test_ingestion_configuration(tmpdir, None,
                                                                config, mode='fast_ingest')
 
-    index_dataset = lambda path: clirunner(['dataset', 'add', str(path)])
+    def index_dataset(path):
+        return clirunner(['dataset', 'add', str(path)])
 
     # Create and Index some example scene datasets
     dataset_paths = generate_test_scenes(tmpdir)

--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -8,8 +8,7 @@ import pytest
 import rasterio
 
 from datacube.compat import string_types
-from integration_tests.utils import assert_click_command
-from integration_tests.conftest import prepare_test_ingestion_configuration
+from integration_tests.utils import assert_click_command, prepare_test_ingestion_configuration
 
 PROJECT_ROOT = Path(__file__).parents[1]
 CONFIG_SAMPLES = PROJECT_ROOT / 'docs/config_samples/'

--- a/integration_tests/test_full_ingestion.py
+++ b/integration_tests/test_full_ingestion.py
@@ -12,8 +12,7 @@ from affine import Affine
 
 from datacube.api.query import query_group_by
 from datacube.utils import geometry, read_documents, netcdf_extract_string
-from integration_tests.utils import prepare_test_ingestion_configuration
-from .conftest import GEOTIFF
+from integration_tests.utils import prepare_test_ingestion_configuration, GEOTIFF
 
 PROJECT_ROOT = Path(__file__).parents[1]
 CONFIG_SAMPLES = PROJECT_ROOT / 'docs/config_samples/'

--- a/integration_tests/test_full_ingestion.py
+++ b/integration_tests/test_full_ingestion.py
@@ -12,7 +12,7 @@ from affine import Affine
 
 from datacube.api.query import query_group_by
 from datacube.utils import geometry, read_documents, netcdf_extract_string
-from integration_tests.conftest import prepare_test_ingestion_configuration
+from integration_tests.utils import prepare_test_ingestion_configuration
 from .conftest import GEOTIFF
 
 PROJECT_ROOT = Path(__file__).parents[1]

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -1,7 +1,12 @@
 import logging
 from contextlib import contextmanager
+from pathlib import Path
 
+import rasterio
+import yaml
 from click.testing import CliRunner
+
+from integration_tests.conftest import TEST_STORAGE_NUM_MEASUREMENTS, load_yaml_file, alter_product_for_testing
 
 
 @contextmanager
@@ -21,3 +26,76 @@ def assert_click_command(command, args):
     print(result.output)
     assert not result.exception
     assert result.exit_code == 0
+
+
+def create_empty_geotiff(path):
+    # Example method, not used
+    metadata = {'count': 1,
+                'crs': 'EPSG:28355',
+                'driver': 'GTiff',
+                'dtype': 'int16',
+                'height': 8521,
+                'nodata': -999.0,
+                'transform': [25.0, 0.0, 638000.0, 0.0, -25.0, 6276000.0],
+                'compress': 'lzw',
+                'width': 9721}
+    with rasterio.open(path, 'w', **metadata) as dst:
+        pass
+
+
+def limit_num_measurements(dataset_type):
+    if 'measurements' not in dataset_type:
+        return
+    measurements = dataset_type['measurements']
+    if len(measurements) > TEST_STORAGE_NUM_MEASUREMENTS:
+        dataset_type['measurements'] = measurements[:TEST_STORAGE_NUM_MEASUREMENTS]
+    return dataset_type
+
+
+def prepare_test_ingestion_configuration(tmpdir,
+                                         output_dir,
+                                         filename,
+                                         mode=None):
+    customizers = {
+        'fast_ingest': edit_for_fast_ingest,
+        'end2end': edit_for_end2end,
+    }
+
+    filename = Path(filename)
+    if output_dir is None:
+        output_dir = tmpdir.mkdir(filename.stem)
+    config = load_yaml_file(filename)[0]
+
+    if mode is not None:
+        if mode not in customizers:
+            raise ValueError('Wrong mode: ' + mode)
+        config = customizers[mode](config)
+
+    config['location'] = str(output_dir)
+
+    # If ingesting with the s3test driver
+    if 'bucket' in config['storage']:
+        config['storage']['bucket'] = str(output_dir)
+
+    config_path = tmpdir.join(filename.name)
+    with open(str(config_path), 'w') as stream:
+        yaml.dump(config, stream)
+    return config_path, config
+
+
+def edit_for_end2end(config):
+    storage = config.get('storage', {})
+
+    storage['crs'] = 'EPSG:3577'
+    storage['tile_size']['x'] = 100000.0
+    storage['tile_size']['y'] = 100000.0
+
+    config['storage'] = storage
+    return config
+
+
+def edit_for_fast_ingest(config):
+    config = alter_product_for_testing(config)
+    config['storage']['crs'] = 'EPSG:28355'
+    config['storage']['chunking']['time'] = 1
+    return config

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -44,6 +44,7 @@ GEOTIFF = {
     }
 }
 
+
 @contextmanager
 def alter_log_level(logger, level=logging.WARN):
     previous_level = logger.getEffectiveLevel()
@@ -61,21 +62,6 @@ def assert_click_command(command, args):
     print(result.output)
     assert not result.exception
     assert result.exit_code == 0
-
-
-def create_empty_geotiff(path):
-    # Example method, not used
-    metadata = {'count': 1,
-                'crs': 'EPSG:28355',
-                'driver': 'GTiff',
-                'dtype': 'int16',
-                'height': 8521,
-                'nodata': -999.0,
-                'transform': [25.0, 0.0, 638000.0, 0.0, -25.0, 6276000.0],
-                'compress': 'lzw',
-                'width': 9721}
-    with rasterio.open(path, 'w', **metadata) as dst:
-        pass
 
 
 def limit_num_measurements(dataset_type):
@@ -114,7 +100,7 @@ def prepare_test_ingestion_configuration(tmpdir,
 
     config_path = tmpdir.join(filename.name)
     with open(str(config_path), 'w') as stream:
-        yaml.dump(config, stream)
+        yaml.safe_dump(config, stream)
     return config_path, config
 
 
@@ -236,8 +222,6 @@ def shrink_storage_type(storage_type, variables, shrink_factors):
         storage['resolution'][var] = storage['resolution'][var] * shrink_factors[0]
         storage['chunking'][var] = storage['chunking'][var] / shrink_factors[1]
     return storage_type
-
-
 
 
 def load_test_products(filename, metadata_type=None):

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -1,13 +1,48 @@
 import logging
+import os
+import shutil
 from contextlib import contextmanager
+from datetime import datetime
 from pathlib import Path
 
+import numpy as np
 import rasterio
 import yaml
 from click.testing import CliRunner
+from yaml import CSafeLoader as SafeLoader
 
-from integration_tests.conftest import TEST_STORAGE_NUM_MEASUREMENTS, load_yaml_file, alter_product_for_testing
+# On Windows, symlinks are not supported in Python 2 and require
+# specific privileges otherwise, so we copy instead of linking
+if os.name == 'nt' or not hasattr(os, 'symlink'):
+    symlink = shutil.copy
+else:
+    symlink = os.symlink
 
+#: Number of bands to place in generated GeoTIFFs
+NUM_BANDS = 3
+
+# Resolution and chunking shrink factors
+TEST_STORAGE_SHRINK_FACTORS = (100, 100)
+TEST_STORAGE_NUM_MEASUREMENTS = 2
+GEOGRAPHIC_VARS = ('latitude', 'longitude')
+PROJECTED_VARS = ('x', 'y')
+
+GEOTIFF = {
+    'date': datetime(1990, 3, 2),
+    'shape': {
+        'x': 432,
+        'y': 321
+    },
+    'pixel_size': {
+        'x': 25.0,
+        'y': -25.0
+    },
+    'crs': 'EPSG:28355',  # 'EPSG:28355'
+    'ul': {
+        'x': 638000.0,  # Coords must match crs
+        'y': 6276000.0  # Coords must match crs
+    }
+}
 
 @contextmanager
 def alter_log_level(logger, level=logging.WARN):
@@ -99,3 +134,124 @@ def edit_for_fast_ingest(config):
     config['storage']['crs'] = 'EPSG:28355'
     config['storage']['chunking']['time'] = 1
     return config
+
+
+def _make_geotiffs(tiffs_dir, day_offset, num_bands=NUM_BANDS):
+    """
+    Generate custom geotiff files, one per band.
+
+    Create ``num_bands`` TIFF files inside ``tiffs_dir``.
+
+    Return a dictionary mapping band_number to filename, eg::
+
+        {
+            0: '/tmp/tiffs/band01_time01.tif',
+            1: '/tmp/tiffs/band02_time01.tif'
+        }
+    """
+    tiffs = {}
+    width = GEOTIFF['shape']['x']
+    height = GEOTIFF['shape']['y']
+    metadata = {'count': 1,
+                'crs': GEOTIFF['crs'],
+                'driver': 'GTiff',
+                'dtype': 'int16',
+                'width': width,
+                'height': height,
+                'nodata': -999.0,
+                'transform': [GEOTIFF['pixel_size']['x'],
+                              0.0,
+                              GEOTIFF['ul']['x'],
+                              0.0,
+                              GEOTIFF['pixel_size']['y'],
+                              GEOTIFF['ul']['y']]}
+
+    for band in range(num_bands):
+        path = str(tiffs_dir.join('band%02d_time%02d.tif' % ((band + 1), day_offset)))
+        with rasterio.open(path, 'w', **metadata) as dst:
+            # Write data in "corners" (rounded down by 100, for a size of 100x100)
+            data = np.zeros((height, width), dtype=np.int16)
+            data[:] = np.arange(height * width
+                                ).reshape((height, width)) + 10 * band + day_offset
+            '''
+            lr = (100 * int(GEOTIFF['shape']['y'] / 100.0),
+                  100 * int(GEOTIFF['shape']['x'] / 100.0))
+            data[0:100, 0:100] = 100 + day_offset
+            data[lr[0] - 100:lr[0], 0:100] = 200 + day_offset
+            data[0:100, lr[1] - 100:lr[1]] = 300 + day_offset
+            data[lr[0] - 100:lr[0], lr[1] - 100:lr[1]] = 400 + day_offset
+            '''
+            dst.write(data, 1)
+        tiffs[band] = path
+    return tiffs
+
+
+def _make_ls5_scene_datasets(geotiffs, tmpdir):
+    """
+
+    Create directory structures like::
+
+        LS5_TM_NBAR_P54_GANBAR01-002_090_084_01
+        |---scene01
+        |     |----- report.txt
+        |     |----- LS5_TM_NBAR_P54_GANBAR01-002_090_084_01_B10.tif
+        |     |----- LS5_TM_NBAR_P54_GANBAR01-002_090_084_01_B20.tif
+        |     |----- LS5_TM_NBAR_P54_GANBAR01-002_090_084_01_B30.tif
+        |--- agdc-metadata.yaml
+
+    :param geotiffs: A list of dictionaries as output by :func:`geotiffs`
+    :param tmpdir:
+    :return:
+    """
+    dataset_dirs = {}
+    dataset_dir = tmpdir.mkdir('ls5_dataset')
+    for geotiff in geotiffs:
+        # Make a directory for the dataset
+        obs_name = 'LS5_TM_NBAR_P54_GANBAR01-002_090_084_%s' % geotiff['day']
+        obs_dir = dataset_dir.mkdir(obs_name)
+        symlink(str(geotiff['path']), str(obs_dir.join('agdc-metadata.yaml')))
+
+        scene_dir = obs_dir.mkdir('scene01')
+        scene_dir.join('report.txt').write('Example')
+        geotiff_name = '%s_B{}0.tif' % obs_name
+        for band in range(NUM_BANDS):
+            path = scene_dir.join(geotiff_name.format(band + 1))
+            symlink(str(geotiff['tiffs'][band]), str(path))
+        dataset_dirs[geotiff['uuid']] = Path(str(obs_dir))
+    return dataset_dirs
+
+
+def load_yaml_file(filename):
+    with open(str(filename)) as f:
+        return list(yaml.load_all(f, Loader=SafeLoader))
+
+
+def is_geogaphic(storage_type):
+    return 'latitude' in storage_type['storage']['resolution']
+
+
+def shrink_storage_type(storage_type, variables, shrink_factors):
+    storage = storage_type['storage']
+    for var in variables:
+        storage['resolution'][var] = storage['resolution'][var] * shrink_factors[0]
+        storage['chunking'][var] = storage['chunking'][var] / shrink_factors[1]
+    return storage_type
+
+
+
+
+def load_test_products(filename, metadata_type=None):
+    dataset_types = load_yaml_file(filename)
+    return [alter_product_for_testing(dataset_type, metadata_type=metadata_type) for dataset_type in dataset_types]
+
+
+def alter_product_for_testing(product, metadata_type=None):
+    limit_num_measurements(product)
+    if 'storage' in product:
+        spatial_variables = GEOGRAPHIC_VARS if is_geogaphic(product) else PROJECTED_VARS
+        product = shrink_storage_type(product,
+                                      spatial_variables,
+                                      TEST_STORAGE_SHRINK_FACTORS)
+    if metadata_type:
+        product['metadata_type'] = metadata_type.name
+    return product


### PR DESCRIPTION
### Reason for this pull request
Integration tests are too hard to write. They also miss out on testing some important functionality. This time, they didn't test that `ingest` worked when outputting to an existing product (see issue #505 and PR #510).

### Proposed changes
- Move most of the test utilities out of `integration_tests/conftest.py` and into `integration_tests/utils.py`
- Add some [hypothesis data generation](url
https://hypothesis.readthedocs.io/en/latest/data.html) tools for generating randomised test datasets.
- Add a test for checking that running `ingest` works both when creating a new product, and on an existing product.

This should be merged after #510, otherwise the build will break.

_There's so much more to clean up, and I know this adds a bunch of code, but I think it's a step in the right direction._
<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->