### PR TITLE
datacube.model.Measurements attr access

### DIFF
--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -331,6 +331,10 @@ class Measurement(dict):
 
         super().__init__(measurement_data)
 
+    def __getattr__(self, key):
+        """ Allow access to items as attributes. """
+        return self[key]
+
     def __repr__(self):
         return "Measurement({})".format(super(Measurement, self).__repr__())
 


### PR DESCRIPTION
### Reason for this pull request
We want to be able to access the values stored into the measurement dict
as attributes of the `datacube.model.Measurement` object. Code in
`datacube-stats` as well as the prototype virtual products make heavy use
of this style.

### Proposed changes
- Add attribute access customization to look up keys in the measurement dict