### PR TITLE
Install git in docker to calculate ODC version number

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Need pip to install more python packages later.
     # The libdpkg-perl is needed to build pyproj
     python3-pip python3-wheel libdpkg-perl \
+    # Git to work out the ODC version number
+    git \
     # G++ because GDAL decided it needed compiling
     g++ \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### Reason for this pull request

The ODC install in the docker images doesn't know it's own version number.


### Proposed changes

We are using [versioneer](https://github.com/warner/python-versioneer) to base
version numbers off of git tags. This requires `git` to be installed.

- Install git in docker to calculate ODC version number


 - [x] Tested locally and works.

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->