### PR TITLE
Have to "jsonify" docs before comparing with DB version

### DIFF
--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -118,7 +118,8 @@ class DatasetResource(object):
         with self._db.connect() as connection:
             existing = set(connection.datasets_intersection(ids_))
 
-        return [x in existing for x in ids_]
+        return [x in existing for x in
+                map((lambda x: UUID(x) if isinstance(x, str) else x), ids_)]
 
     def add(self, dataset, with_lineage=None, **kwargs):
         """

--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -5,7 +5,7 @@ import toolz
 from types import SimpleNamespace
 
 from datacube.model import Dataset
-from datacube.utils import changes, InvalidDocException, SimpleDocNav
+from datacube.utils import changes, InvalidDocException, SimpleDocNav, jsonify_document
 from datacube.model.utils import dedup_lineage, remap_lineage_doc, flatten_datasets
 from datacube.utils.changes import get_doc_changes
 
@@ -152,7 +152,7 @@ def dataset_resolver(index,
 
             for uuid in lineage_uuids:
                 if uuid in db_dss:
-                    ok, err = check_consistent(ds_by_uuid[uuid].doc_without_lineage_sources,
+                    ok, err = check_consistent(jsonify_document(ds_by_uuid[uuid].doc_without_lineage_sources),
                                                db_dss[uuid].metadata_doc)
                     if not ok:
                         bad_lineage.append((uuid, err))

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -163,6 +163,9 @@ def test_has_dataset(index, telemetry_dataset):
     assert not index.datasets.has(UUID('f226a278-e422-11e6-b501-185e0f80a5c0'))
     assert not index.datasets.has('f226a278-e422-11e6-b501-185e0f80a5c0')
 
+    assert index.datasets.bulk_has([_telemetry_uuid, UUID('f226a278-e422-11e6-b501-185e0f80a5c0')]) == [True, False]
+    assert index.datasets.bulk_has([str(_telemetry_uuid), 'f226a278-e422-11e6-b501-185e0f80a5c0']) == [True, False]
+
 
 def test_get_dataset(index, telemetry_dataset):
     # type: (Index, Dataset) -> None


### PR DESCRIPTION
### Reason for this pull request

Certain values like "NaN|+Inf|-Inf" are not valid json values and can not be
stored in DB json blob, so we just turn them into strings before serializing to
DB, same process needs to be applied to "loaded from file" document before
comparing it with the canonical version.

See issue #524 #525


### Proposed changes

- `jsonify` document before comparison

 - [x] Closes #525 
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

Since this is a a fix for an error that didn't exist in the previous release, I don't think we need to update whats_new.

- includes fix to `bulk_has`, uuids supplied as strings would always be reported as missing.