### PR TITLE
fix case where no aliases defined

### DIFF
--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -487,7 +487,7 @@ class DatasetType(object):
         for m in self.measurements:
             if measurement == m:
                 return measurement
-            elif measurement in self.measurements[m]['aliases']:
+            elif measurement in self.measurements[m].get('aliases', []):
                 return m
         raise KeyError(measurement)
 


### PR DESCRIPTION
### Reason for this pull request
The alias resolution could incorrectly assumed the `aliases` key will be present in the `measurements` dictionary.

### Proposed changes
- Fix that