### PR TITLE
Update rasterio pins to point to >= 1.0.2

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -67,7 +67,7 @@ python-dateutil==2.7.2
 pytz==2018.4
 pytzdata==2018.4
 PyYAML==3.12
-rasterio==1.0a12
+rasterio==1.0.2
 redis==2.10.6
 regex==2017.7.28
 requests==2.18.4

--- a/rtd-environment.yml
+++ b/rtd-environment.yml
@@ -1,6 +1,5 @@
 name: odc
 channels:
-- conda-forge/label/dev
 - conda-forge
 - defaults
 - nodefaults

--- a/rtd-environment.yml
+++ b/rtd-environment.yml
@@ -13,7 +13,7 @@ dependencies:
 - cachetools
 - cloudpickle >= 0.4.0 # pickle logger objects
 - numpy
-- rasterio >= 0.9a10 # to handle weird 1.0a ordering...
+- rasterio >= 1.0.2  # multi-band reproject bugs got fixed in that version 
 - singledispatch
 - netcdf4
 - psycopg2

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
         'pypeg2',
         'python-dateutil',
         'pyyaml',
-        'rasterio~=1.0',
+        'rasterio>=1.0.2',  # Multi-band re-project fixed in that version
         'singledispatch',
         'sqlalchemy',
         'toolz',


### PR DESCRIPTION
Multi-band reprojection bugs were fixed in 1.0.2 rasterio release.
 - [x] Closes #533 
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes
