### PR TITLE
Misc cleanup in grid-workflow/indexing

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -17,7 +17,6 @@ try:
     import SharedArray as sa
 except ImportError:
     pass
-from affine import Affine
 from dask import array as da
 
 try:
@@ -29,7 +28,7 @@ from six.moves import zip
 from datacube.config import LocalConfig
 from datacube.compat import string_types
 from datacube.storage.storage import reproject_and_fuse
-from datacube.utils import geometry, intersects, data_resolution_and_offset
+from datacube.utils import geometry, intersects
 from .query import Query, query_group_by, query_geopolygon
 from ..index import index_connect
 from ..drivers import new_datasource
@@ -581,6 +580,7 @@ def apply_aliases(data, product, measurements):
 
     return data.rename({product.canonical_measurement(provided_name): provided_name
                         for provided_name in measurements})
+
 
 def output_geobox(like=None, output_crs=None, resolution=None, align=None,
                   grid_spec=None, datasets=None, **query):

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -346,8 +346,7 @@ class Datacube(object):
         datasets = self.index.datasets.search(limit=limit,
                                               **query.search_terms)
 
-        for dataset in select_datasets_inside_polygon(datasets, query.geopolygon):
-            yield dataset
+        return datasets if query.geopolygon is None else select_datasets_inside_polygon(datasets, query.geopolygon)
 
     @staticmethod
     def product_sources(datasets, group_by):
@@ -614,8 +613,9 @@ def output_geobox(like=None, output_crs=None, resolution=None, align=None,
 
 def select_datasets_inside_polygon(datasets, polygon):
     # Check against the bounding box of the original scene, can throw away some portions
+    assert polygon is not None
     for dataset in datasets:
-        if polygon is None or intersects(polygon.to_crs(dataset.crs), dataset.extent):
+        if intersects(polygon.to_crs(dataset.crs), dataset.extent):
             yield dataset
 
 

--- a/datacube/api/grid_workflow.py
+++ b/datacube/api/grid_workflow.py
@@ -198,12 +198,13 @@ class GridWorkflow(object):
             return cells
         else:
             datasets, query = self._find_datasets(geopolygon, indexers)
+            geobox_cache = {}
 
             if query.geopolygon:
                 # Get a rough region of tiles
                 query_tiles = set(
                     tile_index for tile_index, tile_geobox in
-                    self.grid_spec.tiles_inside_geopolygon(query.geopolygon))
+                    self.grid_spec.tiles_inside_geopolygon(query.geopolygon, geobox_cache=geobox_cache))
 
                 for dataset in datasets:
                     # Go through our datasets and see which tiles each dataset produces, and whether they intersect
@@ -212,14 +213,15 @@ class GridWorkflow(object):
                     bbox = dataset_extent.boundingbox
                     bbox = bbox.buffered(*tile_buffer) if tile_buffer else bbox
 
-                    for tile_index, tile_geobox in self.grid_spec.tiles(bbox):
+                    for tile_index, tile_geobox in self.grid_spec.tiles(bbox, geobox_cache=geobox_cache):
                         if tile_index in query_tiles and intersects(tile_geobox.extent, dataset_extent):
                             add_dataset_to_cells(tile_index, tile_geobox, dataset)
 
             else:
                 for dataset in datasets:
                     for tile_index, tile_geobox in self.grid_spec.tiles_inside_geopolygon(dataset.extent,
-                                                                                          tile_buffer=tile_buffer):
+                                                                                          tile_buffer=tile_buffer,
+                                                                                          geobox_cache=geobox_cache):
                         add_dataset_to_cells(tile_index, tile_geobox, dataset)
 
             return cells

--- a/datacube/api/grid_workflow.py
+++ b/datacube/api/grid_workflow.py
@@ -204,7 +204,7 @@ class GridWorkflow(object):
                 # Get a rough region of tiles
                 query_tiles = set(
                     tile_index for tile_index, tile_geobox in
-                    self.grid_spec.tiles_inside_geopolygon(query.geopolygon, geobox_cache=geobox_cache))
+                    self.grid_spec.tiles_from_geopolygon(query.geopolygon, geobox_cache=geobox_cache))
 
                 for dataset in datasets:
                     # Go through our datasets and see which tiles each dataset produces, and whether they intersect
@@ -219,9 +219,9 @@ class GridWorkflow(object):
 
             else:
                 for dataset in datasets:
-                    for tile_index, tile_geobox in self.grid_spec.tiles_inside_geopolygon(dataset.extent,
-                                                                                          tile_buffer=tile_buffer,
-                                                                                          geobox_cache=geobox_cache):
+                    for tile_index, tile_geobox in self.grid_spec.tiles_from_geopolygon(dataset.extent,
+                                                                                        tile_buffer=tile_buffer,
+                                                                                        geobox_cache=geobox_cache):
                         add_dataset_to_cells(tile_index, tile_geobox, dataset)
 
             return cells

--- a/datacube/drivers/s3aio_index/index.py
+++ b/datacube/drivers/s3aio_index/index.py
@@ -225,13 +225,13 @@ class DatasetResource(BaseDatasetResource):
                 # Add mappings
                 self._add_s3_dataset_mappings(transaction, s3_dataset_id, band, dataset_refs)
 
-    def _make(self, dataset_res, full_info=False):
+    def _make(self, dataset_res, full_info=False, product=None):
         """
         :rtype Dataset
 
         :param bool full_info: Include all available fields
         """
-        dataset = super(DatasetResource, self)._make(dataset_res, full_info)
+        dataset = super(DatasetResource, self)._make(dataset_res, full_info=full_info, product=product)
         self._extend_dataset_with_s3_metadata(dataset)
         return dataset
 

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -691,7 +691,7 @@ class GridSpec(object):
                 tile_index = (x, y)
                 yield tile_index, geobox(tile_index)
 
-    def tiles_inside_geopolygon(self, geopolygon, tile_buffer=None, geobox_cache=None):
+    def tiles_from_geopolygon(self, geopolygon, tile_buffer=None, geobox_cache=None):
         """
         Returns an iterator of tile_index, :py:class:`GeoBox` tuples across
         the grid and overlapping with the specified `geopolygon`.

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -666,7 +666,7 @@ class GridSpec(object):
     def tiles(self, bounds):
         """
         Returns an iterator of tile_index, :py:class:`GeoBox` tuples across
-        the grid and inside the specified `bounds`.
+        the grid and overlapping with the specified `bounds` rectangle.
 
         .. note::
 
@@ -686,7 +686,7 @@ class GridSpec(object):
     def tiles_inside_geopolygon(self, geopolygon, tile_buffer=None):
         """
         Returns an iterator of tile_index, :py:class:`GeoBox` tuples across
-        the grid and inside the specified `polygon`.
+        the grid and overlapping with the specified `geopolygon`.
 
         .. note::
 
@@ -694,7 +694,8 @@ class GridSpec(object):
            dimension order.
 
         :param geometry.Geometry geopolygon: Polygon to tile
-        :param tile_buffer:
+        :param tile_buffer: Optional <float,float> tuple, (extra padding for the query
+                            in native units of this GridSpec)
         :return: iterator of grid cells with :py:class:`GeoBox` tiles
         """
         geopolygon = geopolygon.to_crs(self.crs)

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -683,7 +683,7 @@ class GridSpec(object):
                 tile_index = (x, y)
                 yield tile_index, self.tile_geobox(tile_index)
 
-    def tiles_inside_geopolygon(self, geopolygon, tile_buffer=(0, 0)):
+    def tiles_inside_geopolygon(self, geopolygon, tile_buffer=None):
         """
         Returns an iterator of tile_index, :py:class:`GeoBox` tuples across
         the grid and inside the specified `polygon`.
@@ -697,15 +697,15 @@ class GridSpec(object):
         :param tile_buffer:
         :return: iterator of grid cells with :py:class:`GeoBox` tiles
         """
-        result = []
         geopolygon = geopolygon.to_crs(self.crs)
-        for tile_index, tile_geobox in self.tiles(geopolygon.boundingbox.buffered(*tile_buffer)):
-            if tile_buffer:
-                tile_geobox = tile_geobox.buffered(*tile_buffer)
+        bbox = geopolygon.boundingbox
+        bbox = bbox.buffered(*tile_buffer) if tile_buffer else bbox
+
+        for tile_index, tile_geobox in self.tiles(bbox):
+            tile_geobox = tile_geobox.buffered(*tile_buffer) if tile_buffer else tile_geobox
 
             if intersects(tile_geobox.extent, geopolygon):
-                result.append((tile_index, tile_geobox))
-        return result
+                yield (tile_index, tile_geobox)
 
     @staticmethod
     def grid_range(lower, upper, step):

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -462,27 +462,24 @@ class DatasetType(object):
 
         :rtype: GridSpec
         """
-        if 'storage' not in self.definition:
+        storage = self.definition.get('storage')
+        if storage is None:
             return None
-        storage = self.definition['storage']
 
-        if 'crs' not in storage:
+        crs = storage.get('crs')
+        if crs is None:
             return None
-        crs = geometry.CRS(str(storage['crs']).strip())
 
-        tile_size = None
-        if 'tile_size' in storage:
-            tile_size = [storage['tile_size'][dim] for dim in crs.dimensions]
+        crs = geometry.CRS(str(crs).strip())
 
-        resolution = None
-        if 'resolution' in storage:
-            resolution = [storage['resolution'][dim] for dim in crs.dimensions]
+        def extract_point(name):
+            xx = storage.get(name, None)
+            return None if xx is None else tuple(xx[dim] for dim in crs.dimensions)
 
-        origin = None
-        if 'origin' in storage:
-            origin = [storage['origin'][dim] for dim in crs.dimensions]
+        gs_params = {name: extract_point(name)
+                     for name in ('tile_size', 'resolution', 'origin')}
 
-        return GridSpec(crs=crs, tile_size=tile_size, resolution=resolution, origin=origin)
+        return GridSpec(crs=crs, **gs_params)
 
     def canonical_measurement(self, measurement):
         for m in self.measurements:

--- a/datacube/utils/geometry.py
+++ b/datacube/utils/geometry.py
@@ -367,6 +367,7 @@ class Geometry(object):
     intersects = _wrap_binary_bool(ogr.Geometry.Intersects)
     touches = _wrap_binary_bool(ogr.Geometry.Touches)
     within = _wrap_binary_bool(ogr.Geometry.Within)
+    overlaps = _wrap_binary_bool(ogr.Geometry.Overlaps)
 
     difference = _wrap_binary_geom(ogr.Geometry.Difference)
     intersection = _wrap_binary_geom(ogr.Geometry.Intersection)

--- a/tests/api/test_grid_workflow.py
+++ b/tests/api/test_grid_workflow.py
@@ -52,9 +52,10 @@ def test_gridworkflow():
     assert list(gw.cell_observations(**query,
                                      geopolygon=gridspec.tile_geobox((1, -2)).extent).keys()) == [(1, -2)]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as e:
         list(gw.cell_observations(**query, tile_buffer=(1, 1),
                                   geopolygon=gridspec.tile_geobox((1, -2)).extent).keys())
+    assert str(e.value) == 'Cannot process tile_buffering and geopolygon together.'
 
     # test frontend
     assert len(gw.list_tiles(**query)) == 1

--- a/tests/api/test_grid_workflow.py
+++ b/tests/api/test_grid_workflow.py
@@ -48,6 +48,10 @@ def test_gridworkflow():
     # test backend : that it finds the expected cell/dataset
     assert list(gw.cell_observations(**query).keys()) == [(1, -2)]
 
+    # again but with geopolygon
+    assert list(gw.cell_observations(**query,
+                                     geopolygon=gridspec.tile_geobox((1, -2)).extent).keys()) == [(1, -2)]
+
     # test frontend
     assert len(gw.list_tiles(**query)) == 1
 

--- a/tests/api/test_grid_workflow.py
+++ b/tests/api/test_grid_workflow.py
@@ -1,4 +1,4 @@
-
+import pytest
 import numpy
 from datacube.model import GridSpec
 from datacube.utils import geometry
@@ -51,6 +51,10 @@ def test_gridworkflow():
     # again but with geopolygon
     assert list(gw.cell_observations(**query,
                                      geopolygon=gridspec.tile_geobox((1, -2)).extent).keys()) == [(1, -2)]
+
+    with pytest.raises(ValueError):
+        list(gw.cell_observations(**query, tile_buffer=(1, 1),
+                                  geopolygon=gridspec.tile_geobox((1, -2)).extent).keys())
 
     # test frontend
     assert len(gw.list_tiles(**query)) == 1

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -12,7 +12,7 @@ from datacube.storage.storage import measurement_paths
 def test_gridspec():
     gs = GridSpec(crs=geometry.CRS('EPSG:4326'), tile_size=(1, 1), resolution=(-0.1, 0.1), origin=(10, 10))
     poly = geometry.polygon([(10, 12.2), (10.8, 13), (13, 10.8), (12.2, 10), (10, 12.2)], crs=geometry.CRS('EPSG:4326'))
-    cells = {index: geobox for index, geobox in list(gs.tiles_inside_geopolygon(poly))}
+    cells = {index: geobox for index, geobox in list(gs.tiles_from_geopolygon(poly))}
     assert set(cells.keys()) == {(0, 1), (0, 2), (1, 0), (1, 1), (1, 2), (2, 0), (2, 1)}
     assert numpy.isclose(cells[(2, 0)].coordinates['longitude'].values, numpy.linspace(12.05, 12.95, num=10)).all()
     assert numpy.isclose(cells[(2, 0)].coordinates['latitude'].values, numpy.linspace(10.95, 10.05, num=10)).all()
@@ -20,8 +20,8 @@ def test_gridspec():
     # check geobox_cache
     cache = {}
     poly = gs.tile_geobox((3, 4)).extent
-    (c1, gbox1),  = list(gs.tiles_inside_geopolygon(poly, geobox_cache=cache))
-    (c2, gbox2),  = list(gs.tiles_inside_geopolygon(poly, geobox_cache=cache))
+    (c1, gbox1),  = list(gs.tiles_from_geopolygon(poly, geobox_cache=cache))
+    (c2, gbox2),  = list(gs.tiles_from_geopolygon(poly, geobox_cache=cache))
 
     assert c1 == (3, 4) and c2 == c1
     assert gbox1 is gbox2

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -17,6 +17,15 @@ def test_gridspec():
     assert numpy.isclose(cells[(2, 0)].coordinates['longitude'].values, numpy.linspace(12.05, 12.95, num=10)).all()
     assert numpy.isclose(cells[(2, 0)].coordinates['latitude'].values, numpy.linspace(10.95, 10.05, num=10)).all()
 
+    # check geobox_cache
+    cache = {}
+    poly = gs.tile_geobox((3, 4)).extent
+    (c1, gbox1),  = list(gs.tiles_inside_geopolygon(poly, geobox_cache=cache))
+    (c2, gbox2),  = list(gs.tiles_inside_geopolygon(poly, geobox_cache=cache))
+
+    assert c1 == (3, 4) and c2 == c1
+    assert gbox1 is gbox2
+
 
 def test_gridspec_upperleft():
     """ Test to ensure grid indexes can be counted correctly from bottom left or top left


### PR DESCRIPTION
This is a mishmash of minor(ish) cleanups in GridWorkflow/indexing driver.

### GridWorkflow

- `tiles_inside_geopolygon` - the docs promised iterator, and other code seems to expect that, but code returned a list.
- Rename `tiles_inside_geopolygon` to `tiles_from_geopolygon`, **inside** implies completely inside, but this function returned all tiles overlapping with the polygon
- `GridWorkflow` - changing `tile_buffer` parameter to be nullable and setting default to `None`, was`(0,0)`, some code treated `tile_buffer` as a boolean, but `bool((0,0)) is True`
- Optional `GeoBox` cache to share compute/memory when processing large number of dataset

### Indexing

- Avoid looking up product when it's already known, I know that it's cache and all, but still
- Reduce layering of iterators somewhat, return iterator where possible instead of yielding from a loop
- If decision can be made outside of a loop, don't do it inside of a loop (geopolygon queries)
- Improving test coverage a bit 
