### PR TITLE
Rename _read_decimated to _read_native

### DIFF
--- a/datacube/storage/storage.py
+++ b/datacube/storage/storage.py
@@ -147,8 +147,8 @@ def read_from_source(source, dest, dst_transform, dst_nodata, dst_projection, re
         array_transform = ~src.transform * dst_transform
         # if the CRS is the same use native reads if possible (NN or 1:1 scaling)
         can_use_native_read = (src.crs == dst_projection and
-                                  _no_scale(array_transform) and
-                                  (resampling == Resampling.nearest or _no_fractional_translate(array_transform)))
+                               _no_scale(array_transform) and
+                               (resampling == Resampling.nearest or _no_fractional_translate(array_transform)))
         if can_use_native_read:
             dest.fill(dst_nodata)
             try:

--- a/datacube/storage/storage.py
+++ b/datacube/storage/storage.py
@@ -112,7 +112,7 @@ def _calc_offsets2(off, scale, src_size, dst_size):
         return _calc_offsets_impl(off, scale, src_size, dst_size)
 
 
-def _read_decimated(array_transform, src, dest_shape):
+def _read_native(array_transform, src, dest_shape):
     dy_dx = (array_transform.f, array_transform.c)
     sy_sx = (array_transform.e, array_transform.a)
     read, write, read_shape, write_shape = zip(*map(_calc_offsets2, dy_dx, sy_sx, src.shape, dest_shape))
@@ -152,7 +152,7 @@ def read_from_source(source, dest, dst_transform, dst_nodata, dst_projection, re
         if can_use_decimated_read:
             dest.fill(dst_nodata)
             try:
-                tmp, offset, _ = _read_decimated(array_transform, src, dest.shape)
+                tmp, offset, _ = _read_native(array_transform, src, dest.shape)
                 if tmp is None:
                     return
             except ValueError:

--- a/datacube/storage/storage.py
+++ b/datacube/storage/storage.py
@@ -145,11 +145,11 @@ def read_from_source(source, dest, dst_transform, dst_nodata, dst_projection, re
     """
     with source.open() as src:
         array_transform = ~src.transform * dst_transform
-        # if the CRS is the same use decimated reads if possible (NN or 1:1 scaling)
-        can_use_decimated_read = (src.crs == dst_projection and
+        # if the CRS is the same use native reads if possible (NN or 1:1 scaling)
+        can_use_native_read = (src.crs == dst_projection and
                                   _no_scale(array_transform) and
                                   (resampling == Resampling.nearest or _no_fractional_translate(array_transform)))
-        if can_use_decimated_read:
+        if can_use_native_read:
             dest.fill(dst_nodata)
             try:
                 tmp, offset, _ = _read_native(array_transform, src, dest.shape)

--- a/docs/diagrams/current_data_read_process.plantuml
+++ b/docs/diagrams/current_data_read_process.plantuml
@@ -40,7 +40,7 @@ loop for each measurement/band
         DataSource -> BandSource: open() returns BandSource
         activate BandSource
         alt Non reprojecting read
-            BandSource -> BandSource: _read_decimated()
+            BandSource -> BandSource: _read_native()
         else ReProjecting read
             BandSource -> BandSource: reproject()
         end

--- a/docs/diagrams/proposed_data_read_process.plantuml
+++ b/docs/diagrams/proposed_data_read_process.plantuml
@@ -88,7 +88,7 @@ loop for each time/irregular dimension slice
     activate BandSource
     DataSource -> BandSource: open() returns BandSource
     alt Non reprojecting read
-        BandSource -> BandSource: _read_decimated()
+        BandSource -> BandSource: _read_native()
     else ReProjecting read
         BandSource -> BandSource: reproject()
     end

--- a/examples/io_plugin/dcio_example/pickles.py
+++ b/examples/io_plugin/dcio_example/pickles.py
@@ -49,7 +49,7 @@ class PickleDataSource(object):
             if out_shape is None or out_shape == data.shape:
                 return data
 
-            raise NotImplementedError('Decimated reading not supported for this data source')
+            raise NotImplementedError('Native reading not supported for this data source')
 
         def reproject(self, dest, dst_transform, dst_crs, dst_nodata, resampling, **kwargs):
             source = self.read()


### PR DESCRIPTION
### Reason for this pull request
**_read_decimated** is a confusing name for what is essentially non-reprojecting/warping reads.

### Proposed changes
- rename **_read_decimated** function to **_read_native**

 - [ ] Fully documented, updated references in plantuml
