### PR TITLE
Display first URI regardless of whether it is a local uri or not in dataset __str__

### DIFF
--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -299,9 +299,10 @@ class Dataset(object):
         return hash(self.id)
 
     def __str__(self):
+        str_loc = 'not available' if not self.uris else self.uris[0]
         return "Dataset <id={id} type={type} location={loc}>".format(id=self.id,
                                                                      type=self.type.name,
-                                                                     loc=self.uris[0])
+                                                                     loc=str_loc)
 
     def __repr__(self):
         return self.__str__()

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -301,7 +301,7 @@ class Dataset(object):
     def __str__(self):
         return "Dataset <id={id} type={type} location={loc}>".format(id=self.id,
                                                                      type=self.type.name,
-                                                                     loc=self.local_path)
+                                                                     loc=self.uris[0])
 
     def __repr__(self):
         return self.__str__()


### PR DESCRIPTION
Addresses issue: https://github.com/opendatacube/datacube-core/issues/434

### Reason for this pull request
When working exclusively with remotely hosted datasets (ie S3) the dataset __str__ function will return "None" for location as there are no uri's with the prefix "file://"

### Proposed changes
- Return the first URI regardless of whether it is remote or local

 - [ ] Closes #434 
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes
