### PR TITLE
Make another release, fix Damien release mistake.

### DIFF
--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -5,6 +5,12 @@
 What's New
 **********
 
+v1.6.1 (27 August 2018)
+=======================
+
+Correction release. By mistake, v1.6.0 was identical to v1.6rc2!
+
+
 v1.6.0 (23 August 2018)
 =======================
 


### PR DESCRIPTION
### Reason for this pull request

Release v1.6.0 is wrong, it is identical to v1.6rc2 instead of including
a variety of changes and fixes.

I got mixed up tagging the v1.6.0 release using the GitHub Releases page,
and accidentally tagged the current state of `stable` instead of `develop`.


### Proposed changes

- Add release notes for a 1.6.1 release 




<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->