### PR TITLE
fix datacube.model.Measurement cloudpickle issue

### DIFF
--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -334,7 +334,10 @@ class Measurement(dict):
 
     def __getattr__(self, key):
         """ Allow access to items as attributes. """
-        return self[key]
+        if key in self:
+            return self[key]
+
+        raise AttributeError("'Measurement' object has no attribute '{}'".format(key))
 
     def __repr__(self):
         return "Measurement({})".format(super(Measurement, self).__repr__())


### PR DESCRIPTION
### Reason for this pull request
With recent changes, `datacube.model.Measurement` objects become unpickleable.

### Proposed changes
Retain behaviour of a typical Python object when the object cannot find an attribute.
Our `__getattr__` hack raised a `KeyError` instead of an `AttributeError`.