### PR TITLE
Resampling parameter fixes, allow per band config

### DIFF
--- a/datacube/api/grid_workflow.py
+++ b/datacube/api/grid_workflow.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 from ..utils import intersects
 from .query import Query, query_group_by
-from .core import Datacube, set_resampling_method, apply_aliases
+from .core import Datacube, apply_aliases
 
 _LOG = logging.getLogger(__name__)
 
@@ -378,10 +378,10 @@ class GridWorkflow(object):
         .. seealso::
             :meth:`list_tiles` :meth:`list_cells`
         """
-        measurement_dicts = set_resampling_method(tile.product.lookup_measurements(measurements),
-                                                  resampling)
+        measurement_dicts = tile.product.lookup_measurements(measurements)
 
-        dataset = Datacube.load_data(tile.sources, tile.geobox, list(measurement_dicts.values()),
+        dataset = Datacube.load_data(tile.sources, tile.geobox,
+                                     measurement_dicts, resampling=resampling,
                                      dask_chunks=dask_chunks, fuse_func=fuse_func,
                                      skip_broken_datasets=skip_broken_datasets)
 

--- a/datacube/api/grid_workflow.py
+++ b/datacube/api/grid_workflow.py
@@ -364,7 +364,10 @@ class GridWorkflow(object):
         :param fuse_func: Function to fuse together a tile that has been pre-grouped by calling
             :meth:`list_cells` with a ``group_by`` parameter.
 
-        :param str resampling: The resampling method to use if re-projection is required.
+        :param str|dict resampling:
+
+            The resampling method to use if re-projection is required, could be
+            configured per band using a dictionary (:meth: `load_data`)
 
             Valid values are: ``'nearest', 'cubic', 'bilinear', 'cubic_spline', 'lanczos', 'average'``
 

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -331,10 +331,10 @@ class Measurement(dict):
 
     def __getattr__(self, key):
         """ Allow access to items as attributes. """
-        if key in self:
-            return self[key]
-
-        raise AttributeError("'Measurement' object has no attribute '{}'".format(key))
+        v = self.get(key, self)
+        if v is self:
+            raise AttributeError("'Measurement' object has no attribute '{}'".format(key))
+        return v
 
     def __repr__(self):
         return "Measurement({})".format(super(Measurement, self).__repr__())

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -318,6 +318,22 @@ class Dataset(object):
 
 
 class Measurement(dict):
+    """
+    Describes a single data variable of a Product or Dataset.
+
+    Must include, which can be used when loading and interpreting data:
+
+     - name
+     - dtype - eg: int8, int16, float32
+     - nodata - What value represent No Data
+     - units
+
+    Attributes can be accessed using ``dict []`` syntax.
+
+    Can also include attributes like alternative names 'aliases', and spectral and bit flags
+    definitions to aid with interpreting the data.
+
+    """
     REQUIRED_KEYS = ('name', 'dtype', 'nodata', 'units')
     OPTIONAL_KEYS = ('aliases', 'spectral_definition', 'flags_definition')
     ATTR_BLACKLIST = set(['name', 'dtype', 'aliases', 'resampling_method'])

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -320,17 +320,14 @@ class Dataset(object):
 class Measurement(dict):
     REQUIRED_KEYS = ('name', 'dtype', 'nodata', 'units')
     OPTIONAL_KEYS = ('aliases', 'spectral_definition', 'flags_definition')
-    FILTER_ATTR_KEYS = ('name', 'dtype', 'aliases')
+    ATTR_BLACKLIST = set(['name', 'dtype', 'aliases', 'resampling_method'])
 
-    def __init__(self, **measurement_dict):
-        missing_keys = set(self.REQUIRED_KEYS) - set(measurement_dict)
+    def __init__(self, **kwargs):
+        missing_keys = set(self.REQUIRED_KEYS) - set(kwargs)
         if missing_keys:
             raise ValueError("Measurement required keys missing: {}".format(missing_keys))
 
-        measurement_data = {key: value for key, value in measurement_dict.items()
-                            if key in self.REQUIRED_KEYS + self.OPTIONAL_KEYS}
-
-        super().__init__(measurement_data)
+        super().__init__(**kwargs)
 
     def __getattr__(self, key):
         """ Allow access to items as attributes. """
@@ -349,7 +346,7 @@ class Measurement(dict):
 
     def dataarray_attrs(self):
         """This returns attributes filtered for display in a dataarray."""
-        return {key: value for key, value in self.items() if key not in self.FILTER_ATTR_KEYS}
+        return {key: value for key, value in self.items() if key not in self.ATTR_BLACKLIST}
 
 
 @schema_validated(SCHEMA_PATH / 'metadata-type-schema.yaml')

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -5,6 +5,13 @@
 What's New
 **********
 
+v1.7dev
+=======
+
+- Allow specifying different resampling methods for different data variables of
+  the same Product. (:pull:`551`)
+
+
 v1.6.1 (27 August 2018)
 =======================
 

--- a/tests/api/test_grid_workflow.py
+++ b/tests/api/test_grid_workflow.py
@@ -131,7 +131,8 @@ def test_gridworkflow():
         args = list(args)
         assert args[0] is loadable.sources
         assert args[1] is loadable.geobox
-        assert list(args[2])[0] is measurement
+        assert list(args[2].values())[0] is measurement
+        assert 'resampling' in kwargs
 
     # ------- check single cell index extract -------
     tile = gw.list_tiles(cell_index=(1, -2), **query)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -86,6 +86,9 @@ def test_measurement():
     assert m.bob == 10
     assert m.dataarray_attrs() == {'nodata': 255, 'units': '1', 'bob': 10}
 
+    m['none'] = None
+    assert m.none is None
+
     m['resampling_method'] = 'cubic'
     assert 'resampling_method' not in m.dataarray_attrs()
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -73,15 +73,19 @@ def test_product_dimensions():
 
 
 def test_measurement():
+    # Can create a measurement
     m = Measurement(name='t', dtype='uint8', nodata=255, units='1')
 
+    # retrieve it's vital stats
     assert m.name == 't'
     assert m.dtype == 'uint8'
     assert m.nodata == 255
     assert m.units == '1'
 
+    # retrieve the information required for filling a DataArray
     assert m.dataarray_attrs() == {'nodata': 255, 'units': '1'}
 
+    # Can add a new attribute by name and ensure it updates the DataArray attrs too
     m['bob'] = 10
     assert m.bob == 10
     assert m.dataarray_attrs() == {'nodata': 255, 'units': '1', 'bob': 10}
@@ -89,13 +93,16 @@ def test_measurement():
     m['none'] = None
     assert m.none is None
 
+    # Resampling method is special and *not* needed for DataArray attrs
     m['resampling_method'] = 'cubic'
     assert 'resampling_method' not in m.dataarray_attrs()
 
+    # It's possible to copy and update a Measurement instance
     m2 = m.copy()
     assert m2.bob == 10
     assert m2.dataarray_attrs() == m.dataarray_attrs()
 
+    # Must specify *all* required keys. name, dtype, nodata and units
     with pytest.raises(ValueError) as e:
         Measurement(name='x', units='1', nodata=0)
 


### PR DESCRIPTION
This started off with some confusion about where `resampling_method` configuration comes from (I thought it was defined in the product, but it's not), then some errors in `Measurement` class were found (silently removing `resampling_method` impacting ingestor).

Main goal: allow resampling method configuration per band without fiddling directly with `Measurement` class and calling `load_data` instead of just `load`.

- Make `Measurement` class more like normal dictionary (no silent whitelist on input/copy)
- Move `resampling` parameter handling down to `load_data` (dc.load, GridWorkflow.load just pass it through now)
- Extend `resampling` to support per-band configuration
- Change ingest to use `resampling` dictionary instead of modifying `Measurement` objects directly
- `load_data` can accept `measurement` as dict as well as list now (by the way what is the significance of measurement order?)
- Use attribute access instead of dictionary access `m.nodata` instead of `m['nodata']`


- [x] Closes #550 
- [x] Closes #548 
- [x] Closes #549