### PR TITLE
Fix no-config-file error message string format

### DIFF
--- a/datacube/ui/click.py
+++ b/datacube/ui/click.py
@@ -127,7 +127,7 @@ def _log_queries(ctx, param, value):
 def _set_config(ctx, param, value):
     if value:
         if not any(os.path.exists(p) for p in value):
-            raise ValueError('No specified config paths exist: {}' % value)
+            raise ValueError('No specified config paths exist: {}'.format(value))
 
         if not ctx.obj:
             ctx.obj = {}


### PR DESCRIPTION
A string-formatting error is being thrown when building an error message:
```
$ datacube -C missing-config-file.conf system check
Traceback (most recent call last):
  File "/Users/jez/.miniconda3/bin/datacube", line 11, in <module>
    load_entry_point('datacube', 'console_scripts', 'datacube')()
  File "/Users/jez/.miniconda3/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/jez/.miniconda3/lib/python3.6/site-packages/click/core.py", line 696, in main
    with self.make_context(prog_name, args, **extra) as ctx:
  File "/Users/jez/.miniconda3/lib/python3.6/site-packages/click/core.py", line 621, in make_context
    self.parse_args(ctx, args)
  File "/Users/jez/.miniconda3/lib/python3.6/site-packages/click/core.py", line 1018, in parse_args
    rest = Command.parse_args(self, ctx, args)
  File "/Users/jez/.miniconda3/lib/python3.6/site-packages/click/core.py", line 880, in parse_args
    value, args = param.handle_parse_result(ctx, opts, args)
  File "/Users/jez/.miniconda3/lib/python3.6/site-packages/click/core.py", line 1404, in handle_parse_result
    self.callback, ctx, self, value)
  File "/Users/jez/.miniconda3/lib/python3.6/site-packages/click/core.py", line 78, in invoke_param_callback
    return callback(ctx, param, value)
  File "/Users/jez/dea/datacube-core/datacube/ui/click.py", line 130, in _set_config
    raise ValueError('No specified config paths exist: {}' % value)
TypeError: not all arguments converted during string formatting
```