### PR TITLE
Add libudunits2-dev package to Docker image to allow cf_units to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     # G++ because GDAL decided it needed compiling
     g++ \
+    # numpy requires headers for cf_units
+    libudunits2-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Get the code, and put it in /code


### PR DESCRIPTION
Add missing package to docker image to allow build to complete.