### PR TITLE
Cheaper solar day computations

### DIFF
--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -21,13 +21,10 @@ import logging
 import datetime
 import collections
 import warnings
-import calendar
-import re
 import pandas
 
 from dateutil import tz
 from pandas import to_datetime as pandas_to_datetime
-from pypeg2 import word, attr, List, maybe_some, parse as peg_parse
 import numpy as np
 
 from ..compat import string_types, integer_types
@@ -268,13 +265,13 @@ def _to_datetime(t):
 
     return pandas_to_datetime(t, utc=True, infer_datetime_format=True).to_pydatetime()
 
+
 def _time_to_search_dims(time_range):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
 
         tr_start, tr_end = time_range, time_range
 
-        #pylint: disable=bad-whitespace
         if hasattr(time_range, '__iter__') and not isinstance(time_range, str):
             l = list(time_range)
             tr_start, tr_end = l[0], l[-1]
@@ -285,19 +282,19 @@ def _time_to_search_dims(time_range):
         if hasattr(tr_start, 'isoformat'):
             tr_start = tr_start.isoformat()
         if hasattr(tr_end, 'isoformat'):
-            tr_end   = tr_end.isoformat()
+            tr_end = tr_end.isoformat()
 
         start = _to_datetime(tr_start)
-        end   = _to_datetime(pandas.Period(tr_end)
-                             .end_time
-                             .to_pydatetime()
-                            )
+        end = _to_datetime(pandas.Period(tr_end)
+                           .end_time
+                           .to_pydatetime())
 
         tr = Range(start, end)
         if start == end:
             return tr[0]
 
         return tr
+
 
 def _convert_to_solar_time(utc, longitude):
     seconds_per_degree = 240

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -303,10 +303,16 @@ def _convert_to_solar_time(utc, longitude):
     return utc + offset
 
 
-def solar_day(dataset):
+def solar_day(dataset, longitude=None):
     utc = dataset.center_time
-    bb = dataset.extent.to_crs(geometry.CRS('WGS84')).boundingbox
-    assert bb.left < bb.right  # TODO: Handle dateline?
-    longitude = (bb.left + bb.right) * 0.5
+
+    if longitude is None:
+        m = dataset.metadata
+        if hasattr(m, 'lon'):
+            lon = m.lon
+            longitude = (lon.begin + lon.end)*0.5
+        else:
+            raise ValueError('Cannot compute solar_day: dataset is missing spatial info')
+
     solar_time = _convert_to_solar_time(utc, longitude)
     return np.datetime64(solar_time.date(), 'D')

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -16,11 +16,14 @@ from __future__ import absolute_import, division, print_function
 
 import datetime
 import pandas
+import numpy as np
+from types import SimpleNamespace
 
 import pytest
 
-from datacube.api.query import Query, _datetime_to_timestamp, query_group_by
+from datacube.api.query import Query, _datetime_to_timestamp, query_group_by, solar_day
 from datacube.model import Range
+from datacube.utils import parse_time
 
 
 def test_datetime_to_timestamp():
@@ -146,3 +149,20 @@ def test_time_handling(time_param, expected):
     query = Query(time=time_param)
     assert 'time' in query.search_terms
     assert query.search_terms['time'] == expected
+
+
+def test_solar_day():
+    _s = SimpleNamespace
+    ds = _s(center_time=parse_time('1987-05-22 23:07:44.2270250Z'),
+            metadata=_s(lon=Range(begin=150.415,
+                                  end=152.975)))
+
+    assert solar_day(ds) == np.datetime64('1987-05-23', 'D')
+    assert solar_day(ds, longitude=0) == np.datetime64('1987-05-22', 'D')
+
+    ds.metadata = _s()
+
+    with pytest.raises(ValueError) as e:
+        solar_day(ds)
+
+    assert 'Cannot compute solar_day: dataset is missing spatial info' in str(e.value)


### PR DESCRIPTION
### Reason for this pull request

Solar day computation was recomputing Lon/Lat bound for each dataset

### Proposed changes

- Extract `lon`  from metadata if present, raise error if missing
- Optionally supply longitude instead of reading from dataset
   - GridWorkflow can use that for example by supplying middle of the grid longitude value instead of using different one for each dataset, this would also work in the regions near dateline unlike current approach.


 - [x] Closes #555
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes