### PR TITLE
Fix up Travis-CI AWS credentials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,9 +91,6 @@ deploy:
   # For tags, the object will be datacube/datacube-1.4.2.tar.gz
   # For develop, the object will be datacube/datacube-1.4.1+91.g43bd4e12.tar.gz
   - provider: s3
-    access_key_id: "AKIAJMZN4F5L5KXPQKVQ"
-    secret_access_key:
-      secure: owxrrQc4i1jfAwvASFewdMzNdi93zpwnoEhsTJQS/f3SkD083XpefUr4H7Mg8cZiq5grT6NpoYkG6QDoxz30Kn5IbDIHewRy3I11uwz02JGUkzxv+/7hLOnoM/LM993WWXA+YQJmrO4HvncDy3Hgbw98xkKOeqsQ1XlYR8Lp5NUQnwJtLkouOJYfJSU/ZuIyetYC3bO2JkF/smtEPmVPJ8ZJjAQEqCdiUJsvMWKDlDh+cLOKM6EBTorE8GTECfMY+HUy74nH7xdkJ2xQm6PjO2wJVtcgCW377Jfn7IJqMhmlhA6fnkguyb58S5NkwwSynFizm7GidtbAxTeaIHimB3B6ImWUQu/maiWrWpMZGyqoC+l3+zQ/jg5Pam9Crtff8odFNT/tvwVGMTxuVkUxYRZ87XGM+G4D29xV/FGs0oqyn3Jw4SPXmg1bBymJOwmL+YogYFvJAR77MmbBUcf6SCogJzvI4Z2IFe9afMCbZaNeSD1GGh+EYCjJIKrpc9sY2ZxON1Mgv1bQ9FnSrDxyCUYEsshh8x9AaAFcYdGRGc6V0IT/5gopH3gf+XC+Q2OQHGC5oiaJ0+R4BoT3YuxEYfpBHvrpWk30Ug8C9ZgxoGK2xjabKiJ/2LlKe+xHoe77ZWZCkc1RocZnSHFBaFgaQrzppWsty04WGHl5fIVgH1Q=
     bucket: "datacube-core-deployment"
     region: "ap-southeast-2"
     local_dir: dist


### PR DESCRIPTION
### Reason for this pull request

The Travis-CI builds are broken on `develop` and `stable` because they
are using outdated AWS credentials stored in the `.travis.yml` configuration
file.


### Proposed changes

- Store AWS deployment keys in Travis environment variables instead of the `.travis.yml` configuration file.

They should be easier to maintain and rotate there.