### PR TITLE
Upload Travis-CI code coverage results to codecov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_install:
 # Set paths for building python-gdal
   - export CPLUS_INCLUDE_PATH=/usr/include/gdal
   - export C_INCLUDE_PATH=/usr/include/gdal
-  - pip install coveralls
+  - pip install coveralls codecov
   - pip install --requirement requirements-test.txt
 
 
@@ -80,6 +80,7 @@ after_script:
 
 after_success:
   - test $TRAVIS_PYTHON_VERSION = "3.6" && coveralls
+  - codecov  # Upload test coverage results to codecov.io
 
 before_deploy:
   - python setup.py sdist bdist_wheel


### PR DESCRIPTION
### Reason for this pull request

I'm not entirely happy with coveralls: - It's interface is awkward to view the
changes for a single branch - And awkward to see *when* movement up or down
occurred. It provides SHAs without dates, which aren't particularly helpful.

It should be harmless to upload results to both services, at some point in the future we could discuss turning off one or the other.



### Proposed changes

- Upload code coverage from test results from Travis-CI to https://codecov.io




<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->