### PR TITLE
Simplify polygon from sources extent

### DIFF
--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -566,7 +566,8 @@ GeoPolygon.from_boundingbox = _polygon_from_boundingbox
 def _polygon_from_sources_extents(sources, geobox):
     sources_union = geometry.unary_union(source.extent.to_crs(geobox.crs) for source in sources)
     valid_data = geobox.extent.intersection(sources_union)
-    return valid_data
+    resolution = min([abs(x) for x in geobox.resolution])
+    return valid_data.simplify(tolerance=resolution * 0.01)
 
 
 GeoPolygon.from_sources_extents = _polygon_from_sources_extents


### PR DESCRIPTION
### Reason for this pull request
The valid data region calculated by `datacube-stats` is the union of valid data regions of
its sources. If not simplified, it can take up unnecessary space and make things harder.

### Proposed changes
Simplify the region.

Tests passed so the code must be correct /s