### PR TITLE
Add dc version to app metadata and rename taskfile_version

### DIFF
--- a/datacube/scripts/ingest.py
+++ b/datacube/scripts/ingest.py
@@ -83,13 +83,14 @@ def get_variable_params(config):
     return variable_params
 
 
-def get_app_metadata(config, config_file):
+def get_app_metadata(config_file):
     doc = {
         'lineage': {
             'algorithm': {
                 'name': 'datacube-ingest',
                 'repo_url': 'https://github.com/opendatacube/datacube-core.git',
-                'parameters': {'configuration_file': config_file}
+                'parameters': {'configuration_file': config_file},
+                'version': datacube.__version__,
             },
         }
     }
@@ -103,7 +104,7 @@ def get_filename(config, tile_index, sources, **kwargs):
         tile_index=tile_index,
         start_time=to_datetime(sources.time.values[0]).strftime(time_format),
         end_time=to_datetime(sources.time.values[-1]).strftime(time_format),
-        version=config['taskfile_version'],
+        version=config['taskfile_utctime'],
         **kwargs))
 
 
@@ -172,7 +173,7 @@ def load_config_from_file(path):
 
 
 def create_task_list(index, output_type, year, source_type, config):
-    config['taskfile_version'] = int(time.time())
+    config['taskfile_utctime'] = int(time.time())
 
     query = {}
     if year:
@@ -244,7 +245,7 @@ def ingest_work(config, source_type, output_type, tile, tile_index):
                             extent=tile.geobox.extent,
                             center_time=labels['time'],
                             uri=mk_uri(file_path),
-                            app_info=get_app_metadata(config, config['filename']),
+                            app_info=get_app_metadata(config['filename']),
                             valid_data=GeoPolygon.from_sources_extents(sources, tile.geobox))
 
     datasets = xr_apply(tile.sources, _make_dataset, dtype='O')  # Store in Dataarray to associate Time -> Dataset

--- a/datacube_apps/stacker/fixer.py
+++ b/datacube_apps/stacker/fixer.py
@@ -39,7 +39,7 @@ APP_NAME = 'datacube-fixer'
 
 def make_filename(config, cell_index, start_time):
     file_path_template = str(Path(config['location'], config['file_path_template']))
-    return file_path_template.format(tile_index=cell_index, start_time=start_time, version=config['taskfile_version'])
+    return file_path_template.format(tile_index=cell_index, start_time=start_time, version=config['taskfile_utctime'])
 
 
 def get_temp_file(final_output_path):
@@ -122,7 +122,7 @@ def make_fixer_config(index, config, export_path=None, **query):
 
     config['variable_params'] = variable_params
 
-    config['taskfile_version'] = int(datacube.utils.datetime_to_seconds_since_1970(datetime.datetime.now()))
+    config['taskfile_utctime'] = int(datacube.utils.datetime_to_seconds_since_1970(datetime.datetime.now()))
 
     return config
 
@@ -146,7 +146,7 @@ def build_history_string(config, task, keep_original=True):
         ver=datacube.__version__,
         args=', '.join([config['app_config_file'],
                         str(config['version']),
-                        str(config['taskfile_version']),
+                        str(config['taskfile_utctime']),
                         task['output_filename'],
                         str(task['start_time']),
                         str(task['cell_index'])

--- a/datacube_apps/stacker/stacker.py
+++ b/datacube_apps/stacker/stacker.py
@@ -33,7 +33,7 @@ APP_NAME = 'datacube-stacker'
 
 def get_filename(config, cell_index, year):
     file_path_template = str(Path(config['location'], config['file_path_template']))
-    return file_path_template.format(tile_index=cell_index, start_time=year, version=config['taskfile_version'])
+    return file_path_template.format(tile_index=cell_index, start_time=year, version=config['taskfile_utctime'])
 
 
 def get_temp_file(final_output_path):
@@ -107,7 +107,7 @@ def make_stacker_config(index, config, export_path=None, check_data=None, **quer
 
     config['variable_params'] = variable_params
 
-    config['taskfile_version'] = int(datacube.utils.datetime_to_seconds_since_1970(datetime.datetime.now()))
+    config['taskfile_utctime'] = int(datacube.utils.datetime_to_seconds_since_1970(datetime.datetime.now()))
 
     return config
 
@@ -120,7 +120,7 @@ def get_history_attribute(config, task):
         ver=datacube.__version__,
         args=', '.join([config['app_config_file'],
                         str(config['version']),
-                        str(config['taskfile_version']),
+                        str(config['taskfile_utctime']),
                         task['output_filename'],
                         str(task['year']),
                         str(task['cell_index'])


### PR DESCRIPTION
### Reason for this pull request
Datasets created during `ingest` process did not specify which `datacube.__version__` was used for ingestion. Adding `datacube.__version__` to the metadata would aid us to track `datacube` application used for `ingest` process. Also, `taskfile_version` name is misleading to actual usage.

### Proposed changes
- Add `'version': datacube.__version__` to app metadata document that will be used for `ingest` process.
- Rename `taskfile_version` to `taskfile_utctime`.

 - [ ] Closes #xxxx
 - [x] Tests passed (No update to tests required)