### PR TITLE
Actually run property tests with Hypothesis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,13 +47,13 @@ before_install:
 # Set paths for building python-gdal
   - export CPLUS_INCLUDE_PATH=/usr/include/gdal
   - export C_INCLUDE_PATH=/usr/include/gdal
-  - pip install coveralls codecov
-  - pip install --requirement requirements-test.txt
+  - pip install --progress=off coveralls codecov
+  - pip install --progress=off --requirement requirements-test.txt
 
 
 install:
 # Install datacube
-  - pip install '.[test,celery,s3]'
+  - pip install --progress=off '.[test,celery,s3]'
   - pip install ./tests/drivers/fail_drivers --no-deps --upgrade  # used to test exception paths in driver loader
 
 # Print installed packages in case we need to debug them

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,9 @@ before_install:
   - df -h
   - df -i
 
+# Clean up AWS env variables
+  - [[ ! -v AWS_SECRET_ACCESS_KEY ]] && unset AWS_ACCESS_KEY_ID
+
 # Set paths for building python-gdal
   - export CPLUS_INCLUDE_PATH=/usr/include/gdal
   - export C_INCLUDE_PATH=/usr/include/gdal

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,13 +47,14 @@ before_install:
 # Set paths for building python-gdal
   - export CPLUS_INCLUDE_PATH=/usr/include/gdal
   - export C_INCLUDE_PATH=/usr/include/gdal
-  - pip install --progress=off coveralls codecov
-  - pip install --progress=off --requirement requirements-test.txt
+  - pip install --upgrade pip
+  - pip install --progress-bar off coveralls codecov
+  - pip install --progress-bar off --requirement requirements-test.txt
 
 
 install:
 # Install datacube
-  - pip install --progress=off '.[test,celery,s3]'
+  - pip install --progress-bar off '.[test,celery,s3]'
   - pip install ./tests/drivers/fail_drivers --no-deps --upgrade  # used to test exception paths in driver loader
 
 # Print installed packages in case we need to debug them

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -15,6 +15,7 @@ from uuid import uuid4
 import pytest
 import yaml
 from click.testing import CliRunner
+from hypothesis import HealthCheck, settings
 
 import datacube.scripts.cli_app
 import datacube.utils
@@ -53,6 +54,14 @@ LS5_NBAR_ALBERS_STORAGE_TYPE = LS5_SAMPLES / 'ls5_albers.yaml'
 
 CONFIG_FILE_PATHS = [str(INTEGRATION_TESTS_DIR / 'agdcintegration.conf'),
                      os.path.expanduser('~/.datacube_integration.conf')]
+
+# Configure Hypothesis to allow slower tests, because we're testing datasets
+# and disk IO rather than scalar values in memory.  Ask @Zac-HD for details.
+settings.register_profile(
+    'opendatacube', timeout=-1, deadline=5000, max_examples=10,
+    suppress_health_check=[HealthCheck.too_slow]
+)
+settings.load_profile('opendatacube')
 
 
 @pytest.fixture

--- a/integration_tests/data_utils.py
+++ b/integration_tests/data_utils.py
@@ -142,7 +142,7 @@ def write_test_scene_to_disk(dataset_dict, tmpdir):
 
     # Create directory
     new_dir = tmpdir / dir_name
-    new_dir.mkdir()
+    new_dir.mkdir(exist_ok=True)
 
     _make_geotiffs(new_dir, dataset_dict)
     dataset_file = new_dir / 'agdc-metadata.yaml'

--- a/integration_tests/data_utils.py
+++ b/integration_tests/data_utils.py
@@ -138,7 +138,7 @@ def scene_datasets(draw):
 def write_test_scene_to_disk(dataset_dict, tmpdir):
     tmpdir = Path(str(tmpdir))
     # Make directory name
-    dir_name = dataset_dict['platform']['code'] + dataset_dict['id'][:5]
+    dir_name = dataset_dict['platform']['code'] + dataset_dict['id']
 
     # Create directory
     new_dir = tmpdir / dir_name

--- a/integration_tests/data_utils.py
+++ b/integration_tests/data_utils.py
@@ -135,15 +135,6 @@ def scene_datasets(draw):
     }
 
 
-def generate_test_scenes(tmpdir, num=2):
-    paths_to_datasets = []
-    for i in range(num):
-        ls5_dataset = scene_datasets().example()
-        dataset_file = write_test_scene_to_disk(ls5_dataset, tmpdir)
-        paths_to_datasets.append(dataset_file)
-    return paths_to_datasets
-
-
 def write_test_scene_to_disk(dataset_dict, tmpdir):
     tmpdir = Path(str(tmpdir))
     # Make directory name

--- a/integration_tests/test_double_ingestion.py
+++ b/integration_tests/test_double_ingestion.py
@@ -1,8 +1,10 @@
 from pathlib import Path
 
 import pytest
+from hypothesis import given
+from hypothesis.strategies import lists
 
-from integration_tests.data_utils import generate_test_scenes
+from integration_tests.data_utils import scene_datasets, write_test_scene_to_disk
 from integration_tests.utils import prepare_test_ingestion_configuration
 
 PROJECT_ROOT = Path(__file__).parents[1]
@@ -13,7 +15,8 @@ INGESTER_CONFIGS = PROJECT_ROOT / 'docs/config_samples/' / 'ingester'
 @pytest.mark.parametrize('datacube_env_name', ('datacube',), indirect=True)
 @pytest.mark.usefixtures('default_metadata_type',
                          'indexed_ls5_scene_products')
-def test_double_ingestion(clirunner, index, tmpdir, ingest_configs):
+@given(scenes=lists(scene_datasets(), min_size=2, max_size=2))
+def test_double_ingestion(clirunner, index, tmpdir, ingest_configs, scenes):
     """
     Test for the case where ingestor does not need to create a new product,
     but should re-use an existing target product.
@@ -21,32 +24,11 @@ def test_double_ingestion(clirunner, index, tmpdir, ingest_configs):
     """
     # Make a test ingestor configuration
     config = INGESTER_CONFIGS / ingest_configs['ls5_nbar_albers']
-    config_path, config = prepare_test_ingestion_configuration(tmpdir, None,
-                                                               config, mode='fast_ingest')
+    config_path, config = prepare_test_ingestion_configuration(
+        tmpdir, None, config, mode='fast_ingest')
 
-    def index_dataset(path):
-        return clirunner(['dataset', 'add', str(path)])
-
-    # Create and Index some example scene datasets
-    dataset_paths = generate_test_scenes(tmpdir)
-    for path in dataset_paths:
-        index_dataset(path)
-
-    # Ingest them
-    clirunner([
-        'ingest',
-        '--config-file',
-        str(config_path)
-    ])
-
-    # Create and Index some more scene datasets
-    dataset_paths = generate_test_scenes(tmpdir)
-    for path in dataset_paths:
-        index_dataset(path)
-
-    # Make sure that we can ingest the new scenes
-    clirunner([
-        'ingest',
-        '--config-file',
-        str(config_path)
-    ])
+    for ls5_dataset in scenes:
+        # Write and ingest each dataset in turn
+        dataset_file = write_test_scene_to_disk(ls5_dataset, tmpdir)
+        clirunner(['dataset', 'add', str(dataset_file)])
+        clirunner(['ingest', '--config-file', str(config_path)])

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -84,7 +84,7 @@ def prepare_test_ingestion_configuration(tmpdir,
 
     filename = Path(filename)
     if output_dir is None:
-        output_dir = tmpdir.mkdir(filename.stem)
+        output_dir = tmpdir.ensure(filename.stem)
     config = load_yaml_file(filename)[0]
 
     if mode is not None:

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -84,7 +84,7 @@ def prepare_test_ingestion_configuration(tmpdir,
 
     filename = Path(filename)
     if output_dir is None:
-        output_dir = tmpdir.ensure(filename.stem)
+        output_dir = tmpdir.ensure(filename.stem, dir=True)
     config = load_yaml_file(filename)[0]
 
     if mode is not None:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -22,7 +22,6 @@ dask==0.17.2
 dill==0.2.7.1
 docopt==0.6.2
 docutils==0.14
-GDAL==2.2.4
 graphviz==0.8.2
 hypothesis==3.55.3
 idna==2.6
@@ -55,6 +54,7 @@ psycopg2==2.7.4
 py==1.5.3
 pycodestyle==2.4.0
 pycparser==2.18
+pygdal==2.3.2.4
 pygeoif==0.7
 pylint==1.8.4
 pyparsing==2.2.0
@@ -67,7 +67,7 @@ python-dateutil==2.7.2
 pytz==2018.4
 pytzdata==2018.4
 PyYAML==3.12
-rasterio==1.0.2
+rasterio>=1.0.7
 redis==2.10.6
 regex==2017.7.28
 requests==2.18.4


### PR DESCRIPTION
I'm one of the authors of Hypothesis, regular contributor to Xarray, and happy user of the datacube on NCI.  So I might be the first non-GA person ever to look at these files :stuck_out_tongue_winking_eye: 

Hypothesis provides three parts: strategies for describing valid data, a runner (`@given`) to explore various inputs and shrink failing examples, and incidentals such as config options.

The strategies you've defined look fantastic.  Unfortunately using the `.example()` method is a terrible way to run the tests - it's intended for interaction with strategies under development, and deliberately biased towards very simple examples.  It also can't provide minimal examples, which is *really* useful when working with datasets that have so many parts.

So this pull request converts the existing Hypothesis test over to use `@given`, and configures timeouts etc. to match the tests I wrote for Xarray and Pandas.  cc @omad and @andrewdhicks - I hope this is helpful!