### PR TITLE
Virtual product updates

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -614,7 +614,7 @@ def apply_aliases(data, product, measurements):
 
 
 def output_geobox(like=None, output_crs=None, resolution=None, align=None,
-                  grid_spec=None, datasets=None, **query):
+                  grid_spec=None, datasets=None, geopolygon=None, **query):
     """ Configure output geobox from user provided output specs. """
 
     if like is not None:
@@ -639,8 +639,13 @@ def output_geobox(like=None, output_crs=None, resolution=None, align=None,
             resolution = grid_spec.resolution
         align = align or grid_spec.alignment
 
-    return geometry.GeoBox.from_geopolygon(query_geopolygon(**query) or get_bounds(datasets, crs),
-                                           resolution, crs, align)
+    if geopolygon is None:
+        geopolygon = query_geopolygon(**query)
+
+        if geopolygon is None:
+            geopolygon = get_bounds(datasets, crs)
+
+    return geometry.GeoBox.from_geopolygon(geopolygon, resolution, crs, align)
 
 
 def select_datasets_inside_polygon(datasets, polygon):

--- a/datacube/virtual/__init__.py
+++ b/datacube/virtual/__init__.py
@@ -1,7 +1,7 @@
 import yaml
 
 from .impl import VirtualProduct, Transformation, VirtualProductException
-from .transformations import MakeMask, ApplyMask, ToFloat, Rename
+from .transformations import MakeMask, ApplyMask, ToFloat, Rename, Select
 from .utils import reject_keys
 
 from datacube.model import Measurement
@@ -90,7 +90,8 @@ class NameResolver:
 DEFAULT_RESOLVER = NameResolver(make_mask=MakeMask,
                                 apply_mask=ApplyMask,
                                 to_float=ToFloat,
-                                rename=Rename)
+                                rename=Rename,
+                                select=Select)
 
 
 def construct(**recipe):

--- a/datacube/virtual/__init__.py
+++ b/datacube/virtual/__init__.py
@@ -1,3 +1,5 @@
+import yaml
+
 from .impl import VirtualProduct, Transformation, VirtualProductException
 from .transformations import MakeMask, ApplyMask, ToFloat, Rename
 from .utils import reject_keys
@@ -96,5 +98,11 @@ def construct(**recipe):
     """
     Create a virtual product from a specification dictionary.
     """
-
     return DEFAULT_RESOLVER.construct(**recipe)
+
+
+def construct_from_yaml(recipe):
+    """
+    Create a virtual product from a yaml recipe.
+    """
+    return construct(**yaml.load(recipe, Loader=yaml.CLoader))

--- a/datacube/virtual/impl.py
+++ b/datacube/virtual/impl.py
@@ -283,6 +283,10 @@ class VirtualProduct(Mapping):
         get = self.get
 
         if 'product' in self:
+            product = dc.index.products.get_by_name(self._product)
+            if product is None:
+                raise VirtualProductException("could not find product {}".format(self._product))
+
             originals = Query(dc.index, **reject_keys(self, self._NON_QUERY_KEYS))
             overrides = Query(dc.index, **reject_keys(search_terms, self._NON_QUERY_KEYS))
 
@@ -299,10 +303,6 @@ class VirtualProduct(Mapping):
                 datasets = [dataset
                             for dataset in datasets
                             if get('dataset_predicate')(dataset)]
-
-            # gather information from the index before it disappears from sight
-            # this can also possibly extracted from the product definitions but this is easier
-            product = dc.index.products.get_by_name(self._product)
 
             return QueryResult(list(datasets), product.grid_spec, query.geopolygon,
                                {product.name: product.definition})

--- a/datacube/virtual/transformations.py
+++ b/datacube/virtual/transformations.py
@@ -141,3 +141,18 @@ class Rename(Transformation):
 
     def compute(self, data):
         return data.rename(self.measurement_names)
+
+
+class Select(Transformation):
+    def __init__(self, measurement_names):
+        self.measurement_names = measurement_names
+
+    def measurements(self, input_measurements):
+        return {key: value
+                for key, value in input_measurements.items()
+                if key in self.measurement_names}
+
+    def compute(self, data):
+        return data.drop([measurement
+                          for measurement in data.data_vars
+                          if measurement not in self.measurement_names])

--- a/datacube/virtual/utils.py
+++ b/datacube/virtual/utils.py
@@ -32,6 +32,23 @@ def reject_keys(settings, keys):
             for key, value in settings.items() if key not in keys}
 
 
+def merge_dicts(dicts):
+    """
+    Merge a list of dictionaries into one.
+    Later entries override the earlier ones.
+    """
+    if len(dicts) == 0:
+        return {}
+    if len(dicts) == 1:
+        return dicts[0]
+
+    first, *rest = dicts
+    result = dict(first)
+    for other in rest:
+        result.update(other)
+    return result
+
+
 def merge_search_terms(original, override, keys=None):
     def pick(key, a, b):
         if a == b:

--- a/tests/api/test_virtual.py
+++ b/tests/api/test_virtual.py
@@ -3,13 +3,12 @@ from datetime import datetime
 from types import SimpleNamespace
 
 import pytest
-import yaml
 import mock
 import numpy
 
 from datacube.model import DatasetType, MetadataType, Dataset, GridSpec
 from datacube.utils import geometry
-from datacube.virtual import construct
+from datacube.virtual import construct_from_yaml
 from datacube.virtual.impl import Datacube
 from datacube.virtual.utils import product_definitions_from_index
 
@@ -58,7 +57,7 @@ def example_grid_spatial():
 
 @pytest.fixture
 def cloud_free_nbar():
-    recipe = yaml.load("""
+    return construct_from_yaml("""
     collate:
       - transform: apply_mask
         mask_measurement_name: pixelquality
@@ -94,8 +93,6 @@ def cloud_free_nbar():
               - product: ls7_pq_albers
     index_measurement_name: source_index
     """)
-
-    return construct(**recipe)
 
 
 def product_definitions():
@@ -226,7 +223,7 @@ def test_load_data(cloud_free_nbar, dc, query):
 
 
 def test_rename(dc, query):
-    rename_recipe = yaml.load("""
+    rename = construct_from_yaml("""
         transform: rename
         measurement_names:
             green: verde
@@ -234,8 +231,6 @@ def test_rename(dc, query):
             product: ls8_nbar_albers
             measurements: [blue, green]
     """)
-
-    rename = construct(**rename_recipe)
 
     with mock.patch('datacube.virtual.impl.Datacube') as mock_datacube:
         mock_datacube.load_data = load_data
@@ -248,14 +243,12 @@ def test_rename(dc, query):
 
 
 def test_to_float(dc, query):
-    to_float_recipe = yaml.load("""
+    to_float = construct_from_yaml("""
         transform: to_float
         input:
             product: ls8_nbar_albers
             measurements: [blue]
     """)
-
-    to_float = construct(**to_float_recipe)
 
     with mock.patch('datacube.virtual.impl.Datacube') as mock_datacube:
         mock_datacube.load_data = load_data

--- a/tests/api/test_virtual.py
+++ b/tests/api/test_virtual.py
@@ -221,6 +221,25 @@ def test_load_data(cloud_free_nbar, dc, query):
     assert numpy.array_equal(numpy.unique(data.source_index.values), numpy.array([0, 1]))
 
 
+def test_select(dc, query):
+    select = construct_from_yaml("""
+        transform: select
+        measurement_names:
+            - green
+        input:
+            product: ls8_nbar_albers
+            measurements: [blue, green]
+    """)
+
+    with mock.patch('datacube.virtual.impl.Datacube') as mock_datacube:
+        mock_datacube.load_data = load_data
+        mock_datacube.group_datasets = group_datasets
+        data = select.load(dc, **query)
+
+    assert 'green' in data
+    assert 'blue' not in data
+
+
 def test_rename(dc, query):
     rename = construct_from_yaml("""
         transform: rename


### PR DESCRIPTION
### Reason for this pull request
Usability changes to the virtual product interface.

### Proposed changes
- Add convenience function `construct_from_yaml`
- Add new transformation `select`
- At each stage collect all info required for the execution of subsequent stages

That is, the typical workflow now looks like:
```python
datasets = virtual_product.query(**search_terms)
grouped = virtual_product.group(datasets)
data = virtual_product.fetch(grouped)
```