### PR TITLE
Correctly handle network shares urls on windows

### DIFF
--- a/datacube/utils/__init__.py
+++ b/datacube/utils/__init__.py
@@ -658,6 +658,12 @@ def uri_to_local_path(local_uri):
 
     path = url2pathname(components.path)
 
+    if components.netloc:
+        if os.name == 'nt':
+            path = '//{}{}'.format(components.netloc, path)
+        else:
+            raise ValueError('Only know how to use `netloc` urls on Windows')
+
     return pathlib.Path(path)
 
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -70,7 +70,7 @@ PyYAML==3.12
 rasterio>=1.0.7
 redis==2.10.6
 regex==2017.7.28
-requests==2.18.4
+requests==2.20.1
 s3transfer==0.1.13
 SharedArray==2.0.4
 singledispatch==3.4.0.3

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -80,9 +80,13 @@ def test_stats_dates():
 def test_uri_to_local_path():
     if os.name == 'nt':
         assert 'C:\\tmp\\test.tmp' == str(uri_to_local_path('file:///C:/tmp/test.tmp'))
+        assert '\\\\remote\\path\\file.txt' == str(uri_to_local_path('file://remote/path/file.txt'))
 
     else:
         assert '/tmp/something.txt' == str(uri_to_local_path('file:///tmp/something.txt'))
+
+        with pytest.raises(ValueError):
+            uri_to_local_path('file://remote/path/file.txt')
 
     assert uri_to_local_path(None) is None
 


### PR DESCRIPTION
On windows `file://` urls can have `netloc` part when path is pointing to a network share.

 
 - [x] Closes #598 
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes