### PR TITLE
Future is now

### DIFF
--- a/datacube/__init__.py
+++ b/datacube/__init__.py
@@ -16,7 +16,6 @@ To initialise this class, you will need a config pointing to a database, such as
     db_username: cube_user
 
 """
-from __future__ import absolute_import
 from .version import __version__
 from .api import Datacube
 from .config import set_options

--- a/datacube/_celery_runner.py
+++ b/datacube/_celery_runner.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
 
 import cloudpickle
 from celery import Celery

--- a/datacube/api/__init__.py
+++ b/datacube/api/__init__.py
@@ -2,7 +2,6 @@
 """
 Modules for the Storage and Access Query API
 """
-from __future__ import absolute_import
 
 from datacube.storage.masking import list_flag_names, describe_variable_flags, make_mask
 from .core import Datacube

--- a/datacube/api/geo_xarray.py
+++ b/datacube/api/geo_xarray.py
@@ -7,7 +7,6 @@ The CRS is stored as the 'spatial_ref' attribute of the 'crs' data variable
 Spatial dimensions are either 'latitude' / 'longitude' or 'x' / 'y',
 although this should probably instead check the 'standard_name' as defined by CF
 """
-from __future__ import division, absolute_import, print_function
 
 import copy
 

--- a/datacube/api/grid_workflow.py
+++ b/datacube/api/grid_workflow.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 import logging
 import numpy

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -15,7 +15,6 @@
 Storage Query and Access API module
 """
 
-from __future__ import absolute_import, division, print_function
 
 import logging
 import datetime

--- a/datacube/config.py
+++ b/datacube/config.py
@@ -2,7 +2,6 @@
 """
 User configuration.
 """
-from __future__ import absolute_import
 
 import os
 

--- a/datacube/drivers/__init__.py
+++ b/datacube/drivers/__init__.py
@@ -1,7 +1,6 @@
 """
 This module implements a simple plugin manager for storage and index drivers.
 """
-from __future__ import absolute_import
 
 from .indexes import index_driver_by_name, index_drivers
 from .readers import new_datasource, reader_drivers

--- a/datacube/drivers/driver_cache.py
+++ b/datacube/drivers/driver_cache.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, print_function
 
 import logging
 

--- a/datacube/drivers/indexes.py
+++ b/datacube/drivers/indexes.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 from .driver_cache import load_drivers
 

--- a/datacube/drivers/netcdf/driver.py
+++ b/datacube/drivers/netcdf/driver.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from datacube.storage.storage import write_dataset_to_netcdf, RasterDatasetDataSource
 
 PROTOCOL = 'file'

--- a/datacube/drivers/postgres/__init__.py
+++ b/datacube/drivers/postgres/__init__.py
@@ -4,7 +4,6 @@ Lower-level database access.
 
 This package tries to contain any SQLAlchemy and database-specific code.
 """
-from __future__ import absolute_import
 
 from ._connections import PostgresDb
 

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -9,7 +9,6 @@
 """
 Persistence API implementation for postgres.
 """
-from __future__ import absolute_import
 
 import logging
 import uuid

--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -2,7 +2,6 @@
 """
 Core SQL schema settings.
 """
-from __future__ import absolute_import
 
 import logging
 

--- a/datacube/drivers/postgres/_dynamic.py
+++ b/datacube/drivers/postgres/_dynamic.py
@@ -2,7 +2,6 @@
 """
 Methods for managing dynamic dataset field indexes and views.
 """
-from __future__ import absolute_import
 
 import logging
 

--- a/datacube/drivers/postgres/_schema.py
+++ b/datacube/drivers/postgres/_schema.py
@@ -2,7 +2,6 @@
 """
 Tables for indexing the datasets which were ingested into the AGDC.
 """
-from __future__ import absolute_import
 
 import logging
 

--- a/datacube/drivers/postgres/sql.py
+++ b/datacube/drivers/postgres/sql.py
@@ -2,7 +2,6 @@
 """
 Custom types for postgres & sqlalchemy
 """
-from __future__ import absolute_import
 
 from sqlalchemy import TIMESTAMP
 from sqlalchemy.dialects.postgresql.ranges import RangeOperators

--- a/datacube/drivers/readers.py
+++ b/datacube/drivers/readers.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 from .driver_cache import load_drivers
 

--- a/datacube/drivers/s3/datasource.py
+++ b/datacube/drivers/s3/datasource.py
@@ -2,7 +2,6 @@
 datasource behaviour.
 """
 
-from __future__ import absolute_import, division
 
 import logging
 from contextlib import contextmanager

--- a/datacube/drivers/s3/driver.py
+++ b/datacube/drivers/s3/driver.py
@@ -1,5 +1,4 @@
 """S3 storage driver module."""
-from __future__ import absolute_import
 
 import logging
 from pathlib import Path

--- a/datacube/drivers/s3/storage/s3aio/__init__.py
+++ b/datacube/drivers/s3/storage/s3aio/__init__.py
@@ -2,7 +2,6 @@
 """
 Modules for the S3 Array IO API
 """
-from __future__ import absolute_import
 
 from .s3lio import S3LIO
 from .s3aio import S3AIO

--- a/datacube/drivers/s3/storage/s3aio/s3lio.py
+++ b/datacube/drivers/s3/storage/s3aio/s3lio.py
@@ -4,7 +4,6 @@ S3LIO Class
 Labeled Array access, backed by multiple S3 objects.
 
 """
-from __future__ import absolute_import, division
 
 import SharedArray as sa
 import hashlib

--- a/datacube/drivers/s3/utils.py
+++ b/datacube/drivers/s3/utils.py
@@ -1,6 +1,5 @@
 """Utilities shared by all drivers."""
 
-from __future__ import absolute_import
 
 
 class DriverUtils(object):

--- a/datacube/drivers/s3aio_index/__init__.py
+++ b/datacube/drivers/s3aio_index/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 from .driver import index_driver_init
 from .index import S3AIOIndex

--- a/datacube/drivers/s3aio_index/driver.py
+++ b/datacube/drivers/s3aio_index/driver.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 from .index import S3AIOIndex
 from datacube.model import MetadataType

--- a/datacube/drivers/s3aio_index/index.py
+++ b/datacube/drivers/s3aio_index/index.py
@@ -1,5 +1,4 @@
 """S3 indexing module."""
-from __future__ import absolute_import
 
 import logging
 from uuid import uuid4

--- a/datacube/drivers/s3aio_index/schema.py
+++ b/datacube/drivers/s3aio_index/schema.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 from sqlalchemy import Table, Column, String, Integer, Float, ForeignKey, UniqueConstraint, Boolean, MetaData
 from sqlalchemy.dialects import postgresql as postgres

--- a/datacube/drivers/writers.py
+++ b/datacube/drivers/writers.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 from .driver_cache import load_drivers
 

--- a/datacube/execution/worker.py
+++ b/datacube/execution/worker.py
@@ -1,7 +1,6 @@
 """
   This app launches workers for distributed work loads
 """
-from __future__ import absolute_import, print_function
 
 import click
 

--- a/datacube/helpers.py
+++ b/datacube/helpers.py
@@ -3,7 +3,6 @@ Useful functions for Datacube users
 
 Not used internally, those should go in `utils.py`
 """
-from __future__ import absolute_import
 
 import numpy as np
 import rasterio

--- a/datacube/index/__init__.py
+++ b/datacube/index/__init__.py
@@ -2,7 +2,6 @@
 """
 Modules for interfacing with the index/database.
 """
-from __future__ import absolute_import
 
 from ._api import index_connect
 from .fields import UnknownFieldError

--- a/datacube/index/_api.py
+++ b/datacube/index/_api.py
@@ -2,7 +2,6 @@
 """
 Access methods for indexing datasets & products.
 """
-from __future__ import absolute_import
 
 import logging
 

--- a/datacube/index/_metadata_types.py
+++ b/datacube/index/_metadata_types.py
@@ -1,5 +1,4 @@
 # coding=utf-8
-from __future__ import absolute_import
 
 import logging
 import warnings

--- a/datacube/index/_products.py
+++ b/datacube/index/_products.py
@@ -1,5 +1,4 @@
 # coding=utf-8
-from __future__ import absolute_import
 
 import logging
 

--- a/datacube/index/exceptions.py
+++ b/datacube/index/exceptions.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 
 class DuplicateRecordError(Exception):

--- a/datacube/index/fields.py
+++ b/datacube/index/fields.py
@@ -2,7 +2,6 @@
 """
 Common datatypes for DB drivers.
 """
-from __future__ import absolute_import
 
 from datetime import date, datetime, time
 

--- a/datacube/model/utils.py
+++ b/datacube/model/utils.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 import datetime
 import os

--- a/datacube/scripts/cli_app.py
+++ b/datacube/scripts/cli_app.py
@@ -4,7 +4,6 @@
 Datacube command-line interface
 """
 
-from __future__ import absolute_import
 
 from datacube.ui.click import cli
 import datacube.scripts.dataset

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import csv
 import datetime

--- a/datacube/scripts/metadata_type.py
+++ b/datacube/scripts/metadata_type.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, print_function
 
 import json
 import logging

--- a/datacube/scripts/product.py
+++ b/datacube/scripts/product.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import csv
 import json

--- a/datacube/scripts/search_tool.py
+++ b/datacube/scripts/search_tool.py
@@ -3,8 +3,6 @@
 """
 Query datasets.
 """
-from __future__ import absolute_import
-from __future__ import print_function
 
 import csv
 import datetime

--- a/datacube/scripts/user.py
+++ b/datacube/scripts/user.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import logging
 import click

--- a/datacube/storage/__init__.py
+++ b/datacube/storage/__init__.py
@@ -4,4 +4,3 @@ Modules for creating and accessing Data Store Units
 
 
 """
-from __future__ import absolute_import

--- a/datacube/storage/masking.py
+++ b/datacube/storage/masking.py
@@ -3,7 +3,6 @@ Tools for masking data based on a bit-mask variable with attached definition.
 
 The main functions are `make_mask(variable)` `describe_flags(variable)`
 """
-from __future__ import absolute_import
 
 import collections
 import warnings

--- a/datacube/storage/netcdf_writer.py
+++ b/datacube/storage/netcdf_writer.py
@@ -2,7 +2,6 @@
 """
 Create netCDF4 Storage Units and write data to them
 """
-from __future__ import absolute_import
 
 import logging
 import numbers

--- a/datacube/ui/expression.py
+++ b/datacube/ui/expression.py
@@ -34,7 +34,6 @@ a list of string expressions, and returns a dictionary of expressions to
 pass to the index search API.
 
 """
-from __future__ import absolute_import, print_function, division
 
 import calendar
 import re

--- a/datacube/ui/task_app.py
+++ b/datacube/ui/task_app.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import logging
 import os

--- a/datacube/utils/__init__.py
+++ b/datacube/utils/__init__.py
@@ -1,7 +1,6 @@
 """
 Utility functions
 """
-from __future__ import absolute_import, division, print_function
 
 import logging
 import os

--- a/datacube/utils/serialise.py
+++ b/datacube/utils/serialise.py
@@ -2,7 +2,6 @@
 """
 Serialise function used in YAML output
 """
-from __future__ import absolute_import, division, print_function
 
 import math
 from collections import OrderedDict

--- a/datacube/utils/xarray_geoextensions.py
+++ b/datacube/utils/xarray_geoextensions.py
@@ -9,7 +9,6 @@ This extension is reliant on an `xarray` object having a `.crs` property of type
 `.geobox`, `.affine` and `.extent` respectively.
 
 """
-from __future__ import absolute_import
 
 import xarray
 from affine import Affine

--- a/datacube/version.py
+++ b/datacube/version.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 from datacube._version import get_versions
 

--- a/datacube_apps/movie_generator.py
+++ b/datacube_apps/movie_generator.py
@@ -4,7 +4,6 @@ This app creates time series movies
 
 """
 
-from __future__ import absolute_import, print_function, division
 
 import click
 

--- a/datacube_apps/ncml.py
+++ b/datacube_apps/ncml.py
@@ -2,7 +2,6 @@
 Create statistical summaries command
 
 """
-from __future__ import absolute_import, print_function, division
 
 import logging
 import os

--- a/datacube_apps/simple_replica.py
+++ b/datacube_apps/simple_replica.py
@@ -38,7 +38,6 @@ are specified the same as when using the API to search for datasets.
       time: [2008-01-01, 2010-01-01]
 
 """
-from __future__ import absolute_import
 
 import logging
 import os.path

--- a/datacube_apps/stacker/__init__.py
+++ b/datacube_apps/stacker/__init__.py
@@ -2,7 +2,6 @@
 """
 Module for stacking datasets along the time dimension in a single file.
 """
-from __future__ import absolute_import
 from .stacker import main
 from .fixer import fixer as fixer_main
 

--- a/datacube_apps/stacker/fixer.py
+++ b/datacube_apps/stacker/fixer.py
@@ -4,7 +4,6 @@ Finds single timeslice files that have not been stacked (based on filename), and
 This tool is used to update NetCDF metadata for files that are not picked up by the stacker
 
 """
-from __future__ import absolute_import, print_function, division
 
 import copy
 import datetime

--- a/datacube_apps/stacker/stacker.py
+++ b/datacube_apps/stacker/stacker.py
@@ -2,7 +2,6 @@
 Create time-stacked NetCDF files
 
 """
-from __future__ import absolute_import, print_function, division
 
 import copy
 import datetime

--- a/datacube_apps/worker.py
+++ b/datacube_apps/worker.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from datacube.execution import worker
 
 import warnings

--- a/examples/dummy_task_app/dummy_task_app.py
+++ b/examples/dummy_task_app/dummy_task_app.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 """ Sample task app
 """
-from __future__ import absolute_import, print_function
 
 
 import random

--- a/integration_tests/__init__.py
+++ b/integration_tests/__init__.py
@@ -2,4 +2,3 @@
 """
 Module
 """
-from __future__ import absolute_import

--- a/integration_tests/index/__init__.py
+++ b/integration_tests/index/__init__.py
@@ -2,4 +2,3 @@
 """
 Module
 """
-from __future__ import absolute_import

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -2,7 +2,6 @@
 """
 Module
 """
-from __future__ import absolute_import
 
 import copy
 import json

--- a/tests/api/test_geo_xarray.py
+++ b/tests/api/test_geo_xarray.py
@@ -10,10 +10,6 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-
-
-from __future__ import absolute_import, division, print_function
-
 import numpy
 import xarray as xr
 

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -10,10 +10,6 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-
-
-from __future__ import absolute_import, division, print_function
-
 import datetime
 import pandas
 import numpy as np

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ py.test configuration fixtures
 This module defines any fixtures or other extensions to py.test to be used throughout the
 tests in this and sub packages.
 """
-from __future__ import print_function, absolute_import
 
 import os
 

--- a/tests/index/__init__.py
+++ b/tests/index/__init__.py
@@ -2,4 +2,3 @@
 """
 Module
 """
-from __future__ import absolute_import

--- a/tests/index/test_api_index_dataset.py
+++ b/tests/index/test_api_index_dataset.py
@@ -1,6 +1,5 @@
 # coding=utf-8
 
-from __future__ import absolute_import
 
 import datetime
 from collections import namedtuple

--- a/tests/index/test_fields.py
+++ b/tests/index/test_fields.py
@@ -2,7 +2,6 @@
 """
 Module
 """
-from __future__ import absolute_import
 
 from datacube.drivers.postgres._fields import SimpleDocField, NumericRangeDocField, parse_fields, RangeDocField, \
     IntDocField

--- a/tests/index/test_query.py
+++ b/tests/index/test_query.py
@@ -2,7 +2,6 @@
 """
 Module
 """
-from __future__ import absolute_import
 
 from datetime import datetime
 

--- a/tests/index/test_validate_dataset_type.py
+++ b/tests/index/test_validate_dataset_type.py
@@ -2,7 +2,6 @@
 """
 Module
 """
-from __future__ import absolute_import
 
 from copy import deepcopy
 

--- a/tests/scripts/__init__.py
+++ b/tests/scripts/__init__.py
@@ -2,4 +2,3 @@
 """
 Module
 """
-from __future__ import absolute_import

--- a/tests/scripts/test_search_tool.py
+++ b/tests/scripts/test_search_tool.py
@@ -2,7 +2,6 @@
 """
 Module
 """
-from __future__ import absolute_import, unicode_literals
 
 import datetime
 

--- a/tests/storage/test_netcdfwriter.py
+++ b/tests/storage/test_netcdfwriter.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import
 
 import netCDF4
 import numpy

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -2,7 +2,6 @@
 """
 Module
 """
-from __future__ import absolute_import
 
 import pytest
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,6 @@
 """
 Module
 """
-from __future__ import absolute_import
 
 import configparser
 from textwrap import dedent

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import pytest
 import yaml
 

--- a/tests/ui/test_task_app.py
+++ b/tests/ui/test_task_app.py
@@ -2,7 +2,6 @@
 """
 Module
 """
-from __future__ import absolute_import
 
 from datacube.ui.task_app import task_app, run_tasks
 import datacube.executor

--- a/utils/USGS_precollection_oldscripts/ls_usgs_ard_prepare.py
+++ b/utils/USGS_precollection_oldscripts/ls_usgs_ard_prepare.py
@@ -2,7 +2,6 @@
 """
 Ingest data from the command-line.
 """
-from __future__ import absolute_import, division
 
 import logging
 import uuid

--- a/utils/USGS_precollection_oldscripts/usgs_ls_ard_prepare.py
+++ b/utils/USGS_precollection_oldscripts/usgs_ls_ard_prepare.py
@@ -2,7 +2,6 @@
 """
 Ingest data from the command-line.
 """
-from __future__ import absolute_import, division
 
 import logging
 import uuid

--- a/utils/USGS_precollection_oldscripts/usgslsprepare.py
+++ b/utils/USGS_precollection_oldscripts/usgslsprepare.py
@@ -2,7 +2,6 @@
 """
 Ingest data from the command-line.
 """
-from __future__ import absolute_import, division
 
 import logging
 import uuid

--- a/utils/alos2prepare.py
+++ b/utils/alos2prepare.py
@@ -2,9 +2,7 @@
 """
 Ingest data from the command-line.
 """
-from __future__ import absolute_import, division
 
-from __future__ import print_function
 import logging
 import uuid
 from xml.etree import ElementTree

--- a/utils/bom_rainfall_prepare.py
+++ b/utils/bom_rainfall_prepare.py
@@ -4,7 +4,6 @@ Ingest data from the command-line.
 
 python utils/bom_rainfall_prepare.py --output rainfall.yaml /g/data/rr5/agcd/0_05/rainfall/daily/*/*
 """
-from __future__ import absolute_import
 
 import uuid
 from dateutil.parser import parse

--- a/utils/demprepare.py
+++ b/utils/demprepare.py
@@ -2,7 +2,6 @@
 """
 Ingest data from the command-line.
 """
-from __future__ import absolute_import, division
 
 import uuid
 import logging

--- a/utils/galsprepare.py
+++ b/utils/galsprepare.py
@@ -2,7 +2,6 @@
 """
 Ingest data from the command-line.
 """
-from __future__ import absolute_import, division
 
 import logging
 import uuid

--- a/utils/h8prepare.py
+++ b/utils/h8prepare.py
@@ -2,7 +2,6 @@
 """
 Ingest data from the command-line.
 """
-from __future__ import absolute_import
 
 import uuid
 import logging

--- a/utils/ls8awsprepare.py
+++ b/utils/ls8awsprepare.py
@@ -2,7 +2,6 @@
 """
 Ingest data from the command-line.
 """
-from __future__ import absolute_import
 
 import uuid
 import logging

--- a/utils/ls_usgs_prepare.py
+++ b/utils/ls_usgs_prepare.py
@@ -1,7 +1,6 @@
 """
 Ingest data from the command-line.
 """
-from __future__ import absolute_import
 
 import uuid
 import logging

--- a/utils/ls_usgs_sr_l2.py
+++ b/utils/ls_usgs_sr_l2.py
@@ -2,7 +2,6 @@
 """
 Ingest data from the command-line.
 """
-from __future__ import absolute_import, division
 
 import logging
 import uuid

--- a/utils/modisprepare.py
+++ b/utils/modisprepare.py
@@ -2,7 +2,6 @@
 """
 Ingest data from the command-line.
 """
-from __future__ import absolute_import, division
 
 import uuid
 import logging

--- a/utils/nbartprepare.py
+++ b/utils/nbartprepare.py
@@ -2,7 +2,6 @@
 """
 Ingest data from the command-line.
 """
-from __future__ import absolute_import, division
 
 import logging
 from pathlib import Path

--- a/utils/radiometrics_prepare.py
+++ b/utils/radiometrics_prepare.py
@@ -4,7 +4,6 @@ Ingest data from the command-line.
 
 python utils/radiometrics_prepare.py --output radiometrics.yaml /g/data1/rr2/radiometrics/National/*/*nc
 """
-from __future__ import absolute_import
 
 import uuid
 from dateutil.parser import parse

--- a/utils/s1prepare.py
+++ b/utils/s1prepare.py
@@ -2,9 +2,7 @@
 """
 Ingest data from the command-line.
 """
-from __future__ import absolute_import, division
 
-from __future__ import print_function
 import logging
 import uuid
 from xml.etree import ElementTree

--- a/utils/s2awsprepare.py
+++ b/utils/s2awsprepare.py
@@ -2,7 +2,6 @@
 """
 Ingest data from the command-line.
 """
-from __future__ import absolute_import
 
 import uuid
 import logging

--- a/utils/s2peps_prepare.py
+++ b/utils/s2peps_prepare.py
@@ -2,7 +2,6 @@
 """
 Ingest data from the command-line.
 """
-from __future__ import absolute_import
 
 import uuid
 import logging

--- a/utils/s2prepare.py
+++ b/utils/s2prepare.py
@@ -2,7 +2,6 @@
 """
 Ingest data from the command-line.
 """
-from __future__ import absolute_import
 
 import uuid
 import logging

--- a/utils/s2prepare_cophub_zip.py
+++ b/utils/s2prepare_cophub_zip.py
@@ -9,7 +9,6 @@ example usage:
     S2A_OPER_PRD_MSIL1C_PDMC_20161017T123606_R018_V20161016T034742_20161016T034739.zip
     --output /s2_testing/ --no-checksum
 """
-from __future__ import absolute_import
 
 import hashlib
 import logging

--- a/utils/sen2cor_prepare.py
+++ b/utils/sen2cor_prepare.py
@@ -2,7 +2,6 @@
 """
 Ingest data from the command-line.
 """
-from __future__ import absolute_import
 
 import uuid
 import logging

--- a/utils/srtm_dem1sv1_0_prepare.py
+++ b/utils/srtm_dem1sv1_0_prepare.py
@@ -5,7 +5,6 @@ Ingest data from the command-line.
 python srtm_prepare.py --output Elevation_1secSRTM_DEMs_v1.0_DEM_Mosaic_dem1sv1_0.yaml \
  /g/data/rr1/Elevation/NetCDF/1secSRTM_DEMs_v1.0/DEM/Elevation_1secSRTM_DEMs_v1.0_DEM_Mosaic_dem1sv1_0.nc
 """
-from __future__ import absolute_import
 
 import uuid
 from dateutil.parser import parse

--- a/utils/srtm_prepare.py
+++ b/utils/srtm_prepare.py
@@ -5,7 +5,6 @@ Ingest data from the command-line.
 python srtm_prepare.py --output Elevation_1secSRTM_DEMs_v1.0_DEM_Mosaic_dem1sv1_0.yaml \
   /g/data/rr1/Elevation/NetCDF/1secSRTM_DEMs_v1.0/DEM/Elevation_1secSRTM_DEMs_v1.0_DEM_Mosaic_dem1sv1_0.nc
 """
-from __future__ import absolute_import
 
 import uuid
 from dateutil.parser import parse

--- a/versioneer.py
+++ b/versioneer.py
@@ -348,7 +348,6 @@ https://creativecommons.org/publicdomain/zero/1.0/ .
 
 """
 
-from __future__ import print_function
 try:
     import configparser
 except ImportError:


### PR DESCRIPTION
### Reason for this pull request

Not supporting python2 so get rid of python2 left overs

### Proposed changes

- remove imports from `__future__`
