### PR TITLE
IO driver interface change

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -11,6 +11,7 @@ from dask import array as da
 
 from datacube.config import LocalConfig
 from datacube.storage.storage import reproject_and_fuse
+from datacube.storage import BandInfo
 from datacube.utils import geometry
 from datacube.utils.geometry import intersects
 from .query import Query, query_group_by, query_geopolygon
@@ -617,7 +618,7 @@ def fuse_lazy(datasets, geobox, measurement, skip_broken_datasets=False, prepend
 
 def _fuse_measurement(dest, datasets, geobox, measurement,
                       skip_broken_datasets=False):
-    reproject_and_fuse([new_datasource(dataset, measurement.name) for dataset in datasets],
+    reproject_and_fuse([new_datasource(BandInfo(dataset, measurement.name)) for dataset in datasets],
                        dest,
                        geobox,
                        dest.dtype.type(measurement.nodata),

--- a/datacube/drivers/datasource.py
+++ b/datacube/drivers/datasource.py
@@ -22,33 +22,33 @@ class GeoRasterReader(object, metaclass=ABCMeta):
     @property
     @abstractmethod
     def crs(self):
-        ...
+        ...  # pragma: no cover
 
     @property
     @abstractmethod
     def transform(self) -> Optional[Affine]:
-        ...
+        ...  # pragma: no cover
 
     @property
     @abstractmethod
     def dtype(self) -> Union[str, np.dtype]:
-        ...
+        ...  # pragma: no cover
 
     @property
     @abstractmethod
     def shape(self) -> RasterShape:
-        ...
+        ...  # pragma: no cover
 
     @property
     @abstractmethod
     def nodata(self) -> Optional[Union[int, float]]:
-        ...
+        ...  # pragma: no cover
 
     @abstractmethod
     def read(self,
              window: Optional[RasterWindow] = None,
              out_shape: Optional[RasterShape] = None) -> Optional[np.ndarray]:
-        ...
+        ...  # pragma: no cover
 
 
 class DataSource(object, metaclass=ABCMeta):
@@ -58,4 +58,4 @@ class DataSource(object, metaclass=ABCMeta):
     @abstractmethod
     @contextmanager
     def open(self) -> Iterator[GeoRasterReader]:
-        ...
+        ...  # pragma: no cover

--- a/datacube/drivers/datasource.py
+++ b/datacube/drivers/datasource.py
@@ -1,15 +1,61 @@
-"""Module containing the abstract `DatasetSource` class to be implemented by
-all storage drivers.
+""" Defines abstract types for IO reader drivers.
 """
 from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
+import numpy as np
+from affine import Affine
+from typing import Tuple, Iterator, Optional, Union
+
+
+RasterShape = Tuple[int, int]                 # pylint: disable=invalid-name
+RasterWindow = Union[                         # pylint: disable=invalid-name
+    Tuple[Tuple[int, int], Tuple[int, int]],
+    Tuple[slice, slice]]
+
+# pylint: disable=pointless-statement
+
+
+class GeoRasterReader(object, metaclass=ABCMeta):
+    """ Abstract base class for dataset reader.
+    """
+
+    @property
+    @abstractmethod
+    def crs(self):
+        ...
+
+    @property
+    @abstractmethod
+    def transform(self) -> Optional[Affine]:
+        ...
+
+    @property
+    @abstractmethod
+    def dtype(self) -> Union[str, np.dtype]:
+        ...
+
+    @property
+    @abstractmethod
+    def shape(self) -> RasterShape:
+        ...
+
+    @property
+    @abstractmethod
+    def nodata(self) -> Optional[Union[int, float]]:
+        ...
+
+    @abstractmethod
+    def read(self,
+             window: Optional[RasterWindow] = None,
+             out_shape: Optional[RasterShape] = None) -> Optional[np.ndarray]:
+        ...
 
 
 class DataSource(object, metaclass=ABCMeta):
-    """Abstract base class for dataset source.
+    """ Abstract base class for dataset source.
     """
 
     @abstractmethod
     @contextmanager
-    def open(self):
-        return None
+    def open(self) -> Iterator[GeoRasterReader]:
+        ...

--- a/datacube/drivers/driver_cache.py
+++ b/datacube/drivers/driver_cache.py
@@ -1,12 +1,12 @@
-
 import logging
+from typing import Mapping, Any, Tuple, Iterable
 
 from pkg_resources import iter_entry_points, DistributionNotFound
 
 _LOG = logging.getLogger(__name__)
 
 
-def load_drivers(group):
+def load_drivers(group: str) -> Mapping[str, Any]:
     """
     Load available drivers for a given group name.
 
@@ -18,7 +18,7 @@ def load_drivers(group):
      By having driver entry_points pointing to a function, we defer loading the driver
      module or running any code until required.
 
-    :param str group: Name of the entry point group e.g. "datacube.plugins.io.read"
+    :param group: Name of the entry point group e.g. "datacube.plugins.io.read"
 
     :returns: Dictionary String -> Driver Object
     """
@@ -38,7 +38,7 @@ def load_drivers(group):
 
         try:
             driver = driver_init()
-        except:
+        except Exception:
             _LOG.warning('Exception during driver init, driver name: %s::%s', group, ep.name)
             return None
 
@@ -47,7 +47,7 @@ def load_drivers(group):
 
         return driver
 
-    def resolve_all(group):
+    def resolve_all(group: str) -> Iterable[Tuple[str, Any]]:
         for ep in iter_entry_points(group=group, name=None):
             driver = safe_load(ep)
             if driver is not None:

--- a/datacube/drivers/netcdf/driver.py
+++ b/datacube/drivers/netcdf/driver.py
@@ -14,8 +14,8 @@ class NetcdfReaderDriver(object):
         return (protocol in self.protocols and
                 fmt in self.formats)
 
-    def new_datasource(self, dataset, band_name):
-        return RasterDatasetDataSource(dataset, band_name)
+    def new_datasource(self, band):
+        return RasterDatasetDataSource(band)
 
 
 def reader_driver_init():

--- a/datacube/drivers/postgres/_fields.py
+++ b/datacube/drivers/postgres/_fields.py
@@ -16,7 +16,7 @@ from sqlalchemy.dialects.postgresql import NUMRANGE, TSTZRANGE
 from sqlalchemy.sql import ColumnElement
 
 from datacube import utils
-from datacube.index.fields import Expression, Field
+from datacube.model.fields import Expression, Field
 from datacube.model import Range
 from datacube.utils import get_doc_offset_safe
 from .sql import FLOAT8RANGE

--- a/datacube/drivers/readers.py
+++ b/datacube/drivers/readers.py
@@ -1,9 +1,13 @@
-
+from typing import List, Optional, Callable
 from .driver_cache import load_drivers
+from .datasource import DataSource
+from datacube.model import Dataset
+
+DatasourceFactory = Callable[[Dataset, str], DataSource]  # pylint: disable=invalid-name
 
 
 class ReaderDriverCache(object):
-    def __init__(self, group):
+    def __init__(self, group: str):
         self._drivers = load_drivers(group)
 
         lookup = {}
@@ -16,43 +20,49 @@ class ReaderDriverCache(object):
 
         self._lookup = lookup
 
-    def _find_driver(self, uri_scheme, fmt):
+    def _find_driver(self, uri_scheme: str, fmt: str):
         key = (uri_scheme.lower(), fmt.lower())
         return self._lookup.get(key)
 
-    def __call__(self, uri_scheme, fmt, fallback=None):
+    def __call__(self, uri_scheme: str, fmt: str,
+                 fallback: Optional[DatasourceFactory] = None) -> DatasourceFactory:
         """Lookup `new_datasource` constructor method from the driver. Returns
         `fallback` method if no driver is found.
 
-        :param str uri_scheme: Protocol part of the Dataset uri
-        :param str fmt: Dataset format
+        :param uri_scheme: Protocol part of the Dataset uri
+        :param fmt: Dataset format
         :return: Returns function `(DataSet, band_name:str) => DataSource`
         """
         driver = self._find_driver(uri_scheme, fmt)
-        return fallback if driver is None else driver.new_datasource
+        if driver is not None:
+            return driver.new_datasource
+        if fallback is not None:
+            return fallback
+        else:
+            raise KeyError("No driver found and no fallback provided")
 
-    def drivers(self):
+    def drivers(self) -> List[str]:
         """ Returns list of driver names
         """
         return list(self._drivers.keys())
 
 
-def rdr_cache():
+def rdr_cache() -> ReaderDriverCache:
     """ Singleton for ReaderDriverCache
     """
     # pylint: disable=protected-access
     if not hasattr(rdr_cache, '_instance'):
-        rdr_cache._instance = ReaderDriverCache('datacube.plugins.io.read')
-    return rdr_cache._instance
+        rdr_cache._instance = ReaderDriverCache('datacube.plugins.io.read')  # type: ignore
+    return rdr_cache._instance  # type: ignore
 
 
-def reader_drivers():
+def reader_drivers() -> List[str]:
     """ Returns list driver names
     """
     return rdr_cache().drivers()
 
 
-def choose_datasource(dataset):
+def choose_datasource(dataset: Dataset) -> DatasourceFactory:
     """Returns appropriate `DataSource` class (or a constructor method) for loading
     given `dataset`.
 
@@ -66,11 +76,11 @@ def choose_datasource(dataset):
     NOTE: we assume that all bands can be loaded with the same implementation.
 
     """
-    from ..storage.storage import RasterDatasetDataSource
+    from datacube.storage.storage import RasterDatasetDataSource
     return rdr_cache()(dataset.uri_scheme, dataset.format, fallback=RasterDatasetDataSource)
 
 
-def new_datasource(dataset, band_name=None):
+def new_datasource(dataset: Dataset, band_name: str) -> Optional[DataSource]:
     """Returns a newly constructed data source to read dataset band data.
 
     An appropriate `DataSource` implementation is chosen based on:

--- a/datacube/drivers/readers.py
+++ b/datacube/drivers/readers.py
@@ -1,9 +1,9 @@
 from typing import List, Optional, Callable
 from .driver_cache import load_drivers
 from .datasource import DataSource
-from datacube.model import Dataset
+from datacube.storage._base import BandInfo
 
-DatasourceFactory = Callable[[Dataset, str], DataSource]  # pylint: disable=invalid-name
+DatasourceFactory = Callable[[BandInfo], DataSource]  # pylint: disable=invalid-name
 
 
 class ReaderDriverCache(object):
@@ -62,7 +62,7 @@ def reader_drivers() -> List[str]:
     return rdr_cache().drivers()
 
 
-def choose_datasource(dataset: Dataset) -> DatasourceFactory:
+def choose_datasource(band: 'BandInfo') -> DatasourceFactory:
     """Returns appropriate `DataSource` class (or a constructor method) for loading
     given `dataset`.
 
@@ -77,10 +77,10 @@ def choose_datasource(dataset: Dataset) -> DatasourceFactory:
 
     """
     from datacube.storage.storage import RasterDatasetDataSource
-    return rdr_cache()(dataset.uri_scheme, dataset.format, fallback=RasterDatasetDataSource)
+    return rdr_cache()(band.uri_scheme, band.format, fallback=RasterDatasetDataSource)
 
 
-def new_datasource(dataset: Dataset, band_name: str) -> Optional[DataSource]:
+def new_datasource(band: BandInfo) -> Optional[DataSource]:
     """Returns a newly constructed data source to read dataset band data.
 
     An appropriate `DataSource` implementation is chosen based on:
@@ -98,9 +98,9 @@ def new_datasource(dataset: Dataset, band_name: str) -> Optional[DataSource]:
 
     """
 
-    source_type = choose_datasource(dataset)
+    source_type = choose_datasource(band)
 
     if source_type is None:
         return None
 
-    return source_type(dataset, band_name)
+    return source_type(band)

--- a/datacube/drivers/s3/datasource.py
+++ b/datacube/drivers/s3/datasource.py
@@ -1,16 +1,16 @@
 """A module offering an S3 datasource that mimicks the existing NetCDF
 datasource behaviour.
 """
-
-
 import logging
 from contextlib import contextmanager
+from typing import Dict, Any
 
 from affine import Affine
 from numpy import dtype
 
 from datacube.drivers.datasource import DataSource
 from datacube.storage.storage import OverrideBandDataSource
+from datacube.storage import BandInfo
 from datacube.utils import datetime_to_seconds_since_1970
 from .utils import DriverUtils
 
@@ -42,23 +42,24 @@ class S3Source(object):
             """
             return self.parent.read(indexes, window, out_shape)
 
-    def __init__(self, dataset, band_name, storage):
+    def __init__(self, band: BandInfo, storage):
         """Initialise the data reader.
 
-        :param datacube.model.Dataset dataset: The dataset to be read.
-        :param str band_name: The name of the band to read in the
-          dataset, e.g. 'blue'.
+        :param band: The band from dataset to be read.
         :param datacube.drivers.s3.storage.s3aio.s3lio storage: The s3
           storage used by the s3 driver.
         """
+        if band.driver_data is None:
+            raise ValueError("Missing driver data")
+
         self.logger = logging.getLogger(self.__class__.__name__)
         self.storage = storage
-        self.dataset = dataset
-        self.band_name = band_name
+        self.band = band
+        self.s3_metadata = band.driver_data  # type: Dict[str, Any]
         self.ds = self.S3DS(self)
         self.bidx = 1  # Called but unused in s3
-        self.shape = dataset.s3_metadata[band_name]['s3_dataset'].macro_shape[-2:]
-        self.dtype = dtype(dataset.s3_metadata[band_name]['s3_dataset'].numpy_type)
+        self.shape = self.s3_metadata[band.name]['s3_dataset'].macro_shape[-2:]
+        self.dtype = dtype(self.s3_metadata[band.name]['s3_dataset'].numpy_type)
 
     def read(self, indexes, window, write_shape):
         """Read a dataset slice from the storage.
@@ -73,7 +74,7 @@ class S3Source(object):
           :class:`datacube.storage.storage.OverrideBandDataSource`
           calls.
         """
-        s3_dataset = self.dataset.s3_metadata[self.band_name]['s3_dataset']
+        s3_dataset = self.s3_metadata[self.band.name]['s3_dataset']
         if isinstance(window, S3Source) or window is None:
             slices = tuple([slice(0, a) for a in s3_dataset.macro_shape[-2:]])
         else:
@@ -95,20 +96,22 @@ class S3Source(object):
 class S3DataSource(DataSource):
     """Data source for reading from a Datacube Dataset."""
 
-    def __init__(self, dataset, band_name, storage):
+    def __init__(self, band: BandInfo, storage):
         """Prepare to read from the data source.
 
-        :param datacube.model.Dataset dataset: The dataset to be read.
-        :param str band_name: The name of the band to read in the
-          dataset, e.g. 'blue'.
+        :param band: The band of a dataset to be read.
         :param datacube.drivers.s3.storage.s3aio.s3lio storage: The s3
           storage used by the s3 driver.
         """
+        if band.driver_data is None:
+            raise ValueError("Missing driver data")
+
         self.logger = logging.getLogger(self.__class__.__name__)
-        self._dataset = dataset
-        self.source = S3Source(dataset, band_name, storage)
-        self.nodata = dataset.type.measurements[band_name].get('nodata')
-        self.macro_shape = dataset.s3_metadata[band_name]['s3_dataset'].macro_shape[1:]  # Do NOT use time here
+        self._s3_metadata = band.driver_data  # type: Dict[str, Any]
+        self._band = band
+        self.source = S3Source(band, storage)
+        self.nodata = band.nodata
+        self.macro_shape = self._s3_metadata[band.name]['s3_dataset'].macro_shape[1:]  # Do NOT use time here
 
     @contextmanager
     def open(self):
@@ -126,9 +129,9 @@ class S3DataSource(DataSource):
                                      transform=self.get_transform(self.macro_shape))
 
     def get_bandnumber(self):
-        time = self._dataset.center_time
+        time = self._band.center_time
         sec_since_1970 = datetime_to_seconds_since_1970(time)
-        s3_dataset = self._dataset.s3_metadata[self.source.band_name]['s3_dataset']
+        s3_dataset = self._s3_metadata[self._band.name]['s3_dataset']
 
         if s3_dataset.regular_dims[0]:  # If time is regular
             return int((sec_since_1970 - s3_dataset.regular_index[0]) / s3_dataset.regular_index[2])
@@ -145,11 +148,11 @@ class S3DataSource(DataSource):
         :param shape: The factor to rescale the transform by.
         :return: The scaled dataset.
         """
-        return self._dataset.transform * Affine.scale(1.0 / shape[1], 1.0 / shape[0])
+        return self._band.transform * Affine.scale(1.0 / shape[1], 1.0 / shape[0])
 
     def get_crs(self):
         """The dataset CRS.
 
         :return: The CRS of the dataset.
         """
-        return self._dataset.crs
+        return self._band.crs

--- a/datacube/drivers/s3/driver.py
+++ b/datacube/drivers/s3/driver.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from datacube.drivers.s3.datasource import S3DataSource
 from datacube.drivers.s3.storage.s3aio.s3lio import S3LIO
+from datacube.storage import BandInfo
 from .utils import DriverUtils
 from datacube.utils import DatacubeException
 
@@ -214,8 +215,8 @@ class S3ReaderDriver(object):
         return (protocol in self.protocols and
                 fmt in self.formats)
 
-    def new_datasource(self, dataset, band_name):
-        return S3DataSource(dataset, band_name, self._storage)
+    def new_datasource(self, band: BandInfo):
+        return S3DataSource(band, self._storage)
 
 
 def reader_driver_init():

--- a/datacube/execution/worker.py
+++ b/datacube/execution/worker.py
@@ -40,7 +40,7 @@ def launch_distributed_worker(host, port, nprocs, nthreads=1):
 
 
 @click.command(name='worker')
-@click.option('--executor', type=(click.Choice(KNOWN_WORKER_TYPES), str),
+@click.option('--executor', type=(click.Choice(KNOWN_WORKER_TYPES), str),  # type: ignore
               help="(distributed|dask(alias for distributed)|celery) host:port",
               default=(None, None),
               callback=parse_executor_opt)

--- a/datacube/index/fields.py
+++ b/datacube/index/fields.py
@@ -4,78 +4,22 @@ Common datatypes for DB drivers.
 """
 
 from datetime import date, datetime, time
-
 from dateutil.tz import tz
+from typing import List
 
 from datacube.model import Range
+from datacube.model.fields import Expression, Field
+
+__all__ = ['Field',
+           'Expression',
+           'OrExpression',
+           'UnknownFieldError',
+           'to_expressions',
+           'as_expression']
 
 
 class UnknownFieldError(Exception):
     pass
-
-
-# Allowed values for field 'type' (specified in a metadata type docuemnt)
-_AVAILABLE_TYPE_NAMES = (
-    'numeric-range',
-    'double-range',
-    'integer-range',
-    'datetime-range',
-
-    'string',
-    'numeric',
-    'double',
-    'integer',
-    'datetime',
-
-    # For backwards compatibility (alias for numeric-range)
-    'float-range',
-)
-
-
-class Field(object):
-    """
-    A searchable field within a dataset/storage metadata document.
-    """
-    # type of field.
-    # If type is not specified, the field is a string
-    # This should always be one of _AVAILABLE_TYPE_NAMES
-    type_name = 'string'
-
-    def __init__(self, name: str, description: str):
-        self.name = name
-
-        self.description = description
-
-        # Does selecting this affect the output rows?
-        # (eg. Does this join other tables that aren't 1:1 with datasets.)
-        self.affects_row_selection = False
-
-        assert self.type_name in _AVAILABLE_TYPE_NAMES, "Invalid type name %r" % (self.type_name,)
-
-    def __eq__(self, value):
-        """
-        Is this field equal to a value?
-        :rtype: Expression
-        """
-        raise NotImplementedError('equals expression')
-
-    def between(self, low, high):
-        """
-        Is this field in a range?
-        :rtype: Expression
-        """
-        raise NotImplementedError('between expression')
-
-
-class Expression(object):
-    # No properties at the moment. These are built and returned by the
-    # DB driver (from Field methods), so they're mostly an opaque token.
-
-    # A simple equals implementation for comparison in test code.
-    def __eq__(self, other):
-        if self.__class__ != other.__class__:
-            return False
-        return self.__dict__ == other.__dict__
 
 
 class OrExpression(Expression):
@@ -87,7 +31,7 @@ class OrExpression(Expression):
         return any(expr.evaluate(ctx) for expr in self.exprs)
 
 
-def as_expression(field, value):
+def as_expression(field: Field, value) -> Expression:
     """
     Convert a single field/value to expression, following the "simple" convensions.
     """
@@ -107,7 +51,7 @@ def as_expression(field, value):
     return field == value
 
 
-def _to_expression(get_field, name, value):
+def _to_expression(get_field, name: str, value) -> Expression:
     field = get_field(name)
     if field is None:
         raise UnknownFieldError('Unknown field %r' % name)
@@ -115,11 +59,10 @@ def _to_expression(get_field, name, value):
     return as_expression(field, value)
 
 
-def to_expressions(get_field, **query):
+def to_expressions(get_field, **query) -> List[Expression]:
     """
     Convert a simple query (dict of param names and values) to expression objects.
     :type get_field: (str) -> Field
     :type query: dict[str,str|float|datacube.model.Range]
-    :rtype: list[Expression]
     """
     return [_to_expression(get_field, name, value) for name, value in query.items()]

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -370,7 +370,7 @@ class MetadataType(object):
 
     def __init__(self,
                  definition: Mapping[str, Any],
-                 dataset_search_fields: Mapping[str, Any],
+                 dataset_search_fields: Mapping[str, Field],
                  id_: Optional[int] = None):
         self.definition = definition
         self.dataset_fields = dataset_search_fields

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -121,15 +121,17 @@ class Dataset(object):
         self.archived_time = archived_time
 
     @property
-    def metadata_type(self):
+    def metadata_type(self) -> Optional['MetadataType']:
         return self.type.metadata_type if self.type else None
 
     @property
-    def local_uri(self):
+    def local_uri(self) -> Optional[str]:
         """
         The latest local file uri, if any.
-        :rtype: str
         """
+        if self.uris is None:
+            return None
+
         local_uris = [uri for uri in self.uris if uri.startswith('file:')]
         if local_uris:
             return local_uris[0]
@@ -137,28 +139,25 @@ class Dataset(object):
         return None
 
     @property
-    def local_path(self):
+    def local_path(self) -> Optional[Path]:
         """
         A path to this dataset on the local filesystem (if available).
-
-        :rtype: pathlib.Path
         """
         return uri_to_local_path(self.local_uri)
 
     @property
-    def id(self):
-        """
-        :rtype: UUID
+    def id(self) -> UUID:
+        """ UUID of a dataset
         """
         # This is a string in a raw document.
         return UUID(self.metadata.id)
 
     @property
-    def managed(self):
+    def managed(self) -> bool:
         return self.type.managed
 
     @property
-    def format(self):
+    def format(self) -> str:
         return self.metadata.format
 
     @property

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -5,7 +5,7 @@ Core classes used across modules.
 import logging
 import math
 import warnings
-from collections import namedtuple, OrderedDict, Sequence
+from collections import OrderedDict, Sequence
 from datetime import datetime
 from pathlib import Path
 from uuid import UUID
@@ -22,12 +22,10 @@ from datacube.utils.geometry import (CRS as _CRS,
                                      Coordinate as _Coordinate,
                                      BoundingBox as _BoundingBox, intersects)
 from datacube.utils.serialise import SafeDatacubeDumper
+from .fields import Field
+from ._base import Range, Variable
 
 _LOG = logging.getLogger(__name__)
-
-Range = namedtuple('Range', ('begin', 'end'))
-Variable = namedtuple('Variable', ('dtype', 'nodata', 'dims', 'units'))
-CellIndex = namedtuple('CellIndex', ('x', 'y'))
 
 NETCDF_VAR_OPTIONS = {'zlib', 'complevel', 'shuffle', 'fletcher32', 'contiguous'}
 VALID_VARIABLE_ATTRS = {'standard_name', 'long_name', 'units', 'flags_definition'}
@@ -372,7 +370,7 @@ class MetadataType(object):
 
     def __init__(self,
                  definition: Mapping[str, Any],
-                 dataset_search_fields, #: Mapping[str, datacube.index.fields.Field],
+                 dataset_search_fields: Mapping[str, Any],
                  id_: Optional[int] = None):
         self.definition = definition
         self.dataset_fields = dataset_search_fields
@@ -386,7 +384,7 @@ class MetadataType(object):
     def description(self) -> str:
         return self.definition['description']
 
-    def dataset_reader(self, dataset_doc: Mapping[str, Any]) -> DocReader:
+    def dataset_reader(self, dataset_doc: Mapping[str, Field]) -> DocReader:
         return DocReader(self.definition['dataset'], self.dataset_fields, dataset_doc)
 
     def __str__(self) -> str:

--- a/datacube/model/_base.py
+++ b/datacube/model/_base.py
@@ -1,0 +1,5 @@
+from collections import namedtuple
+
+Range = namedtuple('Range', ('begin', 'end'))
+Variable = namedtuple('Variable', ('dtype', 'nodata', 'dims', 'units'))
+CellIndex = namedtuple('CellIndex', ('x', 'y'))

--- a/datacube/model/fields.py
+++ b/datacube/model/fields.py
@@ -5,7 +5,70 @@ This allows extraction of fields of interest from dataset metadata document.
 import toolz
 import decimal
 from datacube.utils import parse_time
-from datacube.model import Range
+from ._base import Range
+
+# Allowed values for field 'type' (specified in a metadata type docuemnt)
+_AVAILABLE_TYPE_NAMES = (
+    'numeric-range',
+    'double-range',
+    'integer-range',
+    'datetime-range',
+
+    'string',
+    'numeric',
+    'double',
+    'integer',
+    'datetime',
+
+    # For backwards compatibility (alias for numeric-range)
+    'float-range',
+)
+
+
+class Expression(object):
+    # No properties at the moment. These are built and returned by the
+    # DB driver (from Field methods), so they're mostly an opaque token.
+
+    # A simple equals implementation for comparison in test code.
+    def __eq__(self, other) -> bool:
+        if self.__class__ != other.__class__:
+            return False
+        return self.__dict__ == other.__dict__
+
+
+class Field(object):
+    """
+    A searchable field within a dataset/storage metadata document.
+    """
+    # type of field.
+    # If type is not specified, the field is a string
+    # This should always be one of _AVAILABLE_TYPE_NAMES
+    type_name = 'string'
+
+    def __init__(self, name: str, description: str):
+        self.name = name
+
+        self.description = description
+
+        # Does selecting this affect the output rows?
+        # (eg. Does this join other tables that aren't 1:1 with datasets.)
+        self.affects_row_selection = False
+
+        assert self.type_name in _AVAILABLE_TYPE_NAMES, "Invalid type name %r" % (self.type_name,)
+
+    def __eq__(self, value) -> Expression:  # type: ignore
+        """
+        Is this field equal to a value?
+
+        this returns an Expression object (hence type ignore above)
+        """
+        raise NotImplementedError('equals expression')
+
+    def between(self, low, high) -> Expression:
+        """
+        Is this field in a range?
+        """
+        raise NotImplementedError('between expression')
 
 
 class SimpleField(object):

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -4,7 +4,7 @@ import datetime
 import logging
 import sys
 from collections import OrderedDict
-from typing import Iterable
+from typing import Iterable, Mapping, MutableMapping, Any
 
 import click
 import yaml
@@ -298,13 +298,13 @@ def build_dataset_info(index: Index, dataset: Dataset,
                        show_sources: bool = False,
                        show_derived: bool = False,
                        depth: int = 1,
-                       max_depth: int = 99) -> dict:
+                       max_depth: int = 99) -> Mapping[str, Any]:
 
     info = OrderedDict((
         ('id', str(dataset.id)),
         ('product', dataset.type.name),
         ('status', 'archived' if dataset.is_archived else 'active')
-    ))
+    ))  # type: MutableMapping[str, Any]
 
     # Optional when loading a dataset.
     if dataset.indexed_time is not None:
@@ -314,7 +314,7 @@ def build_dataset_info(index: Index, dataset: Dataset,
     info['fields'] = dataset.metadata.search_fields
 
     if depth < max_depth:
-        if show_sources:
+        if show_sources and dataset.sources is not None:
             info['sources'] = {key: build_dataset_info(index, source,
                                                        show_sources=True, show_derived=False,
                                                        depth=depth + 1, max_depth=max_depth)

--- a/datacube/storage/__init__.py
+++ b/datacube/storage/__init__.py
@@ -4,3 +4,14 @@ Modules for creating and accessing Data Store Units
 
 
 """
+
+from ..drivers.datasource import (
+    DataSource,
+    GeoRasterReader,
+    RasterShape,
+    RasterWindow)
+
+__all__ = ['DataSource',
+           'GeoRasterReader',
+           'RasterShape',
+           'RasterWindow']

--- a/datacube/storage/__init__.py
+++ b/datacube/storage/__init__.py
@@ -11,10 +11,13 @@ from ..drivers.datasource import (
     RasterShape,
     RasterWindow)
 
-from ._base import BandInfo
+from ._base import BandInfo, measurement_paths
 
-__all__ = ['BandInfo',
-           'DataSource',
-           'GeoRasterReader',
-           'RasterShape',
-           'RasterWindow']
+__all__ = (
+    'BandInfo',
+    'DataSource',
+    'GeoRasterReader',
+    'RasterShape',
+    'RasterWindow',
+    'measurement_paths',
+)

--- a/datacube/storage/__init__.py
+++ b/datacube/storage/__init__.py
@@ -11,7 +11,10 @@ from ..drivers.datasource import (
     RasterShape,
     RasterWindow)
 
-__all__ = ['DataSource',
+from ._base import BandInfo
+
+__all__ = ['BandInfo',
+           'DataSource',
            'GeoRasterReader',
            'RasterShape',
            'RasterWindow']

--- a/datacube/storage/_base.py
+++ b/datacube/storage/_base.py
@@ -46,6 +46,21 @@ def _extract_driver_data(ds: Dataset) -> Optional[Any]:
     return dd
 
 
+def measurement_paths(ds: Dataset) -> Dict[str, str]:
+    """
+    Returns a dictionary mapping from band name to url pointing to band storage
+    resource.
+
+    :return: Band Name => URL
+    """
+    if ds.uris is None:
+        raise ValueError('No locations on this dataset')
+
+    base = pick_uri(ds.uris)
+    return dict((k, uri_resolve(base, m.get('path')))
+                for k, m in ds.measurements.items())
+
+
 class BandInfo:
     __slots__ = ('name',
                  'uri',

--- a/datacube/storage/_base.py
+++ b/datacube/storage/_base.py
@@ -57,6 +57,7 @@ class BandInfo:
                  'crs',
                  'transform',
                  'center_time',
+                 'format',
                  'driver_data')
 
     def __init__(self,
@@ -86,4 +87,5 @@ class BandInfo:
         self.crs = ds.crs
         self.transform = ds.transform
         self.center_time = ds.center_time
+        self.format = ds.format
         self.driver_data = _extract_driver_data(ds)

--- a/datacube/storage/_base.py
+++ b/datacube/storage/_base.py
@@ -1,0 +1,89 @@
+from typing import Optional, Dict, Any, Tuple
+from datacube.model import Dataset
+from datacube.utils.uris import uri_resolve, pick_uri
+
+
+def _get_band_and_layer(b: Dict[str, Any]) -> Tuple[Optional[int], Optional[str]]:
+    """ Encode legacy logic for extracting band/layer:
+
+        on input:
+        band -- Int | Nothing
+        layer -- Str | Int | Nothing
+
+    Valid combinations are:
+        band  layer  Output
+    ---------------------------
+          -     -    ( - ,  - )
+          -    int   (int,  - )
+         int    -    (int,  - )
+         int   str   (int, str)
+          -    str   ( - , str)
+
+    """
+    band = b.get('band')
+    layer = b.get('layer')
+
+    if band is None:
+        if isinstance(layer, int):
+            return (layer, None)
+        if layer is None or isinstance(layer, str):
+            return (None, layer)
+
+        raise ValueError('Expect `layer` to be one of None,int,str but it is {}'.format(type(layer)))
+    else:
+        if not isinstance(band, int):
+            raise ValueError('Expect `band` to be an integer (it is {})'.format(type(band)))
+        if layer is not None and not isinstance(layer, str):
+            raise ValueError('Expect `layer` to be one of None,str but it is {}'.format(type(layer)))
+
+        return (band, layer)
+
+
+def _extract_driver_data(ds: Dataset) -> Optional[Any]:
+    dd = getattr(ds, 'driver_data', None)
+    if dd is None:
+        dd = getattr(ds, 's3_metadata', None)  # TODO: change CSIRO driver to populate `driver_data`
+    return dd
+
+
+class BandInfo:
+    __slots__ = ('name',
+                 'uri',
+                 'band',
+                 'layer',
+                 'dtype',
+                 'nodata',
+                 'units',
+                 'crs',
+                 'transform',
+                 'center_time',
+                 'driver_data')
+
+    def __init__(self,
+                 ds: Dataset,
+                 band: str,
+                 uri_scheme: Optional[str] = None):
+        mm = ds.measurements.get(band)
+        mp = ds.type.measurements.get(band)
+
+        if mm is None or mp is None:
+            raise ValueError('No such band: {}'.format(band))
+
+        if ds.uris is None:
+            raise ValueError('No uris defined on a dataset')
+
+        base_uri = pick_uri(ds.uris, uri_scheme)
+
+        bint, layer = _get_band_and_layer(mm)
+
+        self.name = band
+        self.uri = uri_resolve(base_uri, mm.get('path'))
+        self.band = bint
+        self.layer = layer
+        self.dtype = mp.dtype
+        self.nodata = mp.nodata
+        self.units = mp.units
+        self.crs = ds.crs
+        self.transform = ds.transform
+        self.center_time = ds.center_time
+        self.driver_data = _extract_driver_data(ds)

--- a/datacube/storage/_base.py
+++ b/datacube/storage/_base.py
@@ -1,4 +1,6 @@
 from typing import Optional, Dict, Any, Tuple
+from urllib.parse import urlparse
+
 from datacube.model import Dataset
 from datacube.utils.uris import uri_resolve, pick_uri
 
@@ -104,3 +106,7 @@ class BandInfo:
         self.center_time = ds.center_time
         self.format = ds.format
         self.driver_data = _extract_driver_data(ds)
+
+    @property
+    def uri_scheme(self) -> str:
+        return urlparse(self.uri).scheme

--- a/datacube/storage/_read.py
+++ b/datacube/storage/_read.py
@@ -17,11 +17,11 @@ from ..utils.geometry import (
     rio_reproject,
     compute_reproject_roi)
 
-from ..utils.geometry._warp import is_resampling_nn
+from ..utils.geometry._warp import is_resampling_nn, Resampling, Nodata
 from ..utils.geometry import gbox as gbx
 
 
-def rdr_geobox(rdr):
+def rdr_geobox(rdr) -> GeoBox:
     """ Construct GeoBox from opened dataset reader.
     """
     h, w = rdr.shape
@@ -105,7 +105,11 @@ def pick_read_scale(scale: float, rdr=None, tol=1e-3):
     return scale
 
 
-def read_time_slice(rdr, dst, dst_gbox: GeoBox, resampling, dst_nodata) -> Tuple[slice, slice]:
+def read_time_slice(rdr,
+                    dst: np.ndarray,
+                    dst_gbox: GeoBox,
+                    resampling: Resampling,
+                    dst_nodata: Nodata) -> Tuple[slice, slice]:
     """ From opened reader object read into `dst`
 
     :returns: affected destination region

--- a/datacube/storage/storage.py
+++ b/datacube/storage/storage.py
@@ -241,19 +241,18 @@ class RasterioDataSource(DataSource):
 class RasterDatasetDataSource(RasterioDataSource):
     """Data source for reading from a Data Cube Dataset"""
 
-    def __init__(self, dataset: Dataset, measurement_id: str):
+    def __init__(self, band: BandInfo):
         """
         Initialise for reading from a Data Cube Dataset.
 
         :param dataset: dataset to read from
         :param measurement_id: measurement to read. a single 'band' or 'slice'
         """
-        bi = BandInfo(dataset, measurement_id)
-        self._band_info = bi
-        self._netcdf = ('netcdf' in bi.format.lower())
-        self._part = get_part_from_uri(bi.uri)
-        filename = _url2rasterio(bi.uri, bi.format, bi.layer)
-        super(RasterDatasetDataSource, self).__init__(filename, nodata=bi.nodata)
+        self._band_info = band
+        self._netcdf = ('netcdf' in band.format.lower())
+        self._part = get_part_from_uri(band.uri)
+        filename = _url2rasterio(band.uri, band.format, band.layer)
+        super(RasterDatasetDataSource, self).__init__(filename, nodata=band.nodata)
 
     def get_bandnumber(self, src=None) -> Optional[int]:
 

--- a/datacube/storage/storage.py
+++ b/datacube/storage/storage.py
@@ -401,7 +401,7 @@ def measurement_paths(dataset: Dataset) -> Dict[str, str]:
     Returns a dictionary mapping from band name to url pointing to band storage
     resource.
 
-    :return: {str: str} Band Name => URL
+    :return: Band Name => URL
     """
     base = _choose_location(dataset)
     return dict((k, _resolve_url(base, m.get('path', '')))

--- a/datacube/storage/storage.py
+++ b/datacube/storage/storage.py
@@ -15,16 +15,15 @@ from affine import Affine
 import rasterio
 from rasterio.warp import Resampling
 import urllib.parse
-from urllib.parse import urlparse, urljoin
-from typing import Dict, Union, Optional, Callable, List, Any, Iterator
+from urllib.parse import urlparse
+from typing import Union, Optional, Callable, List, Any, Iterator
 
-from datacube.model import Dataset
 from datacube.storage import netcdf_writer
 from datacube.utils import datetime_to_seconds_since_1970, DatacubeException, ignore_exceptions_if
 from datacube.utils import geometry
 from datacube.utils.geometry import GeoBox, roi_is_empty
 from datacube.utils.math import num2numpy
-from datacube.utils import is_url, uri_to_local_path, get_part_from_uri
+from datacube.utils import uri_to_local_path, get_part_from_uri
 from . import DataSource, GeoRasterReader, RasterShape, RasterWindow, BandInfo
 
 _LOG = logging.getLogger(__name__)
@@ -317,38 +316,6 @@ def register_scheme(*schemes):
 
 # Not recognised by python by default. Doctests below will fail without it.
 register_scheme('s3')
-
-
-def _resolve_url(base_url, path):
-    """
-    If path is a URL or an absolute path return URL
-    If path is a relative path return base_url joined with path
-
-    >>> _resolve_url('file:///foo/abc', 'bar')
-    'file:///foo/bar'
-    >>> _resolve_url('file:///foo/abc', 'file:///bar')
-    'file:///bar'
-    >>> _resolve_url('file:///foo/abc', None)
-    'file:///foo/abc'
-    >>> _resolve_url('file:///foo/abc', '/bar')
-    'file:///bar'
-    >>> _resolve_url('http://foo.com/abc/odc-metadata.yaml', 'band-5.tif')
-    'http://foo.com/abc/band-5.tif'
-    >>> _resolve_url('s3://foo.com/abc/odc-metadata.yaml', 'band-5.tif')
-    's3://foo.com/abc/band-5.tif'
-    >>> _resolve_url('s3://foo.com/abc/odc-metadata.yaml?something', 'band-5.tif')
-    's3://foo.com/abc/band-5.tif'
-    """
-    if path:
-        if is_url(path):
-            url_str = path
-        elif Path(path).is_absolute():
-            url_str = Path(path).as_uri()
-        else:
-            url_str = urljoin(base_url, path)
-    else:
-        url_str = base_url
-    return url_str
 
 
 def _url2rasterio(url_str, fmt, layer):

--- a/datacube/storage/storage.py
+++ b/datacube/storage/storage.py
@@ -223,27 +223,6 @@ class RasterioDataSource(DataSource):
             raise e
 
 
-class RasterFileDataSource(RasterioDataSource):
-    def __init__(self, filename, bandnumber, nodata=None, crs=None, transform=None):
-        super(RasterFileDataSource, self).__init__(filename, nodata)
-        self.bandnumber = bandnumber
-        self.crs = crs
-        self.transform = transform
-
-    def get_bandnumber(self, src):
-        return self.bandnumber
-
-    def get_transform(self, shape):
-        if self.transform is None:
-            raise RuntimeError('No transform in the data and no fallback')
-        return self.transform
-
-    def get_crs(self):
-        if self.crs is None:
-            raise RuntimeError('No CRS in the data and no fallback')
-        return self.crs
-
-
 class RasterDatasetDataSource(RasterioDataSource):
     """Data source for reading from a Data Cube Dataset"""
 

--- a/datacube/storage/storage.py
+++ b/datacube/storage/storage.py
@@ -396,18 +396,6 @@ def _choose_location(dataset: Dataset) -> str:
     return uris[0]
 
 
-def measurement_paths(dataset: Dataset) -> Dict[str, str]:
-    """
-    Returns a dictionary mapping from band name to url pointing to band storage
-    resource.
-
-    :return: Band Name => URL
-    """
-    base = _choose_location(dataset)
-    return dict((k, _resolve_url(base, m.get('path', '')))
-                for k, m in dataset.measurements.items())
-
-
 def create_netcdf_storage_unit(filename,
                                crs, coordinates, variables, variable_params, global_attributes=None,
                                netcdfparams=None):

--- a/datacube/testutils/__init__.py
+++ b/datacube/testutils/__init__.py
@@ -130,6 +130,7 @@ def mk_sample_product(name,
             measurements=['image', 'bands'],
             sources=['lineage', 'source_datasets'],
             format=['format', 'name'],
+            grid_spatial=['grid_spatial', 'projection'],
         )
     }, dataset_search_fields={
         'time': parse_search_field({

--- a/datacube/testutils/io.py
+++ b/datacube/testutils/io.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from ..storage.storage import (
-    RasterFileDataSource,
+    RasterioDataSource,
     reproject_and_fuse,
 )
 from ..utils.geometry._warp import resampling_s2rio
@@ -9,6 +9,29 @@ from ..storage._read import rdr_geobox
 from ..utils.geometry import GeoBox
 from ..utils.geometry import gbox as gbx
 from types import SimpleNamespace
+
+
+class RasterFileDataSource(RasterioDataSource):
+    """ This is only used in test code
+    """
+    def __init__(self, filename, bandnumber, nodata=None, crs=None, transform=None):
+        super(RasterFileDataSource, self).__init__(filename, nodata)
+        self.bandnumber = bandnumber
+        self.crs = crs
+        self.transform = transform
+
+    def get_bandnumber(self, src):
+        return self.bandnumber
+
+    def get_transform(self, shape):
+        if self.transform is None:
+            raise RuntimeError('No transform in the data and no fallback')
+        return self.transform
+
+    def get_crs(self):
+        if self.crs is None:
+            raise RuntimeError('No CRS in the data and no fallback')
+        return self.crs
 
 
 def dc_read(path,

--- a/datacube/utils/__init__.py
+++ b/datacube/utils/__init__.py
@@ -10,11 +10,11 @@ from datacube.utils.dates import parse_time
 from .dates import datetime_to_seconds_since_1970
 from .documents import InvalidDocException, SimpleDocNav, DocReader, is_supported_document_type, \
     read_strings_from_netcdf, read_documents, validate_document, NoDatesSafeLoader, get_doc_offset, \
-    get_doc_offset_safe, netcdf_extract_string
+    get_doc_offset_safe, netcdf_extract_string, without_lineage_sources
 from .math import unsqueeze_data_array, iter_slices, unsqueeze_dataset, data_resolution_and_offset
 from .py import cached_property, ignore_exceptions_if, import_function
 from .serialise import jsonify_document
-from .uris import is_url, uri_to_local_path, get_part_from_uri, mk_part_uri, without_lineage_sources
+from .uris import is_url, uri_to_local_path, get_part_from_uri, mk_part_uri
 
 _LOG = logging.getLogger(__name__)
 

--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -11,6 +11,8 @@ from itertools import chain
 from pathlib import Path
 from urllib.parse import urlparse
 from urllib.request import urlopen
+import typing
+from typing import Any
 
 import jsonschema
 import netCDF4
@@ -62,6 +64,12 @@ _PROTOCOL_OPENERS = {
 
 def load_from_yaml(handle):
     yield from yaml.load_all(handle, Loader=NoDatesSafeLoader)
+
+
+def parse_yaml(doc: str) -> typing.Mapping[str, Any]:
+    """ Convert a single document yaml string into a parsed document
+    """
+    return yaml.load(doc, Loader=SafeLoader)
 
 
 def load_from_json(handle):

--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -12,7 +12,8 @@ from pathlib import Path
 from urllib.parse import urlparse
 from urllib.request import urlopen
 import typing
-from typing import Any
+from typing import MutableMapping, Any
+from copy import deepcopy
 
 import jsonschema
 import netCDF4
@@ -511,3 +512,24 @@ class DocReader(object):
 
     def __dir__(self):
         return list(self.fields)
+
+
+def without_lineage_sources(doc: MutableMapping[str, Any],
+                            spec,
+                            inplace: bool = False):
+    """ Replace lineage.source_datasets with {}
+
+    :param dict doc: parsed yaml/json document describing dataset
+    :param spec: Product or MetadataType according to which `doc` to be interpreted
+    :param bool inplace: If True modify `doc` in place
+    """
+
+    if not inplace:
+        doc = deepcopy(doc)
+
+    doc_view = spec.dataset_reader(doc)
+
+    if 'sources' in doc_view.fields:
+        doc_view.sources = {}
+
+    return doc

--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -62,8 +62,9 @@ _PROTOCOL_OPENERS = {
 }
 
 
-def load_from_yaml(handle):
-    yield from yaml.load_all(handle, Loader=NoDatesSafeLoader)
+def load_from_yaml(handle, parse_dates=False):
+    loader = SafeLoader if parse_dates else NoDatesSafeLoader
+    yield from yaml.load_all(handle, Loader=loader)
 
 
 def parse_yaml(doc: str) -> typing.Mapping[str, Any]:

--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 from urllib.request import urlopen
 import typing
-from typing import MutableMapping, Any
+from typing import Dict, Any
 from copy import deepcopy
 
 import jsonschema
@@ -514,9 +514,9 @@ class DocReader(object):
         return list(self.fields)
 
 
-def without_lineage_sources(doc: MutableMapping[str, Any],
+def without_lineage_sources(doc: Dict[str, Any],
                             spec,
-                            inplace: bool = False):
+                            inplace: bool = False) -> Dict[str, Any]:
     """ Replace lineage.source_datasets with {}
 
     :param dict doc: parsed yaml/json document describing dataset

--- a/datacube/utils/geometry/_warp.py
+++ b/datacube/utils/geometry/_warp.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Optional
 import rasterio.warp
 import rasterio.crs
 import numpy as np
@@ -6,6 +6,7 @@ from affine import Affine
 from . import GeoBox
 
 Resampling = Union[str, int, rasterio.warp.Resampling]  # pylint: disable=invalid-name
+Nodata = Optional[Union[int, float]]  # pylint: disable=invalid-name
 _WRP_CRS = rasterio.crs.CRS.from_epsg(3857)
 
 
@@ -33,9 +34,9 @@ def warp_affine_rio(src: np.ndarray,
                     dst: np.ndarray,
                     A: Affine,
                     resampling: Resampling,
-                    src_nodata=None,
-                    dst_nodata=None,
-                    **kwargs):
+                    src_nodata: Nodata = None,
+                    dst_nodata: Nodata = None,
+                    **kwargs) -> np.ndarray:
     """
     Perform Affine warp using rasterio as backend library.
 
@@ -90,9 +91,9 @@ def warp_affine(src: np.ndarray,
                 dst: np.ndarray,
                 A: Affine,
                 resampling: Resampling,
-                src_nodata=None,
-                dst_nodata=None,
-                **kwargs):
+                src_nodata: Nodata = None,
+                dst_nodata: Nodata = None,
+                **kwargs) -> np.ndarray:
     """
     Perform Affine warp using best available backend (GDAL via rasterio is the only one so far).
 
@@ -118,9 +119,9 @@ def rio_reproject(src: np.ndarray,
                   s_gbox: GeoBox,
                   d_gbox: GeoBox,
                   resampling: Resampling,
-                  src_nodata=None,
-                  dst_nodata=None,
-                  **kwargs):
+                  src_nodata: Nodata = None,
+                  dst_nodata: Nodata = None,
+                  **kwargs) -> np.ndarray:
     """
     Perform reproject from ndarray->ndarray using rasterio as backend library.
 

--- a/datacube/utils/uris.py
+++ b/datacube/utils/uris.py
@@ -3,7 +3,6 @@ import os
 import pathlib
 import re
 from typing import Optional, List
-from copy import deepcopy
 from urllib.parse import urlparse, parse_qsl, urljoin
 from urllib.request import url2pathname
 from pathlib import Path
@@ -130,26 +129,8 @@ def default_base_dir():
     return pwd
 
 
-def without_lineage_sources(doc, spec, inplace=False):
-    """ Replace lineage.source_datasets with {}
-
-    :param dict doc: parsed yaml/json document describing dataset
-    :param spec: Product or MetadataType according to which `doc` to be interpreted
-    :param bool inplace: If True modify `doc` in place
-    """
-
-    if not inplace:
-        doc = deepcopy(doc)
-
-    doc_view = spec.dataset_reader(doc)
-
-    if 'sources' in doc_view.fields:
-        doc_view.sources = {}
-
-    return doc
-
-
-def normalise_path(p, base=None):
+def normalise_path(p: Union[str, pathlib.Path],
+                   base: Optional[Union[str, pathlib.Path]] = None) -> pathlib.Path:
     """Turn path into absolute path resolving any `../` and `.`
 
        If path is relative pre-pend `base` path to it, `base` if set should be

--- a/datacube/utils/uris.py
+++ b/datacube/utils/uris.py
@@ -2,7 +2,7 @@ import os
 
 import pathlib
 import re
-from typing import Optional, List
+from typing import Optional, List, Union
 from urllib.parse import urlparse, parse_qsl, urljoin
 from urllib.request import url2pathname
 from pathlib import Path
@@ -10,7 +10,7 @@ from pathlib import Path
 URL_RE = re.compile(r'\A\s*[\w\d\+]+://')
 
 
-def is_url(url_str):
+def is_url(url_str: str) -> bool:
     """
     Check if url_str tastes like a url (starts with blah://)
 
@@ -31,12 +31,9 @@ def is_url(url_str):
         return False
 
 
-def uri_to_local_path(local_uri):
+def uri_to_local_path(local_uri: Optional[str]) -> Optional[pathlib.Path]:
     """
     Transform a URI to a platform dependent Path.
-
-    :type local_uri: str
-    :rtype: pathlib.Path
 
     For example on Unix:
     'file:///tmp/something.txt' -> '/tmp/something.txt'
@@ -65,13 +62,13 @@ def uri_to_local_path(local_uri):
     return pathlib.Path(path)
 
 
-def mk_part_uri(uri, idx):
+def mk_part_uri(uri: str, idx: int) -> str:
     """ Appends fragment part to the uri recording index of the part
     """
     return '{}#part={:d}'.format(uri, idx)
 
 
-def get_part_from_uri(uri):
+def get_part_from_uri(uri: str) -> Optional[int]:
     """
     Reverse of mk_part_uri
 
@@ -90,14 +87,14 @@ def get_part_from_uri(uri):
     return maybe_int(opts.get('part', None))
 
 
-def as_url(maybe_uri):
+def as_url(maybe_uri: str) -> str:
     if is_url(maybe_uri):
         return maybe_uri
     else:
         return pathlib.Path(maybe_uri).absolute().as_uri()
 
 
-def default_base_dir():
+def default_base_dir() -> pathlib.Path:
     """Return absolute path to current directory. If PWD environment variable is
        set correctly return that, note that PWD might be set to "symlinked"
        path instead of "real" path.
@@ -110,11 +107,11 @@ def default_base_dir():
     """
     cwd = pathlib.Path('.').resolve()
 
-    pwd = os.environ.get('PWD')
-    if pwd is None:
+    _pwd = os.environ.get('PWD')
+    if _pwd is None:
         return cwd
 
-    pwd = pathlib.Path(pwd)
+    pwd = pathlib.Path(_pwd)
     if not pwd.is_absolute():
         return cwd
 

--- a/datacube/virtual/__init__.py
+++ b/datacube/virtual/__init__.py
@@ -1,4 +1,4 @@
-import yaml
+from typing import Mapping, Any
 
 from .impl import VirtualProduct, Transformation, VirtualProductException
 from .transformations import MakeMask, ApplyMask, ToFloat, Rename, Select
@@ -6,6 +6,7 @@ from .utils import reject_keys
 
 from datacube.model import Measurement
 from datacube.utils import import_function
+from datacube.utils.documents import parse_yaml
 
 __all__ = ['construct', 'Transformation', 'Measurement']
 
@@ -94,16 +95,15 @@ DEFAULT_RESOLVER = NameResolver(make_mask=MakeMask,
                                 select=Select)
 
 
-def construct(**recipe):
-    # type: (Dict[str, Any]) -> VirtualProduct
+def construct(**recipe: Mapping[str, Any]) -> VirtualProduct:
     """
     Create a virtual product from a specification dictionary.
     """
     return DEFAULT_RESOLVER.construct(**recipe)
 
 
-def construct_from_yaml(recipe):
+def construct_from_yaml(recipe: str) -> VirtualProduct:
     """
     Create a virtual product from a yaml recipe.
     """
-    return construct(**yaml.load(recipe, Loader=yaml.CLoader))
+    return construct(**parse_yaml(recipe))

--- a/docs/architecture/driver.rst
+++ b/docs/architecture/driver.rst
@@ -61,8 +61,8 @@ Example code to implement a reader driver
     class AbstractReaderDriver(object):
         def supports(self, protocol: str, fmt: str) -> bool:
             pass
-        def new_datasource(self, dataset, band_name) -> DataSource:
-            return AbstractDataSource(dataset, band_name)
+        def new_datasource(self, band: BandInfo) -> DataSource:
+            return AbstractDataSource(band)
 
     class AbstractDataSource(object):  # Same interface as before
         ...

--- a/examples/io_plugin/dcio_example/pickles.py
+++ b/examples/io_plugin/dcio_example/pickles.py
@@ -3,7 +3,6 @@
 from contextlib import contextmanager
 import pickle
 
-from datacube.storage import measurement_paths
 
 PROTOCOL = 'file'
 FORMAT = 'pickle'
@@ -50,9 +49,9 @@ class PickleDataSource(object):
 
             raise NotImplementedError('Native reading not supported for this data source')
 
-    def __init__(self, dataset, band_name):
-        self._band_name = band_name
-        uri = measurement_paths(dataset)[band_name]
+    def __init__(self, band):
+        self._band = band
+        uri = band.uri
         self._filename, protocol = uri_split(uri)
 
         if protocol not in [PROTOCOL, 'pickle']:
@@ -63,7 +62,7 @@ class PickleDataSource(object):
         with open(self._filename, 'rb') as f:
             ds = pickle.load(f)
 
-        yield PickleDataSource.BandDataSource(ds[self._band_name].isel(time=0))
+        yield PickleDataSource.BandDataSource(ds[self._band.name].isel(time=0))
 
 
 class PickleReaderDriver(object):
@@ -76,8 +75,8 @@ class PickleReaderDriver(object):
         return (protocol in self.protocols and
                 fmt in self.formats)
 
-    def new_datasource(self, dataset, band_name):
-        return PickleDataSource(dataset, band_name)
+    def new_datasource(self, band):
+        return PickleDataSource(band)
 
 
 def rdr_driver_init():

--- a/examples/io_plugin/dcio_example/pickles.py
+++ b/examples/io_plugin/dcio_example/pickles.py
@@ -3,7 +3,7 @@
 from contextlib import contextmanager
 import pickle
 
-from datacube.storage.storage import measurement_paths
+from datacube.storage import measurement_paths
 
 PROTOCOL = 'file'
 FORMAT = 'pickle'

--- a/examples/io_plugin/dcio_example/zeros.py
+++ b/examples/io_plugin/dcio_example/zeros.py
@@ -13,7 +13,7 @@ class ZerosReaderDriver(object):
     def supports(self, protocol, fmt):
         return protocol == 'zero'
 
-    def new_datasource(self, dataset, band_name):
+    def new_datasource(self, band):
         return None  # TODO
 
 

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -4,8 +4,6 @@ Module
 """
 
 import copy
-import json
-
 import pytest
 import yaml
 
@@ -15,7 +13,6 @@ from datacube.index._metadata_types import default_metadata_type_docs
 from datacube.model import MetadataType, DatasetType
 from datacube.model import Range, Dataset
 from datacube.utils import changes
-import datacube.scripts.cli_app
 
 _DATASET_METADATA = {
     'id': 'f7018d80-8807-11e5-aeaa-1040f381a756',
@@ -307,13 +304,12 @@ def test_update_dataset_type(index, ls5_telem_type, ls5_telem_doc, ga_metadata_t
     assert updated_type.definition['metadata']['ga_label'] == 'something'
 
 
-def test_product_update_cli(index,
+def test_product_update_cli(index: Index,
                             clirunner,
-                            ls5_telem_type,
-                            ls5_telem_doc,
-                            ga_metadata_type,
-                            tmpdir):
-    # type: (Index, callable, DatasetType, dict, MetadataType) -> None
+                            ls5_telem_type: DatasetType,
+                            ls5_telem_doc: dict,
+                            ga_metadata_type: MetadataType,
+                            tmpdir) -> None:
     """
     Test updating products via cli
     """

--- a/integration_tests/test_model.py
+++ b/integration_tests/test_model.py
@@ -1,8 +1,8 @@
-from datacube.model import Dataset
+from datacube.model import Dataset, DatasetType
+from typing import List
 
 
-def test_crs_parse(indexed_ls5_scene_products):
-    # type: (MetadataType) -> None
+def test_crs_parse(indexed_ls5_scene_products: List[DatasetType]) -> None:
     product = indexed_ls5_scene_products[2]
 
     # Explicit CRS, should load fine.

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -209,7 +209,7 @@ def _make_ls5_scene_datasets(geotiffs, tmpdir):
 
 def load_yaml_file(filename):
     with open(str(filename)) as f:
-        return list(load_from_yaml(f))
+        return list(load_from_yaml(f, parse_dates=True))
 
 
 def is_geogaphic(storage_type):

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -4,19 +4,19 @@ import shutil
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
-
 import numpy as np
 import rasterio
 import yaml
 from click.testing import CliRunner
-from yaml import CSafeLoader as SafeLoader
+
+from datacube.utils.documents import load_from_yaml
 
 # On Windows, symlinks are not supported in Python 2 and require
 # specific privileges otherwise, so we copy instead of linking
 if os.name == 'nt' or not hasattr(os, 'symlink'):
     symlink = shutil.copy
 else:
-    symlink = os.symlink
+    symlink = os.symlink  # type: ignore
 
 #: Number of bands to place in generated GeoTIFFs
 NUM_BANDS = 3
@@ -209,7 +209,7 @@ def _make_ls5_scene_datasets(geotiffs, tmpdir):
 
 def load_yaml_file(filename):
     with open(str(filename)) as f:
-        return list(yaml.load_all(f, Loader=SafeLoader))
+        return list(load_from_yaml(f))
 
 
 def is_geogaphic(storage_type):

--- a/tests/storage/test_base.py
+++ b/tests/storage/test_base.py
@@ -46,6 +46,7 @@ def test_band_info():
     assert binfo.nodata == 33
     assert binfo.center_time == ds.center_time
     assert binfo.uri == 'file:///tmp/b.tiff'
+    assert binfo.format == ds.format
     assert binfo.driver_data is None
 
     with pytest.raises(ValueError):

--- a/tests/storage/test_base.py
+++ b/tests/storage/test_base.py
@@ -1,0 +1,60 @@
+import pytest
+from datacube.storage import BandInfo
+from datacube.testutils import mk_sample_dataset
+from datacube.storage._base import _get_band_and_layer
+
+
+def test_band_layer():
+    def t(band=None, layer=None):
+        return _get_band_and_layer(dict(band=band, layer=layer))
+
+    assert t() == (None, None)
+    assert t(1) == (1, None)
+    assert t(None, 3) == (3, None)
+    assert t(1, 'foo') == (1, 'foo')
+    assert t(None, 'foo') == (None, 'foo')
+
+    bad_inputs = [('string', None),  # band has to be int|None
+                  (None, {}),  # layer has to be int|str|None
+                  (1, 3)]  # if band is set layer should be str|None
+
+    for bad in bad_inputs:
+        with pytest.raises(ValueError):
+            t(*bad)
+
+
+def test_band_info():
+    bands = [dict(name=n,
+                  dtype='uint8',
+                  units='K',
+                  nodata=33,
+                  path=n+'.tiff')
+             for n in 'a b c'.split(' ')]
+
+    ds = mk_sample_dataset(bands,
+                           uri='file:///tmp/datataset.yml',
+                           format='GeoTIFF')
+
+    binfo = BandInfo(ds, 'b')
+    assert binfo.name == 'b'
+    assert binfo.band is None
+    assert binfo.layer is None
+    assert binfo.dtype == 'uint8'
+    assert binfo.transform is None
+    assert binfo.crs is None
+    assert binfo.units == 'K'
+    assert binfo.nodata == 33
+    assert binfo.center_time == ds.center_time
+    assert binfo.uri == 'file:///tmp/b.tiff'
+    assert binfo.driver_data is None
+
+    with pytest.raises(ValueError):
+        BandInfo(ds, 'no_such_band')
+
+    ds.uris = []
+    with pytest.raises(ValueError):
+        BandInfo(ds, 'a')
+
+    ds.uris = None
+    with pytest.raises(ValueError):
+        BandInfo(ds, 'a')

--- a/tests/storage/test_base.py
+++ b/tests/storage/test_base.py
@@ -48,6 +48,7 @@ def test_band_info():
     assert binfo.uri == 'file:///tmp/b.tiff'
     assert binfo.format == ds.format
     assert binfo.driver_data is None
+    assert binfo.uri_scheme == 'file'
 
     with pytest.raises(ValueError):
         BandInfo(ds, 'no_such_band')

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -12,6 +12,7 @@ from datacube.drivers.datasource import DataSource
 from datacube.model import Dataset, DatasetType, MetadataType
 from datacube.model import Variable
 from datacube.testutils.io import RasterFileDataSource
+from datacube.storage import BandInfo
 from datacube.storage.storage import create_netcdf_storage_unit
 from datacube.storage.storage import write_dataset_to_netcdf, reproject_and_fuse, Resampling, \
     RasterDatasetDataSource
@@ -591,7 +592,7 @@ def test_multiband_support_in_datasetsource(example_gdal_path):
     # Without new band attribute, default to band number 1
     d = Dataset(_EXAMPLE_DATASET_TYPE, defn, uris=['file:///tmp'])
 
-    ds = RasterDatasetDataSource(d, measurement_id='green')
+    ds = RasterDatasetDataSource(BandInfo(d, 'green'))
 
     bandnum = ds.get_bandnumber(None)
 
@@ -607,7 +608,7 @@ def test_multiband_support_in_datasetsource(example_gdal_path):
     defn['image']['bands']['green']['band'] = band_num
     d = Dataset(_EXAMPLE_DATASET_TYPE, defn, uris=['file:///tmp'])
 
-    ds = RasterDatasetDataSource(d, measurement_id='green')
+    ds = RasterDatasetDataSource(BandInfo(d, 'green'))
 
     assert ds.get_bandnumber(None) == band_num
 
@@ -631,7 +632,7 @@ def test_netcdf_multi_part():
 
     def ds(uri):
         d = Dataset(_EXAMPLE_DATASET_TYPE, defn, uris=[uri])
-        return RasterDatasetDataSource(d, measurement_id='green')
+        return RasterDatasetDataSource(BandInfo(d, 'green'))
 
     for i in range(3):
         assert ds('file:///tmp.nc#part=%d' % i).get_bandnumber() == (i+1)

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -11,7 +11,8 @@ import datacube
 from datacube.drivers.datasource import DataSource
 from datacube.model import Dataset, DatasetType, MetadataType
 from datacube.model import Variable
-from datacube.storage.storage import RasterFileDataSource, create_netcdf_storage_unit
+from datacube.testutils.io import RasterFileDataSource
+from datacube.storage.storage import create_netcdf_storage_unit
 from datacube.storage.storage import write_dataset_to_netcdf, reproject_and_fuse, Resampling, \
     RasterDatasetDataSource
 from datacube.storage._read import read_time_slice

--- a/tests/storage/test_storage_read.py
+++ b/tests/storage/test_storage_read.py
@@ -7,7 +7,7 @@ from datacube.storage._read import (
     pick_read_scale,
     rdr_geobox)
 
-from datacube.storage.storage import RasterFileDataSource
+from datacube.testutils.io import RasterFileDataSource
 from datacube.utils.geometry import (
     compute_reproject_roi,
     GeoBox,

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -76,6 +76,8 @@ def test_netcdf_driver_import():
     except ImportError:
         assert False and 'Failed to load netcdf writer driver'
 
+    assert datacube.drivers.netcdf.driver.reader_driver_init is not None
+
 
 def test_metadata_type_from_doc():
     metadata_doc = yaml.safe_load('''
@@ -99,3 +101,13 @@ dataset:
         assert metadata.id is None
         assert metadata.name == 'minimal'
         assert 'some_custom_field' in metadata.dataset_fields
+
+
+def test_reader_cache_throws_on_missing_fallback():
+    from datacube.drivers.readers import rdr_cache
+
+    rdrs = rdr_cache()
+    assert rdrs is not None
+
+    with pytest.raises(KeyError):
+        rdrs('file', 'aint-such-format')

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -6,6 +6,7 @@ from collections import namedtuple
 from datacube.drivers import new_datasource, reader_drivers, writer_drivers
 from datacube.drivers import index_drivers, index_driver_by_name
 from datacube.drivers.indexes import IndexDriverCache
+from datacube.storage import BandInfo
 from datacube.storage.storage import RasterDatasetDataSource
 from datacube.testutils import mk_sample_dataset
 from datacube.model import MetadataType
@@ -28,7 +29,7 @@ def test_new_datasource_s3():
     assert dataset.format == s3_driver.FORMAT
     assert dataset.uri_scheme == s3_driver.PROTOCOL
 
-    rdr = new_datasource(dataset, 'green')
+    rdr = new_datasource(BandInfo(dataset, 'green'))
     assert rdr is not None
     assert isinstance(rdr, S3DataSource)
 
@@ -40,7 +41,7 @@ def test_new_datasource_fallback():
 
     assert dataset.uri_scheme == 'file'
 
-    rdr = new_datasource(dataset, 'green')
+    rdr = new_datasource(BandInfo(dataset, 'green'))
     assert rdr is not None
     assert isinstance(rdr, RasterDatasetDataSource)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4,7 +4,7 @@ import numpy
 from datacube.testutils import mk_sample_dataset, mk_sample_product
 from datacube.model import GridSpec, Measurement
 from datacube.utils import geometry
-from datacube.storage.storage import measurement_paths
+from datacube.storage import measurement_paths
 
 
 def test_gridspec():
@@ -60,6 +60,10 @@ def test_dataset_measurement_paths():
 
     for k, v in paths.items():
         assert v == 'file:///tmp/' + k + '.tiff'
+
+    ds.uris = None
+    with pytest.raises(ValueError):
+        measurement_paths(ds)
 
 
 def test_product_dimensions():

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -54,6 +54,7 @@ def test_dataset_measurement_paths():
                            uri='file:///tmp/datataset.yml',
                            format=format)
 
+    assert ds.local_uri == ds.uris[0]
     assert ds.uri_scheme == 'file'
     assert ds.format == format
     paths = measurement_paths(ds)
@@ -62,6 +63,7 @@ def test_dataset_measurement_paths():
         assert v == 'file:///tmp/' + k + '.tiff'
 
     ds.uris = None
+    assert ds.local_uri is None
     with pytest.raises(ValueError):
         measurement_paths(ds)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,10 +31,10 @@ from datacube.utils.dates import date_sequence
 from datacube.utils.generic import map_with_lookahead
 from datacube.utils.math import clamp
 from datacube.utils.py import sorted_items
-from datacube.utils.documents import parse_yaml
+from datacube.utils.documents import parse_yaml, without_lineage_sources
 from datacube.utils.uris import (uri_to_local_path, mk_part_uri, get_part_from_uri, as_url, is_url,
                                  pick_uri, uri_resolve,
-                                 without_lineage_sources, normalise_path, default_base_dir)
+                                 normalise_path, default_base_dir)
 
 
 def test_stats_dates():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,15 +24,16 @@ from datacube.utils.math import num2numpy, is_almost_int, valid_mask
 from datacube.model import MetadataType
 from datacube.model.utils import xr_apply, traverse_datasets, flatten_datasets, dedup_lineage
 from datacube.testutils import mk_sample_product, make_graph_abcde, gen_dataset_test_dag, dataset_maker
-from datacube.utils import gen_password, write_user_secret_file, slurp, read_documents, InvalidDocException, \
-    SimpleDocNav
+from datacube.utils import (gen_password, write_user_secret_file, slurp, read_documents, InvalidDocException,
+                            SimpleDocNav)
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes, MISSING, DocumentMismatchError
 from datacube.utils.dates import date_sequence
 from datacube.utils.generic import map_with_lookahead
 from datacube.utils.math import clamp
 from datacube.utils.py import sorted_items
-from datacube.utils.uris import uri_to_local_path, mk_part_uri, get_part_from_uri, as_url, is_url, \
-    without_lineage_sources, normalise_path, default_base_dir
+from datacube.utils.documents import parse_yaml
+from datacube.utils.uris import (uri_to_local_path, mk_part_uri, get_part_from_uri, as_url, is_url,
+                                 without_lineage_sources, normalise_path, default_base_dir)
 
 
 def test_stats_dates():
@@ -299,6 +300,10 @@ def test_map_with_lookahead():
     assert list(map_with_lookahead(range(5), if_one, if_many)) == list(map(if_many, range(5)))
     assert list(map_with_lookahead(range(10), if_one=if_one)) == list(range(10))
     assert list(map_with_lookahead(iter([1]), if_many=if_many)) == [1]
+
+
+def test_parse_yaml():
+    assert parse_yaml('a: 10') == {'a': 10}
 
 
 def test_part_uri():


### PR DESCRIPTION
Replaces `(ds: Dataset, band_name: str)` with `BandInfo` class.

Reasons:

- Dataset can encode multiple resource locations, currently both `driver` and `core` code need to pick the same one. This choice should be with `core`, potentially driver selection is affected by chosen location (`file://` vs `http://` for example)

- Avoid "no such band name" possible errors within `driver` code

- To reduce memory pressure, `Dataset` object can be rather large, but only small subset is needed for loading data, `dask`-based loading for large queries can benefit from shrinking datasets to just bare-bones data needed for loading.

As usual this will include various cleanups/type annotations.

<!--

### Reason for this pull request

...


### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
