### PR TITLE
Add all resampling methods from rasterio enum

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -219,7 +219,8 @@ class Datacube(object):
         :param str|dict resampling:
             The resampling method to use if re-projection is required.
 
-            Valid values are: ``'nearest', 'cubic', 'bilinear', 'cubic_spline', 'lanczos', 'average'``
+            Valid values are: ``'nearest', 'cubic', 'bilinear', 'cubic_spline', 'lanczos', 'average',
+            'mode', 'gauss',  'max', 'min', 'med', 'q1', 'q3'``
             .. seealso:: :meth:`load_data`
 
         :param (float,float) align:
@@ -451,7 +452,8 @@ class Datacube(object):
             indicate "apply to all other bands", for example ``{'*': 'cubic', 'fmask': 'nearest'}`` would
             use `cubic` for all bands except ``fmask`` for which `nearest` will be used.
 
-            Valid values are: ``'nearest', 'cubic', 'bilinear', 'cubic_spline', 'lanczos', 'average'``
+            Valid values are: ``'nearest', 'cubic', 'bilinear', 'cubic_spline', 'lanczos', 'average',
+            'mode', 'gauss',  'max', 'min', 'med', 'q1', 'q3'``
 
             Default is to use ``nearest`` for all bands.
 

--- a/datacube/storage/storage.py
+++ b/datacube/storage/storage.py
@@ -32,14 +32,7 @@ from rasterio.warp import Resampling
 
 _LOG = logging.getLogger(__name__)
 
-RESAMPLING_METHODS = {
-    'nearest': Resampling.nearest,
-    'cubic': Resampling.cubic,
-    'bilinear': Resampling.bilinear,
-    'cubic_spline': Resampling.cubic_spline,
-    'lanczos': Resampling.lanczos,
-    'average': Resampling.average,
-}
+RESAMPLING_METHODS = {r.name: r for r in Resampling}
 
 GDAL_NETCDF_DIM = ('NETCDF_DIM_'
                    if str(rasterio.__gdal_version__) >= '1.10.0' else

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -10,6 +10,7 @@ v1.7dev
 
 - Allow specifying different resampling methods for different data variables of
   the same Product. (:pull:`551`)
+- Allow all reampling methods supported by `rasterio`. (:pull:`622`)
 - Bugfixes and improved performance of `dask`-backed arrays (:pull:`547`)
 - Improve :ref:`api-reference` documentation.
 - Bug fix (Index out of bounds causing ingestion failures)


### PR DESCRIPTION
### Reason for this pull request
Allow all resampling options from rasterio to be accepted by the api.

 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

