### PR TITLE
Cleanup up old "compatibility code"

### DIFF
--- a/datacube/api/__init__.py
+++ b/datacube/api/__init__.py
@@ -3,8 +3,7 @@
 Modules for the Storage and Access Query API
 """
 
-from datacube.storage.masking import list_flag_names, describe_variable_flags, make_mask
 from .core import Datacube
 from .grid_workflow import GridWorkflow, Tile
 
-__all__ = ['Datacube', 'GridWorkflow', 'Tile', 'list_flag_names', 'describe_variable_flags', 'make_mask']
+__all__ = ['Datacube', 'GridWorkflow', 'Tile']

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -4,9 +4,7 @@ from itertools import groupby
 from math import ceil
 
 import numpy
-import pandas
 import xarray
-
 from dask import array as da
 
 from datacube.config import LocalConfig
@@ -88,6 +86,7 @@ class Datacube(object):
         if not with_pandas:
             return rows
 
+        import pandas
         keys = set(k for r in rows for k in r)
         main_cols = ['id', 'name', 'description']
         grid_cols = ['crs', 'resolution', 'tile_size', 'spatial_dimensions']
@@ -106,6 +105,8 @@ class Datacube(object):
         measurements = self._list_measurements()
         if not with_pandas:
             return measurements
+
+        import pandas
         return pandas.DataFrame.from_dict(measurements).set_index(['product', 'measurement'])
 
     def _list_measurements(self):

--- a/datacube/drivers/driver_cache.py
+++ b/datacube/drivers/driver_cache.py
@@ -1,8 +1,6 @@
 import logging
 from typing import Dict, Any, Tuple, Iterable
 
-from pkg_resources import iter_entry_points, DistributionNotFound
-
 _LOG = logging.getLogger(__name__)
 
 
@@ -24,6 +22,7 @@ def load_drivers(group: str) -> Dict[str, Any]:
     """
 
     def safe_load(ep):
+        from pkg_resources import DistributionNotFound
         # pylint: disable=broad-except,bare-except
         try:
             driver_init = ep.load()
@@ -48,6 +47,7 @@ def load_drivers(group: str) -> Dict[str, Any]:
         return driver
 
     def resolve_all(group: str) -> Iterable[Tuple[str, Any]]:
+        from pkg_resources import iter_entry_points
         for ep in iter_entry_points(group=group, name=None):
             driver = safe_load(ep)
             if driver is not None:

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -10,14 +10,12 @@ from datetime import datetime
 from pathlib import Path
 from uuid import UUID
 
-import yaml
 from affine import Affine
 from typing import Optional, List, Mapping, Any, Dict, Tuple, Iterator
 
 from urllib.parse import urlparse
 from datacube.utils import geometry, without_lineage_sources, parse_time, cached_property, uri_to_local_path, \
     schema_validated, DocReader
-from datacube.utils.serialise import SafeDatacubeDumper
 from .fields import Field
 from ._base import Range
 
@@ -723,22 +721,3 @@ def metadata_from_doc(doc: Mapping[str, Any]) -> MetadataType:
     from .fields import get_dataset_fields
     MetadataType.validate(doc)  # type: ignore
     return MetadataType(doc, get_dataset_fields(doc))
-
-
-def _range_representer(dumper: yaml.Dumper, data: Range) -> yaml.Node:
-    begin, end = data
-
-    # pyyaml doesn't output timestamps in flow style as timestamps(?)
-    if isinstance(begin, datetime):
-        begin = begin.isoformat()
-    if isinstance(end, datetime):
-        end = end.isoformat()
-
-    return dumper.represent_mapping(
-        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
-        (('begin', begin), ('end', end)),
-        flow_style=True
-    )
-
-
-SafeDatacubeDumper.add_representer(Range, _range_representer)

--- a/datacube/storage/_rio.py
+++ b/datacube/storage/_rio.py
@@ -7,7 +7,6 @@ from contextlib import contextmanager
 import numpy as np
 from affine import Affine
 import rasterio
-import urllib.parse
 from urllib.parse import urlparse
 from typing import Optional, Iterator
 
@@ -240,20 +239,6 @@ class RasterDatasetDataSource(RasterioDataSource):
 
     def get_crs(self):
         return self._band_info.crs
-
-
-def register_scheme(*schemes):
-    """
-    Register additional uri schemes as supporting relative offsets (etc), so that band/measurement paths can be
-    calculated relative to the base uri.
-    """
-    urllib.parse.uses_netloc.extend(schemes)
-    urllib.parse.uses_relative.extend(schemes)
-    urllib.parse.uses_params.extend(schemes)
-
-
-# Not recognised by python by default. Doctests below will fail without it.
-register_scheme('s3')
 
 
 def _url2rasterio(url_str, fmt, layer):

--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -15,8 +15,6 @@ import typing
 from typing import Dict, Any
 from copy import deepcopy
 
-import jsonschema
-import netCDF4
 import numpy
 import toolz
 import yaml
@@ -180,6 +178,8 @@ def netcdf_extract_string(chars):
     """
     Convert netcdf S|U chars to Unicode string.
     """
+    import netCDF4
+
     if isinstance(chars, str):
         return chars
 
@@ -198,12 +198,16 @@ def read_strings_from_netcdf(path, variable):
 
     Useful for loading dataset metadata information.
     """
+    import netCDF4
+
     with netCDF4.Dataset(str(path)) as ds:
         for chars in ds[variable]:
             yield netcdf_extract_string(chars)
 
 
 def validate_document(document, schema, schema_folder=None):
+    import jsonschema
+
     try:
         # Allow schemas to reference other schemas in the given folder.
         def doc_reference(path):

--- a/datacube/utils/serialise.py
+++ b/datacube/utils/serialise.py
@@ -13,6 +13,7 @@ import numpy
 import yaml
 
 from datacube.utils.documents import transform_object_tree
+from datacube.model._base import Range
 
 
 class SafeDatacubeDumper(yaml.SafeDumper):  # pylint: disable=too-many-ancestors
@@ -27,8 +28,25 @@ def _reduced_accuracy_decimal_representer(dumper: yaml.Dumper, data: Decimal) ->
     return dumper.represent_float(float(data))
 
 
+def _range_representer(dumper: yaml.Dumper, data: Range) -> yaml.Node:
+    begin, end = data
+
+    # pyyaml doesn't output timestamps in flow style as timestamps(?)
+    if isinstance(begin, datetime):
+        begin = begin.isoformat()
+    if isinstance(end, datetime):
+        end = end.isoformat()
+
+    return dumper.represent_mapping(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+        (('begin', begin), ('end', end)),
+        flow_style=True
+    )
+
+
 SafeDatacubeDumper.add_representer(OrderedDict, _dict_representer)
 SafeDatacubeDumper.add_representer(Decimal, _reduced_accuracy_decimal_representer)
+SafeDatacubeDumper.add_representer(Range, _range_representer)
 
 
 def jsonify_document(doc):

--- a/datacube/utils/uris.py
+++ b/datacube/utils/uris.py
@@ -3,6 +3,7 @@ import os
 import pathlib
 import re
 from typing import Optional, List, Union
+import urllib.parse
 from urllib.parse import urlparse, parse_qsl, urljoin
 from urllib.request import url2pathname
 from pathlib import Path
@@ -202,3 +203,18 @@ def pick_uri(uris: List[str], scheme: Optional[str] = None) -> str:
         raise ValueError('No uri with required scheme was found')
 
     return uris[0]
+
+
+def register_scheme(*schemes):
+    """
+    Register additional uri schemes as supporting relative offsets (etc), so that band/measurement paths can be
+    calculated relative to the base uri.
+    """
+    urllib.parse.uses_netloc.extend(schemes)
+    urllib.parse.uses_relative.extend(schemes)
+    urllib.parse.uses_params.extend(schemes)
+
+
+# s3:// not recognised by python by default
+#  without this `urljoin` might be broken for s3 urls
+register_scheme('s3')


### PR DESCRIPTION
### Reason for this pull request

- Removing old code, often not covered by tests, that was introduced in 2016-2017 when things moved around.
- Removed `masking` imports from `datacube.api`
  - mostly to clean up dependency graph of imports
- Moved yaml formatter for `Range` class into utils where the rest of them are
- Delaying some of the costlier imports until first use, 3 seconds to `import datacube` is annoying
  - `pandas` optionally used by some `list*` functions
  - `pkg_resources` used by driver importing code
  - `jsonschema`, `netCDF4` in `utils.documents`
- Removed some unused constants in `model`
  - Netcdf related constants
- More type annotation fixes and some errors uncovered by `mypy` (use of None as if it was list)
  - Some code was assuming that `ds.uris` is not None and is not an empty list



 - [x] Closes #635 
