### PR TITLE
WIP: fix gdal version related problems in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,8 @@ before_install:
   - export C_INCLUDE_PATH=/usr/include/gdal
   - pip install --upgrade pip
   - pip install --progress-bar off coveralls codecov
+# Install pygdal bindings compatible with dpkg based gdal libs
+  - pip install pygdal=="$(gdal-config --version)"
   - pip install --progress-bar off --requirement requirements-test.txt
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ before_install:
 # Set paths for building python-gdal
   - export CPLUS_INCLUDE_PATH=/usr/include/gdal
   - export C_INCLUDE_PATH=/usr/include/gdal
+  - export GDAL_DATA="$(gdal-config --datadir)"
   - pip install --upgrade pip
   - pip install --progress-bar off coveralls codecov
 # Install pygdal bindings compatible with dpkg based gdal libs

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ before_install:
   - pip install --upgrade pip
   - pip install --progress-bar off coveralls codecov
 # Install pygdal bindings compatible with dpkg based gdal libs
-  - pip install pygdal=="$(gdal-config --version)"
+  - pip install pygdal>="$(gdal-config --version)"
   - pip install --progress-bar off --requirement requirements-test.txt
 
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -56,7 +56,6 @@ psycopg2==2.7.4
 py==1.5.3
 pycodestyle==2.4.0
 pycparser==2.18
-pygdal==2.3.2.4
 pygeoif==0.7
 pylint==1.8.4
 pyparsing==2.2.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -68,7 +68,7 @@ python-dateutil==2.7.2
 pytz==2018.4
 pytzdata==2018.4
 PyYAML==3.12
-rasterio>=1.0.7
+rasterio==1.0.15
 redis==2.10.6
 regex==2017.7.28
 requests==2.20.1

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
         'click>=5.0',
         'cloudpickle>=0.4',
         'dask[array]',
-        'gdal>=1.9,<2.4',
+        'gdal>=1.9',
         'jsonschema',
         'netcdf4',
         'numpy',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -823,7 +823,25 @@ def test_testutils_geobox():
     assert gbox.crs.epsg == 3578
     assert gbox.transform == A
 
-    crs_ = dc_crs_from_rio(CRS.from_wkt(crs.wkt))
+    wkt = '''PROJCS["unnamed",
+    GEOGCS["NAD83",
+       DATUM["North_American_Datum_1983",
+             SPHEROID["GRS 1980",6378137,298.257222101, AUTHORITY["EPSG","7019"]],
+             TOWGS84[0,0,0,0,0,0,0],AUTHORITY["EPSG","6269"]],
+       PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],
+       UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],
+       ],
+    PROJECTION["Albers_Conic_Equal_Area"],
+    PARAMETER["standard_parallel_1",61.66666666666666],
+    PARAMETER["standard_parallel_2",68],
+    PARAMETER["latitude_of_center",59],
+    PARAMETER["longitude_of_center",-132.5],
+    PARAMETER["false_easting",500000],
+    PARAMETER["false_northing",500000],
+    UNIT["Meter",1]]
+    '''
+
+    crs_ = dc_crs_from_rio(CRS.from_wkt(wkt))
     assert crs_.epsg is None
 
 


### PR DESCRIPTION
1. Install pygdal based on information from `gdal-config`
2. Need to set GDAL_DATA based on `gdal-config`
3. Some tests relied on EPSG erasing behaviour of `rasterio.CRS().wkt` that was fixed in the newest version
