### PR TITLE
[WIP] N-dim datacube

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -13,7 +13,7 @@ from datacube.storage import reproject_and_fuse, BandInfo
 from datacube.utils import geometry
 from datacube.utils.generic import fresh_name
 from datacube.utils.geometry import intersects
-from .query import Query, query_group_by, normalize_group_by, query_geopolygon
+from .query import Query, query_group_by, normalize_grouping_policy, query_geopolygon
 from ..index import index_connect
 from ..drivers import new_datasource
 
@@ -244,8 +244,8 @@ class Datacube(object):
         :param str group_by:
             When specified, perform basic combining/reducing of the data.
             May either be a string specifying the method to group by,
-            or a :class:`datacube.api.query.GroupBy` object,
-            or a dictionary mapping strings to :class:`datacube.api.query.GroupBy` objects
+            or a :class:`datacube.api.query.GroupDatasetsPolicy` object,
+            or a dictionary mapping strings to :class:`datacube.api.query.GroupDatasetsPolicy` objects
 
         :param fuse_func:
             Function used to fuse/combine/reduce data with the ``group_by`` parameter. By default,
@@ -342,13 +342,14 @@ class Datacube(object):
         Group datasets along defined non-spatial dimensions (ie. time).
 
         :param datasets: a list of datasets, typically from :meth:`find_datasets`
-        :param group_by: either a :class:`datacube.api.query.GroupBy` object,
-                         or a dictionary mapping strings to `GroupBy` objects
+        :param group_by: either a :class:`datacube.api.query.GroupDatasetsPolicy` object,
+                         or a dictionary mapping strings to
+                         :class:`datacube.api.query.GroupDatasetsPolicy` objects
         :rtype: xarray.DataArray
 
         .. seealso:: :meth:`find_datasets`, :meth:`load_data`, :meth:`query_group_by`
         """
-        group_by = normalize_group_by(group_by)
+        group_by = normalize_grouping_policy(group_by)
         datasets = tuple(datasets)
 
         keys = list(group_by)

--- a/datacube/api/grid_workflow.py
+++ b/datacube/api/grid_workflow.py
@@ -245,7 +245,7 @@ class GridWorkflow(object):
 
         :param observations: datasets grouped by cell index, like from :py:meth:`cell_observations`
         :param group_by: grouping method, as returned by :py:meth:`datacube.api.query.query_group_by`
-        :type group_by: :py:class:`datacube.api.query.GroupBy`
+        :type group_by: :py:class:`datacube.api.query.GroupDatasetsPolicy`
         :return: tiles grouped by cell index
         :rtype: dict[(int,int), :class:`.Tile`]
 
@@ -267,7 +267,7 @@ class GridWorkflow(object):
 
         :param observations: datasets grouped by cell index, like from :meth:`cell_observations`
         :param group_by: grouping method, as returned by :py:meth:`datacube.api.query.query_group_by`
-        :type group_by: :py:class:`datacube.api.query.GroupBy`
+        :type group_by: :py:class:`datacube.api.query.GroupDatasetsPolicy`
         :return: tiles grouped by cell index and time
         :rtype: dict[tuple(int, int, numpy.datetime64), :py:class:`.Tile`]
 

--- a/datacube/api/grid_workflow.py
+++ b/datacube/api/grid_workflow.py
@@ -288,7 +288,7 @@ class GridWorkflow(object):
                                            fastpath=True)
                 coord = xarray.Variable((group_by.dimension,),
                                         numpy.array([key], dtype='datetime64[ns]'),
-                                        attrs={'units': group_by.units},
+                                        attrs=group_by.attrs,
                                         fastpath=True)
                 coords = OrderedDict([(group_by.dimension, coord)])
                 sources = xarray.DataArray(variable, coords=coords, fastpath=True)

--- a/datacube/api/grid_workflow.py
+++ b/datacube/api/grid_workflow.py
@@ -278,19 +278,19 @@ class GridWorkflow(object):
         """
         tiles = {}
         for cell_index, observation in observations.items():
-            observation['datasets'].sort(key=group_by.group_by_func)
-            groups = [(key, tuple(group)) for key, group in groupby(observation['datasets'], group_by.group_by_func)]
+            observation['datasets'].sort(key=group_by.group_key)
+            groups = [(key, tuple(group)) for key, group in groupby(observation['datasets'], group_by.group_key)]
 
             for key, datasets in groups:
                 data = numpy.empty(1, dtype=object)
                 data[0] = datasets
-                variable = xarray.Variable((group_by.dimension,), data,
+                variable = xarray.Variable((group_by.dim,), data,
                                            fastpath=True)
-                coord = xarray.Variable((group_by.dimension,),
+                coord = xarray.Variable((group_by.dim,),
                                         numpy.array([key], dtype='datetime64[ns]'),
                                         attrs=group_by.attrs,
                                         fastpath=True)
-                coords = OrderedDict([(group_by.dimension, coord)])
+                coords = OrderedDict([(group_by.dim, coord)])
                 sources = xarray.DataArray(variable, coords=coords, fastpath=True)
 
                 tile_index = cell_index + (coord.values[0],)

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -40,7 +40,7 @@ OTHER_KEYS = ('measurements', 'group_by', 'output_crs', 'resolution', 'set_nan',
               'source_filter')
 
 
-class GroupBy:
+class GroupDatasetsPolicy:
     """
     Information needed to group datasets.
 
@@ -180,21 +180,21 @@ def query_group_by(group_by='time', **kwargs):
     if group_by is None:
         return collections.OrderedDict()
 
-    if isinstance(group_by, (collections.Mapping, GroupBy)):
+    if isinstance(group_by, (collections.Mapping, GroupDatasetsPolicy)):
         return group_by
 
-    time_grouper = GroupBy(dim='time',
-                           group_key=lambda ds: ds.center_time.replace(tzinfo=None),
-                           attrs=dict(units='seconds since 1970-01-01 00:00:00'))
+    time_grouper = GroupDatasetsPolicy(dim='time',
+                                       group_key=lambda ds: ds.center_time.replace(tzinfo=None),
+                                       attrs=dict(units='seconds since 1970-01-01 00:00:00'))
 
     def solar_time(datasets):
         return min(ds.center_time for ds in datasets)
 
-    solar_day_grouper = GroupBy(dim='time',
-                                group_key=solar_day,
-                                attrs=dict(units='seconds since 1970-01-01 00:00:00'),
-                                axis_value=solar_time,
-                                sort_key=lambda ds: ds.center_time)
+    solar_day_grouper = GroupDatasetsPolicy(dim='time',
+                                            group_key=solar_day,
+                                            attrs=dict(units='seconds since 1970-01-01 00:00:00'),
+                                            axis_value=solar_time,
+                                            sort_key=lambda ds: ds.center_time)
 
     if not isinstance(group_by, str):
         raise ValueError('Invalid group_by object %r' % group_by)
@@ -210,13 +210,13 @@ def query_group_by(group_by='time', **kwargs):
         raise LookupError('No group by function for', group_by)
 
 
-def normalize_group_by(group_by):
+def normalize_grouping_policy(group_by):
     """
     Normalize user-supplied grouping setting for :func:`Datacube.group_datasets` to use.
 
-    :return: normalized group_by of type `Dict[str, GroupBy]`
+    :return: normalized group_by of type `Dict[str, GroupDatasetsPolicy]`
     """
-    if isinstance(group_by, GroupBy):
+    if isinstance(group_by, GroupDatasetsPolicy):
         group_by = {group_by.dim: group_by}
 
     if not isinstance(group_by, collections.Mapping):

--- a/datacube/utils/generic.py
+++ b/datacube/utils/generic.py
@@ -26,3 +26,18 @@ def map_with_lookahead(it, if_one=None, if_many=None):
 
     for v in itertools.chain(iter(p1), it):
         yield proc(v)
+
+
+def fresh_name(prefix, used_names):
+    """
+    Generate a fresh name not in the list of used names.
+    """
+    if prefix not in used_names:
+        return prefix
+
+    counter = 0
+    while True:
+        candidate = "{}_{}".format(prefix, counter)
+        if candidate not in used_names:
+            return candidate
+        counter = counter + 1

--- a/tests/api/test_core.py
+++ b/tests/api/test_core.py
@@ -1,4 +1,4 @@
-from datacube.api.query import GroupBy
+from datacube.api.query import GroupDatasetsPolicy
 
 from datacube import Datacube
 import datetime
@@ -15,7 +15,7 @@ def test_grouping_datasets():
         {'time': datetime.datetime(2016, 2, 1), 'value': 'bar'}
     ]
 
-    group_by = GroupBy(dimension, group_func, dict(units=units), sort_key=group_func)
+    group_by = GroupDatasetsPolicy(dimension, group_func, dict(units=units), sort_key=group_func)
     grouped = Datacube.group_datasets(datasets, group_by)
 
     assert str(grouped.time.dtype) == 'datetime64[ns]'
@@ -48,5 +48,5 @@ def _group_datasets_by_date(datasets):
     dimension = 'time'
     units = None
 
-    group_by = GroupBy(dimension, group_func, dict(units=units), sort_key=sort_key)
+    group_by = GroupDatasetsPolicy(dimension, group_func, dict(units=units), sort_key=sort_key)
     return Datacube.group_datasets(datasets, group_by)

--- a/tests/api/test_core.py
+++ b/tests/api/test_core.py
@@ -48,5 +48,5 @@ def _group_datasets_by_date(datasets):
     dimension = 'time'
     units = None
 
-    group_by = GroupBy(dimension, group_func, dict(units=units), sort_key)
+    group_by = GroupBy(dimension, group_func, dict(units=units), sort_key=sort_key)
     return Datacube.group_datasets(datasets, group_by)

--- a/tests/api/test_core.py
+++ b/tests/api/test_core.py
@@ -15,7 +15,7 @@ def test_grouping_datasets():
         {'time': datetime.datetime(2016, 2, 1), 'value': 'bar'}
     ]
 
-    group_by = GroupBy(dimension, group_func, units, sort_key=group_func)
+    group_by = GroupBy(dimension, group_func, dict(units=units), sort_key=group_func)
     grouped = Datacube.group_datasets(datasets, group_by)
 
     assert str(grouped.time.dtype) == 'datetime64[ns]'
@@ -48,5 +48,5 @@ def _group_datasets_by_date(datasets):
     dimension = 'time'
     units = None
 
-    group_by = GroupBy(dimension, group_func, units, sort_key)
+    group_by = GroupBy(dimension, group_func, dict(units=units), sort_key)
     return Datacube.group_datasets(datasets, group_by)


### PR DESCRIPTION
### WIP DO NOT MERGE

### Reason for this pull request
The `group_by` keyword to `Datacube.load` is unnecessarily restrictive: it understands only two methods that are looked up from a dictionary.

Perhaps more importantly, we want to be able to load N-dimensional data (N >= 2).

### Proposed changes
- Add ability to specify a `datacube.api.query.GroupBy` object directly
- Generalise `units` to arbitrary attributes (of the dimension added)
- Allow N-dim group by
- Update data loading accordingly