### PR TITLE
Fix edge-case error in `compute_reproject_roi`

### DIFF
--- a/datacube/utils/geometry/tools.py
+++ b/datacube/utils/geometry/tools.py
@@ -601,6 +601,9 @@ def compute_reproject_roi(src, dst, padding=None, align=None):
         XY = np.vstack(tr.back(gbox_boundary(dst, pts_per_side)))
         roi_src = roi_from_points(XY, src.shape, padding, align=align)
 
+        if roi_is_empty(roi_src):
+            return (roi_src, np.s_[0:0, 0:0])
+
         # project src roi back into dst and compute roi from that
         xy = np.vstack(tr(roi_boundary(roi_src, pts_per_side)))
         roi_dst = roi_from_points(xy, dst.shape, padding=0)  # no need to add padding twice

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -960,7 +960,6 @@ def test_compute_reproject_roi():
     assert roi_shape(rr.roi_dst) == src[roi_].shape
 
 
-@pytest.mark.xfail
 def test_compute_reproject_roi_issue647():
     """ In some scenarios non-overlapping geoboxes will result in non-empty
     `roi_dst` even though `roi_src` is empty.
@@ -981,8 +980,6 @@ def test_compute_reproject_roi_issue647():
     assert src.extent.overlaps(dst.extent.to_crs(src.crs)) is False
 
     rr = compute_reproject_roi(src, dst)
-    print(rr.roi_src)
-    print(rr.roi_dst)
 
     assert roi_is_empty(rr.roi_src)
     assert roi_is_empty(rr.roi_dst)


### PR DESCRIPTION
I removed original work-around in read_slice, and did a proper fix in `compute_reproject_roi`

- [x] Closes #647
