### PR TITLE
When constructing geometry with None, return None

### DIFF
--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -303,6 +303,8 @@ def _get_coordinates(geom):
 
 
 def _make_geom_from_ogr(geom, crs):
+    if geom is None:
+        return None
     result = Geometry.__new__(Geometry)
     result._geom = geom  # pylint: disable=protected-access
     result.crs = crs

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -199,6 +199,8 @@ def test_unary_union():
     assert union4.type == 'Polygon'
     assert union4.area == 2.5 * box1.area
 
+    assert geometry.unary_union([]) is None
+
     with pytest.raises(ValueError):
         pt = geometry.point(6, 7, epsg4326)
         geometry.unary_union([pt, pt])


### PR DESCRIPTION
`Geometry` wrapper class assumes that it wraps valid `ogr.*` object, so when there is no valid object during construction don't create `Geometry` and instead pass-through `None`


 - [x] Closes #651
 - [x] Tests added / passed
