### PR TITLE
Fix order of datasets returned from `group_datasets`

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -350,6 +350,9 @@ class Datacube(object):
 
         .. seealso:: :meth:`find_datasets`, :meth:`load_data`, :meth:`query_group_by`
         """
+        if isinstance(group_by, str):
+            group_by = query_group_by(group_by=group_by)
+
         dimension, group_func, units, sort_key = group_by
         datasets.sort(key=sort_key)
         groups = [Group(key, tuple(group)) for key, group in groupby(datasets, group_func)]

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -158,6 +158,9 @@ def query_geopolygon(geopolygon=None, **kwargs):
 
 
 def query_group_by(group_by='time', **kwargs):
+    if not isinstance(group_by, str):
+        return group_by
+
     time_grouper = GroupBy(dimension='time',
                            group_by_func=lambda ds: ds.center_time,
                            units='seconds since 1970-01-01 00:00:00',

--- a/tests/api/test_core.py
+++ b/tests/api/test_core.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+from types import SimpleNamespace
 from datacube.api.query import GroupBy
 
 from datacube import Datacube
@@ -6,17 +8,26 @@ import datetime
 
 def test_grouping_datasets():
     def group_func(d):
-        return d['time']
+        return d.time
     dimension = 'time'
     units = None
     datasets = [
-        {'time': datetime.datetime(2016, 1, 1), 'value': 'foo'},
-        {'time': datetime.datetime(2016, 1, 1), 'value': 'flim'},
-        {'time': datetime.datetime(2016, 2, 1), 'value': 'bar'}
+        SimpleNamespace(time=datetime.datetime(2016, 1, 1), value='foo', id=UUID(int=10)),
+        SimpleNamespace(time=datetime.datetime(2016, 2, 1), value='bar', id=UUID(int=1)),
+        SimpleNamespace(time=datetime.datetime(2016, 1, 1), value='flim', id=UUID(int=9)),
     ]
 
     group_by = GroupBy(dimension, group_func, units, sort_key=group_func)
     grouped = Datacube.group_datasets(datasets, group_by)
+    dss = grouped.isel(time=0).values[()]
+    assert isinstance(dss, tuple)
+    assert len(dss) == 2
+    assert [ds.value for ds in dss] == ['flim', 'foo']
+
+    dss = grouped.isel(time=1).values[()]
+    assert isinstance(dss, tuple)
+    assert len(dss) == 1
+    assert [ds.value for ds in dss] == ['bar']
 
     assert str(grouped.time.dtype) == 'datetime64[ns]'
     assert grouped.loc['2016-01-01':'2016-01-15']

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -17,7 +17,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from datacube.api.query import Query, _datetime_to_timestamp, query_group_by, solar_day
+from datacube.api.query import Query, _datetime_to_timestamp, query_group_by, solar_day, GroupBy
 from datacube.model import Range
 from datacube.utils import parse_time
 
@@ -83,6 +83,10 @@ def test_query_kwargs():
 
     with pytest.raises(LookupError):
         query_group_by(group_by='magic')
+
+    gb = query_group_by('time')
+    assert isinstance(gb, GroupBy)
+    assert query_group_by(group_by=gb) is gb
 
 
 def format_test(start_out, end_out):

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -76,7 +76,7 @@ def test_load_data(tmpdir):
     assert ds.time is not None
     assert ds.time == ds2.time
 
-    sources = Datacube.group_datasets([ds], group_by)
+    sources = Datacube.group_datasets([ds], 'time')
     sources2 = Datacube.group_datasets([ds, ds2], group_by)
 
     mm = ['aa']


### PR DESCRIPTION
In `group_datasets` dataset order within a group is defined by user supplied method, usually it is ordered by timestamp, earlier time first. However when there are multiple datasets with the same key dataset order is arbitrary. Dataset order is important as different dataset order might result in different raster output if datasets have overlapping pixels.

What's more `group_dataset` assumed that `sort_key` and `group_key` are related, since it is assumed that `sort_key` will put datasets with the same `group_key` together, this doesn't work when two are completely unrelated, say `group_key` returns scene id, and `sort_key` returns time.

Approach now is as following:

1. Use `group_key` to compute groups
2. For each group
   - Sort datasets within the group using (`sort_key(ds), ds.id`) as key
   - Use `sort_key(ds)` where ds is first dataset in the group as a coordinate value    
3. Order groups based on coordinate value computed in step 2

### Other

Harmonise `group_by` parameter use across `.load|.group_datasets`, allow either name as a string, e.g. `solar_day`, or custom `GroupBy` object.


 - [x] Closes #646 
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes