### PR TITLE
Tiny Mergify tweak

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,8 +6,12 @@ pull_request_rules:
   - '#approved-reviews-by>=1'
   - "#changes-requested-reviews-by=0"
   - base=develop
-  - status-success=continuous-integration/travis-ci
+  - status-success=continuous-integration/travis-ci/pr
   actions:
     merge:
       method: rebase
       rebase_fallback: merge
+- name: delete head branch after merge
+  conditions: []
+  actions:
+    delete_head_branch: {}


### PR DESCRIPTION
Mergify wasn't noticing the Travis-CI build success markers. This should fix that.
Also, delete the head branch after merging. This was done by a separate service which we can now remove. Consolidation++