### PR TITLE
Faster construction of lazy arrays

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -488,6 +488,8 @@ class Datacube(object):
         :param dict dask_chunks:
             If provided, the data will be loaded on demand using using :class:`dask.array.Array`.
             Should be a dictionary specifying the chunking size for each output dimension.
+            Unspecified dimensions will be auto-guessed, currently this means use chunk size of 1 for non-spatial
+            dimensions and use whole dimension (no chunking unless specified) for spatial dimensions.
 
             See the documentation on using `xarray with dask <http://xarray.pydata.org/en/stable/dask.html>`_
             for more information.
@@ -696,8 +698,9 @@ def _calculate_chunk_sizes(sources, geobox, dask_chunks):
     if bad_keys:
         raise KeyError('Unknown dask_chunk dimension {}. Valid dimensions are: {}'.format(bad_keys, valid_keys))
 
-    # If chunk size is not specified, the entire dimension length is used, as in xarray
-    chunks = {dim: size for dim, size in zip(sources.dims, sources.shape)}
+    # For non-spatial default to 1 since this is "native"
+    chunks = {dim: 1 for dim in sources.dims}
+    # For non-spatial default to entire dimension length as in xarray
     chunks.update({dim: size for dim, size in zip(geobox.dimensions, geobox.shape)})
 
     chunks.update(dask_chunks)

--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -1,7 +1,8 @@
 import functools
+import itertools
 import math
 from collections import namedtuple, OrderedDict
-from typing import Tuple, Callable, Iterable
+from typing import Tuple, Callable, Iterable, List
 
 import cachetools
 import numpy
@@ -36,6 +37,24 @@ class BoundingBox(_BoundingBox):
     @property
     def height(self):
         return self.top - self.bottom
+
+    @property
+    def points(self) -> List[Tuple[float, float]]:
+        """Extract four corners of the bounding box
+        """
+        x0, y0, x1, y1 = self
+        return list(itertools.product((x0, x1), (y0, y1)))
+
+    def transform(self, transform: Affine) -> 'BoundingBox':
+        """Transform bounding box through a linear transform
+
+           Apply linear transform on 4 points of the bounding box and compute
+           bounding box of these four points.
+        """
+        pts = [transform*pt for pt in self.points]
+        xx = [x for x, _ in pts]
+        yy = [y for _, y in pts]
+        return BoundingBox(min(xx), min(yy), max(xx), max(yy))
 
 
 class CRSProjProxy(object):

--- a/datacube/utils/geometry/gbox.py
+++ b/datacube/utils/geometry/gbox.py
@@ -121,6 +121,11 @@ class GeoboxTiles():
     """
 
     def __init__(self, box: GeoBox, tile_shape: Tuple[int, int]):
+        """ Construct from a ``GeoBox``
+
+        :param box: source :class:`datacube.utils.geometry.GeoBox`
+        :param tile_shape: Shape of sub-tiles in pixels (rows, cols)
+        """
         self._gbox = box
         self._tile_shape = tile_shape
         self._shape = tuple(math.ceil(float(N)/n)
@@ -129,6 +134,8 @@ class GeoboxTiles():
 
     @property
     def shape(self):
+        """ Number of tiles along each dimension
+        """
         return self._shape
 
     def _idx_to_slice(self, idx: Tuple[int, int]) -> Tuple[slice, slice]:
@@ -144,6 +151,12 @@ class GeoboxTiles():
         return (ir, ic)
 
     def __getitem__(self, idx: Tuple[int, int]) -> GeoBox:
+        """ Lookup tile by index, index is in matrix access order: (row, col)
+
+            :param idx: (row, col) index
+
+            Will raise IndexError when index is outside of [(0,0) -> .shape)
+        """
         sub_gbox = self._cache.get(idx, None)
         if sub_gbox is not None:
             return sub_gbox

--- a/datacube/utils/geometry/gbox.py
+++ b/datacube/utils/geometry/gbox.py
@@ -147,10 +147,10 @@ class GeoboxTiles():
     def _idx_to_slice(self, idx: Tuple[int, int]) -> Tuple[slice, slice]:
         def _slice(i, N, n) -> slice:
             _in = i*n
-            if _in >= N:
-                raise IndexError()
-
-            return slice(_in, min(_in + n, N))
+            if 0 <= _in < N:
+                return slice(_in, min(_in + n, N))
+            else:
+                raise IndexError("Index ({},{})is out of range".format(*idx))
 
         ir, ic = (_slice(i, N, n)
                   for i, N, n in zip(idx, self._gbox.shape, self._tile_shape))
@@ -160,8 +160,8 @@ class GeoboxTiles():
         """ Lookup tile by index, index is in matrix access order: (row, col)
 
             :param idx: (row, col) index
-
-            Will raise IndexError when index is outside of [(0,0) -> .shape)
+            :returns: GeoBox of a tile
+            :raises: IndexError when index is outside of [(0,0) -> .shape)
         """
         sub_gbox = self._cache.get(idx, None)
         if sub_gbox is not None:

--- a/datacube/utils/geometry/gbox.py
+++ b/datacube/utils/geometry/gbox.py
@@ -156,6 +156,24 @@ class GeoboxTiles():
                   for i, N, n in zip(idx, self._gbox.shape, self._tile_shape))
         return (ir, ic)
 
+    def chunk_shape(self, idx: Tuple[int, int]) -> Tuple[int, int]:
+        """ Chunk shape for a given chunk index.
+
+            :param idx: (row, col) index
+            :returns: (nrow, ncols) shape of a tile (edge tiles might be smaller)
+            :raises: IndexError when index is outside of [(0,0) -> .shape)
+        """
+        def _sz(i: int, n: int, tile_sz: int, total_sz: int) -> int:
+            if 0 <= i < n - 1:  # not edge tile
+                return tile_sz
+            elif i == n - 1:    # edge tile
+                return total_sz - (i*tile_sz)
+            else:               # out of index case
+                raise IndexError("Index ({},{}) is out of range".format(*idx))
+
+        n1, n2 = map(_sz, idx, self._shape, self._tile_shape, self._gbox.shape)
+        return (n1, n2)
+
     def __getitem__(self, idx: Tuple[int, int]) -> GeoBox:
         """ Lookup tile by index, index is in matrix access order: (row, col)
 

--- a/datacube/utils/geometry/gbox.py
+++ b/datacube/utils/geometry/gbox.py
@@ -135,6 +135,10 @@ class GeoboxTiles():
         self._cache = {}  # type: Dict[Tuple[int, int], GeoBox]
 
     @property
+    def base(self) -> GeoBox:
+        return self._gbox
+
+    @property
     def shape(self):
         """ Number of tiles along each dimension
         """

--- a/docs/dev/api/index.rst
+++ b/docs/dev/api/index.rst
@@ -257,6 +257,8 @@ Geometry Classes
    utils.geometry.BoundingBox
    utils.geometry.CRS
    utils.geometry.Geometry
+   utils.geometry.GeoBox
+   utils.geometry.gbox.GeoboxTiles
    model.GridSpec
 
 .. Geometry.contains

--- a/tests/test_gbox_ops.py
+++ b/tests/test_gbox_ops.py
@@ -116,6 +116,7 @@ def test_gbox_tiles():
     gbox = GeoBox(W, H, A, epsg3857)
     tt = gbx.GeoboxTiles(gbox, (h, w))
     assert tt.shape == (300/10, 200/20)
+    assert tt.base is gbox
 
     assert tt[0, 0] == gbox[0:h, 0:w]
     assert tt[0, 1] == gbox[0:h, w:w+w]

--- a/tests/test_gbox_ops.py
+++ b/tests/test_gbox_ops.py
@@ -1,5 +1,6 @@
 from affine import Affine
 import numpy as np
+import pytest
 from datacube.utils.geometry import gbox as gbx
 from datacube.utils import geometry
 from datacube.utils.geometry import GeoBox
@@ -106,3 +107,28 @@ def test_gbox_ops():
         assert d.extent != s.extent
         np.testing.assert_almost_equal(d.extent.area, s.extent.area, 1e-5)
         assert s[49:52, 499:502].extent.contains(d[50:51, 500:501].extent), "Check that center pixel hasn't moved"
+
+
+def test_gbox_tiles():
+    A = Affine.identity()
+    H, W = (300, 200)
+    h, w = (10, 20)
+    gbox = GeoBox(W, H, A, epsg3857)
+    tt = gbx.GeoboxTiles(gbox, (h, w))
+    assert tt.shape == (300/10, 200/20)
+
+    assert tt[0, 0] == gbox[0:h, 0:w]
+    assert tt[0, 1] == gbox[0:h, w:w+w]
+
+    assert tt[0, 0] is tt[0, 0]  # Should cache exact same object
+    assert tt[4, 1].shape == (h, w)
+
+    H, W = (11, 22)
+    h, w = (10, 9)
+    gbox = GeoBox(W, H, A, epsg3857)
+    tt = gbx.GeoboxTiles(gbox, (h, w))
+    assert tt.shape == (2, 3)
+    assert tt[1, 2] == gbox[10:11, 18:22]
+
+    with pytest.raises(IndexError):
+        tt[tt.shape]

--- a/tests/test_gbox_ops.py
+++ b/tests/test_gbox_ops.py
@@ -135,9 +135,20 @@ def test_gbox_tiles():
         with pytest.raises(IndexError):
             tt[idx]
 
+        with pytest.raises(IndexError):
+            tt.chunk_shape(idx)
+
     cc = np.zeros(tt.shape, dtype='int32')
     for idx in tt.tiles(gbox.extent):
         cc[idx] += 1
     np.testing.assert_array_equal(cc, np.ones(tt.shape))
 
     assert list(tt.tiles(gbox[:h, :w].extent)) == [(0, 0)]
+
+    (H, W) = (11, 22)
+    (h, w) = (10, 20)
+    tt = gbx.GeoboxTiles(GeoBox(W, H, A, epsg3857), (h, w))
+    assert tt.chunk_shape((0, 0)) == (h, w)
+    assert tt.chunk_shape((0, 1)) == (h, 2)
+    assert tt.chunk_shape((1, 1)) == (1, 2)
+    assert tt.chunk_shape((1, 0)) == (1, w)

--- a/tests/test_gbox_ops.py
+++ b/tests/test_gbox_ops.py
@@ -131,8 +131,9 @@ def test_gbox_tiles():
     assert tt.shape == (2, 3)
     assert tt[1, 2] == gbox[10:11, 18:22]
 
-    with pytest.raises(IndexError):
-        tt[tt.shape]
+    for idx in [tt.shape, (-1, 0), (0, -1), (-33, 1)]:
+        with pytest.raises(IndexError):
+            tt[idx]
 
     cc = np.zeros(tt.shape, dtype='int32')
     for idx in tt.tiles(gbox.extent):

--- a/tests/test_gbox_ops.py
+++ b/tests/test_gbox_ops.py
@@ -132,3 +132,10 @@ def test_gbox_tiles():
 
     with pytest.raises(IndexError):
         tt[tt.shape]
+
+    cc = np.zeros(tt.shape, dtype='int32')
+    for idx in tt.tiles(gbox.extent):
+        cc[idx] += 1
+    np.testing.assert_array_equal(cc, np.ones(tt.shape))
+
+    assert list(tt.tiles(gbox[:h, :w].extent)) == [(0, 0)]

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -96,6 +96,10 @@ def test_props():
     bbox = geometry.BoundingBox(1, 0, 10, 13)
     assert bbox.width == 9
     assert bbox.height == 13
+    assert bbox.points == [(1, 0), (1, 13), (10, 0), (10, 13)]
+
+    assert bbox.transform(Affine.identity()) == bbox
+    assert bbox.transform(Affine.translation(1, 2)) == geometry.BoundingBox(2, 2, 11, 15)
 
     pt = geometry.point(3, 4, crs)
     assert pt.json['coordinates'] == (3.0, 4.0)


### PR DESCRIPTION
Why and how described in #661 and #663

Single day of Sentinel NRT across Australia using 1kx1k chunks completes in ~7secs now, used to take minutes. This is `335,928  by 400,307` pixels  across lazy array.

 - [x] Closes #663
 - [x] Closes #661
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes