### PR TITLE
Change default behaviour of ignore_exceptions_if to catch them all

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -128,6 +128,7 @@ class Datacube(object):
 
     #: pylint: disable=too-many-arguments, too-many-locals
     def load(self, product=None, measurements=None, output_crs=None, resolution=None, resampling=None,
+             skip_broken_datasets=False,
              dask_chunks=None, like=None, fuse_func=None, align=None, datasets=None, **query):
         """
         Load data as an ``xarray`` object.  Each measurement will be a data variable in the :class:`xarray.Dataset`.
@@ -293,6 +294,7 @@ class Datacube(object):
                                 resampling=resampling,
                                 fuse_func=fuse_func,
                                 dask_chunks=dask_chunks,
+                                skip_broken_datasets=skip_broken_datasets,
                                 **legacy_args)
 
         return apply_aliases(result, datacube_product, measurements)

--- a/datacube/storage/_rio.py
+++ b/datacube/storage/_rio.py
@@ -141,7 +141,7 @@ class RasterioDataSource(DataSource):
         """Context manager which returns a :class:`BandDataSource`"""
         try:
             _LOG.debug("opening %s", self.filename)
-            with rasterio.open(self.filename) as src:
+            with rasterio.open(self.filename, sharing=False) as src:
                 override = False
 
                 transform = src.transform

--- a/datacube/utils/py.py
+++ b/datacube/utils/py.py
@@ -25,12 +25,15 @@ def import_function(func_ref):
 
 
 @contextmanager
-def ignore_exceptions_if(ignore_errors):
+def ignore_exceptions_if(ignore_errors, errors=None):
     """Ignore Exceptions raised within this block if ignore_errors is True"""
+    if errors is None:
+        errors = (Exception,)
+
     if ignore_errors:
         try:
             yield
-        except OSError as e:
+        except errors as e:
             _LOG.warning('Ignoring Exception: %s', e)
     else:
         yield


### PR DESCRIPTION
### Reason for this pull request

`skip_broken_datasets=True` doesn't work when reading from s3 see #649 . 

Also, nothing in the name of `ignore_exceptions_if(..)` function suggests that it captures `OSError` only (this is "file not found" error). A corrupt but existing file will also break through this exception guard.

### Proposed changes

- Catch all exception by default
- Allow list of classes of error to catch

### Other Changes

- Use thread-safe version of `rasterio.open(..)` (needed for dask work)
- Accept `skip_broken_datasets=True` on `.load` not just `.load_data`

------------------------------------------

 - [x] Closes #649
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
