### PR TITLE
Remove default PHOTOMETRIC value that gave gdal warning

### DIFF
--- a/datacube/helpers.py
+++ b/datacube/helpers.py
@@ -14,7 +14,6 @@ DEFAULT_PROFILE = {
     'driver': 'GTiff',
     'interleave': 'band',
     'nodata': 0.0,
-    'photometric': 'RGBA',
     'tiled': True}
 
 


### PR DESCRIPTION
### Reason for this pull request
Stop warning messages
...


### Proposed changes
Remove default PHOTOMETRIC value that gave gdal warning
- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
