### PR TITLE
Added stored schemas for postgres

### DIFF
--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -31,7 +31,7 @@ from ._fields import (
 )
 from .sql import escape_pg_identifier
 from ._schema import (
-    DATASET, DATASET_SOURCE, METADATA_TYPE, DATASET_LOCATION, DATASET_TYPE
+    DATASET, DATASET_SOURCE, METADATA_TYPE, DATASET_LOCATION, DATASET_TYPE, SCHEMA_VERSION
 )
 
 from typing import Iterable, Tuple
@@ -964,3 +964,24 @@ class PostgresDbAPI(object):
                 raise ValueError('Unknown user %r' % user)
 
         _core.grant_role(self._connection, pg_role, users)
+
+    def get_schema_version_info(self):
+        """
+        Return the latest row of SCHEMA_VERSION table as a dictionary with column
+        names as keys. If such a row does not exist, it returns None
+        """
+
+        result = self._connection.execute(
+            select(
+                [SCHEMA_VERSION]
+            ).select_from(
+                SCHEMA_VERSION
+            ).order_by(
+                SCHEMA_VERSION.c.id.desc()
+            ).limit(
+                1
+            )
+        ).first()
+        if result:
+            return {key: result[index] for index, key in enumerate(SCHEMA_VERSION.c.keys())}
+        return None

--- a/datacube/drivers/postgres/_schema.py
+++ b/datacube/drivers/postgres/_schema.py
@@ -12,8 +12,10 @@ from sqlalchemy.sql import func
 
 from . import sql
 from . import _core
+from datacube.version import __version__ as datacube_version
 
 _LOG = logging.getLogger(__name__)
+
 
 METADATA_TYPE = Table(
     'metadata_type', _core.METADATA,
@@ -110,4 +112,20 @@ DATASET_SOURCE = Table(
 
     PrimaryKeyConstraint('dataset_ref', 'classifier'),
     UniqueConstraint('source_dataset_ref', 'dataset_ref'),
+)
+
+# Schema version
+SCHEMA_VERSION = Table(
+    'schema_version', _core.METADATA,
+    Column('id', Integer, primary_key=True, autoincrement=True),
+
+    # The version of the schema applied
+    Column('schema_version', String, nullable=False),
+
+    # The datacube version that applied the last change
+    Column('datacube_version_applied', String, default=datacube_version, nullable=False),
+
+    # When it was added and by whom.
+    Column('added', DateTime(timezone=True), server_default=func.now(), nullable=False),
+    Column('added_by', sql.PGNAME, server_default=func.current_user(), nullable=False),
 )

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -16,6 +16,7 @@ v1.7dev
 - Bug fix (Index out of bounds causing ingestion failures)
 - Add "virtual products" (:pull:`522`, :pull:`597`) for multi-product loading
 - Support indexing data directly from HTTP/HTTPS/S3 URLs (:pull:`607`)
+- Stored `schema_version` added
 
 
 v1.6.1 (27 August 2018)

--- a/integration_tests/test_schema.py
+++ b/integration_tests/test_schema.py
@@ -1,0 +1,8 @@
+from datacube.drivers.postgres.sql import pg_exists
+from datacube.drivers.postgres._core import schema_qualified, __schema_version__
+
+
+def test_schema_version(initialised_postgres_db):
+    with initialised_postgres_db.connect() as dbapi:
+        assert pg_exists(dbapi._connection.engine, schema_qualified('schema_version'))
+        assert dbapi.get_schema_version_info()['schema_version'] == __schema_version__


### PR DESCRIPTION
### Reason for this pull request
### Postgres Schema changes require tracking
Currently we infer whether the `postgres` database schema is up to date without tracking `schema versions`. `Stored schema version` make this ability easier and add other abilities such as tracking. Further, the `datacube version` that applied a specific schema update is useful to track.
...

#### Proposed changes
- Added a new `schema_version` table. 
- Updated `ensure_db`, `schema_is_latest`, and `update_schema` functions of `datacube.drivers.postgres._core` to reflect stored schema. 
- It is assumed that `schema_version` is coded in `datacube.drivers.postgres._core` whenever schema is changed. 
- In order to allow continued use of an existing `datacube` database that does not have `stored schema`, a log warning is provided instead of stopping further queries. 
- A new function `get_schema_version` is added to `PostgresDbAPI` that returns the latest schema added. The latest schema version is resolved by extracting the schema update having the highest id which is the primary key auto-incremented.    

 - [Y] Tests added / passed
 - [Y] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
