### PR TITLE
Update pip in docker build. Version installed by apt may be out of date

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,10 @@ WORKDIR $APPDIR
 # Set the locale, this is required for some of the Python packages
 ENV LC_ALL C.UTF-8
 
+# Ensure pip is up to date
+RUN pip3 install --upgrade pip \
+    && rm -rf $HOME/.cache/pip
+
 # Install psycopg2 as a special case, to quiet the warning message 
 RUN pip3 install --no-cache --no-binary :all: psycopg2 \
     && rm -rf $HOME/.cache/pip


### PR DESCRIPTION
### Reason for this pull request
The version of pip installed by Ubuntu in apt-get may not be the most up to date version of pip.


### Proposed changes

- Allow pip to update itself in the Docker build process to the latest version

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
