### PR TITLE
Update dc.load resampling documentation to match dc.load_data

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -220,10 +220,15 @@ class Datacube(object):
             Typically when using most CRSs, the first number would be negative.
 
         :param str|dict resampling:
-            The resampling method to use if re-projection is required.
+            The resampling method to use if re-projection is required. This could be a string or
+            a dictionary mapping band name to resampling mode. When using a dict use ``'*'`` to
+            indicate "apply to all other bands", for example ``{'*': 'cubic', 'fmask': 'nearest'}`` would
+            use `cubic` for all bands except ``fmask`` for which `nearest` will be used.
 
             Valid values are: ``'nearest', 'cubic', 'bilinear', 'cubic_spline', 'lanczos', 'average',
             'mode', 'gauss',  'max', 'min', 'med', 'q1', 'q3'``
+
+            Default is to use ``nearest`` for all bands.
             .. seealso:: :meth:`load_data`
 
         :param (float,float) align:


### PR DESCRIPTION
### Reason for this pull request
The `resampling` parameter is currently better documented for the `dc.load_data` function vs`dc.load` itself, despite `dc.load` being the entry point function for loading data. For example, even though the doc string specifies that a dict can be used, no example is given on how to use this to use different resampling methods for different bands. Additionally, the documentation for `dc.load` does not currently state what resampling is used by default ("nearest").

### Proposed changes
This pull request copies the documentation from `dc.load_data` to `dc.load`, which will hopefully result in better discoverability for this dict resampling functionality.
