### PR TITLE
SQL Alchemy 1.3.0 Function Quoting fix

### DIFF
--- a/datacube/drivers/postgres/sql.py
+++ b/datacube/drivers/postgres/sql.py
@@ -57,7 +57,11 @@ class CommonTimestamp(GenericFunction):
     package = 'agdc'
     identifier = 'common_timestamp'
 
-    name = '%s.common_timestamp' % SCHEMA_NAME
+    name = 'common_timestamp'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.packagenames = ['%s' % SCHEMA_NAME]
 
 
 # pylint: disable=too-many-ancestors
@@ -66,7 +70,11 @@ class Float8Range(GenericFunction):
     package = 'agdc'
     identifier = 'float8range'
 
-    name = '%s.float8range' % SCHEMA_NAME
+    name = 'float8range'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.packagenames = ['%s' % SCHEMA_NAME]
 
 
 class PGNAME(sqltypes.Text):


### PR DESCRIPTION
Initialize packagenames variable in SQL function classes derived from sqlalchemy GenericFunctions. Setting the packagenames list with the `agdc` string allows sqlalchemy > 1.3.0 to correctly quote the SQL function name. Possible fix for #668

### Reason for this pull request
#668 reported issues with SQL Alchemy 1.3.0 and this is potential fix to our code base to allow us to use SQL Alchemy 1.3.0.

It appears that this change https://github.com/sqlalchemy/sqlalchemy/issues/4467 changed the way that SQL Alchemy quoted function identifiers -> the entire function name that was specified in our `CommonTimestamp` and `Float8Range` classes was quoted (`"agdc.common_timestamp"`) which is invalid in psql.

### Proposed changes
- Set the `packagenames` variable of the `CommonTimestamp` and `Float8Range` classes which are derived from `sqlalchemy.sql.functions.GenericFunction`. Setting this member variable means that SQLAlchemy will quote `"agdc"` and `"common_timestamp"` separately instead of together (i.e. `"agdc"."common_timestamp"`)

 - [ ] Closes #668
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
