### PR TITLE
Update docker to use requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,12 +40,13 @@ ENV LC_ALL C.UTF-8
 RUN pip3 install --upgrade pip \
     && rm -rf $HOME/.cache/pip
 
-# Install psycopg2 as a special case, to quiet the warning message 
-RUN pip3 install --no-cache --no-binary :all: psycopg2 \
+# Install psycopg2 as a special case to quiet the warning message 
+# Make sure this version is the same as in the requirements-test.txt file
+RUN pip3 install --no-cache --no-binary :all: psycopg2==2.7.7 \
     && rm -rf $HOME/.cache/pip
 
-# Now use the setup.py file to identify dependencies
-RUN pip3 install '.[test,celery,s3]' --upgrade \
+# Use the setup.py file to identify dependencies
+RUN pip3 install -r requirements-test.txt \
     && rm -rf $HOME/.cache/pip
 
 # Install ODC

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,8 +4,8 @@ astroid==1.6.3
 attrs==17.4.0
 billiard==3.5.0.3
 boto==2.49.0
-boto3==1.7.80
-botocore==1.10.80
+boto3==1.9.117
+botocore==1.12.117
 cachetools==2.0.1
 celery==4.1.0
 certifi==2018.1.18
@@ -40,7 +40,7 @@ mccabe==0.6.1
 mock==2.0.0
 more-itertools==4.1.0
 multiprocess==0.70.5
-netCDF4==1.3.1
+netCDF4==1.4.3
 nose==1.3.7
 numpy==1.14.2
 objgraph==3.4.0
@@ -52,7 +52,7 @@ pendulum==1.4.4
 pluggy==0.6.0
 pox==0.2.3
 ppft==1.6.4.7.1
-psycopg2==2.7.4
+psycopg2==2.7.7
 py==1.5.3
 pycodestyle==2.4.0
 pycparser==2.18
@@ -68,11 +68,11 @@ python-dateutil==2.7.2
 pytz==2018.4
 pytzdata==2018.4
 PyYAML==3.12
-rasterio==1.0.15
+rasterio==1.0.21
 redis==2.10.6
 regex==2017.7.28
 requests==2.20.1
-s3transfer==0.1.13
+s3transfer==0.2.0
 SharedArray==2.0.4
 singledispatch==3.4.0.3
 snuggs==1.4.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -40,7 +40,7 @@ mccabe==0.6.1
 mock==2.0.0
 more-itertools==4.1.0
 multiprocess==0.70.5
-netCDF4==1.4.3
+netCDF4==1.3.1
 nose==1.3.7
 numpy==1.14.2
 objgraph==3.4.0


### PR DESCRIPTION
### Reason for this pull request

The Dockerfile was using a different method to install dependencies to what the test suite uses.

### Proposed changes

- Install dependencies of the ODC using the `requirements-test.txt` file
- Increment versions of a number of dependencies

