### PR TITLE
Set the version of Python to 3.6

### DIFF
--- a/docs/ops/conda_base.rst
+++ b/docs/ops/conda_base.rst
@@ -9,7 +9,7 @@
 4. Create a virtual environment in conda
     .. code::
 
-        conda create --name cubeenv python=3.5 datacube
+        conda create --name cubeenv python=3.6 datacube
 
 5. Activate the virtual environment
     .. code::


### PR DESCRIPTION
### Reason for this pull request

With Python 3.5 and miniconda `datacube -v system init` currently fails with `ImportError: libpoppler.so.76: cannot open shared object file: No such file or directory`.

### Proposed changes

- Set the version of Python to 3.6 when creating a virtual environment through miniconda

 - [ ] Closes #687