### PR TITLE
fix query crs getting lost

### DIFF
--- a/datacube/virtual/impl.py
+++ b/datacube/virtual/impl.py
@@ -256,10 +256,11 @@ class Product(VirtualProduct):
         if product is None:
             raise VirtualProductException("could not find product {}".format(self._product))
 
-        originals = Query(dc.index, **reject_keys(self, self._NON_QUERY_KEYS))
-        overrides = Query(dc.index, **reject_keys(search_terms, self._NON_QUERY_KEYS))
+        originals = Query(dc.index, **self)
+        overrides = Query(dc.index, **search_terms)
+        merged = merge_search_terms(originals.search_terms, overrides.search_terms)
 
-        query = Query(dc.index, **merge_search_terms(originals.search_terms, overrides.search_terms))
+        query = Query(dc.index, **merged)
         self._assert(query.product == self._product,
                      "query for {} returned another product {}".format(self._product, query.product))
 


### PR DESCRIPTION
### Reason for this pull request
Building query drops settings in the current implementation.

### Proposed changes
Retain as much as possible before passing on to `Query`.