### PR TITLE
More robust handling of CRS as a string

### DIFF
--- a/datacube/helpers.py
+++ b/datacube/helpers.py
@@ -26,17 +26,17 @@ def write_geotiff(filename, dataset, profile_override=None, time_index=None):
     :param profile_override: option dict, overrides rasterio file creation options.
     :param time_index: DEPRECATED
     """
+    if time_index is not None:
+        raise ValueError('''The write_geotiff function no longer supports passing in `time_index`.
+        The same function can be achieved by calling `dataset.isel(time=<time_index>)` before passing
+ in your dataset. It was removed because it made the function much less useful for more advanced cases.''')
+
     profile_override = profile_override or {}
 
     geobox = getattr(dataset, 'geobox', None)
 
     if geobox is None:
         raise ValueError('Can only write datasets with specified `crs` attribute')
-
-    if time_index is not None:
-        raise ValueError('''The write_geotiff function no longer supports passing in `time_index`.
-        The same function can be achieved by calling `dataset.isel(time=<time_index>)` before passing
-        in your dataset. It was removed because it made the function much less useful for more advanced cases.''')
 
     try:
         dtypes = {val.dtype for val in dataset.data_vars.values()}

--- a/datacube/helpers.py
+++ b/datacube/helpers.py
@@ -26,7 +26,16 @@ def write_geotiff(filename, dataset, profile_override=None, time_index=None):
     :param profile_override: option dict, overrides rasterio file creation options.
     :param time_index: DEPRECATED
     """
+    from datacube.utils.geometry import CRS
     profile_override = profile_override or {}
+
+    crs = dataset.attrs.get('crs', None)
+
+    if crs is None:
+        raise ValueError('Can only write datasets with sepcified `crs` attribute')
+
+    if isinstance(crs, str):
+        crs = CRS(crs)
 
     if time_index is not None:
         raise ValueError('''The write_geotiff function no longer supports passing in `time_index`.
@@ -41,10 +50,10 @@ def write_geotiff(filename, dataset, profile_override=None, time_index=None):
 
     profile = DEFAULT_PROFILE.copy()
     profile.update({
-        'width': dataset.dims[dataset.crs.dimensions[1]],
-        'height': dataset.dims[dataset.crs.dimensions[0]],
+        'width': dataset.dims[crs.dimensions[1]],
+        'height': dataset.dims[crs.dimensions[0]],
         'transform': dataset.affine,
-        'crs': dataset.crs.crs_str,
+        'crs': crs.crs_str,
         'count': len(dataset.data_vars),
         'dtype': str(dtypes.pop())
     })

--- a/datacube/utils/xarray_geoextensions.py
+++ b/datacube/utils/xarray_geoextensions.py
@@ -16,20 +16,38 @@ from affine import Affine
 from datacube.utils import data_resolution_and_offset, geometry
 
 
+def _norm_crs(crs):
+    if crs is None or isinstance(crs, geometry.CRS):
+        return crs
+    elif isinstance(crs, str):
+        return geometry.CRS(crs)
+    else:
+        raise ValueError('Can not interpret {} as CRS'.format(type(crs)))
+
+
 def _xarray_affine(obj):
-    dims = obj.crs.dimensions
+    crs = _norm_crs(obj.crs)
+    if crs is None:
+        return None
+
+    dims = crs.dimensions
     xres, xoff = data_resolution_and_offset(obj[dims[1]].values)
     yres, yoff = data_resolution_and_offset(obj[dims[0]].values)
     return Affine.translation(xoff, yoff) * Affine.scale(xres, yres)
 
 
 def _xarray_extent(obj):
-    return obj.geobox.extent
+    geobox = obj.geobox
+    return None if geobox is None else geobox.extent
 
 
 def _xarray_geobox(obj):
-    dims = obj.crs.dimensions
-    return geometry.GeoBox(obj[dims[1]].size, obj[dims[0]].size, obj.affine, obj.crs)
+    crs = _norm_crs(obj.crs)
+    if crs is None:
+        return None
+
+    dims = crs.dimensions
+    return geometry.GeoBox(obj[dims[1]].size, obj[dims[0]].size, obj.affine, crs)
 
 
 xarray.Dataset.geobox = property(_xarray_geobox)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -237,6 +237,26 @@ def test_write_geotiff(tmpdir, odc_style_xr_dataset):
         assert (written_data == odc_style_xr_dataset['B10']).all()
 
 
+def test_write_geotiff_str_crs(tmpdir, odc_style_xr_dataset):
+    """Ensure the geotiff helper writer works, and supports crs as a string."""
+    filename = tmpdir + '/test.tif'
+
+    original_crs = odc_style_xr_dataset.crs
+
+    odc_style_xr_dataset.attrs['crs'] = str(original_crs)
+    write_geotiff(filename, odc_style_xr_dataset)
+    assert filename.exists()
+
+    with rasterio.open(str(filename)) as src:
+        written_data = src.read(1)
+
+        assert (written_data == odc_style_xr_dataset['B10']).all()
+
+    del odc_style_xr_dataset.attrs['crs']
+    with pytest.raises(ValueError):
+        write_geotiff(filename, odc_style_xr_dataset)
+
+
 def test_write_geotiff_time_index_deprecated():
     """The `time_index` parameter to `write_geotiff()` was a poorly thought out addition and is now deprecated."""
 

--- a/tests/test_xarray_extension.py
+++ b/tests/test_xarray_extension.py
@@ -1,0 +1,27 @@
+import pytest
+from datacube.utils.xarray_geoextensions import (
+    _norm_crs,
+    _xarray_affine,
+    _xarray_geobox,
+    _xarray_extent,
+)
+from datacube.testutils.geom import epsg4326
+
+
+def test_xr_extension(odc_style_xr_dataset):
+    assert _norm_crs(None) is None
+    assert _norm_crs(epsg4326) is epsg4326
+    assert _norm_crs(str(epsg4326)) == epsg4326
+
+    with pytest.raises(ValueError):
+        _norm_crs([])
+
+    assert odc_style_xr_dataset.geobox.shape == odc_style_xr_dataset.B10.shape
+
+    (sx, zz0, tx, zz1, sy, ty) = odc_style_xr_dataset.affine[:6]
+    assert (zz0, zz1) == (0, 0)
+
+    odc_style_xr_dataset.attrs['crs'] = None
+    assert _xarray_affine(odc_style_xr_dataset) is None
+    assert _xarray_geobox(odc_style_xr_dataset) is None
+    assert _xarray_extent(odc_style_xr_dataset) is None


### PR DESCRIPTION
In the case when `crs` attribute is a string, treat it a string representation of CRS class, rather than just assume it is CRS class and fail with attribute access failures.


 - [x] Closes #501 
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes