### PR TITLE
Output cli error messages on stderr

### DIFF
--- a/datacube/scripts/metadata.py
+++ b/datacube/scripts/metadata.py
@@ -113,7 +113,7 @@ def show_metadata_type(index, metadata_type_name, output_format):
         for name in metadata_type_name:
             m = index.metadata_types.get_by_name(name)
             if m is None:
-                echo('No such metadata: {}'.format(name))
+                echo('No such metadata: {!r}'.format(name), err=True)
                 sys.exit(1)
             else:
                 mm.append(m)
@@ -130,7 +130,7 @@ def show_metadata_type(index, metadata_type_name, output_format):
                       indent=4)
     elif output_format == 'json':
         if len(mm) > 1:
-            echo('Can not output more than 1 metadata document in json format')
+            echo('Can not output more than 1 metadata document in json format', err=True)
             sys.exit(1)
         m = mm[0]
         echo(json.dumps(m.definition, indent=4))
@@ -145,7 +145,7 @@ def list_metadata_types(index):
     metadata_types = list(index.metadata_types.get_all())
 
     if not metadata_types:
-        echo('No metadata types found :(')
+        echo('No metadata types found :(', err=True)
         sys.exit(1)
 
     max_w = max(len(m.name) for m in metadata_types)

--- a/datacube/scripts/product.py
+++ b/datacube/scripts/product.py
@@ -202,13 +202,13 @@ def show_product(dc, product_name, output_format):
         for name in product_name:
             p = dc.index.products.get_by_name(name)
             if p is None:
-                echo('No such product: {}'.format(name))
+                echo('No such product: {!r}'.format(name), err=True)
                 sys.exit(1)
             else:
                 products.append(p)
 
     if len(products) == 0:
-        echo('No products')
+        echo('No products', err=True)
         sys.exit(1)
 
     if output_format == 'yaml':
@@ -219,7 +219,7 @@ def show_product(dc, product_name, output_format):
                       indent=4)
     elif output_format == 'json':
         if len(products) > 1:
-            echo('Can not output more than 1 product in json format')
+            echo('Can not output more than 1 product in json format', err=True)
             sys.exit(1)
         product, *_ = products
         click.echo_via_pager(json.dumps(product.definition, indent=4))


### PR DESCRIPTION
Especially useful since the output often piped to files, and is not valid yaml.

```
    $ datacube product show ls8_nbar_albrs > albers.yaml
    No such product: 'ls8_nbar_albrs'
    $
```

(I also changed the product name formatting to use the `repr()`, as it makes many common mistakes more obvious, such as trailing whitespace)
