### PR TITLE
Deal with datetime axis values in a special way

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -370,8 +370,9 @@ class Datacube(object):
             if isinstance(x, datetime.datetime):
                 # For datetime we convert to UTC, then strip timezone info
                 # to avoid numpy/pandas warning about timezones
-                x = x.astimezone(datetime.timezone.utc)
-                return numpy.datetime64(x.replace(tzinfo=None), 'ns')
+                if x.tzinfo is not None:
+                    x = x.astimezone(datetime.timezone.utc).replace(tzinfo=None)
+                return numpy.datetime64(x, 'ns')
             return x
 
         def mk_group(group):


### PR DESCRIPTION
Address issue #662, explicitly handle timezone, force every datetime into UTC,
and manually convert to np.datetime64 without tz data.

 - [x] Closes #662 
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes
