### PR TITLE
GDAL environment setup for better COG read performance

### DIFF
--- a/datacube/storage/_rio.py
+++ b/datacube/storage/_rio.py
@@ -14,6 +14,7 @@ from datacube.utils import datetime_to_seconds_since_1970
 from datacube.utils import geometry
 from datacube.utils.math import num2numpy
 from datacube.utils import uri_to_local_path, get_part_from_uri
+from datacube.utils.rio import activate_from_config
 from . import DataSource, GeoRasterReader, RasterShape, RasterWindow, BandInfo
 
 _LOG = logging.getLogger(__name__)
@@ -139,6 +140,9 @@ class RasterioDataSource(DataSource):
     @contextmanager
     def open(self) -> Iterator[GeoRasterReader]:
         """Context manager which returns a :class:`BandDataSource`"""
+
+        activate_from_config()  # check if settings changed and apply new
+
         try:
             _LOG.debug("opening %s", self.filename)
             with rasterio.open(self.filename, sharing=False) as src:

--- a/datacube/utils/aws/__init__.py
+++ b/datacube/utils/aws/__init__.py
@@ -3,10 +3,10 @@ Helper methods for working with AWS
 """
 import botocore
 import botocore.session
+from urllib.request import urlopen
 
 
 def _fetch_text(url, timeout=0.1):
-    from urllib.request import urlopen
     try:
         with urlopen(url, timeout=timeout) as resp:
             if 200 <= resp.getcode() < 300:

--- a/datacube/utils/aws/__init__.py
+++ b/datacube/utils/aws/__init__.py
@@ -1,0 +1,69 @@
+"""
+Helper methods for working with AWS
+"""
+import botocore
+import botocore.session
+
+
+def _fetch_text(url, timeout=0.1):
+    from urllib.request import urlopen
+    try:
+        with urlopen(url, timeout=timeout) as resp:
+            if 200 <= resp.getcode() < 300:
+                return resp.read().decode('utf8')
+            else:
+                return None
+    except IOError:
+        return None
+
+
+def ec2_metadata(timeout=0.1):
+    """ When running inside AWS returns dictionary describing instance identity.
+        Returns None when not inside AWS
+    """
+    import json
+    txt = _fetch_text('http://169.254.169.254/latest/dynamic/instance-identity/document', timeout)
+
+    if txt is None:
+        return None
+
+    try:
+        return json.loads(txt)
+    except json.JSONDecodeError:
+        return None
+
+
+def ec2_current_region():
+    """ Returns name of the region  this EC2 instance is running in.
+    """
+    cfg = ec2_metadata()
+    if cfg is None:
+        return None
+    return cfg.get('region', None)
+
+
+def botocore_default_region(session=None):
+    """ Returns default region name as configured on the system.
+    """
+    if session is None:
+        session = botocore.session.get_session()
+    return session.get_config_variable('region')
+
+
+def auto_find_region(session=None):
+    """
+    Try to figure out which region name to use
+
+    1. Region as configured for this/default session
+    2. Region this EC2 instance is running in
+    3. None
+    """
+    region_name = botocore_default_region(session)
+
+    if region_name is None:
+        region_name = ec2_current_region()
+
+    if region_name is None:
+        raise ValueError('Region name is not supplied and default can not be found')
+
+    return region_name

--- a/datacube/utils/rio/__init__.py
+++ b/datacube/utils/rio/__init__.py
@@ -7,10 +7,14 @@ from ._rio import (
     activate_rio_env,
     deactivate_rio_env,
     get_rio_env,
+    set_default_rio_config,
+    activate_from_config,
 )
 
 __all__ = (
     'activate_rio_env',
     'deactivate_rio_env',
     'get_rio_env',
+    'set_default_rio_config',
+    'activate_from_config',
 )

--- a/datacube/utils/rio/__init__.py
+++ b/datacube/utils/rio/__init__.py
@@ -1,0 +1,14 @@
+"""
+This will move into IO driver eventually.
+
+For now this provides tools to configure GDAL environment for performant reads from S3.
+"""
+from ._rio import (
+    activate_rio_env,
+    get_rio_env,
+)
+
+__all__ = (
+    'activate_rio_env',
+    'get_rio_env',
+)

--- a/datacube/utils/rio/__init__.py
+++ b/datacube/utils/rio/__init__.py
@@ -5,10 +5,12 @@ For now this provides tools to configure GDAL environment for performant reads f
 """
 from ._rio import (
     activate_rio_env,
+    deactivate_rio_env,
     get_rio_env,
 )
 
 __all__ = (
     'activate_rio_env',
+    'deactivate_rio_env',
     'get_rio_env',
 )

--- a/datacube/utils/rio/_rio.py
+++ b/datacube/utils/rio/_rio.py
@@ -2,7 +2,7 @@
 """
 import threading
 import rasterio
-from rasterio.session import AWSSession
+from rasterio.session import AWSSession, DummySession
 import rasterio.env
 
 _local = threading.local()  # pylint: disable=invalid-name
@@ -55,7 +55,7 @@ def activate_rio_env(aws=None, cloud_defaults=False, **kwargs):
     :param cloud_defaults: When True inject settings for reading COGs
     :param **kwargs: Passed on to rasterio.Env(..) constructor
     """
-    session = None
+    session = DummySession()
 
     if aws is not None:
         if not (aws == 'auto' or

--- a/datacube/utils/rio/_rio.py
+++ b/datacube/utils/rio/_rio.py
@@ -1,0 +1,81 @@
+""" rasterio environment management tools
+"""
+import threading
+import rasterio
+from rasterio.session import AWSSession
+import rasterio.env
+
+_local = threading.local()
+
+SECRET_KEYS = ('AWS_ACCESS_KEY_ID',
+               'AWS_SECRET_ACCESS_KEY',
+               'AWS_SESSION_TOKEN')
+
+
+def _sanitize(opts, keys):
+    return {k: (v if k not in keys
+                else 'xx..xx')
+            for k, v in opts.items()}
+
+
+def get_rio_env(sanitize=True):
+    """ Get GDAL params configured by rasterio for the current thread.
+
+    :param sanitize: If True replace sensitive Values with 'x'
+    """
+
+    env = rasterio.env.local._env
+    if env is None:
+        return {}
+    opts = env.get_config_options()
+    if sanitize:
+        opts = _sanitize(opts, SECRET_KEYS)
+
+    return opts
+
+
+def activate_rio_env(aws=None, cloud_defaults=False, **kwargs):
+    """ Inject activated rasterio.Env into current thread.
+
+    This de-activates previously setup environment.
+
+    :param aws: Dictionary of options for rasterio.session.AWSSession
+                OR False in which case session won't be setup
+                OR None -- session = rasterio.session.AWSSession()
+
+    :param cloud_defaults: When True inject settings for reading COGs
+    :param **kwargs: Passed on to rasterio.Env(..) constructor
+    """
+    env_old = getattr(_local, 'env', None)
+
+    if env_old is not None:
+        env_old.__exit__(None, None, None)
+        _local.env = None
+
+    if aws is False:
+        session = None
+    else:
+        aws = {} if aws is None else dict(**aws)
+        region_name = aws.get('region_name', 'auto')
+
+        if region_name == 'auto':
+            from datacube.utils.aws import auto_find_region
+            try:
+                aws['region_name'] = auto_find_region()
+            except Exception as e:
+                # only treat it as error if it was requested by user
+                if 'region_name' in aws:
+                    raise e
+
+        session = AWSSession(**aws)
+
+    opts = dict(
+        GDAL_DISABLE_READDIR_ON_OPEN='EMPTY_DIR'
+    ) if cloud_defaults else {}
+
+    opts.update(**kwargs)
+
+    env = rasterio.Env(session=session, **opts)
+    env.__enter__()
+    _local.env = env
+    return get_rio_env()

--- a/datacube/utils/rio/_rio.py
+++ b/datacube/utils/rio/_rio.py
@@ -5,7 +5,7 @@ import rasterio
 from rasterio.session import AWSSession
 import rasterio.env
 
-_local = threading.local()
+_local = threading.local()  # pylint: disable=invalid-name
 
 SECRET_KEYS = ('AWS_ACCESS_KEY_ID',
                'AWS_SECRET_ACCESS_KEY',
@@ -24,7 +24,7 @@ def get_rio_env(sanitize=True):
     :param sanitize: If True replace sensitive Values with 'x'
     """
 
-    env = rasterio.env.local._env
+    env = rasterio.env.local._env  # pylint: disable=protected-access
     if env is None:
         return {}
     opts = env.get_config_options()
@@ -69,7 +69,7 @@ def activate_rio_env(aws=None, cloud_defaults=False, **kwargs):
             from datacube.utils.aws import auto_find_region
             try:
                 aws['region_name'] = auto_find_region()
-            except Exception as e:
+            except Exception as e:  # pylint: disable=broad-except
                 # only treat it as error if it was requested by user
                 if 'region_name' in aws:
                     raise e

--- a/datacube/utils/rio/_rio.py
+++ b/datacube/utils/rio/_rio.py
@@ -40,8 +40,7 @@ def activate_rio_env(aws=None, cloud_defaults=False, **kwargs):
     This de-activates previously setup environment.
 
     :param aws: Dictionary of options for rasterio.session.AWSSession
-                OR False in which case session won't be setup
-                OR None -- session = rasterio.session.AWSSession()
+                OR 'auto' -- session = rasterio.session.AWSSession()
 
     :param cloud_defaults: When True inject settings for reading COGs
     :param **kwargs: Passed on to rasterio.Env(..) constructor
@@ -52,10 +51,10 @@ def activate_rio_env(aws=None, cloud_defaults=False, **kwargs):
         env_old.__exit__(None, None, None)
         _local.env = None
 
-    if aws is False:
-        session = None
-    else:
-        aws = {} if aws is None else dict(**aws)
+    session = None
+
+    if aws is not None:
+        aws = {} if aws == 'auto' else dict(**aws)
         region_name = aws.get('region_name', 'auto')
 
         if region_name == 'auto':

--- a/datacube/utils/rio/_rio.py
+++ b/datacube/utils/rio/_rio.py
@@ -69,7 +69,7 @@ def activate_rio_env(aws=None, cloud_defaults=False, **kwargs):
             from datacube.utils.aws import auto_find_region
             try:
                 aws['region_name'] = auto_find_region()
-            except Exception as e:  # pylint: disable=broad-except
+            except ValueError as e:
                 # only treat it as error if it was requested by user
                 if 'region_name' in aws:
                     raise e

--- a/tests/test_utils_aws.py
+++ b/tests/test_utils_aws.py
@@ -1,0 +1,65 @@
+import pytest
+import mock
+import json
+
+from datacube.utils.aws import (
+    _fetch_text,
+    ec2_current_region,
+    auto_find_region,
+)
+
+
+def _json(**kw):
+    return json.dumps(kw)
+
+
+def mock_urlopen(text, code=200):
+    m = mock.MagicMock()
+    m.getcode.return_value = code
+    m.read.return_value = text.encode('utf8')
+    m.__enter__.return_value = m
+    return m
+
+
+def test_ec2_current_region():
+    tests = [(None, None),
+             (_json(region='TT'), 'TT'),
+             (_json(x=3), None),
+             ('not valid json', None)]
+
+    for (rv, expect) in tests:
+        with mock.patch('datacube.utils.aws._fetch_text', return_value=rv):
+            assert ec2_current_region() == expect
+
+
+@mock.patch('datacube.utils.aws.botocore_default_region',
+            return_value=None)
+def test_auto_find_region(*mocks):
+    with mock.patch('datacube.utils.aws._fetch_text', return_value=None):
+        with pytest.raises(ValueError):
+            auto_find_region()
+
+    with mock.patch('datacube.utils.aws._fetch_text', return_value=_json(region='TT')):
+        assert auto_find_region() == 'TT'
+
+
+@mock.patch('datacube.utils.aws.botocore_default_region',
+            return_value='tt-from-botocore')
+def test_auto_find_region_2(*mocks):
+    assert auto_find_region() == 'tt-from-botocore'
+
+
+def test_fetch_text():
+    with mock.patch('datacube.utils.aws.urlopen',
+                    return_value=mock_urlopen('', 505)):
+        assert _fetch_text('http://localhost:8817') is None
+
+    with mock.patch('datacube.utils.aws.urlopen',
+                    return_value=mock_urlopen('text', 200)):
+        assert _fetch_text('http://localhost:8817') == 'text'
+
+    def fake_urlopen(*args, **kw):
+        raise IOError("Always broken")
+
+    with mock.patch('datacube.utils.aws.urlopen', fake_urlopen):
+        assert _fetch_text('http://localhost:8817') is None

--- a/tests/test_utils_rio.py
+++ b/tests/test_utils_rio.py
@@ -80,6 +80,17 @@ def test_rio_env_aws_auto_region():
     assert get_rio_env() == {}
 
 
+def test_rio_env_aws_auto_region_dummy():
+    "Just call it we don't know if it will succeed"
+
+    # at least it should not raise error since we haven't asked for region_name='auto'
+    ee = activate_rio_env(aws={})
+    assert isinstance(ee, dict)
+
+    deactivate_rio_env()
+    assert get_rio_env() == {}
+
+
 def test_rio_env_via_config():
     ee = activate_from_config()
     assert ee is not None

--- a/tests/test_utils_rio.py
+++ b/tests/test_utils_rio.py
@@ -11,6 +11,8 @@ from datacube.utils.rio import (
 
 
 def test_rio_env_no_aws():
+    deactivate_rio_env()
+
     # make sure we start without env configured
     assert get_rio_env() == {}
 
@@ -30,6 +32,8 @@ def test_rio_env_no_aws():
 
 
 def test_rio_env_aws():
+    deactivate_rio_env()
+
     # make sure we start without env configured
     assert get_rio_env() == {}
 
@@ -72,6 +76,9 @@ def test_rio_env_aws_auto_region():
     ee = activate_rio_env(aws={})
     assert 'AWS_REGION' in ee
 
+    deactivate_rio_env()
+    assert get_rio_env() == {}
+
 
 def test_rio_env_via_config():
     ee = activate_from_config()
@@ -86,3 +93,6 @@ def test_rio_env_via_config():
     ee = activate_from_config()
     assert ee is not None
     assert 'GDAL_DISABLE_READDIR_ON_OPEN' in ee
+
+    deactivate_rio_env()
+    assert get_rio_env() == {}

--- a/tests/test_utils_rio.py
+++ b/tests/test_utils_rio.py
@@ -5,6 +5,8 @@ from datacube.utils.rio import (
     activate_rio_env,
     deactivate_rio_env,
     get_rio_env,
+    set_default_rio_config,
+    activate_from_config,
 )
 
 
@@ -66,6 +68,21 @@ def test_rio_env_aws():
 
 @pytest.mark.skipif(os.environ.get('TRAVIS', None) == 'true',
                     reason='Not running auto_region tests on Travis')
-def test_rio_aws_auto_region():
+def test_rio_env_aws_auto_region():
     ee = activate_rio_env(aws={})
     assert 'AWS_REGION' in ee
+
+
+def test_rio_env_via_config():
+    ee = activate_from_config()
+    assert ee is not None
+
+    # Second call should not change anything
+    assert activate_from_config() is None
+
+    set_default_rio_config(aws=None, cloud_defaults=True)
+
+    # config change should activate new env
+    ee = activate_from_config()
+    assert ee is not None
+    assert 'GDAL_DISABLE_READDIR_ON_OPEN' in ee

--- a/tests/test_utils_rio.py
+++ b/tests/test_utils_rio.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 
 from datacube.utils.rio import (
     activate_rio_env,
@@ -63,6 +64,8 @@ def test_rio_env_aws():
     assert get_rio_env() == {}
 
 
+@pytest.mark.skipif(os.environ.get('TRAVIS', None) == 'true',
+                    reason='Not running auto_region tests on Travis')
 def test_rio_aws_auto_region():
     ee = activate_rio_env(aws={})
     assert 'AWS_REGION' in ee

--- a/tests/test_utils_rio.py
+++ b/tests/test_utils_rio.py
@@ -1,0 +1,68 @@
+import pytest
+
+from datacube.utils.rio import (
+    activate_rio_env,
+    deactivate_rio_env,
+    get_rio_env,
+)
+
+
+def test_rio_env_no_aws():
+    # make sure we start without env configured
+    assert get_rio_env() == {}
+
+    ee = activate_rio_env()
+    assert isinstance(ee, dict)
+    assert ee == get_rio_env()
+    assert 'GDAL_DISABLE_READDIR_ON_OPEN' not in ee
+    assert 'GDAL_DATA' in ee
+    assert 'AWS_ACCESS_KEY_ID' not in ee
+
+    ee = activate_rio_env(cloud_defaults=True)
+    assert 'GDAL_DISABLE_READDIR_ON_OPEN' in ee
+    assert ee == get_rio_env()
+
+    deactivate_rio_env()
+    assert get_rio_env() == {}
+
+
+def test_rio_env_aws():
+    # make sure we start without env configured
+    assert get_rio_env() == {}
+
+    with pytest.raises(ValueError):
+        activate_rio_env(aws='something')
+
+    # note: setting region_name to avoid auto-lookup
+    ee = activate_rio_env(aws=dict(aws_unsigned=True,
+                                   region_name='us-west-1'))
+
+    assert ee.get('AWS_NO_SIGN_REQUEST') == 'YES'
+
+    ee = activate_rio_env(cloud_defaults=True,
+                          aws=dict(aws_secret_access_key='blabla',
+                                   aws_access_key_id='not a real one',
+                                   aws_session_token='faketoo',
+                                   region_name='us-west-1'))
+
+    assert 'AWS_NO_SIGN_REQUEST' not in ee
+    # check secrets are sanitized
+    assert ee.get('AWS_ACCESS_KEY_ID') == 'xx..xx'
+    assert ee.get('AWS_SECRET_ACCESS_KEY') == 'xx..xx'
+    assert ee.get('AWS_SESSION_TOKEN') == 'xx..xx'
+
+    assert ee.get('AWS_REGION') == 'us-west-1'
+
+    # check sanitize can be turned off
+    ee = get_rio_env(sanitize=False)
+    assert ee.get('AWS_SECRET_ACCESS_KEY') == 'blabla'
+    assert ee.get('AWS_ACCESS_KEY_ID') == 'not a real one'
+    assert ee.get('AWS_SESSION_TOKEN') == 'faketoo'
+
+    deactivate_rio_env()
+    assert get_rio_env() == {}
+
+
+def test_rio_aws_auto_region():
+    ee = activate_rio_env(aws={})
+    assert 'AWS_REGION' in ee


### PR DESCRIPTION
### GDAL environment setup for better COG read performance.

GDAL has per thread configuration, this is constructed when one calls `with rasterio.Env(..):` , if you don't call this explicitly `rasterio` will generate this call on every `.open`. The cost of this construction is relatively high. Activating GDAL environments once per thread and leaving it activated between reads should improve performance when reading many files. Furthermore for cloud environments in particular customisation of GDAL environment is necessary to achieve reasonable IO performance and to provide credentials for S3 access.

This pull request introduces a mechanism for end user to customise GDAL environment

```python
from datacube.utils.rio import set_default_rio_config
set_default_rio_config(aws=dict(aws_unsigned=True), 
                       cloud_defaults=True)
# then call dc.load
dc.load(..)
```

 - [ ] Closes #xxxx
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes
