### PR TITLE
Virtual product formula transformation

### DIFF
--- a/datacube/virtual/__init__.py
+++ b/datacube/virtual/__init__.py
@@ -2,7 +2,7 @@ from typing import Mapping, Any
 
 from .impl import VirtualProduct, Transformation, VirtualProductException
 from .impl import from_validated_recipe
-from .transformations import MakeMask, ApplyMask, ToFloat, Rename, Select
+from .transformations import MakeMask, ApplyMask, ToFloat, Rename, Select, Formula
 from .transformations import Mean, year, month, week, day
 from .utils import reject_keys
 
@@ -45,7 +45,7 @@ class NameResolver:
         kind_keys = {key for key in recipe if key in ['product', 'transform', 'collate', 'juxtapose', 'aggregate']}
         if len(kind_keys) < 1:
             raise VirtualProductException("virtual product kind not specified in {}".format(recipe))
-        elif len(kind_keys) > 1:
+        if len(kind_keys) > 1:
             raise VirtualProductException("ambiguous kind in {}".format(recipe))
 
         if 'product' in recipe:
@@ -100,7 +100,8 @@ DEFAULT_RESOLVER = NameResolver({'transform': dict(make_mask=MakeMask,
                                                    apply_mask=ApplyMask,
                                                    to_float=ToFloat,
                                                    rename=Rename,
-                                                   select=Select),
+                                                   select=Select,
+                                                   formula=Formula),
                                  'aggregate': dict(mean=Mean),
                                  'aggregate/group_by': dict(year=year,
                                                             month=month,

--- a/datacube/virtual/transformations.py
+++ b/datacube/virtual/transformations.py
@@ -254,7 +254,7 @@ class Formula(Transformation):
 
         def measurement(output_var, output_desc):
             return Measurement(name=output_var, dtype=deduce_type(output_var, output_desc),
-                               nodata=output_desc['nodata'], units=output_desc['units'])
+                               nodata=output_desc.get('nodata'), units=output_desc.get('units'))
 
         return {output_var: measurement(output_var, output_desc)
                 for output_var, output_desc in self.output.items()}

--- a/docs/dev/virtual-products.rst
+++ b/docs/dev/virtual-products.rst
@@ -172,6 +172,7 @@ ODC has a (growing) set of built-in transformations:
 - ``to_float``
 - ``rename``
 - ``select``
+- ``formula``
 
 For more information on transformations, see :ref:`user-defined-virtual-product-transforms`.
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -33,6 +33,7 @@ Jinja2==2.10
 jmespath==0.9.3
 jsonschema==2.6.0
 kombu==4.1.0
+lark-parser==0.6.7
 lazy-object-proxy==1.3.1
 lxml==4.2.1
 MarkupSafe==1.0

--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,7 @@ setup(
         'numpy',
         'psycopg2',
         'pypeg2',
+        'lark-parser>=0.6.7',
         'python-dateutil',
         'pyyaml',
         'rasterio>=1.0.2',  # Multi-band re-project fixed in that version

--- a/tests/api/test_virtual.py
+++ b/tests/api/test_virtual.py
@@ -306,6 +306,29 @@ def test_aliases(dc, query):
     assert 'green' not in data
 
 
+def test_formula(dc, query):
+    bluegreen = construct_from_yaml("""
+        transform: formula
+        output:
+            bluegreen:
+                formula: blue + green
+        input:
+            product: ls8_nbar_albers
+            measurements: [blue, green]
+    """)
+
+    measurements = bluegreen.output_measurements({product.name: product
+                                                  for product in dc.index.products.get_all()})
+    assert 'bluegreen' in measurements
+
+    with mock.patch('datacube.virtual.impl.Datacube') as mock_datacube:
+        mock_datacube.load_data = load_data
+        mock_datacube.group_datasets = group_datasets
+        data = bluegreen.load(dc, **query)
+
+    assert 'bluegreen' in data
+
+
 def test_aggregate(dc, query):
     aggr = construct_from_yaml("""
         aggregate: mean


### PR DESCRIPTION
### Reason for this pull request
Add a useful transformation `formula` that supports Python's expression language
to do band maths in virtual products.

### Proposed changes
- Add `formula` transformation
- Add simple test
- Update documentation to mention the transformation
- Add `lark-parser` as a dependency
