### PR TITLE
minimal viable implementation of virtual product catalogs

### DIFF
--- a/datacube/virtual/__init__.py
+++ b/datacube/virtual/__init__.py
@@ -4,6 +4,7 @@ from .impl import VirtualProduct, Transformation, VirtualProductException
 from .impl import from_validated_recipe
 from .transformations import MakeMask, ApplyMask, ToFloat, Rename, Select, Formula
 from .transformations import Mean, year, month, week, day
+from .catalog import Catalog
 from .utils import reject_keys
 
 from datacube.model import Measurement
@@ -109,15 +110,31 @@ DEFAULT_RESOLVER = NameResolver({'transform': dict(make_mask=MakeMask,
                                                             day=day)})
 
 
-def construct(**recipe: Mapping[str, Any]) -> VirtualProduct:
+def construct(name_resolver=None, **recipe: Mapping[str, Any]) -> VirtualProduct:
     """
     Create a virtual product from a specification dictionary.
     """
+    if name_resolver is None:
+        name_resolver = DEFAULT_RESOLVER
+
     return DEFAULT_RESOLVER.construct(**recipe)
 
 
-def construct_from_yaml(recipe: str) -> VirtualProduct:
+def construct_from_yaml(recipe: str, name_resolver=None) -> VirtualProduct:
     """
     Create a virtual product from a yaml recipe.
     """
+    if name_resolver is None:
+        name_resolver = DEFAULT_RESOLVER
+
     return construct(**parse_yaml(recipe))
+
+
+def catalog_from_yaml(catalog_body: str, name_resolver=None) -> Catalog:
+    """
+    Load a catalog of virtual products from a yaml document.
+    """
+    if name_resolver is None:
+        name_resolver = DEFAULT_RESOLVER
+
+    return Catalog(DEFAULT_RESOLVER, parse_yaml(catalog_body))

--- a/datacube/virtual/catalog.py
+++ b/datacube/virtual/catalog.py
@@ -1,0 +1,26 @@
+"""
+Catalog of virtual products.
+"""
+
+from collections.abc import Mapping
+
+class Catalog(Mapping):
+    """
+    A catalog of virtual products specified in a yaml document.
+    """
+
+    def __init__(self, name_resolver, catalog):
+        self.name_resolver = name_resolver
+        self.catalog = catalog
+
+    def __getitem__(self, key):
+        """
+        Look up virtual product by name.
+        """
+        return self.name_resolver.construct(**self.catalog['products'][key]['recipe'])
+
+    def __len__(self):
+        return len(self.catalog['products'])
+
+    def __iter__(self):
+        return iter(self.catalog['products'])


### PR DESCRIPTION
### Reason for this pull request
Virtual product recipes should be more convenient if we can keep a collection of them around.
This PR implements loading multiple virtual products into a catalog of products where we can
look them up by name. In the future, these products may also be searchable by tags, and have
additional metadata attached to them.

Being stored in the same YAML document has the added advantage of being able to share
parts of the recipes.

### Proposed changes
- Add a minimal catalog loading mechanism for now