### PR TITLE
Adding optional data loading progress callback

### DIFF
--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -18,6 +18,8 @@ v1.7dev
 - Support indexing data directly from HTTP/HTTPS/S3 URLs (:pull:`607`)
 - Renamed `datacube metadata_type` to just `datacube metadata` (:pull:`692`)
 - More useful output from `datacube {product|metadata} {show|list}`
+- Add optional `progress_cbk` to `dc.load(_data)` (:pull:`702`), allows user to
+  monitor data loading progress.
 
 
 v1.6.1 (27 August 2018)

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -74,6 +74,32 @@ def test_second_source_used_when_first_is_empty():
     assert (output_data == 2).all()
 
 
+def test_progress_cbk():
+    crs = epsg4326
+    shape = (2, 2)
+    no_data = -1
+    output_data = np.full(shape, fill_value=no_data, dtype='int16')
+
+    src = FakeDatasetSource([[2, 2], [2, 2]], crs=crs, shape=shape)
+
+    def _cbk(n_so_far, n_total, out):
+        out.append((n_so_far, n_total))
+
+    cbk_args = []
+    reproject_and_fuse([src], output_data,
+                       mk_gbox(shape, crs=crs),
+                       dst_nodata=no_data, progress_cbk=lambda *a: _cbk(*a, cbk_args))
+
+    assert cbk_args == [(1, 1)]
+
+    cbk_args = []
+    reproject_and_fuse([src, src], output_data,
+                       mk_gbox(shape, crs=crs),
+                       dst_nodata=no_data, progress_cbk=lambda *a: _cbk(*a, cbk_args))
+
+    assert cbk_args == [(1, 2), (2, 2)]
+
+
 def test_mixed_result_when_first_source_partially_empty():
     crs = epsg4326
     shape = (2, 2)

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -95,10 +95,18 @@ def test_load_data(tmpdir):
         custom_fuser_call_count += 1
         dest[:] += delta
 
-    ds_data = Datacube.load_data(sources2, gbox, mm, fuse_func=custom_fuser)
+    progress_call_data = []
+
+    def progress_cbk(n, nt):
+        progress_call_data.append((n, nt))
+
+    ds_data = Datacube.load_data(sources2, gbox, mm, fuse_func=custom_fuser,
+                                 progress_cbk=progress_cbk)
     assert ds_data.aa.nodata == nodata
     assert custom_fuser_call_count > 0
     np.testing.assert_array_equal(nodata + aa + aa, ds_data.aa.values[0])
+
+    assert progress_call_data == [(1, 2), (2, 2)]
 
 
 def test_rio_slurp(tmpdir):


### PR DESCRIPTION
### Reason for this pull request

`dc.load(..)` can take long time to fetch all the pixels, this change makes it possible to monitor loading progress. When `progress_cbk` function is supplied it will be called once for every file fetched with two integer arguments: "files fetched so far", "total files to fetch". Here "file" refers to individual band being loaded, even if bands are fetched from the same file on disk.


 - [ ] Closes #xxxx
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes