### PR TITLE
Acquire global lock when accessing HDF5 library via GDAL

### DIFF
--- a/datacube/testutils/io.py
+++ b/datacube/testutils/io.py
@@ -12,8 +12,8 @@ from types import SimpleNamespace
 class RasterFileDataSource(RasterioDataSource):
     """ This is only used in test code
     """
-    def __init__(self, filename, bandnumber, nodata=None, crs=None, transform=None):
-        super(RasterFileDataSource, self).__init__(filename, nodata)
+    def __init__(self, filename, bandnumber, nodata=None, crs=None, transform=None, lock=None):
+        super(RasterFileDataSource, self).__init__(filename, nodata, lock=lock)
         self.bandnumber = bandnumber
         self.crs = crs
         self.transform = transform

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -20,6 +20,7 @@ v1.7dev
 - More useful output from `datacube {product|metadata} {show|list}`
 - Add optional `progress_cbk` to `dc.load(_data)` (:pull:`702`), allows user to
   monitor data loading progress.
+- Thread-safe netcdf access within `dc.load` (:pull:`705`)
 
 
 v1.6.1 (27 August 2018)


### PR DESCRIPTION
When loading Netcdf based datasets acquire global lock for HDF5 library access.

Locks calls to `.open` and `.read` when opening/reading netcdf files only. Reading TIFFs should not be affected. It's a bit ugly in the `open` section, but this is because it's a context manager and we need to only hold lock while calling `open, read` and not between `open` and `read`.


 - [x] Closes #704 
 - [ ] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes
