### PR TITLE
Update 3p deps

### DIFF
--- a/datacube/utils/math.py
+++ b/datacube/utils/math.py
@@ -104,7 +104,7 @@ def data_resolution_and_offset(data):
     """
     res = (data[data.size - 1] - data[0]) / (data.size - 1.0)
     off = data[0] - 0.5 * res
-    return numpy.asscalar(res), numpy.asscalar(off)
+    return res.item(), off.item()
 
 
 def iter_slices(shape, chunk_size):

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -43,10 +43,10 @@ more-itertools==4.1.0
 multiprocess==0.70.5
 netCDF4==1.3.1  # rq.filter: >=1.3.1,<1.4
 nose==1.3.7
-numpy==1.14.2
+numpy==1.16.2
 objgraph==3.4.0
 OWSLib==0.16.0
-pandas==0.22.0
+pandas==0.24.2
 pathos==0.2.1
 pbr==4.0.2
 pendulum==1.4.4
@@ -69,7 +69,7 @@ python-dateutil==2.7.2
 pytz==2018.4
 pytzdata==2018.4
 PyYAML==3.12
-rasterio==1.0.21  # rq.filter: >=1.0.21,<1.1
+rasterio==1.0.22  # rq.filter: >=1.0.21,<1.1
 redis==2.10.6
 regex==2017.7.28
 requests==2.20.1
@@ -83,5 +83,5 @@ tzlocal==1.5.1
 urllib3==1.23
 vine==1.1.4
 wrapt==1.10.11
-xarray==0.10.9 # rq.filter: >=1.10.0,<0.11
+xarray==0.12.1 # rq.filter: >=1.10.0
 zstandard==0.9.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -77,7 +77,7 @@ s3transfer==0.2.0
 SharedArray==2.0.4
 singledispatch==3.4.0.3
 snuggs==1.4.1
-SQLAlchemy==1.2.6  # rq.filter: >=1.2.6,<1.3
+SQLAlchemy==1.3.1
 toolz==0.9.0
 tzlocal==1.5.1
 urllib3==1.23

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -214,10 +214,10 @@ def test_more_check_doc_unchanged():
     # No exception raised
     check_doc_unchanged({'a': 1}, {'a': 1}, 'Letters')
 
-    with pytest.raises(DocumentMismatchError, message='Letters differs from stored (a: 1!=2)'):
+    with pytest.raises(DocumentMismatchError, match='^Letters differs from stored.*a: 1!=2'):
         check_doc_unchanged({'a': 1}, {'a': 2}, 'Letters')
 
-    with pytest.raises(DocumentMismatchError, message='Letters differs from stored (a.b: 1!=2)'):
+    with pytest.raises(DocumentMismatchError, match='^Letters differs from stored.*a.b: 1!=2'):
         check_doc_unchanged({'a': {'b': 1}}, {'a': {'b': 2}}, 'Letters')
 
 


### PR DESCRIPTION
Update various third party dependencies for travis tests. Address some deprecation warnings.

 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
