### PR TITLE
fix issue 585

### DIFF
--- a/integration_tests/index/test_search.py
+++ b/integration_tests/index/test_search.py
@@ -1137,14 +1137,15 @@ def test_csv_search_via_cli(clirunner: Any,
     matches_none('150<lat<160')
 
     # Match only a single dataset using multiple fields
-    matches_1('platform=LANDSAT_8', '2014-07-24<time<2014-07-27')
+    matches_1('platform=LANDSAT_8', '2014-07-24<time<2014-07-26')
 
     # One matching field, one non-matching
     no_such_product('2014-07-24<time<2014-07-27', 'platform=LANDSAT_5')
 
     # Test date shorthand
     matches_both('2014-7 < time < 2014-8')
-    matches_none('2014-6 < time < 2014-7')
+    matches_none('2014-5 < time < 2014-6')
+    matches_both('2014-7 < time < 2014-7')
 
     matches_both('time in 2014-07')
     matches_none('time in 2014-08')
@@ -1153,10 +1154,10 @@ def test_csv_search_via_cli(clirunner: Any,
 
     matches_both('2014 < time < 2015')
     matches_none('2015 < time < 2016')
-    matches_none('2014 < time < 2014')
+    matches_both('2014 < time < 2014')
 
     matches_both('time in range(2014-7, 2014-8)')
-    matches_none('time in range(2014-6, 2014-7)')
+    matches_both('time in range(2014-6, 2014-7)')
     matches_both('time in range(2005, 2015)')
 
 

--- a/tests/index/test_query.py
+++ b/tests/index/test_query.py
@@ -58,35 +58,35 @@ def test_parse_dates():
     assert march_2014 == parse_expressions('time = 2014-03')
     assert march_2014 == parse_expressions('time = 2014-3')
 
-    implied_feb_2014 = {
-        'time': Range(datetime(2014, 2, 1, tzinfo=tzutc()), datetime(2014, 3, 1, tzinfo=tzutc()))
+    implied_feb_and_march_2014 = {
+        'time': Range(datetime(2014, 2, 1, tzinfo=tzutc()), datetime(2014, 3, 31, 23, 59, 59, 999999, tzinfo=tzutc()))
     }
-    assert implied_feb_2014 == parse_expressions('2014-02 < time < 2014-03')
-    assert implied_feb_2014 == parse_expressions('time in range (2014-02, 2014-03)')
+    assert implied_feb_and_march_2014 == parse_expressions('2014-02 < time < 2014-03')
+    assert implied_feb_and_march_2014 == parse_expressions('time in range (2014-02, 2014-03)')
 
 
 def test_parse_date_ranges():
     eighth_march_2014 = {
-        'time': Range(datetime(2014, 3, 8, tzinfo=tzutc()), datetime(2014, 3, 8, 23, 59, 59, tzinfo=tzutc()))
+        'time': Range(datetime(2014, 3, 8, tzinfo=tzutc()), datetime(2014, 3, 8, 23, 59, 59, 999999, tzinfo=tzutc()))
     }
     assert eighth_march_2014 == parse_expressions('time in 2014-03-08')
     assert eighth_march_2014 == parse_expressions('time in 2014-03-8')
 
     march_2014 = {
-        'time': Range(datetime(2014, 3, 1, tzinfo=tzutc()), datetime(2014, 3, 31, 23, 59, 59, tzinfo=tzutc()))
+        'time': Range(datetime(2014, 3, 1, tzinfo=tzutc()), datetime(2014, 3, 31, 23, 59, 59, 999999, tzinfo=tzutc()))
     }
     assert march_2014 == parse_expressions('time in 2014-03')
     assert march_2014 == parse_expressions('time in 2014-3')
     # Leap year, 28 days
     feb_2014 = {
-        'time': Range(datetime(2014, 2, 1, tzinfo=tzutc()), datetime(2014, 2, 28, 23, 59, 59, tzinfo=tzutc()))
+        'time': Range(datetime(2014, 2, 1, tzinfo=tzutc()), datetime(2014, 2, 28, 23, 59, 59, 999999, tzinfo=tzutc()))
     }
     assert feb_2014 == parse_expressions('time in 2014-02')
     assert feb_2014 == parse_expressions('time in 2014-2')
 
     # Entire year
     year_2014 = {
-        'time': Range(datetime(2014, 1, 1, tzinfo=tzutc()), datetime(2014, 12, 31, 23, 59, 59, tzinfo=tzutc()))
+        'time': Range(datetime(2014, 1, 1, tzinfo=tzutc()), datetime(2014, 12, 31, 23, 59, 59, 999999, tzinfo=tzutc()))
     }
     assert year_2014 == parse_expressions('time in 2014')
 


### PR DESCRIPTION
### Reason for this pull request
- See #585 
- The interpretation of a vague date query, such as `time=('2018-09', '2018-10')` was different for datacube query and the CLI interface

### Proposed changes
- Use the datacube datetime normalization functions directly to interpret command line values
- Closes #585 