### PR TITLE
Add a new search expression syntax: 'time in [2018-01, 2018-02]'

### DIFF
--- a/datacube/ui/click.py
+++ b/datacube/ui/click.py
@@ -338,9 +338,11 @@ def parsed_search_expressions(f):
     the shell will try to interpret them.
 
     \b
-    eg. '1996-01-01 < time < 1996-12-31'
-        '130<lon<140' '-30 > lat > -40'
+    eg. 'time in [1996-01-01, 1996-12-31]'
+        'lon in [130, 140]' 'lat in [-40, -30]'
         product=ls5_nbar_albers
+
+    or (deprecated) '1996-01-01 < time < 1996-12-31'
     """
 
     def my_parse(ctx, param, value):


### PR DESCRIPTION
### Reason for this pull request
Datacube command line dataset search using the old-style between expression is buggy.

### Proposed changes
- Add a new syntax `'time in [2018-01, 2018-02]'` that matches `dc.load`
- Deprecate old-style query syntax

- [ ] Closes #585 

NOTE: @Kirill888 opposed breaking changes before the release, so preserving the bug as is :smile: 