### PR TITLE
Allow cancellation of active load via progress_cbk

### DIFF
--- a/datacube/api/__init__.py
+++ b/datacube/api/__init__.py
@@ -3,7 +3,12 @@
 Modules for the Storage and Access Query API
 """
 
-from .core import Datacube
+from .core import Datacube, TerminateCurrentLoad
 from .grid_workflow import GridWorkflow, Tile
 
-__all__ = ['Datacube', 'GridWorkflow', 'Tile']
+__all__ = (
+    'Datacube',
+    'GridWorkflow',
+    'Tile',
+    'TerminateCurrentLoad',
+)

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -19,6 +19,13 @@ from ..index import index_connect
 from ..drivers import new_datasource
 
 
+class TerminateCurrentLoad(Exception):
+    """ This exception is raised by user code from `progress_cbk`
+        to terminate currently running `.load`
+    """
+    pass
+
+
 class Datacube(object):
     """
     Interface to search, read and write a datacube.
@@ -502,9 +509,12 @@ class Datacube(object):
             for m in measurements:
                 t_slice = data[m.name].values[index]
 
-                _fuse_measurement(t_slice, datasets, geobox, m,
-                                  skip_broken_datasets=skip_broken_datasets,
-                                  progress_cbk=_cbk)
+                try:
+                    _fuse_measurement(t_slice, datasets, geobox, m,
+                                      skip_broken_datasets=skip_broken_datasets,
+                                      progress_cbk=_cbk)
+                except TerminateCurrentLoad:
+                    return data
 
         return data
 

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -513,7 +513,8 @@ class Datacube(object):
                     _fuse_measurement(t_slice, datasets, geobox, m,
                                       skip_broken_datasets=skip_broken_datasets,
                                       progress_cbk=_cbk)
-                except TerminateCurrentLoad:
+                except (TerminateCurrentLoad, KeyboardInterrupt):
+                    data.attrs['dc_partial_load'] = True
                     return data
 
         return data

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -80,7 +80,7 @@ snuggs==1.4.1
 SQLAlchemy==1.3.1
 toolz==0.9.0
 tzlocal==1.5.1
-urllib3==1.23
+urllib3==1.24.2
 vine==1.1.4
 wrapt==1.10.11
 xarray==0.12.1 # rq.filter: >=1.10.0


### PR DESCRIPTION
If user wants to abort current load they can raise `TerminateCurrentLoad`
exception from within `progress_cbk`, `dc.load` will then intercept this
exception and return partially loaded xarray dataset to the user. Non-loaded
data will be set to the `nodata` value.

For notebook users interrupting kernel with "Interrupt Kernel" menu option (⬛) will now allow graceful shutdown within non-lazy `dc.load` returning partially loaded data.

To indicate to user that data was only partially loaded a `dc_partial_load` attribute is set on the top-level `xr.Dataset` object.

Other misc:

- add test that verifies callback correctness for multi-band case.
- bump `urllib` version due to CVE
