### PR TITLE
Make Geometry eq operator more robust

### DIFF
--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -525,11 +525,8 @@ class Geometry(object):
         return not self.is_empty
 
     def __eq__(self, other):
-        return (hasattr(other, 'crs') and
-                self.crs == other.crs and
-                hasattr(other, '_geom') and
-                self._geom.Equal(other._geom)
-                )  # pylint: disable=protected-access
+        return (hasattr(other, 'crs') and self.crs == other.crs and
+                hasattr(other, '_geom') and self._geom.Equal(other._geom))  # pylint: disable=protected-access
 
     def __str__(self):
         return 'Geometry(%s, %r)' % (self.__geo_interface__, self.crs)

--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -525,7 +525,11 @@ class Geometry(object):
         return not self.is_empty
 
     def __eq__(self, other):
-        return self.crs == other.crs and self._geom.Equal(other._geom)  # pylint: disable=protected-access
+        return (hasattr(other, 'crs') and
+                self.crs == other.crs and
+                hasattr(other, '_geom') and
+                self._geom.Equal(other._geom)
+                )  # pylint: disable=protected-access
 
     def __str__(self):
         return 'Geometry(%s, %r)' % (self.__geo_interface__, self.crs)

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -145,7 +145,13 @@ def test_tests():
 def test_ops():
     box1 = geometry.box(10, 10, 30, 30, crs=epsg4326)
     box2 = geometry.box(20, 10, 40, 30, crs=epsg4326)
+    box3 = geometry.box(20, 10, 40, 30, crs=epsg4326)
     box4 = geometry.box(40, 10, 60, 30, crs=epsg4326)
+    no_box = None
+
+    assert box1 != box2
+    assert box2 == box3
+    assert box3 != no_box
 
     union1 = box1.union(box2)
     assert union1.area == 600.0


### PR DESCRIPTION
Some internals of virtual products need to compare query parameters. When this involves geopolygon objects, sometimes it is compared with `None`, which the `Geometry.__eq__()` operator doesn't support.
This PR addresses this.

 - [X] Tests added / passed