### PR TITLE
Be more robust when comparing CRS to other objects

### DIFF
--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -14,6 +14,8 @@ from .tools import roi_normalise, roi_shape
 Coordinate = namedtuple('Coordinate', ('values', 'units'))
 _BoundingBox = namedtuple('BoundingBox', ('left', 'bottom', 'right', 'top'))
 
+# pylint: disable=too-many-lines
+
 
 class BoundingBox(_BoundingBox):
     """Bounding box, defining extent in cartesian coordinates.

--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -204,8 +204,12 @@ class CRS(object):
         return "CRS('%s')" % self.crs_str
 
     def __eq__(self, other):
+        if other is self:
+            return True
         if isinstance(other, str):
             other = CRS(other)
+        elif not isinstance(other, CRS):
+            return False
         gdal_thinks_issame = self._crs.IsSame(other._crs) == 1  # pylint: disable=protected-access
         if gdal_thinks_issame:
             return True

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -287,6 +287,15 @@ class TestCRSEqualityComparisons(object):
 
         assert a != epsg4326
 
+    def test_comparison_edge_cases(self):
+        a = epsg4326
+        none_crs = None
+        assert a == a
+        assert a == str(a)
+        assert (a == none_crs) is False
+        assert (a == []) is False
+        assert (a == TestCRSEqualityComparisons) is False
+
     def test_grs80_comparison(self):
         a = geometry.CRS("""GEOGCS["GEOCENTRIC DATUM of AUSTRALIA",
                                 DATUM["GDA94",SPHEROID["GRS80",6378137,298.257222101]],


### PR DESCRIPTION
### Reason for this pull request

Comparing CRS object to None or other type of object would result in an error, instead this should just return `False`

### Proposed changes

- Deal with non-CRS objects (including `None`) gracefully inside `__eq__` operator of CRS
- Short circuit same object comparison, since we maintain CRS cache often it's the same object rather than two equivalent objects.



 - [ ] Closes #xxxx
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
