### PR TITLE
fix issue #713

### DIFF
--- a/datacube/virtual/impl.py
+++ b/datacube/virtual/impl.py
@@ -431,7 +431,9 @@ class Aggregate(VirtualProduct):
             return result
 
         groups = list(xr_map(grouped.pile, statistic))
-        return xarray.concat(groups, dim=dim).assign_attrs(**select_unique([g.attrs for g in groups]))
+        result = xarray.concat(groups, dim=dim).assign_attrs(**select_unique([g.attrs for g in groups]))
+        result.coords[dim].attrs.update(grouped.pile[dim].attrs)
+        return result
 
 
 class Collate(VirtualProduct):


### PR DESCRIPTION
### Reason for this pull request
The `time` coordinate can have attributes attached to it (like `units`) that
were getting lost when loading and then concatenating.


### Proposed changes
- Restore the attributes from the `VirtualDatasetBox` object

 - [x] Closes #713 
