### PR TITLE
Use query CRS when pruning datasets after query

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -706,8 +706,9 @@ def output_geobox(like=None, output_crs=None, resolution=None, align=None,
 def select_datasets_inside_polygon(datasets, polygon):
     # Check against the bounding box of the original scene, can throw away some portions
     assert polygon is not None
+    query_crs = polygon.crs
     for dataset in datasets:
-        if intersects(polygon.to_crs(dataset.crs), dataset.extent):
+        if intersects(polygon, dataset.extent.to_crs(query_crs)):
             yield dataset
 
 


### PR DESCRIPTION
Rather than projecting query polygon into projection of an individual dataset
project dataset footprint into query domain. Fixes issue #721.

 - [x] Closes #721
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
