### PR TITLE
Setup and Suggest usage of pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,10 @@ repos:
           - id: requirements-txt-fixer
           - id: check-added-large-files
           - id: check-merge-conflict
+    -   repo: https://github.com/pre-commit/mirrors-pylint
+        rev: 'v2.3.1'  # Use the sha / tag you want to point at
+        hooks:
+        -   id: pylint
 
 #    - repo: https://github.com/pre-commit/mirrors-pylint
 #      hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+    - repo: https://github.com/adrienverge/yamllint.git
+      sha: v1.15.0
+      hooks:
+          - id: yamllint
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v2.1.0
+      hooks:
+          - id: flake8
+          - id: end-of-file-fixer
+          - id: check-docstring-first
+          - id: check-json
+          - id: check-yaml
+          - id: debug-statements
+          - id: name-tests-test
+          - id: requirements-txt-fixer
+          - id: check-added-large-files
+          - id: check-merge-conflict
+
+#    - repo: https://github.com/pre-commit/mirrors-pylint
+#      hooks:
+#          - id: pylint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
           - id: check-yaml
           - id: debug-statements
           - id: name-tests-test
+            args: ['--django']
           - id: requirements-txt-fixer
           - id: check-added-large-files
           - id: check-merge-conflict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,26 +2,22 @@ repos:
     - repo: https://github.com/adrienverge/yamllint.git
       sha: v1.15.0
       hooks:
-          - id: yamllint
+        - id: yamllint
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v2.1.0
       hooks:
-          - id: flake8
-          - id: end-of-file-fixer
-          - id: check-docstring-first
-          - id: check-json
-          - id: check-yaml
-          - id: debug-statements
-          - id: name-tests-test
-            args: ['--django']
-          - id: requirements-txt-fixer
-          - id: check-added-large-files
-          - id: check-merge-conflict
+        - id: flake8
+        - id: end-of-file-fixer
+        - id: check-docstring-first
+        - id: check-json
+        - id: check-yaml
+        - id: debug-statements
+        - id: name-tests-test
+          args: ['--django']
+        - id: requirements-txt-fixer
+        - id: check-added-large-files
+        - id: check-merge-conflict
     -   repo: https://github.com/pre-commit/mirrors-pylint
         rev: 'v2.3.1'  # Use the sha / tag you want to point at
         hooks:
         -   id: pylint
-
-#    - repo: https://github.com/pre-commit/mirrors-pylint
-#      hooks:
-#          - id: pylint

--- a/README.rst
+++ b/README.rst
@@ -36,28 +36,34 @@ Developer setup
 
    -  ``git clone https://github.com/opendatacube/datacube-core.git``
 
-2. Install the native libraries for `GDAL <http://www.gdal.org/>`__ &
-   NetCDF4.
+2. Create a Python environment to use ODC within, we recommend `conda <https://docs.conda.io/en/latest/miniconda.html>`__ as the
+   easiest way to handle Python dependencies.
 
-   -  This depends on your OS.
-   -  Eg. ``yum install gdal``
+::
 
-3. Install Python dependencies:
+   conda create -n odc -c conda-forge python=3.7 datacube pre_commit
+   conda activate odc
 
-   ``python setup.py develop``
+3. Install a develop version of datacube-core.
 
-   Note that the versions must match between GDAL's Python bindings and
-   the native GDAL library. If you receive a gdal error when installing
-   dependencies, you may need to install a specific version first:
+::
 
-   eg. ``pip install gdal==2.0.1``
+   cd datacube-core
+   pip install --upgrade -e .
+
+4. Install the `pre-commit <https://pre-commit.com>`__ hooks to help follow ODC coding
+  conventions when committing with git.
+
+::
+
+   pre-commit install
 
 4. Run unit tests + PyLint
 
    ``./check-code.sh``
 
    (this script approximates what is run by Travis. You can
-   alternatively run ``py.test`` yourself)
+   alternatively run ``pytest`` yourself)
 
 5. **(or)** Run all tests, including integration tests.
 


### PR DESCRIPTION
### Reason for this pull request

It's *super* annoying when you carefully write, test and polish your code, only to have Travis-CI throw red errors back in your face because you added one local variable too many, or forgot to delete every-single-trailing-whitespace in your files.


### Proposed changes
- Add a [pre-commit](https://pre-commit.com/) configuration to run linting checks before every git commit.
- Add the suggestion to use **pre-commit** to the README.rst

I've been trying this out for a few days and it seems to work really well. It handles:
- downloading and installing specific versions of the links/checks/fixers
- only running the checks on the files you are committing (fast!)
- temporarily stashing changes so you only see errors about exactly what you are committing

It makes for a **much** faster and nicer developer cycle.


