### PR TITLE
Swap pygdal to GDAL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,10 +52,11 @@ before_install:
   - export CPLUS_INCLUDE_PATH=/usr/include/gdal
   - export C_INCLUDE_PATH=/usr/include/gdal
   - export GDAL_DATA="$(gdal-config --datadir)"
+  - gdal-config --version
   - pip install --upgrade pip
   - pip install --progress-bar off coveralls codecov
 # Install pygdal bindings compatible with dpkg based gdal libs
-  - pip install pygdal>="$(gdal-config --version)"
+  - pip install GDAL=="$(gdal-config --version)"
   - pip install --progress-bar off --requirement requirements-test.txt
 
 


### PR DESCRIPTION
Fix travis build due to changes in third party packages.

Somehow we were installing both GDAL and pygdal, which are different but incompatible packages. `pygdal` was installed manually and `GDAL` was pulled in from datacube dependencies.

So, don't install `pygdal` manually, instead install `GDAL` version compatible with current `gdal-config`.

 - [x] Closes #727 
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes