### PR TITLE
Refactor native geobox computation out of native_load

### DIFF
--- a/datacube/testutils/__init__.py
+++ b/datacube/testutils/__init__.py
@@ -109,6 +109,21 @@ def isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
     return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
 
 
+def geobox_to_gridspatial(geobox):
+    if geobox is None:
+        return {}
+
+    l, b, r, t = geobox.extent.boundingbox
+    return {"grid_spatial": {
+        "projection": {
+            "geo_ref_points": {
+                "ll": {"x": l, "y": b},
+                "lr": {"x": r, "y": b},
+                "ul": {"x": l, "y": t},
+                "ur": {"x": r, "y": t}},
+            "spatial_reference": str(geobox.crs)}}}
+
+
 def mk_sample_product(name,
                       description='Sample',
                       measurements=('red', 'green', 'blue'),
@@ -181,7 +196,9 @@ def mk_sample_dataset(bands,
                       product_name='sample',
                       format='GeoTiff',
                       timestamp=None,
-                      id='3a1df9e0-8484-44fc-8102-79184eab85dd'):
+                      id='3a1df9e0-8484-44fc-8102-79184eab85dd',
+                      geobox=None,
+                      product_opts=None):
     # pylint: disable=redefined-builtin
     image_bands_keys = 'path layer band'.split(' ')
     measurement_keys = 'dtype units nodata aliases name'.split(' ')
@@ -192,8 +209,12 @@ def mk_sample_dataset(bands,
     measurements = [with_keys(m, measurement_keys) for m in bands]
     image_bands = dict((m['name'], with_keys(m, image_bands_keys)) for m in bands)
 
+    if product_opts is None:
+        product_opts = {}
+
     ds_type = mk_sample_product(product_name,
-                                measurements=measurements)
+                                measurements=measurements,
+                                **product_opts)
 
     if timestamp is None:
         timestamp = '2018-06-29'
@@ -203,6 +224,7 @@ def mk_sample_dataset(bands,
         'format': {'name': format},
         'image': {'bands': image_bands},
         'time': timestamp,
+        **geobox_to_gridspatial(geobox),
     }, uris=[uri])
 
 

--- a/datacube/testutils/io.py
+++ b/datacube/testutils/io.py
@@ -62,6 +62,15 @@ def native_geobox(ds, measurements=None, basis=None):
 
     :return: GeoBox describing native storage coordinates.
     """
+    gs = ds.type.grid_spec
+    if gs is not None:
+        # Dataset is from ingested product, figure out GeoBox of the tile this dataset covers
+        bb = [gbox for _, gbox in gs.tiles(ds.bounds)]
+        if len(bb) != 1:
+            # Ingested product but dataset overlaps several/none tiles -- no good
+            raise ValueError('Broken GridSpec detected')
+        return bb[0]
+
     if basis is not None:
         return get_raster_info(ds, [basis])[basis].geobox
 

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -292,7 +292,7 @@ def test_missing_file_handling():
 
 
 def test_native_load(tmpdir):
-    from datacube.testutils.io import native_load
+    from datacube.testutils.io import native_load, native_geobox
 
     tmpdir = Path(str(tmpdir))
     spatial = dict(resolution=(15, -15),
@@ -326,13 +326,19 @@ def test_native_load(tmpdir):
     with pytest.raises(ValueError):
         xx = native_load(ds)
 
+    # cc is different size from aa,bb
+    with pytest.raises(ValueError):
+        xx = native_geobox(ds)
+
     # aa and bb are the same
+    assert native_geobox(ds, ['aa', 'bb']) == gbox
     xx = native_load(ds, ['aa', 'bb'])
     assert xx.geobox == gbox
     np.testing.assert_array_equal(aa, xx.isel(time=0).aa.values)
     np.testing.assert_array_equal(aa, xx.isel(time=0).bb.values)
 
     # cc will be reprojected
+    assert native_geobox(ds, basis='aa') == gbox
     xx = native_load(ds, basis='aa')
     assert xx.geobox == gbox
     np.testing.assert_array_equal(aa, xx.isel(time=0).aa.values)

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -291,6 +291,18 @@ def test_missing_file_handling():
             rio_slurp('no-such-file.tiff')
 
 
+def test_native_geobox_ingested():
+    from datacube.testutils.io import native_geobox
+    from datacube.testutils.geom import AlbersGS
+
+    gbox = AlbersGS.tile_geobox((15, -40))
+    ds = mk_sample_dataset([dict(name='a')],
+                           geobox=gbox,
+                           product_opts=dict(with_grid_spec=True))
+
+    assert native_geobox(ds) == gbox
+
+
 def test_native_load(tmpdir):
     from datacube.testutils.io import native_load, native_geobox
 

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -302,6 +302,14 @@ def test_native_geobox_ingested():
 
     assert native_geobox(ds) == gbox
 
+    # check that dataset covering several tiles is detected as invalid
+    ds = mk_sample_dataset([dict(name='a')],
+                           geobox=gbox.buffered(10, 10),
+                           product_opts=dict(with_grid_spec=True))
+
+    with pytest.raises(ValueError):
+        native_geobox(ds)
+
 
 def test_native_load(tmpdir):
     from datacube.testutils.io import native_load, native_geobox


### PR DESCRIPTION
Sometimes you just want to know what native pixel grid is like and not load data