### PR TITLE
Only parse dates if key is `time' (#740)

### DIFF
--- a/datacube/ui/expression.py
+++ b/datacube/ui/expression.py
@@ -295,7 +295,10 @@ class BetweenExpression(Expr):
         return get_field(self.field_name).between(search_range.begin, search_range.end)
 
     def as_query(self):
-        return {self.field_name: _time_to_search_dims([self.low_value.value, self.high_value.value])}
+        if self.field_name == 'time':
+            return {self.field_name: _time_to_search_dims([self.low_value.value, self.high_value.value])}
+        else:
+            return {self.field_name: Range(self.low_value.as_value(), self.high_value.as_value())}
 
 
 class ExpressionList(List):

--- a/tests/ui/test_expression_parsing.py
+++ b/tests/ui/test_expression_parsing.py
@@ -1,0 +1,21 @@
+from datacube.ui import parse_expressions
+from datacube.model import Range
+from datetime import datetime
+
+
+def test_between_expression():
+    q = parse_expressions('time in [2014, 2015]')
+    assert 'time' in q
+    r = q['time']
+    assert isinstance(r, Range)
+    assert isinstance(r.begin, datetime)
+    assert isinstance(r.end, datetime)
+
+    for k in ('lon', 'lat', 'x', 'y'):
+        q = parse_expressions('{} in [10, 11.3]'.format(k))
+        assert k in q
+        r = q[k]
+        assert isinstance(r, Range)
+        assert isinstance(r.begin, float)
+        assert isinstance(r.end, float)
+        assert r == Range(10, 11.3)


### PR DESCRIPTION
### Reason for this pull request

Broken search behaviour when using new style `<var> in [<start>, <stop>]` query expression for cases when `<var>` is not `time`.

### Proposed changes

Only parse `<start>, <stop>` as vague dates if `<var>` is `time`.


 - [x] Closes #740 
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
