### PR TITLE
Include a click option that exposes the config parameter

### DIFF
--- a/datacube/ui/click.py
+++ b/datacube/ui/click.py
@@ -149,6 +149,9 @@ logfile_option = click.option('--log-file', multiple=True, callback=_add_logfile
 #: pylint: disable=invalid-name
 config_option = click.option('--config', '--config_file', '-C', multiple=True, default='', callback=_set_config,
                              expose_value=False)
+#: pylint: disable=invalid-name
+config_option_exposed = click.option('--config', '--config_file', '-C', multiple=True, default='', callback=_set_config,
+                             expose_value=True)
 environment_option = click.option('--env', '-E', callback=_set_environment,
                                   expose_value=False)
 #: pylint: disable=invalid-name

--- a/datacube/ui/click.py
+++ b/datacube/ui/click.py
@@ -151,7 +151,7 @@ config_option = click.option('--config', '--config_file', '-C', multiple=True, d
                              expose_value=False)
 #: pylint: disable=invalid-name
 config_option_exposed = click.option('--config', '--config_file', '-C', multiple=True, default='', callback=_set_config,
-                             expose_value=True)
+                                     expose_value=True)
 environment_option = click.option('--env', '-E', callback=_set_environment,
                                   expose_value=False)
 #: pylint: disable=invalid-name


### PR DESCRIPTION
### Reason for this pull request
DB config parameters not being passed around are causing issues; https://github.com/GeoscienceAustralia/fc/issues/16
...


### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
