### PR TITLE
Fix Read The Docs Build

### DIFF
--- a/datacube/scripts/product.py
+++ b/datacube/scripts/product.py
@@ -1,4 +1,3 @@
-
 import csv
 import json
 import logging
@@ -46,7 +45,7 @@ def add_products(index, allow_exclusive_lock, files):
         except InvalidDocException as e:
             _LOG.exception(e)
             _LOG.error('Invalid product definition: %s', descriptor_path)
-            continue
+            sys.exit(1)
 
 
 @product_cli.command('update')

--- a/docs/conda-requirements.yml
+++ b/docs/conda-requirements.yml
@@ -149,6 +149,5 @@ dependencies:
   - zict=0.1.4=py_0
   - zlib=1.2.11=h14c3975_1004
   - pip:
-    - pypeg2==2.15.2
-    - sphinxcontrib-plantuml==0.14
-
+      - pypeg2==2.15.2
+      - sphinxcontrib-plantuml==0.14

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -7,4 +7,4 @@ build:
 #    - requirements: docs/rtd-requirements.txt
 #  system_packages: true
 conda:
-  environment: docs/conda-requirements.txt
+  environment: docs/conda-requirements.yml


### PR DESCRIPTION
Read The Docs has updated their conda version. It includes
a change requiring YAML files to end in .yml or .yaml.

Our conda build environment specification had the wrong name, which 
breaks the documentation build.

*Also*

Changing the file name broke some dumb `datacube product add` test that is using all the files in `docs/` as being not product definitions. `datacube product add` was not returning an error result if you gave it a YAML or JSON document, only logged a failure.

`datacube product add` now returns an error code for any document that couldn't be added as a product.