### PR TITLE
make `_default_fuser` use `invalid_mask`

### DIFF
--- a/datacube/storage/_load.py
+++ b/datacube/storage/_load.py
@@ -15,7 +15,7 @@ from typing import (
 )
 
 from datacube.utils import ignore_exceptions_if
-from datacube.utils.math import dtype_is_float
+from datacube.utils.math import invalid_mask
 from datacube.utils.geometry import GeoBox, Coordinate, roi_is_empty
 from datacube.model import Measurement
 from datacube.drivers._types import ReaderDriver
@@ -33,18 +33,7 @@ def _default_fuser(dst: np.ndarray, src: np.ndarray, dst_nodata) -> None:
         For every pixel in dst that equals to dst_nodata replace it with pixel
         from src.
     """
-    if dtype_is_float(dst.dtype):
-        if dst_nodata is None or np.isnan(dst_nodata):
-            where_nodata = np.isnan(dst)
-        else:
-            where_nodata = np.isnan(dst) | (dst == dst_nodata)
-    else:
-        if dst_nodata is None:
-            where_nodata = np.full_like(dst, False, dtype=np.bool)
-        else:
-            where_nodata = dst == dst_nodata
-
-    np.copyto(dst, src, where=where_nodata)
+    np.copyto(dst, src, where=invalid_mask(dst, dst_nodata))
 
 
 def reproject_and_fuse(datasources: List[DataSource],

--- a/datacube/storage/masking.py
+++ b/datacube/storage/masking.py
@@ -12,7 +12,7 @@ import numpy
 import xarray
 from xarray import DataArray, Dataset
 
-from datacube.utils.math import dtype_is_float
+from datacube.utils.math import dtype_is_float, valid_mask
 
 
 FLAGS_ATTR_NAME = 'flags_definition'
@@ -119,15 +119,7 @@ def valid_data_mask(data):
 
     nodata = data.attrs.get('nodata', None)
 
-    if dtype_is_float(data.dtype):
-        if nodata is None or numpy.isnan(nodata):
-            return ~xarray.ufuncs.isnan(data)
-        return (data != nodata) & ~xarray.ufuncs.isnan(data)
-
-    # not float
-    if nodata is None:
-        return xarray.full_like(data, True, dtype=numpy.bool)
-    return data != nodata
+    return xarray.apply_ufunc(lambda xx: valid_mask(xx, nodata), data)
 
 
 def mask_valid_data(data, keep_attrs=True):

--- a/datacube/utils/math.py
+++ b/datacube/utils/math.py
@@ -63,15 +63,32 @@ def dtype_is_float(dtype) -> bool:
     return numpy.dtype(dtype).kind == 'f'
 
 
-def valid_mask(xx, nodata):
+def valid_mask(dst, dst_nodata):
     """
-    Compute mask such that xx[mask] contains valid pixels.
+    Compute mask such that dst[mask] contains only valid pixels.
     """
-    if nodata is None:
-        return numpy.ones(xx.shape, dtype='bool')
-    if numpy.isnan(nodata):
-        return ~numpy.isnan(xx)
-    return xx != nodata
+    if dtype_is_float(dst.dtype):
+        if dst_nodata is None or numpy.isnan(dst_nodata):
+            return ~numpy.isnan(dst)
+        return ~numpy.isnan(dst) & (dst != dst_nodata)
+
+    if dst_nodata is None:
+        return numpy.full_like(dst, True, dtype=numpy.bool)
+    return dst != dst_nodata
+
+
+def invalid_mask(dst, dst_nodata):
+    """
+    Compute mask such that dst[mask] contains only invalid pixels.
+    """
+    if dtype_is_float(dst.dtype):
+        if dst_nodata is None or numpy.isnan(dst_nodata):
+            return numpy.isnan(dst)
+        return numpy.isnan(dst) | (dst == dst_nodata)
+
+    if dst_nodata is None:
+        return numpy.full_like(dst, False, dtype=numpy.bool)
+    return dst == dst_nodata
 
 
 def num2numpy(x, dtype, ignore_range=None):

--- a/datacube/utils/math.py
+++ b/datacube/utils/math.py
@@ -63,32 +63,32 @@ def dtype_is_float(dtype) -> bool:
     return numpy.dtype(dtype).kind == 'f'
 
 
-def valid_mask(dst, dst_nodata):
+def valid_mask(xx, nodata):
     """
-    Compute mask such that dst[mask] contains only valid pixels.
+    Compute mask such that xx[mask] contains only valid pixels.
     """
-    if dtype_is_float(dst.dtype):
-        if dst_nodata is None or numpy.isnan(dst_nodata):
-            return ~numpy.isnan(dst)
-        return ~numpy.isnan(dst) & (dst != dst_nodata)
+    if dtype_is_float(xx.dtype):
+        if nodata is None or numpy.isnan(nodata):
+            return ~numpy.isnan(xx)
+        return ~numpy.isnan(xx) & (xx != nodata)
 
-    if dst_nodata is None:
-        return numpy.full_like(dst, True, dtype=numpy.bool)
-    return dst != dst_nodata
+    if nodata is None:
+        return numpy.full_like(xx, True, dtype=numpy.bool)
+    return xx != nodata
 
 
-def invalid_mask(dst, dst_nodata):
+def invalid_mask(xx, nodata):
     """
-    Compute mask such that dst[mask] contains only invalid pixels.
+    Compute mask such that xx[mask] contains only invalid pixels.
     """
-    if dtype_is_float(dst.dtype):
-        if dst_nodata is None or numpy.isnan(dst_nodata):
-            return numpy.isnan(dst)
-        return numpy.isnan(dst) | (dst == dst_nodata)
+    if dtype_is_float(xx.dtype):
+        if nodata is None or numpy.isnan(nodata):
+            return numpy.isnan(xx)
+        return numpy.isnan(xx) | (xx == nodata)
 
-    if dst_nodata is None:
-        return numpy.full_like(dst, False, dtype=numpy.bool)
-    return dst == dst_nodata
+    if nodata is None:
+        return numpy.full_like(xx, False, dtype=numpy.bool)
+    return xx == nodata
 
 
 def num2numpy(x, dtype, ignore_range=None):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,7 +30,7 @@ from datacube.utils.changes import check_doc_unchanged, get_doc_changes, MISSING
 from datacube.utils.dates import date_sequence
 from datacube.utils.documents import parse_yaml, without_lineage_sources
 from datacube.utils.generic import map_with_lookahead
-from datacube.utils.math import num2numpy, is_almost_int, valid_mask, clamp
+from datacube.utils.math import num2numpy, is_almost_int, valid_mask, invalid_mask, clamp
 from datacube.utils.py import sorted_items
 from datacube.utils.uris import (uri_to_local_path, mk_part_uri, get_part_from_uri, as_url, is_url,
                                  pick_uri, uri_resolve,
@@ -928,26 +928,46 @@ def test_valid_mask():
     assert mm.shape == xx.shape
     assert not mm.all()
     assert not mm.any()
+    nn = invalid_mask(xx, 0)
+    assert nn.dtype == 'bool'
+    assert nn.shape == xx.shape
+    assert nn.all()
+    assert nn.any()
 
     mm = valid_mask(xx, 13)
     assert mm.dtype == 'bool'
     assert mm.shape == xx.shape
     assert mm.all()
+    nn = invalid_mask(xx, 13)
+    assert nn.dtype == 'bool'
+    assert nn.shape == xx.shape
+    assert not nn.any()
 
     mm = valid_mask(xx, None)
     assert mm.dtype == 'bool'
     assert mm.shape == xx.shape
     assert mm.all()
+    nn = invalid_mask(xx, None)
+    assert nn.dtype == 'bool'
+    assert nn.shape == xx.shape
+    assert not nn.any()
 
     mm = valid_mask(xx, np.nan)
     assert mm.dtype == 'bool'
     assert mm.shape == xx.shape
     assert mm.all()
+    nn = invalid_mask(xx, np.nan)
+    assert nn.dtype == 'bool'
+    assert nn.shape == xx.shape
+    assert not nn.any()
 
     xx[0, 0] = np.nan
     mm = valid_mask(xx, np.nan)
     assert not mm[0, 0]
     assert mm.sum() == (4 * 8 - 1)
+    nn = invalid_mask(xx, np.nan)
+    assert nn[0, 0]
+    assert nn.sum() == 1
 
 
 def test_num2numpy():


### PR DESCRIPTION
### Reason for this pull request
Most of the logic in the default fuser is there to calculate which pixels are invalid.
Given that the public use of that function is discouraged, we extract the logic into a separate method.

### Proposed changes
- Add `valid_mask` and `invalid_mask` methods in `datacube.utils.math` that understand both NaNs and nodata as invalid pixels
- Simplify `datacube.storage._load._default_fuser` implementation
- Simplify `datacube.storage.masking.valid_data_mask` implementation

 - [X] Tests added / passed
