### PR TITLE
copy bands in VP expressions

### DIFF
--- a/datacube/virtual/transformations.py
+++ b/datacube/virtual/transformations.py
@@ -273,6 +273,10 @@ class Expressions(Transformation):
             return result.dtype
 
         def measurement(output_var, output_desc):
+            if isinstance(output_desc, str):
+                # copy measurement over
+                return input_measurements[output_desc]
+
             return Measurement(name=output_var, dtype=deduce_type(output_var, output_desc),
                                nodata=output_desc.get('nodata', float('nan')),
                                units=output_desc.get('units', '1'))
@@ -320,6 +324,10 @@ class Expressions(Transformation):
 
         def result(output_var, output_desc):
             # pylint: disable=invalid-unary-operand-type
+
+            if isinstance(output_desc, str):
+                # copy measurement over
+                return data[output_desc]
 
             nodata = output_desc.get('nodata')
 

--- a/tests/api/test_virtual.py
+++ b/tests/api/test_virtual.py
@@ -352,6 +352,7 @@ def test_expressions(dc, query):
             bluegreen:
                 formula: blue + green
                 nodata: -999
+            blue: blue
         input:
             product: ls8_nbar_albers
             measurements: [blue, green]
@@ -368,6 +369,9 @@ def test_expressions(dc, query):
 
     assert 'bluegreen' in data
     assert numpy.all((data.bluegreen == -999).values)
+    assert 'blue' in data
+    assert numpy.all((data.blue == -999).values)
+    assert 'green' not in data
 
 
 def test_aggregate(dc, query, catalog):


### PR DESCRIPTION
### Reason for this pull request
Currently. the `expressions` transformation requires every output band to be specified
in a verbose format. Sometimes it is convenient to leave bands as is (output = input).

### Proposed changes
A recipe like this:
```
transform: expressions
output:
    ndvi:
        formula: (nir - red) / (nir + red)
    green: green
input:
    product: ls8_nbar_albers
    measurements: [green, red, nir]
``` 
will now result in a dataset with bands `ndvi` and `green`.

 - [X] Tests added / passed
