### PR TITLE
Fix empty and one line dask chunks in reproject virtual product

### DIFF
--- a/datacube/utils/__init__.py
+++ b/datacube/utils/__init__.py
@@ -11,7 +11,7 @@ from .dates import datetime_to_seconds_since_1970
 from .documents import InvalidDocException, SimpleDocNav, DocReader, is_supported_document_type, \
     read_strings_from_netcdf, read_documents, validate_document, NoDatesSafeLoader, get_doc_offset, \
     get_doc_offset_safe, netcdf_extract_string, without_lineage_sources
-from .math import unsqueeze_data_array, iter_slices, unsqueeze_dataset, data_resolution_and_offset
+from .math import unsqueeze_data_array, iter_slices, unsqueeze_dataset, data_resolution_and_offset, data_resolution
 from .py import cached_property, ignore_exceptions_if, import_function
 from .serialise import jsonify_document
 from .uris import is_url, uri_to_local_path, get_part_from_uri, mk_part_uri

--- a/datacube/utils/math.py
+++ b/datacube/utils/math.py
@@ -119,6 +119,14 @@ def num2numpy(x, dtype, ignore_range=None):
     return None
 
 
+def data_resolution(data):
+    if data.size == 1:
+        return None
+
+    res = (data[data.size - 1] - data[0]) / (data.size - 1.0)
+    return res.item()
+
+
 def data_resolution_and_offset(data):
     """
     >>> data_resolution_and_offset(numpy.array([1.5, 2.5, 3.5]))


### PR DESCRIPTION
### Reason for this pull request
Make reproject work correctly with empty or one line dask chunks


### Proposed changes

- Fall back to `xarray.attrs` or the other axis if the pixel(s) size is `(1, 1)` or `(1, n)` respectively 
- Make the target dask chunk if right size and filled with `nodata` when input dask chunk size is `(0, n)`

