### PR TITLE
Xarray reductions

### DIFF
--- a/datacube/virtual/__init__.py
+++ b/datacube/virtual/__init__.py
@@ -3,7 +3,7 @@ from typing import Mapping, Any
 from .impl import VirtualProduct, Transformation, VirtualProductException
 from .impl import from_validated_recipe
 from .transformations import MakeMask, ApplyMask, ToFloat, Rename, Select, Expressions
-from .transformations import Mean, year, month, week, day
+from .transformations import XarrayReduction, year, month, week, day
 from .catalog import Catalog
 from .utils import reject_keys
 
@@ -113,7 +113,7 @@ DEFAULT_RESOLVER = NameResolver({'transform': dict(make_mask=MakeMask,
                                                    rename=Rename,
                                                    select=Select,
                                                    expressions=Expressions),
-                                 'aggregate': dict(mean=Mean),
+                                 'aggregate': dict(xarray_reduction=XarrayReduction),
                                  'aggregate/group_by': dict(year=year,
                                                             month=month,
                                                             week=week,

--- a/tests/api/test_virtual.py
+++ b/tests/api/test_virtual.py
@@ -142,7 +142,8 @@ def catalog():
 
             mean_blue:
                 recipe:
-                    aggregate: mean
+                    aggregate: xarray_reduction
+                    method: mean
                     group_by: month
                     input:
                         transform: to_float


### PR DESCRIPTION
### Reason for this pull request
There's only one built-in aggregate at the moment: mean. Not too helpful, probably no one is using it at the moment. This PR generalizes it to a slightly broader class of reductions: any reducing methods on `xarray.DataArray` objects.

### Proposed changes
To do a sum of valid `fmask` pixels (value 1) we can now do this:
```yaml
            aggregate: xarray_reduction
            group_by: year
            method: sum
            dtype: int16
            input:
                transform: expressions
                output:
                    fmask:
                        formula: fmask == 1
                        nodata: False
                        units: "1"
                input:
                    product: ga_ls8c_ard_3
                    measurements: [fmask]
```