### PR TITLE
VP expressions: add type conversion capability

### DIFF
--- a/datacube/virtual/transformations.py
+++ b/datacube/virtual/transformations.py
@@ -266,6 +266,9 @@ class Expressions(Transformation):
         ev = EvaluateType()
 
         def deduce_type(output_var, output_desc):
+            if 'dtype' in output_desc:
+                return numpy.dtype(output_desc['dtype'])
+
             formula = output_desc['formula']
             tree = parser.parse(formula)
 
@@ -330,6 +333,7 @@ class Expressions(Transformation):
                 return data[output_desc]
 
             nodata = output_desc.get('nodata')
+            dtype = output_desc.get('dtype')
 
             formula = output_desc['formula']
             tree = parser.parse(formula)
@@ -340,9 +344,14 @@ class Expressions(Transformation):
             result.attrs['units'] = output_desc.get('units', '1')
 
             if not self.masked:
-                return result
+                if dtype is None:
+                    return result
+                return result.astype(dtype)
 
             # masked output
+            if dtype is not None:
+                result = result.astype(dtype)
+
             dtype = result.dtype
             mask = ev_mask.transform(tree)
 


### PR DESCRIPTION
### Reason for this pull request
The idea is to enable the user to cast the result of a computation to a different data type in the end.
So something like:

```yaml
transform: expressions
output:
    ndvi:
        formula: 1000.0 * (nir - red) / (nir + red)
        dtype: int16
        nodata: -999
    
input:
    product: ls8_nbar_albers
    measurements: [nir, red]
```

would return an `int16` array where invalid pixels are `-999`. Note that the `dtype` of the `nodata` value should be the `dtype` provided.

Note that this probably makes `to_float` superfluous now.

### Proposed changes
As above.

 - [X] Tests added / passed
