### PR TITLE
Add pad_wh utility to `geometry.gbox.` module

### DIFF
--- a/datacube/utils/geometry/gbox.py
+++ b/datacube/utils/geometry/gbox.py
@@ -7,6 +7,7 @@ import math
 from affine import Affine
 
 from . import Geometry, GeoBox, BoundingBox
+from .tools import align_up
 from datacube.utils.math import clamp
 
 # pylint: disable=invalid-name
@@ -53,6 +54,20 @@ def pad(gbox: GeoBox, padx: int, pady: MaybeInt = None) -> GeoBox:
     H, W = gbox.shape
     A = gbox.affine*Affine.translation(-padx, -pady)
     return GeoBox(W + padx*2, H + pady*2, A, gbox.crs)
+
+
+def pad_wh(gbox: GeoBox,
+           alignx: int = 16,
+           aligny: MaybeInt = None) -> GeoBox:
+    """
+    Expand GeoBox such that width and height are multiples of supplied number.
+    """
+    aligny = alignx if aligny is None else aligny
+    H, W = gbox.shape
+
+    return GeoBox(align_up(W, alignx),
+                  align_up(H, aligny),
+                  gbox.affine, gbox.crs)
 
 
 def zoom_out(gbox: GeoBox, factor: float) -> GeoBox:

--- a/tests/test_gbox_ops.py
+++ b/tests/test_gbox_ops.py
@@ -62,6 +62,24 @@ def test_gbox_ops():
     assert d[1:-1, 1:-1].affine == s.affine
     assert d[1:-1, 1:-1].shape == s.shape
 
+    d = gbx.pad_wh(s, 10)
+    assert d == s
+
+    d = gbx.pad_wh(s, 100, 8)
+    assert d.width == s.width
+    assert d.height % 8 == 0
+    assert d.height > s.height
+    assert d.affine == s.affine
+    assert d.crs is s.crs
+
+    d = gbx.pad_wh(s, 13, 17)
+    assert d.affine == s.affine
+    assert d.crs is s.crs
+    assert d.height % 17 == 0
+    assert d.width % 13 == 0
+    assert d.height > s.height
+    assert d.width > s.width
+
     d = gbx.translate_pix(s, 1, 2)
     assert d.crs is s.crs
     assert d.resolution == s.resolution

--- a/tests/test_gbox_ops.py
+++ b/tests/test_gbox_ops.py
@@ -68,7 +68,7 @@ def test_gbox_ops():
     d = gbx.pad_wh(s, 100, 8)
     assert d.width == s.width
     assert d.height % 8 == 0
-    assert d.height > s.height
+    assert 0 < d.height - s.height < 8
     assert d.affine == s.affine
     assert d.crs is s.crs
 
@@ -77,8 +77,8 @@ def test_gbox_ops():
     assert d.crs is s.crs
     assert d.height % 17 == 0
     assert d.width % 13 == 0
-    assert d.height > s.height
-    assert d.width > s.width
+    assert 0 < d.height - s.height < 17
+    assert 0 < d.width - s.width < 13
 
     d = gbx.translate_pix(s, 1, 2)
     assert d.crs is s.crs


### PR DESCRIPTION
Expands geobox to have width/height that are multiples of some desired
multiplier.

It is often desirable to have W/H be multiple of 16 or 32 this utility operates on `GeoBox` class to produce a padded version with W/H being multiple of some desired integer.