### PR TITLE
Virtual product reproject working

### DIFF
--- a/datacube/api/geo_xarray.py
+++ b/datacube/api/geo_xarray.py
@@ -15,7 +15,10 @@ import numpy as np
 import rasterio
 import rasterio.warp
 
-from rasterio.warp import Resampling
+try:
+    from rasterio.warp import Resampling
+except ImportError:
+    from rasterio.warp import RESAMPLING as Resampling
 from rasterio import Affine
 
 import xarray as xr

--- a/datacube/virtual/catalog.py
+++ b/datacube/virtual/catalog.py
@@ -4,6 +4,7 @@ Catalog of virtual products.
 
 from collections.abc import Mapping
 
+
 class Catalog(Mapping):
     """
     A catalog of virtual products specified in a yaml document.

--- a/datacube/virtual/catalog.py
+++ b/datacube/virtual/catalog.py
@@ -4,7 +4,6 @@ Catalog of virtual products.
 
 from collections.abc import Mapping
 
-
 class Catalog(Mapping):
     """
     A catalog of virtual products specified in a yaml document.

--- a/tests/test_gbox_ops.py
+++ b/tests/test_gbox_ops.py
@@ -18,6 +18,7 @@ def test_gbox_ops():
     assert d.resolution == (-s.resolution[0], s.resolution[1])
     assert d.extent.contains(s.extent)
     with pytest.raises(ValueError):
+        # flipped grid
         (s | d)
 
     d = gbx.flipx(s)
@@ -45,6 +46,7 @@ def test_gbox_ops():
     assert d.extent.contains(s.extent)
     assert all(ds < ss for ds, ss in zip(d.shape, s.shape))
     with pytest.raises(ValueError):
+        # lower resolution grid
         (s | d)
 
     d = gbx.zoom_to(s, s.shape)


### PR DESCRIPTION
### Reason for this pull request
VP should load data given enough information. If output CRS and resolution is not provided but we are going to load only one dataset, it should ask the dataset for the CRS/resolution.

### Proposed changes
- reduce some diff noise vs develop
- clearer separation of concern in `VirtualDatasetBox`
    - `load_natively` now is a flag to indicate that the `geopolygon` should be used, not the `geobox`
- remove `auto_geobox` as a `group` argument
