### PR TITLE
VP: catalog usability enhancements

### DIFF
--- a/datacube/virtual/__init__.py
+++ b/datacube/virtual/__init__.py
@@ -148,3 +148,11 @@ def catalog_from_yaml(catalog_body: str, name_resolver=None) -> Catalog:
         name_resolver = DEFAULT_RESOLVER
 
     return Catalog(name_resolver, parse_yaml(catalog_body))
+
+
+def catalog_from_file(filename: str, name_resolver=None) -> Catalog:
+    """
+    Load a catalog of virtual products from a yaml file.
+    """
+    with open(filename) as fl:
+        return catalog_from_yaml(fl.read(), name_resolver=name_resolver)

--- a/datacube/virtual/catalog.py
+++ b/datacube/virtual/catalog.py
@@ -4,23 +4,30 @@ Catalog of virtual products.
 
 from collections.abc import Mapping
 
+
 class Catalog(Mapping):
     """
     A catalog of virtual products specified in a yaml document.
     """
 
-    def __init__(self, name_resolver, catalog):
+    def __init__(self, name_resolver, contents):
         self.name_resolver = name_resolver
-        self.catalog = catalog
+        self.contents = contents
 
-    def __getitem__(self, key):
+    def __getitem__(self, product_name):
         """
         Look up virtual product by name.
         """
-        return self.name_resolver.construct(**self.catalog['products'][key]['recipe'])
+        return self.name_resolver.construct(**self.contents['products'][product_name]['recipe'])
 
     def __len__(self):
-        return len(self.catalog['products'])
+        return len(self.contents['products'])
 
     def __iter__(self):
-        return iter(self.catalog['products'])
+        return iter(self.contents['products'])
+
+    def describe(self, product_name):
+        """
+        Section describing the product in the catalog.
+        """
+        return self.contents['products'][product_name]


### PR DESCRIPTION
### Reason for this pull request
Even though we currently support loading a virtual product from a catalog, there may potentially be other useful information about the product (like global metadata) in the catalog.

### Proposed changes
- Add a method `describe` which returns the relevant section of the catalog yaml document without constructing a virtual product object
- Add a method `catalog_from_file` to help load directly from a given filename