### PR TITLE
VP: minor usability enhancement to the NameResolver

### DIFF
--- a/datacube/virtual/__init__.py
+++ b/datacube/virtual/__init__.py
@@ -1,4 +1,5 @@
 from typing import Mapping, Any
+import copy
 
 from .impl import VirtualProduct, Transformation, VirtualProductException
 from .impl import from_validated_recipe
@@ -19,6 +20,10 @@ class NameResolver:
 
     def __init__(self, lookup_table):
         self.lookup_table = lookup_table
+
+    def clone(self):
+        """ Safely copy the resolver in order to possibly extend it. """
+        return NameResolver(copy.deepcopy(self.lookup_table))
 
     def construct(self, **recipe) -> VirtualProduct:
         """ Validate recipe and construct virtual product. """


### PR DESCRIPTION
### Reason for this pull request
Even though ODC comes with a set of built-in transformations, one particularly important use case for virtual products is user-defined transformations. When the recipe to construct a virtual product is in a catalog yaml, the user can refer to their custom transformation by the fully qualified name. An alternative is for the `NameResolver` to understand that a particular name resolves to a given (callable) object. Although the user can modify the `DEFAULT_RESOLVER` directly, it is not nice for the UX.

### Proposed changes
- Add a `clone` method to `NameResolver` to safely clone it.

This allows the following:

```python
from datacube.virtual import catalog_from_file, DEFAULT_RESOLVER, Transformation

class FractionalCover(Transformation):
    ...

resolver = DEFAULT_RESOLVER.clone()
resolver.register('transform', 'fractional_cover', FractionalCover)

catalog = catalog_from_file('catalog.yaml', name_resolver=resolver)
```

where `catalog.yaml` can now refer to this class by the nicer name:
```yaml
products:
    ls8_fc:
        transform: fractional_cover
        input:
            product: ls8_ard
```