### PR TITLE
Virtual product expressions: finer masking

### DIFF
--- a/datacube/virtual/transformations.py
+++ b/datacube/virtual/transformations.py
@@ -261,7 +261,7 @@ class Expressions(Transformation):
         @lark.v_args(inline=True)
         class EvaluateType(EvaluateTree):
             def var_name(self, key):
-                return numpy.array([0], dtype=input_measurements[key.value].dtype)
+                return numpy.array([], dtype=input_measurements[key.value].dtype)
 
         ev = EvaluateType()
 


### PR DESCRIPTION
### Reason for this pull request
Masking `nodata` is a complicated issue. The `expressions` transform should alleviate the headache of figuring out the right masking strategy as much as possible.

### Proposed changes
Currently whether the output is masked for `nodata` or not can only be specified as a top-level setting for the `expressions` transform.

The default is `masked=True`, then the output is `nodata` wherever any of the inputs are, but have to specify a `nodata` value in the spec. On the other hand, `masked=False` just returns the output as computed by the formula. This PR enables the user to specify this setting for each bands separately, while falling back to the top-level `masked` when omitted. This is probably too complicated and the top-level `masked` can be removed entirely with masking turned on by default.

By the way, since `bool` types cannot have a reasonable `nodata` value, we now set it to `False` whenever input is `nodata`. The boolean output band itself has no `nodata` defined in this case. This means for a `bool` output, setting `masked` to `False` has potentially very confusing behavior that depends on the actual value of `nodata` in the input dataset, and is therefore not recommended.