### PR TITLE
cogs

### DIFF
--- a/datacube/utils/aws/__init__.py
+++ b/datacube/utils/aws/__init__.py
@@ -165,8 +165,11 @@ def get_aws_settings(profile: Optional[str] = None,
 
     see also `datacube.utils.rio.set_default_rio_config`
 
-    Returns a tuple of (aws: Dictionary, creds: session credentials from
-    botocore). Note that credentials are baked in to `aws` setting dictionary,
+    Returns a tuple of:
+      (aws: Dictionary,
+       creds: session credentials from botocore).
+
+    Note that credentials are baked in to `aws` setting dictionary,
     however since those might be STS credentials they might require refresh
     hence they are returned from this function separately as well.
     """

--- a/datacube/utils/aws/__init__.py
+++ b/datacube/utils/aws/__init__.py
@@ -7,6 +7,7 @@ from botocore.credentials import Credentials, ReadOnlyCredentials
 from botocore.session import Session
 import time
 from urllib.request import urlopen
+from urllib.parse import urlparse
 from typing import Optional, Dict, Tuple, Any
 
 
@@ -19,6 +20,15 @@ def _fetch_text(url: str, timeout: float = 0.1) -> Optional[str]:
                 return None
     except IOError:
         return None
+
+
+def s3_url_parse(url: str) -> Tuple[str, str]:
+    """ Return Bucket, Key tuple
+    """
+    uu = urlparse(url)
+    if uu.scheme != "s3":
+        raise ValueError("Not a valid s3 url")
+    return uu.netloc, uu.path.lstrip('/')
 
 
 def ec2_metadata(timeout: float = 0.1) -> Optional[Dict[str, Any]]:

--- a/datacube/utils/aws/__init__.py
+++ b/datacube/utils/aws/__init__.py
@@ -3,11 +3,14 @@ Helper methods for working with AWS
 """
 import botocore
 import botocore.session
+from botocore.credentials import Credentials, ReadOnlyCredentials
+from botocore.session import Session
 import time
 from urllib.request import urlopen
+from typing import Optional, Dict, Tuple, Any
 
 
-def _fetch_text(url, timeout=0.1):
+def _fetch_text(url: str, timeout: float = 0.1) -> Optional[str]:
     try:
         with urlopen(url, timeout=timeout) as resp:
             if 200 <= resp.getcode() < 300:
@@ -18,7 +21,7 @@ def _fetch_text(url, timeout=0.1):
         return None
 
 
-def ec2_metadata(timeout=0.1):
+def ec2_metadata(timeout: float = 0.1) -> Optional[Dict[str, Any]]:
     """ When running inside AWS returns dictionary describing instance identity.
         Returns None when not inside AWS
     """
@@ -34,7 +37,7 @@ def ec2_metadata(timeout=0.1):
         return None
 
 
-def ec2_current_region():
+def ec2_current_region() -> Optional[str]:
     """ Returns name of the region  this EC2 instance is running in.
     """
     cfg = ec2_metadata()
@@ -43,7 +46,7 @@ def ec2_current_region():
     return cfg.get('region', None)
 
 
-def botocore_default_region(session=None):
+def botocore_default_region(session: Optional[Session] = None) -> Optional[str]:
     """ Returns default region name as configured on the system.
     """
     if session is None:
@@ -51,7 +54,7 @@ def botocore_default_region(session=None):
     return session.get_config_variable('region')
 
 
-def auto_find_region(session=None):
+def auto_find_region(session: Optional[Session] = None) -> str:
     """
     Try to figure out which region name to use
 
@@ -70,7 +73,9 @@ def auto_find_region(session=None):
     return region_name
 
 
-def get_creds_with_retry(session, max_tries=10, sleep=0.1):
+def get_creds_with_retry(session: Session,
+                         max_tries: int = 10,
+                         sleep: float = 0.1) -> Optional[Credentials]:
     """ Attempt to obtain credentials upto `max_tries` times with back off
     :param session: botocore session, see get_boto_session
     :param max_tries: number of attempt before failing and returing None
@@ -88,9 +93,9 @@ def get_creds_with_retry(session, max_tries=10, sleep=0.1):
     return None
 
 
-def mk_boto_session(profile=None,
-                    creds=None,
-                    region_name=None):
+def mk_boto_session(profile: Optional[str] = None,
+                    creds: Optional[ReadOnlyCredentials] = None,
+                    region_name: Optional[str] = None) -> Session:
     """ Get botocore session with correct `region` configured
 
     :param profile: profile name to lookup
@@ -115,10 +120,10 @@ def mk_boto_session(profile=None,
     return session
 
 
-def get_aws_settings(profile=None,
-                     region_name="auto",
-                     aws_unsigned=False,
-                     requester_pays=False):
+def get_aws_settings(profile: Optional[str] = None,
+                     region_name: str = "auto",
+                     aws_unsigned: bool = False,
+                     requester_pays: bool = False) -> Tuple[Dict[str, Any], Credentials]:
     """Compute `aws=` parameter for `set_default_rio_config`
 
     see also `datacube.utils.rio.set_default_rio_config`

--- a/datacube/utils/cog.py
+++ b/datacube/utils/cog.py
@@ -149,7 +149,9 @@ def write_cog(geo_im: xr.DataArray,
     :param overview_levels: List of shrink factors to compute overiews for: [2,4,8,16,32]
     :param **extra_rio_opts: Any other option is passed to `rasterio.open`
     """
-    pix, geobox, nodata = geo_im.data, geo_im.geobox, geo_im.attrs.get("nodata", None)
+    pix = geo_im.data
+    geobox = getattr(geo_im, 'geobox', None)
+    nodata = geo_im.attrs.get("nodata", None)
 
     if geobox is None:
         raise ValueError("Need geo-registered array on input")

--- a/datacube/utils/cog.py
+++ b/datacube/utils/cog.py
@@ -1,0 +1,194 @@
+import rasterio
+from rasterio.shutil import copy as rio_copy
+import numpy as np
+import xarray as xr
+import dask
+from dask.delayed import Delayed
+from pathlib import Path
+from typing import Union, Optional, List, Any
+
+from .io import check_write_path
+from .geometry import GeoBox
+
+__all__ = ("write_cog", "to_cog")
+
+
+def _write_cog(pix: np.ndarray,
+               geobox: GeoBox,
+               fname: Union[Path, str],
+               nodata: Optional[float] = None,
+               overwrite: bool = False,
+               blocksize: Optional[int] = None,
+               overview_resampling: Optional[str] = None,
+               overview_levels: Optional[List[int]] = None,
+               **extra_rio_opts) -> Union[Path, bytes]:
+    """Write geo-registered ndarray to GeoTiff file or RAM.
+
+    :param pix: xarray.DataArray with crs or (ndarray, geobox, nodata) triple
+    :param fname:  Output file or ":mem:"
+    :param nodata: Set `nodata` flag to this value if supplied
+    :param overwrite: True -- replace existing file, False -- abort with IOError exception
+    :param blocksize: Size of internal tiff tiles (512x512 pixels)
+    :param overview_resampling: Use this resampling when computing overviews
+    :param overview_levels: List of shrink factors to compute overiews for: [2,4,8,16,32]
+    :param **extra_rio_opts: Any other option is passed to `rasterio.open`
+
+    When fname=":mem:" write COG to memory rather than to a file and return it
+    as memoryview object.
+
+    NOTE: about memory requirements
+
+    This function generates temporary in memory tiff file without compression
+    to speed things up. It then adds overviews to this file and only then
+    copies it to the final destination with requested compression settings.
+    This is necessary to produce compliant COG, since COG standard demands
+    overviews to be placed before native resolution data and double pass is the
+    only way to achieve this currently.
+
+    This means that this function will use about 1.5 to 2 times memory taken by `pix`.
+    """
+    # pylint: disable=too-many-locals
+    if blocksize is None:
+        blocksize = 512
+    if overview_levels is None:
+        overview_levels = [2 ** i for i in range(1, 6)]
+    if overview_resampling is None:
+        overview_resampling = "nearest"
+
+    if pix.ndim == 2:
+        h, w = pix.shape
+        nbands = 1
+        band = 1  # type: Any
+    elif pix.ndim == 3:
+        nbands, h, w = pix.shape
+        band = tuple(i for i in range(1, nbands + 1))
+    else:
+        raise ValueError("Need 2d or 3d ndarray on input")
+
+    assert geobox.shape == (h, w)
+
+    if fname != ":mem:":
+        path = check_write_path(
+            fname, overwrite
+        )  # aborts if overwrite=False and file exists already
+
+    resampling = rasterio.enums.Resampling[overview_resampling]
+
+    rio_opts = dict(
+        width=w,
+        height=h,
+        count=nbands,
+        dtype=pix.dtype.name,
+        crs=str(geobox.crs),
+        transform=geobox.transform,
+        tiled=True,
+        blockxsize=min(blocksize, w),
+        blockysize=min(blocksize, h),
+        zlevel=6,
+        predictor=3 if pix.dtype.kind == "f" else 2,
+        compress="DEFLATE",
+    )
+
+    if nodata is not None:
+        rio_opts.update(nodata=nodata)
+
+    rio_opts.update(extra_rio_opts)
+
+    # copy re-compresses anyway so skip compression for temp image
+    tmp_opts = rio_opts.copy()
+    tmp_opts.pop("compress")
+    tmp_opts.pop("predictor")
+    tmp_opts.pop("zlevel")
+
+    with rasterio.Env(GDAL_TIFF_OVR_BLOCKSIZE=blocksize):
+        with rasterio.MemoryFile() as mem:
+            with mem.open(driver="GTiff", **tmp_opts) as tmp:
+                tmp.write(pix, band)
+                tmp.build_overviews(overview_levels, resampling)
+
+                if fname == ":mem:":
+                    with rasterio.MemoryFile() as mem2:
+                        rio_copy(
+                            tmp,
+                            mem2.name,
+                            driver="GTiff",
+                            copy_src_overviews=True,
+                            **rio_opts
+                        )
+                        return bytes(mem2.getbuffer())
+
+                rio_copy(
+                    tmp, path, driver="GTiff", copy_src_overviews=True, **rio_opts
+                )
+
+    return path
+
+
+_delayed_write_cog_to_mem = dask.delayed(  # pylint: disable=invalid-name
+    _write_cog,
+    name="compress-cog", pure=True, nout=1
+)
+
+_delayed_write_cog_to_file = dask.delayed(   # pylint: disable=invalid-name
+    _write_cog,
+    name="save-cog", pure=False, nout=1
+)
+
+
+def write_cog(geo_im: xr.DataArray,
+              fname: Union[str, Path],
+              blocksize: Optional[int] = None,
+              overview_resampling: Optional[str] = None,
+              overview_levels: Optional[List[int]] = None,
+              **extra_rio_opts) -> Union[Path, bytes, Delayed]:
+    """Compress xarray.DataArray to GeoTiff bytes.
+
+    :param geo_im: xarray.DataArray with crs
+    :param blocksize: Size of internal tiff tiles (512x512 pixels)
+    :param overview_resampling: Use this resampling when computing overviews
+    :param overview_levels: List of shrink factors to compute overiews for: [2,4,8,16,32]
+    :param **extra_rio_opts: Any other option is passed to `rasterio.open`
+    """
+    pix, geobox, nodata = geo_im.data, geo_im.geobox, geo_im.attrs.get("nodata", None)
+
+    if geobox is None:
+        raise ValueError("Need geo-registered array on input")
+
+    if dask.is_dask_collection(pix):
+        real_op = _delayed_write_cog_to_mem if fname == ":mem:" else _delayed_write_cog_to_file
+    else:
+        real_op = _write_cog
+
+    return real_op(
+        pix,
+        geobox,
+        fname,
+        nodata=nodata,
+        blocksize=blocksize,
+        overview_resampling=overview_resampling,
+        overview_levels=overview_levels,
+        **extra_rio_opts)
+
+
+def to_cog(geo_im: xr.DataArray,
+           blocksize: Optional[int] = None,
+           overview_resampling: Optional[str] = None,
+           overview_levels: Optional[List[int]] = None,
+           **extra_rio_opts) -> Union[bytes, Delayed]:
+    """Compress xarray.Array to GeoTiff bytes.
+
+    :param geo_im: xarray.DataArray with crs
+    :param blocksize: Size of internal tiff tiles (512x512 pixels)
+    :param overview_resampling: Use this resampling when computing overviews
+    :param overview_levels: List of shrink factors to compute overiews for: [2,4,8,16,32]
+    :param **extra_rio_opts: Any other option is passed to `rasterio.open`
+    """
+    bb = write_cog(geo_im,
+                   ":mem:",
+                   blocksize=blocksize,
+                   overview_resampling=overview_resampling,
+                   overview_levels=overview_levels,
+                   **extra_rio_opts)
+
+    assert isinstance(bb, (bytes, Delayed))  # for mypy sake for :mem: output it bytes or delayed bytes
+    return bb

--- a/datacube/utils/dask.py
+++ b/datacube/utils/dask.py
@@ -10,6 +10,7 @@ import dask
 import threading
 import logging
 from botocore.credentials import ReadOnlyCredentials
+from botocore.exceptions import BotoCoreError
 from .aws import s3_dump, s3_client
 
 
@@ -223,6 +224,7 @@ def _save_blob_to_s3(data: Union[bytes, str],
     (url, True) tuple on success
     (url, False) on any error
     """
+    from botocore.errorfactory import ClientError
     try:
         s3 = s3_client(profile=profile,
                        creds=creds,
@@ -230,7 +232,7 @@ def _save_blob_to_s3(data: Union[bytes, str],
                        cache=True)
 
         result = s3_dump(data, url, s3=s3, **kw)
-    except IOError:
+    except (IOError, BotoCoreError, ClientError):
         result = False
 
     return url, result

--- a/datacube/utils/dask.py
+++ b/datacube/utils/dask.py
@@ -1,0 +1,161 @@
+""" Dask Distributed Tools
+
+"""
+from typing import Any, Iterable, Optional
+from random import randint
+import toolz
+import queue
+from dask.distributed import Client
+import dask
+import threading
+import logging
+
+__all__ = (
+    "start_local_dask",
+    "pmap",
+    "compute_tasks",
+    "partition_map",
+)
+
+_LOG = logging.getLogger(__name__)
+
+
+def start_local_dask(n_workers: int = 1,
+                     threads_per_worker: Optional[int] = None,
+                     mem_safety_margin: Optional[int] = None,
+                     **kw):
+    """Wrapper around `distributed.Client(..)` constructor that deals with memory better.
+
+    :param n_workers: number of worker processes to launch
+    :param threads_per_worker: number of threads per worker, default is as many as there are CPUs
+    :param mem_safety_margin: bytes to reserve for the rest of the system, only applicable
+                              if `memory_limit=` is not supplied.
+
+    NOTE: if `memory_limit` is supplied, it will passed on to `distributed.Client`
+    unmodified. It applies per worker not per whole cluster, so if you have
+    `n_workers > 1`, total cluster memory will then be `n_workers*memory_limit`
+    you should take that into account.
+    """
+
+    mem = kw.pop('memory_limit', None)
+    if mem is None:
+        from psutil import virtual_memory
+        total_bytes = virtual_memory().total
+        if mem_safety_margin is None:
+            # Default to 500Mb or half of all memory if there is less than 1G of RAM
+            mem_safety_margin = min(500*(1024*1024), total_bytes//2)
+
+        mem = (total_bytes - mem_safety_margin)//n_workers
+
+    client = Client(n_workers=n_workers,
+                    threads_per_worker=threads_per_worker,
+                    memory_limit=mem,
+                    **kw)
+
+    return client
+
+
+def _randomize(prefix):
+    return '{}-{:08x}'.format(prefix, randint(0, 0xFFFFFFFF))
+
+
+def partition_map(n: int, func: Any, its: Iterable[Any],
+                  name: str = 'compute') -> Iterable[Any]:
+    """ Partition sequence into lumps of size `n`, then construct dask delayed computation evaluating to:
+
+    [func(x) for x in its[0:1n]],
+    [func(x) for x in its[n:2n]],
+    ...
+    [func(x) for x in its[]],
+
+    :param n: number of elements to process in one go
+    :param func: Function to apply (non-dask)
+    :param its:  Values to feed to fun
+    :param name: How the computation should be named in dask visualizations
+    """
+    def lump_proc(dd):
+        return [func(d) for d in dd]
+
+    proc = dask.delayed(lump_proc, nout=1, pure=True)
+    data_name = _randomize('data_' + name)
+    name = _randomize(name)
+
+    for i, dd in enumerate(toolz.partition_all(n, its)):
+        lump = dask.delayed(dd,
+                            pure=True,
+                            traverse=False,
+                            name=data_name + str(i))
+        yield proc(lump, dask_key_name=name + str(i))
+
+
+def compute_tasks(tasks: Iterable[Any], client: Client,
+                  max_in_flight: int = 3) -> Iterable[Any]:
+    """ Parallel compute stream with back pressure.
+
+        Equivalent to:
+
+        (client.compute(task).result()
+          for task in tasks)
+
+        but with up to `max_in_flight` tasks being processed at the same time.
+        Input/Output order is preserved, so there is a possibility of head of
+        line blocking.
+
+        NOTE: lower limit is 3 concurrent tasks to simplify implementation,
+              there is no point calling this function if you want one active
+              task and supporting exactly 2 active tasks is not worth the complexity,
+              for now. We might special-case `2` at some point.
+
+    """
+    # New thread:
+    #    1. Take dask task from iterator
+    #    2. Submit to client for processing
+    #    3. Send it of to wrk_q
+    #
+    # Calling thread:
+    #    1. Pull scheduled future from wrk_q
+    #    2. Wait for result of the future
+    #    3. yield result to calling code
+    from .generic import it2q, qmap
+
+    # (max_in_flight - 2) -- one on each side of queue
+    wrk_q = queue.Queue(maxsize=max(1, max_in_flight - 2))  # type: queue.Queue
+
+    # fifo_timeout='0ms' ensures that priority of later tasks is lower
+    futures = (client.compute(task, fifo_timeout='0ms') for task in tasks)
+
+    in_thread = threading.Thread(target=it2q, args=(futures, wrk_q))
+    in_thread.start()
+
+    yield from qmap(lambda f: f.result(), wrk_q)
+
+    in_thread.join()
+
+
+def pmap(func: Any,
+         its: Iterable[Any],
+         client: Client,
+         lump: int = 1,
+         max_in_flight: int = 3,
+         name: str = 'compute') -> Iterable[Any]:
+    """ Parallel map with back pressure.
+
+    Equivalent to this:
+
+       (func(x) for x in its)
+
+    Except that ``func(x)`` runs concurrently on dask cluster.
+
+    :param func:   Method that will be applied concurrently to data from ``its``
+    :param its:    Iterator of input values
+    :param client: Connected dask client
+    :param lump:   Group this many datasets into one task
+    :param max_in_flight: Maximum number of active tasks to submit
+    :param name:   Dask name for computation
+    """
+    max_in_flight = max_in_flight // lump
+
+    tasks = partition_map(lump, func, its, name=name)
+
+    for xx in compute_tasks(tasks, client=client, max_in_flight=max_in_flight):
+        yield from xx

--- a/datacube/utils/io.py
+++ b/datacube/utils/io.py
@@ -1,6 +1,14 @@
 import os
 from pathlib import Path
-from typing import Union
+from typing import Union, Optional
+
+
+def _norm_path(path: Union[str, Path], in_home_dir: bool = False) -> Path:
+    if isinstance(path, str):
+        path = Path(path)
+    if in_home_dir:
+        path = Path.home()/path
+    return path
 
 
 def check_write_path(fname: Union[Path, str], overwrite: bool) -> Path:
@@ -27,20 +35,23 @@ def check_write_path(fname: Union[Path, str], overwrite: bool) -> Path:
     return fname
 
 
-def write_user_secret_file(text, fname, in_home_dir=False, mode='w'):
+def write_user_secret_file(text: Union[str, bytes],
+                           fname: Union[str, Path],
+                           in_home_dir: bool = False,
+                           mode: str = 'w'):
     """Write file only readable/writeable by the user"""
 
-    if in_home_dir:
-        fname = os.path.join(os.environ['HOME'], fname)
-
+    fname = _norm_path(fname, in_home_dir)
     open_flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
     access = 0o600  # Make sure file is readable by current user only
-    with os.fdopen(os.open(fname, open_flags, access), mode) as handle:
+    with os.fdopen(os.open(str(fname), open_flags, access), mode) as handle:
         handle.write(text)
         handle.close()
 
 
-def slurp(fname, in_home_dir=False, mode='r'):
+def slurp(fname: Union[str, Path],
+          in_home_dir: bool = False,
+          mode: str = 'r') -> Optional[Union[bytes, str]]:
     """
     Read an entire file into a string
 
@@ -48,10 +59,9 @@ def slurp(fname, in_home_dir=False, mode='r'):
     :param in_home_dir: if True treat fname as a path relative to $HOME folder
     :return: Content of a file or None if file doesn't exist or can not be read for any other reason
     """
-    if in_home_dir:
-        fname = os.path.join(os.environ['HOME'], fname)
+    fname = _norm_path(fname, in_home_dir)
     try:
-        with open(fname, mode) as handle:
+        with open(str(fname), mode) as handle:
             return handle.read()
     except IOError:
         return None

--- a/datacube/utils/rio/__init__.py
+++ b/datacube/utils/rio/__init__.py
@@ -9,6 +9,7 @@ from ._rio import (
     get_rio_env,
     set_default_rio_config,
     activate_from_config,
+    configure_s3_access,
 )
 
 __all__ = (
@@ -17,4 +18,5 @@ __all__ = (
     'get_rio_env',
     'set_default_rio_config',
     'activate_from_config',
+    'configure_s3_access',
 )

--- a/datacube/virtual/transformations.py
+++ b/datacube/virtual/transformations.py
@@ -99,6 +99,7 @@ class ApplyMask(Transformation):
         def dilate(array):
             """Dilation e.g. for the mask"""
             # e.g. kernel = [[1] * 7] * 7 # blocky 3-pixel dilation
+            # pylint: disable=invalid-unary-operand-type
             y, x = numpy.ogrid[-self.dilation:(self.dilation+1), -self.dilation:(self.dilation+1)]
             kernel = ((x * x) + (y * y) <= (self.dilation + 0.5) ** 2)  # disk-like `self.dilation` radial dilation
             return ~scipy.ndimage.binary_dilation(~array, structure=kernel.reshape((1, )+kernel.shape))

--- a/integration_tests/index/test_search.py
+++ b/integration_tests/index/test_search.py
@@ -688,6 +688,7 @@ def test_search_conflicting_types(index, pseudo_ls8_dataset, pseudo_ls8_type):
 
 def test_fetch_all_of_md_type(index: Index, pseudo_ls8_dataset: Dataset) -> None:
     # Get every dataset of the md type.
+    assert pseudo_ls8_dataset.metadata_type is not None  # to shut up mypy
     results = index.datasets.search_eager(
         metadata_type=pseudo_ls8_dataset.metadata_type.name
     )
@@ -1063,7 +1064,7 @@ def test_find_duplicates(index, pseudo_ls8_type,
     f = pseudo_ls8_type.metadata_type.dataset_fields.get
     field_res = sorted(index.datasets.search_product_duplicates(
         pseudo_ls8_type,
-        f('time').lower.day
+        f('time').lower.day  # type: ignore
     ))
 
     # Datasets 1 & 3 are on the 26th.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -20,7 +20,8 @@ cloudpickle==0.5.2
 compliance-checker==3.1.1
 coverage==4.5.1
 coveralls==1.3.0
-dask==0.17.2
+dask==2.3.0
+distributed==2.0.1
 dill==0.2.7.1
 docopt==0.6.2
 docutils==0.14

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ setup(
         'click>=5.0',
         'cloudpickle>=0.4',
         'dask[array]',
+        'distributed',
         'gdal>=1.9',
         'jsonschema',
         'netcdf4',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,12 @@ from affine import Affine
 from datacube.utils import geometry
 
 
+AWS_ENV_VARS = ("AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN"
+                "AWS_DEFAULT_REGION AWS_DEFAULT_OUTPUT AWS_PROFILE "
+                "AWS_ROLE_SESSION_NAME AWS_CA_BUNDLE "
+                "AWS_SHARED_CREDENTIALS_FILE AWS_CONFIG_FILE").split(" ")
+
+
 @pytest.fixture
 def example_gdal_path(data_folder):
     """Return the pathname of a sample geotiff file
@@ -74,6 +80,12 @@ def odc_style_xr_dataset():
     #  {'nodata': 0, 'units': '1', 'crs': geobox.crs})
 
     return dataset
+
+
+@pytest.fixture
+def without_aws_env(monkeypatch):
+    for e in AWS_ENV_VARS:
+        monkeypatch.delenv(e, raising=False)
 
 
 GEO_PROJ = 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],' \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,3 +91,14 @@ def without_aws_env(monkeypatch):
 GEO_PROJ = 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],' \
            'AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433],' \
            'AUTHORITY["EPSG","4326"]]'
+
+
+@pytest.fixture(scope="module")
+def dask_client():
+    from distributed import Client
+    client = Client(processes=False,
+                    threads_per_worker=1,
+                    dashboard_address=None)
+    yield client
+    client.close()
+    del client

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -363,6 +363,17 @@ def test_map_with_lookahead():
     assert list(map_with_lookahead(iter([1]), if_many=if_many)) == [1]
 
 
+def test_qmap():
+    from datacube.utils.generic import qmap, it2q
+    from queue import Queue
+
+    q = Queue(maxsize=100)
+    it2q(range(10), q)
+    rr = [x for x in qmap(str, q)]
+    assert rr == [str(x) for x in range(10)]
+    q.join()  # should not block
+
+
 def test_parse_yaml():
     assert parse_yaml('a: 10') == {'a': 10}
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,7 +29,6 @@ from datacube.utils import (gen_password, write_user_secret_file, slurp, read_do
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes, MISSING, DocumentMismatchError
 from datacube.utils.dates import date_sequence
 from datacube.utils.documents import parse_yaml, without_lineage_sources
-from datacube.utils.generic import map_with_lookahead
 from datacube.utils.math import num2numpy, is_almost_int, valid_mask, invalid_mask, clamp
 from datacube.utils.py import sorted_items
 from datacube.utils.uris import (uri_to_local_path, mk_part_uri, get_part_from_uri, as_url, is_url,
@@ -347,31 +346,6 @@ def test_without_lineage_sources():
 
     assert without_lineage_sources(mk_sample(10), no_sources_type) == mk_sample(10)
     assert without_lineage_sources(mk_sample(10), no_sources_type, inplace=True) == mk_sample(10)
-
-
-def test_map_with_lookahead():
-    def if_one(x):
-        return 'one' + str(x)
-
-    def if_many(x):
-        return 'many' + str(x)
-
-    assert list(map_with_lookahead(iter([]), if_one, if_many)) == []
-    assert list(map_with_lookahead(iter([1]), if_one, if_many)) == [if_one(1)]
-    assert list(map_with_lookahead(range(5), if_one, if_many)) == list(map(if_many, range(5)))
-    assert list(map_with_lookahead(range(10), if_one=if_one)) == list(range(10))
-    assert list(map_with_lookahead(iter([1]), if_many=if_many)) == [1]
-
-
-def test_qmap():
-    from datacube.utils.generic import qmap, it2q
-    from queue import Queue
-
-    q = Queue(maxsize=100)
-    it2q(range(10), q)
-    rr = [x for x in qmap(str, q)]
-    assert rr == [str(x) for x in range(10)]
-    q.join()  # should not block
 
 
 def test_parse_yaml():

--- a/tests/test_utils_aws.py
+++ b/tests/test_utils_aws.py
@@ -2,10 +2,13 @@ import pytest
 import mock
 import json
 
+from datacube.testutils import write_files
+
 from datacube.utils.aws import (
     _fetch_text,
     ec2_current_region,
     auto_find_region,
+    get_aws_settings,
 )
 
 
@@ -63,3 +66,61 @@ def test_fetch_text():
 
     with mock.patch('datacube.utils.aws.urlopen', fake_urlopen):
         assert _fetch_text('http://localhost:8817') is None
+
+
+def test_get_aws_settings(monkeypatch):
+
+    pp = write_files({
+        "config": """
+[default]
+region = us-west-2
+
+[profile east]
+region = us-east-1
+[profile no_region]
+""",
+        "credentials": """
+[default]
+aws_access_key_id = AKIAWYXYXYXYXYXYXYXY
+aws_secret_access_key = fake-fake-fake
+[east]
+aws_access_key_id = AKIAEYXYXYXYXYXYXYXY
+aws_secret_access_key = fake-fake-fake
+"""
+    })
+
+    assert (pp/"credentials").exists()
+    assert (pp/"config").exists()
+
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(pp/"config"))
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(pp/"credentials"))
+
+    aws, creds = get_aws_settings()
+    assert aws['region_name'] == 'us-west-2'
+    assert aws['aws_access_key_id'] == 'AKIAWYXYXYXYXYXYXYXY'
+    assert aws['aws_secret_access_key'] == 'fake-fake-fake'
+
+    aws, creds = get_aws_settings(profile='east')
+    assert aws['region_name'] == 'us-east-1'
+    assert aws['aws_access_key_id'] == 'AKIAEYXYXYXYXYXYXYXY'
+    assert aws['aws_secret_access_key'] == 'fake-fake-fake'
+
+    aws, creds = get_aws_settings(aws_unsigned=True)
+    assert creds is None
+    assert aws['region_name'] == 'us-west-2'
+    assert aws['aws_unsigned'] is True
+
+    aws, creds = get_aws_settings(profile="no_region",
+                                  region_name="us-west-1",
+                                  aws_unsigned=True)
+
+    assert aws['region_name'] == 'us-west-1'
+    assert aws['aws_unsigned'] is True
+
+    with mock.patch('datacube.utils.aws._fetch_text',
+                    return_value=_json(region="mordor")):
+        aws, creds = get_aws_settings(profile="no_region",
+                                      aws_unsigned=True)
+
+        assert aws['region_name'] == 'mordor'
+        assert aws['aws_unsigned'] is True

--- a/tests/test_utils_aws.py
+++ b/tests/test_utils_aws.py
@@ -142,6 +142,7 @@ aws_secret_access_key = fake-fake-fake
 
 def test_creds_with_retry():
     session = mock.MagicMock()
-    session.get_credentials = lambda: None
+    session.get_credentials = mock.MagicMock(return_value=None)
 
     assert get_creds_with_retry(session, 2, 0.01) is None
+    assert session.get_credentials.call_count == 2

--- a/tests/test_utils_aws.py
+++ b/tests/test_utils_aws.py
@@ -208,6 +208,7 @@ def test_s3_io(monkeypatch, without_aws_env):
             s3_fetch(url, range=s_[::2], s3=s3)
 
 
+@mock.patch('datacube.utils.aws.ec2_current_region', return_value="us-west-2")
 def test_s3_client_cache(monkeypatch, without_aws_env):
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "fake-key-id")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "fake-secret")

--- a/tests/test_utils_aws.py
+++ b/tests/test_utils_aws.py
@@ -92,6 +92,12 @@ aws_secret_access_key = fake-fake-fake
     assert (pp/"credentials").exists()
     assert (pp/"config").exists()
 
+    for e in ("AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN"
+              "AWS_DEFAULT_REGION AWS_DEFAULT_OUTPUT AWS_PROFILE "
+              "AWS_ROLE_SESSION_NAME AWS_CA_BUNDLE "
+              "AWS_SHARED_CREDENTIALS_FILE AWS_CONFIG_FILE").split(" "):
+        monkeypatch.delenv(e, raising=False)
+
     monkeypatch.setenv("AWS_CONFIG_FILE", str(pp/"config"))
     monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(pp/"credentials"))
 

--- a/tests/test_utils_aws.py
+++ b/tests/test_utils_aws.py
@@ -10,6 +10,7 @@ from datacube.utils.aws import (
     auto_find_region,
     get_aws_settings,
     mk_boto_session,
+    get_creds_with_retry,
 )
 
 
@@ -137,3 +138,10 @@ aws_secret_access_key = fake-fake-fake
     with mock.patch('datacube.utils.aws.get_creds_with_retry', return_value=None):
         with pytest.raises(ValueError):
             aws, creds = get_aws_settings(profile='no_region')
+
+
+def test_creds_with_retry():
+    session = mock.MagicMock()
+    session.get_credentials = lambda: None
+
+    assert get_creds_with_retry(session, 2, 0.01) is None

--- a/tests/test_utils_aws.py
+++ b/tests/test_utils_aws.py
@@ -69,7 +69,7 @@ def test_fetch_text():
         assert _fetch_text('http://localhost:8817') is None
 
 
-def test_get_aws_settings(monkeypatch):
+def test_get_aws_settings(monkeypatch, without_aws_env):
 
     pp = write_files({
         "config": """
@@ -92,12 +92,6 @@ aws_secret_access_key = fake-fake-fake
 
     assert (pp/"credentials").exists()
     assert (pp/"config").exists()
-
-    for e in ("AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN"
-              "AWS_DEFAULT_REGION AWS_DEFAULT_OUTPUT AWS_PROFILE "
-              "AWS_ROLE_SESSION_NAME AWS_CA_BUNDLE "
-              "AWS_SHARED_CREDENTIALS_FILE AWS_CONFIG_FILE").split(" "):
-        monkeypatch.delenv(e, raising=False)
 
     monkeypatch.setenv("AWS_CONFIG_FILE", str(pp/"config"))
     monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(pp/"credentials"))

--- a/tests/test_utils_aws.py
+++ b/tests/test_utils_aws.py
@@ -11,6 +11,7 @@ from datacube.utils.aws import (
     get_aws_settings,
     mk_boto_session,
     get_creds_with_retry,
+    s3_url_parse,
 )
 
 
@@ -146,3 +147,12 @@ def test_creds_with_retry():
 
     assert get_creds_with_retry(session, 2, 0.01) is None
     assert session.get_credentials.call_count == 2
+
+
+def test_s3():
+    assert s3_url_parse('s3://bucket/key') == ('bucket', 'key')
+    assert s3_url_parse('s3://bucket/key/') == ('bucket', 'key/')
+    assert s3_url_parse('s3://bucket/k/k/key') == ('bucket', 'k/k/key')
+
+    with pytest.raises(ValueError):
+        s3_url_parse("file://some/path")

--- a/tests/test_utils_aws.py
+++ b/tests/test_utils_aws.py
@@ -139,10 +139,12 @@ aws_secret_access_key = fake-fake-fake
         assert aws['region_name'] == 'mordor'
         assert aws['aws_unsigned'] is True
 
-    # test failing due to credentials missing
-    with mock.patch('datacube.utils.aws.get_creds_with_retry', return_value=None):
-        with pytest.raises(ValueError):
-            aws, creds = get_aws_settings(profile='no_region')
+
+@mock.patch('datacube.utils.aws.get_creds_with_retry', return_value=None)
+def test_get_aws_settings_no_credentials(without_aws_env):
+    # get_aws_settings should fail when credentials are not available
+    with pytest.raises(ValueError, match="Couldn't get credentials"):
+        aws, creds = get_aws_settings(region_name="fake")
 
 
 def test_creds_with_retry():
@@ -167,6 +169,7 @@ def test_s3_basics(without_aws_env):
     assert s3_fmt_range((0, 3)) == "bytes=0-2"
     assert s3_fmt_range(s_[4:10]) == "bytes=4-9"
     assert s3_fmt_range(s_[:10]) == "bytes=0-9"
+    assert s3_fmt_range(None) is None
 
     for bad in (s_[10:], s_[-2:3], s_[:-3], (-1, 3), (3, -1), s_[1:100:3]):
         with pytest.raises(ValueError):

--- a/tests/test_utils_aws.py
+++ b/tests/test_utils_aws.py
@@ -12,6 +12,7 @@ from datacube.utils.aws import (
     mk_boto_session,
     get_creds_with_retry,
     s3_url_parse,
+    s3_fmt_range,
 )
 
 
@@ -150,9 +151,18 @@ def test_creds_with_retry():
 
 
 def test_s3():
+    from numpy import s_
     assert s3_url_parse('s3://bucket/key') == ('bucket', 'key')
     assert s3_url_parse('s3://bucket/key/') == ('bucket', 'key/')
     assert s3_url_parse('s3://bucket/k/k/key') == ('bucket', 'k/k/key')
 
     with pytest.raises(ValueError):
         s3_url_parse("file://some/path")
+
+    assert s3_fmt_range((0, 3)) == "bytes=0-2"
+    assert s3_fmt_range(s_[4:10]) == "bytes=4-9"
+    assert s3_fmt_range(s_[:10]) == "bytes=0-9"
+
+    for bad in (s_[10:], s_[-2:3], s_[:-3], (-1, 3), (3, -1), s_[1:100:3]):
+        with pytest.raises(ValueError):
+            s3_fmt_range(bad)

--- a/tests/test_utils_cog.py
+++ b/tests/test_utils_cog.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+import numpy as np
+from types import SimpleNamespace
+
+from datacube.testutils import (
+    mk_test_image,
+    gen_tiff_dataset,
+)
+from datacube.testutils.io import native_load, rio_slurp_xarray
+from datacube.utils.cog import write_cog, to_cog
+
+
+def gen_test_data(prefix, dask=False):
+    w, h, dtype, nodata, ndw = 96, 64, 'int16', -999, 7
+
+    aa = mk_test_image(w, h, dtype, nodata, nodata_width=ndw)
+
+    ds, gbox = gen_tiff_dataset(
+        SimpleNamespace(name='aa', values=aa, nodata=nodata), prefix)
+    extras = {}
+
+    if dask:
+        extras.update(dask_chunks={})
+
+    xx = native_load(ds, **extras)
+
+    return xx.aa.isel(time=0), ds
+
+
+def test_cog_file(tmpdir):
+    pp = Path(str(tmpdir))
+    xx, ds = gen_test_data(pp)
+
+    # write to file
+    ff = write_cog(xx, pp / "cog.tif")
+    assert isinstance(ff, Path)
+    assert ff == pp / "cog.tif"
+    assert ff.exists()
+
+    yy = rio_slurp_xarray(pp / "cog.tif")
+    np.testing.assert_array_equal(yy.values, xx.values)
+    assert yy.geobox == xx.geobox
+    assert yy.nodata == xx.nodata
+
+
+def test_cog_mem(tmpdir):
+    pp = Path(str(tmpdir))
+    xx, ds = gen_test_data(pp)
+
+    # write to memory 1
+    bb = write_cog(xx, ":mem:")
+    assert isinstance(bb, bytes)
+    path = pp / "cog1.tiff"
+    with open(str(path), "wb") as f:
+        f.write(bb)
+
+    yy = rio_slurp_xarray(path)
+    np.testing.assert_array_equal(yy.values, xx.values)
+    assert yy.geobox == xx.geobox
+    assert yy.nodata == xx.nodata
+
+    # write to memory 2
+    bb = to_cog(xx)
+    assert isinstance(bb, bytes)
+    path = pp / "cog2.tiff"
+    with open(str(path), "wb") as f:
+        f.write(bb)
+
+    yy = rio_slurp_xarray(path)
+    np.testing.assert_array_equal(yy.values, xx.values)
+    assert yy.geobox == xx.geobox
+    assert yy.nodata == xx.nodata

--- a/tests/test_utils_cog.py
+++ b/tests/test_utils_cog.py
@@ -1,3 +1,4 @@
+import pytest
 from pathlib import Path
 import numpy as np
 from types import SimpleNamespace
@@ -124,3 +125,17 @@ def test_cog_mem_dask(tmpdir):
     np.testing.assert_array_equal(yy.values, xx.values)
     assert yy.geobox == xx.geobox
     assert yy.nodata == xx.nodata
+
+
+@pytest.mark.parametrize("with_dask", [True, False])
+def test_cog_no_crs(tmpdir, with_dask):
+    pp = Path(str(tmpdir))
+
+    xx, ds = gen_test_data(pp, dask=with_dask)
+    del xx.attrs['crs']
+
+    with pytest.raises(ValueError):
+        write_cog(xx, ":mem:")
+
+    with pytest.raises(ValueError):
+        to_cog(xx)

--- a/tests/test_utils_dask.py
+++ b/tests/test_utils_dask.py
@@ -73,6 +73,9 @@ def test_save_blob_file_direct(tmpdir, blob):
     assert _save_blob_to_file(blob, fname) == (fname, True)
     assert slurp(fname, mode=mode) == blob
 
+    fname = tmpdir/"missing"/"file.txt"
+    assert _save_blob_to_file(blob, fname) == (fname, False)
+
 
 @pytest.mark.parametrize("blob", [
     "some utf8 string",
@@ -86,8 +89,11 @@ def test_save_blob_file(tmpdir, blob, dask_client):
 
     rr = save_blob_to_file(dask_blob, fname)
     assert dask_client.compute(rr).result() == (fname, True)
-
     assert slurp(fname, mode=mode) == blob
+
+    fname = tmpdir/"missing"/"file.txt"
+    rr = save_blob_to_file(dask_blob, fname)
+    assert dask_client.compute(rr).result() == (fname, False)
 
 
 @pytest.mark.parametrize("blob", [

--- a/tests/test_utils_dask.py
+++ b/tests/test_utils_dask.py
@@ -1,12 +1,38 @@
+import pytest
+import moto
+from pathlib import Path
 import dask
 import dask.delayed
+
+from datacube.utils.io import slurp
 
 from datacube.utils.dask import (
     start_local_dask,
     compute_tasks,
     pmap,
     partition_map,
+    save_blob_to_file,
+    save_blob_to_s3,
+    _save_blob_to_file,
+    _save_blob_to_s3,
 )
+
+from datacube.utils.aws import (
+    s3_url_parse,
+    s3_fetch,
+    s3_client,
+)
+
+
+@pytest.fixture(scope="module")
+def dask_client():
+    from distributed import Client
+    client = Client(processes=False,
+                    threads_per_worker=1,
+                    dashboard_address=None)
+    yield client
+    client.close()
+    del client
 
 
 def test_compute_tasks():
@@ -44,3 +70,103 @@ def test_pmap():
 
     client.close()
     del client
+
+
+@pytest.mark.parametrize("blob", [
+    "some utf8 string",
+    b"raw bytes",
+])
+def test_save_blob_file_direct(tmpdir, blob):
+    tmpdir = Path(str(tmpdir))
+    fname = str(tmpdir/"file.txt")
+    mode = "rt" if isinstance(blob, str) else "rb"
+
+    assert _save_blob_to_file(blob, fname) == (fname, True)
+    assert slurp(fname, mode=mode) == blob
+
+
+@pytest.mark.parametrize("blob", [
+    "some utf8 string",
+    b"raw bytes",
+])
+def test_save_blob_file(tmpdir, blob, dask_client):
+    tmpdir = Path(str(tmpdir))
+    fname = str(tmpdir/"file.txt")
+    dask_blob = dask.delayed(blob)
+    mode = "rt" if isinstance(blob, str) else "rb"
+
+    rr = save_blob_to_file(dask_blob, fname)
+    assert dask_client.compute(rr).result() == (fname, True)
+
+    assert slurp(fname, mode=mode) == blob
+
+
+@pytest.mark.parametrize("blob", [
+    "some utf8 string",
+    b"raw bytes",
+])
+def test_save_blob_s3_direct(blob, monkeypatch):
+    region_name = "us-west-2"
+    blob2 = blob + blob
+
+    url = "s3://bucket/file.txt"
+    url2 = "s3://bucket/file-2.txt"
+
+    bucket, _ = s3_url_parse(url)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "fake-key-id")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "fake-secret")
+
+    with moto.mock_s3():
+        s3 = s3_client(region_name=region_name)
+        s3.create_bucket(Bucket=bucket)
+
+        assert _save_blob_to_s3(blob, url, region_name=region_name) == (url, True)
+        assert _save_blob_to_s3(blob2, url2, region_name=region_name) == (url2, True)
+
+        bb1 = s3_fetch(url, s3=s3)
+        bb2 = s3_fetch(url2, s3=s3)
+        if isinstance(blob, str):
+            bb1 = bb1.decode("utf8")
+            bb2 = bb2.decode("utf8")
+
+        assert bb1 == blob
+        assert bb2 == blob2
+
+
+@pytest.mark.parametrize("blob", [
+    "some utf8 string",
+    b"raw bytes",
+])
+def test_save_blob_s3(blob, monkeypatch, dask_client):
+    region_name = "us-west-2"
+
+    blob2 = blob + blob
+
+    dask_blob = dask.delayed(blob)
+    dask_blob2 = dask.delayed(blob2)
+
+    url = "s3://bucket/file.txt"
+    url2 = "s3://bucket/file-2.txt"
+
+    bucket, _ = s3_url_parse(url)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "fake-key-id")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "fake-secret")
+
+    with moto.mock_s3():
+        s3 = s3_client(region_name=region_name)
+        s3.create_bucket(Bucket=bucket)
+
+        rr = save_blob_to_s3(dask_blob, url, region_name=region_name)
+        assert rr.compute() == (url, True)
+
+        rr = save_blob_to_s3(dask_blob2, url2, region_name=region_name)
+        assert dask_client.compute(rr).result() == (url2, True)
+
+        bb1 = s3_fetch(url, s3=s3)
+        bb2 = s3_fetch(url2, s3=s3)
+        if isinstance(blob, str):
+            bb1 = bb1.decode("utf8")
+            bb2 = bb2.decode("utf8")
+
+        assert bb1 == blob
+        assert bb2 == blob2

--- a/tests/test_utils_dask.py
+++ b/tests/test_utils_dask.py
@@ -73,7 +73,7 @@ def test_save_blob_file_direct(tmpdir, blob):
     assert _save_blob_to_file(blob, fname) == (fname, True)
     assert slurp(fname, mode=mode) == blob
 
-    fname = tmpdir/"missing"/"file.txt"
+    fname = str(tmpdir/"missing"/"file.txt")
     assert _save_blob_to_file(blob, fname) == (fname, False)
 
 
@@ -91,7 +91,7 @@ def test_save_blob_file(tmpdir, blob, dask_client):
     assert dask_client.compute(rr).result() == (fname, True)
     assert slurp(fname, mode=mode) == blob
 
-    fname = tmpdir/"missing"/"file.txt"
+    fname = str(tmpdir/"missing"/"file.txt")
     rr = save_blob_to_file(dask_blob, fname)
     assert dask_client.compute(rr).result() == (fname, False)
 

--- a/tests/test_utils_dask.py
+++ b/tests/test_utils_dask.py
@@ -1,0 +1,46 @@
+import dask
+import dask.delayed
+
+from datacube.utils.dask import (
+    start_local_dask,
+    compute_tasks,
+    pmap,
+    partition_map,
+)
+
+
+def test_compute_tasks():
+    client = start_local_dask(threads_per_worker=1,
+                              dashboard_address=None)
+
+    tasks = (dask.delayed(x) for x in range(100))
+    xx = [x for x in compute_tasks(tasks, client)]
+    assert xx == [x for x in range(100)]
+
+    client.close()
+    del client
+
+
+def test_partition_map():
+    tasks = partition_map(10, str, range(101))
+    tt = [t for t in tasks]
+    assert len(tt) == 11
+    lump = tt[0].compute()
+    assert len(lump) == 10
+    assert lump == [str(x) for x in range(10)]
+
+    lump = tt[-1].compute()
+    assert len(lump) == 1
+
+
+def test_pmap():
+    client = start_local_dask(threads_per_worker=1,
+                              dashboard_address=None)
+
+    xx_it = pmap(str, range(101), client=client)
+    xx = [x for x in xx_it]
+
+    assert xx == [str(x) for x in range(101)]
+
+    client.close()
+    del client

--- a/tests/test_utils_dask.py
+++ b/tests/test_utils_dask.py
@@ -24,17 +24,6 @@ from datacube.utils.aws import (
 )
 
 
-@pytest.fixture(scope="module")
-def dask_client():
-    from distributed import Client
-    client = Client(processes=False,
-                    threads_per_worker=1,
-                    dashboard_address=None)
-    yield client
-    client.close()
-    del client
-
-
 def test_compute_tasks():
     client = start_local_dask(threads_per_worker=1,
                               dashboard_address=None)

--- a/tests/test_utils_dask.py
+++ b/tests/test_utils_dask.py
@@ -127,6 +127,8 @@ def test_save_blob_s3_direct(blob, monkeypatch):
         assert bb1 == blob
         assert bb2 == blob2
 
+        assert _save_blob_to_s3("", "s3://not-a-bucket/f.txt") == ("s3://not-a-bucket/f.txt", False)
+
 
 @pytest.mark.parametrize("blob", [
     "some utf8 string",

--- a/tests/test_utils_generic.py
+++ b/tests/test_utils_generic.py
@@ -1,5 +1,10 @@
 from queue import Queue
-from datacube.utils.generic import qmap, it2q, map_with_lookahead
+from datacube.utils.generic import (
+    qmap,
+    it2q,
+    map_with_lookahead,
+    thread_local_cache,
+)
 
 
 def test_map_with_lookahead():
@@ -22,3 +27,17 @@ def test_qmap():
     rr = [x for x in qmap(str, q)]
     assert rr == [str(x) for x in range(10)]
     q.join()  # should not block
+
+
+def test_thread_local_cache():
+    name = "test_0123394"
+    v = {}
+
+    assert thread_local_cache(name, v) is v
+    assert thread_local_cache(name) is v
+    assert thread_local_cache(name, purge=True) is v
+    assert thread_local_cache(name, 33) == 33
+    assert thread_local_cache(name, purge=True) == 33
+
+    assert thread_local_cache("no_such_key", purge=True) is None
+    assert thread_local_cache("no_such_key", 111, purge=True) == 111

--- a/tests/test_utils_generic.py
+++ b/tests/test_utils_generic.py
@@ -1,0 +1,24 @@
+from queue import Queue
+from datacube.utils.generic import qmap, it2q, map_with_lookahead
+
+
+def test_map_with_lookahead():
+    def if_one(x):
+        return 'one' + str(x)
+
+    def if_many(x):
+        return 'many' + str(x)
+
+    assert list(map_with_lookahead(iter([]), if_one, if_many)) == []
+    assert list(map_with_lookahead(iter([1]), if_one, if_many)) == [if_one(1)]
+    assert list(map_with_lookahead(range(5), if_one, if_many)) == list(map(if_many, range(5)))
+    assert list(map_with_lookahead(range(10), if_one=if_one)) == list(range(10))
+    assert list(map_with_lookahead(iter([1]), if_many=if_many)) == [1]
+
+
+def test_qmap():
+    q = Queue(maxsize=100)
+    it2q(range(10), q)
+    rr = [x for x in qmap(str, q)]
+    assert rr == [str(x) for x in range(10)]
+    q.join()  # should not block

--- a/tests/test_utils_rio.py
+++ b/tests/test_utils_rio.py
@@ -124,9 +124,7 @@ def test_rio_env_via_config():
     assert get_rio_env() == {}
 
 
-def test_rio_configure_aws_access(monkeypatch, without_aws_env):
-    from distributed import Client
-
+def test_rio_configure_aws_access(monkeypatch, without_aws_env, dask_client):
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "fake-key-id")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "fake-secret")
     monkeypatch.setenv("AWS_DEFAULT_REGION", "fake-region")
@@ -152,12 +150,8 @@ def test_rio_configure_aws_access(monkeypatch, without_aws_env):
     assert ee['GDAL_DISABLE_READDIR_ON_OPEN'] == 'EMPTY_DIR'
 
     ee_local = ee
+    client = dask_client
 
-    client = Client(processes=False,
-                    threads_per_worker=1,
-                    dashboard_address=None)
-
-    assert client
     creds = configure_s3_access(client=client)
     cc = creds.get_frozen_credentials()
     assert cc.access_key == 'fake-key-id'


### PR DESCRIPTION
Moving (with heavy modifications) some utilities from `odc.aws.*` and cog code from wofs summary work

- `datacube.utils.aws` AWS related helpers, mostly needed over just raw `botocore` because
   1. Configures `region_name`, it's important when reading large number of files, without it every request will contain redirect.
   2. Integrates with thread-local caching, needed when calling from dask tasks, one can't just pickle pre-configures botocore s3 client, and creating everything from scratch is costly because of STS and because without http connection re-use things are really slow for small reads in particular.

- `datacube.utils.cog` Dask aware COG generation, will do work directly on numpy arrays will produce delayed computation when given dask-backed arrays. 
   - Can save to file or to RAM
   - Save to RAM case can then be paired to `s3_dump`
   - Only works with "fits in memory and plenty more room left" inputs

- `datacube.utils.dask` various tools for working with dask
   - Processing large set of independent tasks from a stream with back-pressure
   - wrappers for saving to s3/file

- More cleanups
   - Use `Path.home()` instead of env variable (pointed out as problematic in the previous PR)
   - Some `mypy` fixes
   - Adding type annotations in more places
   - moving some tests around a bit



  