### PR TITLE
compatible to gdal coords convention

### DIFF
--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -105,6 +105,11 @@ class CRS(object):
             crs_str = crs_str.crs_str
         self.crs_str = crs_str
         self._crs = _make_crs(crs_str)
+        # compatible with GDAL 3.0+
+        try:
+            self._crs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+        except AttributeError as e:
+            pass
 
     def __getitem__(self, item):
         return self._crs.GetAttrValue(item)


### PR DESCRIPTION
### Reason for this pull request
convention of `lat/lon` order has been changed since `GDAL-3.0`. Hence datasets query would return `null`.

refer to https://gdal.org/tutorials/osr_api_tut.html#crs-and-axis-order
### Proposed changes
See the file changed
