### PR TITLE
VP transform: every band needs the CRS attribute

### DIFF
--- a/datacube/virtual/impl.py
+++ b/datacube/virtual/impl.py
@@ -485,7 +485,12 @@ class Transform(VirtualProduct):
         return self._input.group(datasets, **group_settings)
 
     def fetch(self, grouped: VirtualDatasetBox, **load_settings: Dict[str, Any]) -> xarray.Dataset:
-        return self._transformation.compute(self._input.fetch(grouped, **load_settings))
+        input_data = self._input.fetch(grouped, **load_settings)
+        output_data = self._transformation.compute(input_data)
+        output_data.attrs['crs'] = input_data.attrs['crs']
+        for data_var in output_data.data_vars:
+            output_data[data_var].attrs['crs'] = input_data.attrs['crs']
+        return output_data
 
 
 class Aggregate(VirtualProduct):


### PR DESCRIPTION
### Reason for this pull request
When data is loaded, the resultant `xarray.Dataset` object has a `crs` attribute. The `xarray.DataArray` objects that represents the bands also has the same `crs` attribute.

A virtual product `transform` cannot change the CRS, but ensuring that the result of a compute meets the above specification is a burden.

Not attaching CRS info to bands causes reproject to fail.

### Proposed changes
- Add CRS information to the result in virtual product transform