### PR TITLE
mask_invalid_data should not retain used up nodata

### DIFF
--- a/datacube/storage/masking.py
+++ b/datacube/storage/masking.py
@@ -151,7 +151,9 @@ def mask_invalid_data(data, keep_attrs=True):
             return data
         out_data_array = data.where(data != data.nodata)
         if keep_attrs:
-            out_data_array.attrs = data.attrs
+            out_data_array.attrs = {key: value
+                                    for key, value in data.attrs.items()
+                                    if key != 'nodata'}
         return out_data_array
 
     raise TypeError('mask_invalid_data not supported for type {}'.format(type(data)))


### PR DESCRIPTION
### Reason for this pull request
When `datacube.storage.masking.mask_invalid_data` is applied, the `nodata` attribute is retained for no good reason. Since all the `nodata` pixels are masked out, that attribute is superfluous.


### Proposed changes
- Omit `nodata` attribute which is interpreted as NaNs representing nodata