### PR TITLE
Configure GDAL to enable retries when reading from S3

### DIFF
--- a/datacube/utils/rio/_rio.py
+++ b/datacube/utils/rio/_rio.py
@@ -94,7 +94,9 @@ def activate_rio_env(aws=None, cloud_defaults=False, **kwargs):
         session = AWSSession(**aws)
 
     opts = dict(
-        GDAL_DISABLE_READDIR_ON_OPEN='EMPTY_DIR'
+        GDAL_DISABLE_READDIR_ON_OPEN='EMPTY_DIR',
+        GDAL_HTTP_MAX_RETRY='10',
+        GDAL_HTTP_RETRY_DELAY='0.5',
     ) if cloud_defaults else {}
 
     opts.update(**kwargs)

--- a/datacube/utils/rio/_rio.py
+++ b/datacube/utils/rio/_rio.py
@@ -157,7 +157,8 @@ def configure_s3_access(profile=None,
                         aws_unsigned=False,
                         requester_pays=False,
                         cloud_defaults=True,
-                        client=None):
+                        client=None,
+                        **gdal_opts):
     """ Credentialize for S3 bucket access.
 
     This function obtains credentials for S3 access and passes them on to
@@ -189,11 +190,12 @@ def configure_s3_access(profile=None,
                                   requester_pays=requester_pays)
 
     if client is None:
-        set_default_rio_config(aws=aws, cloud_defaults=cloud_defaults)
+        set_default_rio_config(aws=aws, cloud_defaults=cloud_defaults, **gdal_opts)
     else:
         client.register_worker_callbacks(
             functools.partial(set_default_rio_config,
                               aws=aws,
-                              cloud_defaults=cloud_defaults))
+                              cloud_defaults=cloud_defaults,
+                              **gdal_opts))
 
     return creds


### PR DESCRIPTION
### Reason for this pull request

Sometimes S3 can respond with 503 as it scales up resources for a given bucket, default behaviour in this case is to fail. 

### Proposed changes

- Setting `GDAL_HTTP_MAX_RETRY` and `GDAL_HTTP_RETRY_DELAY` to reasonable values.
- Accept gdal options in `configure_s3_access`  and pass them along

 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
