### PR TITLE
Accept `GeoBox` in `like` parameter of `dc.{load,find_datasets}`

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -682,6 +682,9 @@ def output_geobox(like=None, output_crs=None, resolution=None, align=None,
         assert output_crs is None, "'like' and 'output_crs' are not supported together"
         assert resolution is None, "'like' and 'resolution' are not supported together"
         assert align is None, "'like' and 'align' are not supported together"
+        if isinstance(like, GeoBox):
+            return like
+
         return like.geobox
 
     if output_crs is not None:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -122,3 +122,11 @@ def test_measurement():
 
     assert 'required keys missing:' in str(e.value)
     assert 'dtype' in str(e.value)
+
+
+def test_like_geobox():
+    from datacube.testutils.geom import AlbersGS
+    from datacube.api.core import output_geobox
+
+    geobox = AlbersGS.tile_geobox((15, -40))
+    assert output_geobox(like=geobox) is geobox


### PR DESCRIPTION
### Reason for this pull request

`dc.load` and `dc.find_datasets` both accept a `like` parameter, which is expected to be a previously loaded `xr.Dataset`. The `like` parameter is used as an alternative to specifying *ALL* of `geopolygon+CRS+resolution+align` (tedious, to say the least), and might also constrain the time range if a `time` axis exists on the input. Supplying a `GeoBox` into the `like` parameter makes perfect sense as it captures exactly the spatial information the current system gets out of an `xr.Dataset`


