### PR TITLE
Better compatibilty with other geo libs for CRS class

### DIFF
--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -141,11 +141,11 @@ class Query(object):
 
 def query_geopolygon(geopolygon=None, **kwargs):
     spatial_dims = {dim: v for dim, v in kwargs.items() if dim in SPATIAL_KEYS}
-    crs = {v for k, v in kwargs.items() if k in CRS_KEYS}
+    crs = [v for k, v in kwargs.items() if k in CRS_KEYS]
     if len(crs) == 1:
-        spatial_dims['crs'] = crs.pop()
+        spatial_dims['crs'] = crs[0]
     elif len(crs) > 1:
-        raise ValueError('Spatial dimensions must be in the same coordinate reference system: {}'.format(crs))
+        raise ValueError('CRS is supplied twice')
 
     if geopolygon is not None and len(spatial_dims) > 0:
         raise ValueError('Cannot specify "geopolygon" and one of %s at the same time' % (SPATIAL_KEYS + CRS_KEYS,))

--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -101,9 +101,12 @@ class CRS(object):
         :param crs_str: string representation of a CRS, often an EPSG code like 'EPSG:4326'
         :raises: InvalidCRSError
         """
-        to_wkt = getattr(crs_str, 'to_wkt', None)
-        if to_wkt is not None:
+        if not isinstance(crs_str, str):
+            to_wkt = getattr(crs_str, 'to_wkt', None)
+            if to_wkt is None:
+                raise ValueError("Expect string or any object with `.to_wkt()` method")
             crs_str = to_wkt()
+
         self.crs_str = crs_str
         self._crs = _make_crs(crs_str)
         # compatible with GDAL 3.0+

--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -228,7 +228,10 @@ class CRS(object):
         if isinstance(other, str):
             other = CRS(other)
         elif not isinstance(other, CRS):
-            return False
+            to_wkt = getattr(other, 'to_wkt', None)
+            if to_wkt is None:
+                return False
+            other = CRS(to_wkt())
         gdal_thinks_issame = self._crs.IsSame(other._crs) == 1  # pylint: disable=protected-access
         if gdal_thinks_issame:
             return True

--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -219,6 +219,9 @@ class CRS(object):
     def __str__(self):
         return self.crs_str
 
+    def __hash__(self):
+        return hash(self.to_wkt())
+
     def __repr__(self):
         return "CRS('%s')" % self.crs_str
 

--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -101,8 +101,9 @@ class CRS(object):
         :param crs_str: string representation of a CRS, often an EPSG code like 'EPSG:4326'
         :raises: InvalidCRSError
         """
-        if isinstance(crs_str, CRS):
-            crs_str = crs_str.crs_str
+        to_wkt = getattr(crs_str, 'to_wkt', None)
+        if to_wkt is not None:
+            crs_str = to_wkt()
         self.crs_str = crs_str
         self._crs = _make_crs(crs_str)
         # compatible with GDAL 3.0+
@@ -120,6 +121,14 @@ class CRS(object):
     def __setstate__(self, state):
         self.__init__(state['crs_str'])
 
+    def to_wkt(self):
+        """
+        WKT representation of the CRS
+
+        :type: str
+        """
+        return self._crs.ExportToWkt()
+
     @property
     def wkt(self):
         """
@@ -127,7 +136,7 @@ class CRS(object):
 
         :type: str
         """
-        return self._crs.ExportToWkt()
+        return self.to_wkt()
 
     @property
     def epsg(self):

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -72,7 +72,7 @@ python-dateutil==2.7.2
 pytz==2018.4
 pytzdata==2018.4
 PyYAML==3.12
-rasterio==1.0.24  # rq.filter: >=1.0.21,<1.1
+rasterio==1.1.0  # rq.filter: >=1.0.21,<2
 redis==2.10.6
 regex==2017.7.28
 requests==2.20.1

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -20,6 +20,7 @@ import pytest
 from datacube.api.query import Query, _datetime_to_timestamp, query_group_by, solar_day, GroupBy
 from datacube.model import Range
 from datacube.utils import parse_time
+from datacube.utils.geometry import CRS
 
 
 def test_datetime_to_timestamp():
@@ -63,6 +64,11 @@ def test_query_kwargs():
     assert 'lon' in query.search_terms
 
     query = Query(index=mock_index, y=-4174726, x=1515184, crs='EPSG:3577')
+    assert query.geopolygon
+    assert 'lat' in query.search_terms
+    assert 'lon' in query.search_terms
+
+    query = Query(index=mock_index, y=-4174726, x=1515184, crs=CRS('EPSG:3577'))
     assert query.geopolygon
     assert 'lat' in query.search_terms
     assert 'lon' in query.search_terms

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1095,6 +1095,8 @@ def test_crs_compat():
     crs_rio = rasterio.crs.CRS(init='epsg:3577')
     assert CRS(crs_rio).epsg == 3577
 
+    assert (CRS(crs_rio) == crs_rio) is True
+
     assert rasterio.crs.CRS.from_user_input(crs).to_epsg() == 3577
 
     with pytest.raises(ValueError):

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -7,6 +7,7 @@ import pickle
 from datacube.utils import geometry
 from datacube.utils.geometry import (
     GeoBox,
+    CRS,
     BoundingBox,
     bbox_union,
     decompose_rws,
@@ -1081,3 +1082,20 @@ def test_axis_overlap():
     # D: |<--->|
     assert compute_axis_overlap(10, 10, 1, -11) == s_[0:0, 10:10]
     assert compute_axis_overlap(40, 10, 1, -11) == s_[0:0, 10:10]
+
+
+def test_crs_compat():
+    import rasterio.crs
+
+    crs = CRS("epsg:3577")
+    assert crs.epsg == 3577
+    crs2 = CRS(crs)
+    assert crs.epsg == crs2.epsg
+
+    crs_rio = rasterio.crs.CRS(init='epsg:3577')
+    assert CRS(crs_rio).epsg == 3577
+
+    assert rasterio.crs.CRS.from_user_input(crs).to_epsg() == 3577
+
+    with pytest.raises(ValueError):
+        CRS(("random", "tuple"))

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1101,3 +1101,11 @@ def test_crs_compat():
 
     with pytest.raises(ValueError):
         CRS(("random", "tuple"))
+
+
+def test_crs_hash():
+    crs = CRS("epsg:3577")
+    crs2 = CRS(crs)
+
+    assert crs is not crs2
+    assert len(set([crs, crs2])) == 1


### PR DESCRIPTION
- Add `to_wkt()` method, allow construction from any object that has `to_wkt()`  method, this was proposed by @snowman2 in issue #810.
- Deal with non-string representations in `query_geopolygon` function


 - [x] Closes #810 
 - [x] Closes #811
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
