### PR TITLE
Fix incompatibility with recent xarray (#816)

### DIFF
--- a/datacube/api/grid_workflow.py
+++ b/datacube/api/grid_workflow.py
@@ -110,8 +110,7 @@ class Tile(object):
         :param kwargs: other keyword arguments passed to ``pandas.period_range``
         :return: Generator[tuple(str, Tile)] generator of the key string (eg '1994') and the slice of Tile
         """
-        start_range = self.sources[time_dim][0].data
-        end_range = self.sources[time_dim][-1].data
+        start_range, end_range = self.sources[time_dim].data[[0, -1]]
 
         for p in pd.period_range(start=start_range,
                                  end=end_range,

--- a/datacube/api/grid_workflow.py
+++ b/datacube/api/grid_workflow.py
@@ -110,6 +110,8 @@ class Tile(object):
         :param kwargs: other keyword arguments passed to ``pandas.period_range``
         :return: Generator[tuple(str, Tile)] generator of the key string (eg '1994') and the slice of Tile
         """
+        # extract first and last timestamps from the time axis, note this will
+        # work with 1 element arrays as well
         start_range, end_range = self.sources[time_dim].data[[0, -1]]
 
         for p in pd.period_range(start=start_range,


### PR DESCRIPTION
Minor fix to the way we extract time range in `split_by_time` function.

At some point `xarray` changed what `.data` contains when extracting a single element, used to be a single `numpy` value, now it's a `numpy` array with a single element.

Solution: use destructuring assignment to extract values from numpy array instead.