### PR TITLE
Fix conda python version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Developer setup
 
 ::
 
-   conda create -n odc -c conda-forge python=3.7 datacube pre_commit
+   conda create -n odc -c conda-forge python=3.6 datacube pre_commit
    conda activate odc
 
 3. Install a develop version of datacube-core.


### PR DESCRIPTION
### Reason for this pull request

1. Tested the current instruction `conda create -n odc -c conda-forge python=3.7 datacube pre_commit` but it is failing
2. Confirmed `python=3.6` is working


### Proposed changes

- Change README instruction to `conda create -n odc -c conda-forge python=3.6 datacube pre_commit`

- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
