### PR TITLE
added support for vsicurl with URL's

### DIFF
--- a/datacube/utils/uris.py
+++ b/datacube/utils/uris.py
@@ -1,14 +1,13 @@
 import os
-
 import pathlib
 import re
-from typing import Optional, List, Union
 import urllib.parse
-from urllib.parse import urlparse, parse_qsl, urljoin
-from urllib.request import url2pathname
 from pathlib import Path
+from typing import List, Optional, Union
+from urllib.parse import parse_qsl, urljoin, urlparse
+from urllib.request import url2pathname
 
-URL_RE = re.compile(r'\A\s*[\w\d\+]+://')
+URL_RE = re.compile(r'\A\s*(?:/vsicurl/)?[\w\d\+]+://')
 
 
 def is_url(url_str: str) -> bool:

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -717,6 +717,11 @@ def test_rio_driver_specifics():
     assert _url2rasterio('file:///f.nc', 'HDF5', 'band') == 'HDF5:"/f.nc":band'
     assert _url2rasterio('file:///f.nc', 'HDF4_EOS:EOS_GRID', 'band') == 'HDF4_EOS:EOS_GRID:"/f.nc":band'
     assert _url2rasterio('file:///f.tiff', 'GeoTIFF', None) == '/f.tiff'
+    curl_path = '/vsicurl/https://bucket.s3.amazonaws.com/path/to/file.tif'
+    assert _url2rasterio(curl_path, 'GeoTIFF', None) == curl_path
+    nc_curl_path = "/vsicurl/https://bucket.s3.amazonaws.com/path/to/file.tif"
+    assert _url2rasterio(nc_curl_path, 'NetCDF', "band") == 'NetCDF:"{}":band'.format(nc_curl_path)
+
     s3_url = 's3://bucket/file'
     assert _url2rasterio(s3_url, 'GeoTIFF', None) is s3_url
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -880,6 +880,7 @@ def test_testutils_geobox():
     ("sftp://user:pass@host.name.com/path/file.txt", True),
     ("file+gzip://host.name.com/path/file.txt", True),
     ("bongo:host.name.com/path/file.txt", False),
+    ("/vsicurl/https://bucket.s3.amazonaws.com/path/to/file.tif", True),
 ])
 def test_is_url(test_input, expected):
     assert is_url(test_input) == expected


### PR DESCRIPTION
### Reason for this pull request

*First off, apologies for not opening an issue earlier. By the time we nailed down the problem, we had the solution coded up and figured a PR would be a good place to discuss.*

When attempting to load in a netCDF via `vsicurl` it fails due to parsing the URL as a path and removing the `/` (ex: `https:// -> http:/).

For example:
`/vsicurl/https://bucket.s3.amazonaws.com/path/to/file.tif` gets converted to `/vsicurl/https:/bucket.s3.amazonaws.com/path/to/file.tif`.

This works with older versions of GDAL ~2.2. But GDAL 2.4+ fails when this is stripped from the path with the error `rasterio._err.CPLE_IllegalArgError: Missing url parameter`.

It should be noted that the `.tif` files don't need `/vsicurl/` prepended as `rasterio` handles it automatically. However, this is not the case for a `netcdf` subdataset (https://github.com/mapbox/rasterio/issues/1838).

cc: @alfredoahds

### Proposed changes

- update `_url2rasterio` to support paths with `/vsicurl/`
- update `is_url` to support paths with `/vsicurl/`

 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes