### PR TITLE
Support `/vsi**` style dataset locations

### DIFF
--- a/datacube/utils/__init__.py
+++ b/datacube/utils/__init__.py
@@ -5,7 +5,7 @@ Utility functions
 from .dates import datetime_to_seconds_since_1970, parse_time
 from .py import cached_property, ignore_exceptions_if, import_function
 from .serialise import jsonify_document
-from .uris import is_url, uri_to_local_path, get_part_from_uri, mk_part_uri
+from .uris import is_url, uri_to_local_path, get_part_from_uri, mk_part_uri, is_vsipath
 from .io import slurp, check_write_path, write_user_secret_file
 from .documents import (
     InvalidDocException,
@@ -43,6 +43,7 @@ __all__ = (
     "import_function",
     "jsonify_document",
     "is_url",
+    "is_vsipath",
     "uri_to_local_path",
     "get_part_from_uri",
     "mk_part_uri",

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -10,6 +10,7 @@ v1.7.1 (???)
 
 - New virtual product combinator ``reproject`` for on-the-fly reprojection of rasters (:pull:`773`)
 - Enhancements to the ``expressions`` transformation in virtual products (:pull:`776`, :pull:`761`)
+- Support ``/vsi**`` style paths for dataset locations (:pull:`825`)
 
 
 v1.7.0 (16 May 2019)

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -720,8 +720,19 @@ def test_rio_driver_specifics():
     s3_url = 's3://bucket/file'
     assert _url2rasterio(s3_url, 'GeoTIFF', None) is s3_url
 
+    vsi_url = '/vsicurl/https://host.tld/path'
+    assert _url2rasterio(vsi_url, 'GeoTIFF', None) is vsi_url
+    assert _url2rasterio(vsi_url, 'NetCDF', 'aa') == 'NetCDF:"{}":aa'.format(vsi_url)
+    assert _url2rasterio(vsi_url, 'HDF5', 'aa') == 'HDF5:"{}":aa'.format(vsi_url)
+
     with pytest.raises(ValueError):
         _url2rasterio('file:///f.nc', 'NetCDF', None)
 
     with pytest.raises(RuntimeError):
         _url2rasterio('http://example.com/f.nc', 'NetCDF', 'aa')
+
+    with pytest.raises(ValueError):
+        _url2rasterio('/some/path/', 'GeoTIFF', None)
+
+    with pytest.raises(ValueError):
+        _url2rasterio('/some/path/', 'NetCDF', 'aa')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -106,6 +106,8 @@ def test_uri_resolve():
     some_uri = 'http://example.com/file.txt'
     s3_base = 's3://foo'
     gs_base = 'gs://foo'
+    vsi_base = '/vsizip//vsicurl/https://host.tld/some/path'
+
     assert uri_resolve(s3_base, abs_path) == "file://" + abs_path
     assert uri_resolve(s3_base, some_uri) is some_uri
     assert uri_resolve(s3_base, None) is s3_base
@@ -116,6 +118,9 @@ def test_uri_resolve():
     assert uri_resolve(gs_base, None) is gs_base
     assert uri_resolve(gs_base, '') is gs_base
     assert uri_resolve(gs_base, 'relative/path') == gs_base + '/relative/path'
+
+    assert uri_resolve(vsi_base, 'relative/path') == vsi_base + '/relative/path'
+    assert uri_resolve(vsi_base + '/', 'relative/path') == vsi_base + '/relative/path'
 
 
 def test_pick_uri():


### PR DESCRIPTION
# Reason for this pull request

While we prefer url syntax, sometimes falling back to GDAL's native
representation is necessary. This is currently needed for netdcf over http as
there is no agreed URL syntax for that use-case that rasterio supports.


### Proposed changes

Detect `/vsi**` style paths and treat them properly when constructing relative paths and HDF 

 - [x] Closes #824 
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes
