### PR TITLE
Make tests run with compliance-checker lib version 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ addons:
       - libgdal-dev
       - libgdal20
       - libudunits2-0
+      - libudunits2-dev
 
 before_install:
 # Create a database for the integration tests.

--- a/integration_tests/test_full_ingestion.py
+++ b/integration_tests/test_full_ingestion.py
@@ -188,18 +188,22 @@ def check_cf_compliance(dataset):
         warnings.warn('compliance_checker unavailable, skipping NetCDF-CF Compliance Checks')
         return
 
+    if compliance_checker.__version__ < '4.0.0':
+        warnings.warn('Please upgrade compliance-checker to 4+ version')
+        warnings.warn('compliance_checker version is too old, skipping NetCDF-CF Compliance Checks')
+        return
+
+    skip = ['check_dimension_order',
+            'check_all_features_are_same_type',
+            'check_conventions_version',
+            'check_appendix_a']
+
     cs = CheckSuite()
     cs.load_all_available_checkers()
-    if compliance_checker.__version__ >= '2.3.0':
-        # This skips a failing compliance check. Our files don't contain all the lats/lons
-        # as an auxiliary cordinate var as it's unnecessary for any software we've tried.
-        # It may be added at some point in the future, and this check should be re-enabled.
-        score_groups = cs.run(dataset, ['check_dimension_order'], 'cf')
-    else:
-        warnings.warn('Please upgrade to compliance-checker 2.3.0 or higher.')
-        score_groups = cs.run(dataset, 'cf')
+    score_groups = cs.run(dataset, skip, 'cf')
+    score_dict = {dataset.filepath(): score_groups}
 
-    groups = ComplianceChecker.stdout_output(cs, score_groups, verbose=1, limit=COMPLIANCE_CHECKER_NORMAL_LIMIT)
+    groups = ComplianceChecker.stdout_output(cs, score_dict, verbose=1, limit=COMPLIANCE_CHECKER_NORMAL_LIMIT)
     assert cs.passtree(groups, limit=COMPLIANCE_CHECKER_NORMAL_LIMIT)
 
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -17,7 +17,7 @@ click==6.7
 click-plugins==1.0.3
 cligj==0.4.0
 cloudpickle==0.5.2
-compliance-checker==3.1.1
+compliance-checker==4.3.1
 coverage==4.5.1
 coveralls==1.3.0
 dask==2.3.0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 import os
 
 tests_require = [
-    'compliance-checker',
+    'compliance-checker>=4.0.0',
     'hypothesis',
     'mock',
     'pycodestyle',


### PR DESCRIPTION
No longer supporting older versions of compliance-checker lib

 - [x] Closes #xxxx
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes