### PR TITLE
improve rio tests

### DIFF
--- a/tests/test_utils_rio.py
+++ b/tests/test_utils_rio.py
@@ -1,5 +1,6 @@
 import pytest
 import mock
+import os
 
 from datacube.utils.rio import (
     activate_rio_env,
@@ -17,11 +18,13 @@ def test_rio_env_no_aws():
     # make sure we start without env configured
     assert get_rio_env() == {}
 
-    ee = activate_rio_env()
+    ee = activate_rio_env(FAKE_OPTION=1)
     assert isinstance(ee, dict)
     assert ee == get_rio_env()
     assert 'GDAL_DISABLE_READDIR_ON_OPEN' not in ee
-    assert 'GDAL_DATA' in ee
+    if os.getenv('GDAL_DATA', None):
+        assert 'GDAL_DATA' in ee
+    assert ee.get('FAKE_OPTION') == 1
     assert 'AWS_ACCESS_KEY_ID' not in ee
 
     ee = activate_rio_env(cloud_defaults=True)

--- a/tests/test_utils_rio.py
+++ b/tests/test_utils_rio.py
@@ -2,6 +2,7 @@ import pytest
 import mock
 import os
 
+from datacube.testutils import write_files
 from datacube.utils.rio import (
     activate_rio_env,
     deactivate_rio_env,
@@ -74,10 +75,18 @@ def test_rio_env_aws():
     assert get_rio_env() == {}
 
 
-@pytest.mark.xfail(reason='This test fails if a default region is set in `~/.aws/config`')
-@mock.patch('datacube.utils.aws.botocore_default_region',
-            return_value=None)
-def test_rio_env_aws_auto_region(*mocks):
+def test_rio_env_aws_auto_region(monkeypatch, without_aws_env):
+    import datacube.utils.aws
+
+    pp = write_files({
+        "config": """[default]
+"""})
+
+    assert (pp/"config").exists()
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(pp/"config"))
+
+    assert datacube.utils.aws.botocore_default_region() is None
+
     aws = dict(aws_secret_access_key='blabla',
                aws_access_key_id='not a real one',
                aws_session_token='faketoo')


### PR DESCRIPTION
- Instead of mocking things in `test_rio_env_aws_auto_region`, which seems to be breaking, generate empty config and point botocore to it.

- Do not rely on `GDAL_DATA` env variable in `test_rio_env_no_aws`

