### PR TITLE
Use textual SQL instead of String.format

### DIFF
--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -1016,23 +1016,19 @@ class PostgresDbAPI(object):
     def create_user(self, username, password, role, description=None):
         pg_role = _core.to_pg_role(role)
         username = escape_pg_identifier(self._connection, username)
-        sql = text('create user :username password :password in role :role')
+        sql = text('create user {username} password :password in role {role}'.format(username=username, role=pg_role))
         self._connection.execute(sql,
-                                 username=username,
-                                 role=pg_role,
                                  password=password)
         if description:
-            sql = text('comment on role :username is :description')
+            sql = text('comment on role {username} is :description'.format(username=username))
             self._connection.execute(sql,
-                                     username=username,
                                      description=description)
 
     def drop_users(self, users):
         # type: (Iterable[str]) -> None
         for username in users:
-            sql = text('drop role :username')
-            self._connection.execute(sql,
-                                     username=escape_pg_identifier(self._connection, username))
+            sql = text('drop role {username}'.format(username=escape_pg_identifier(self._connection, username)))
+            self._connection.execute(sql)
 
     def grant_role(self, role, users):
         # type: (str, Iterable[str]) -> None

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -1016,20 +1016,23 @@ class PostgresDbAPI(object):
     def create_user(self, username, password, role, description=None):
         pg_role = _core.to_pg_role(role)
         username = escape_pg_identifier(self._connection, username)
-        self._connection.execute(
-            'create user {username} password %s in role {role}'.format(username=username, role=pg_role),
-            password
-        )
+        sql = text('create user :username password :password in role :role')
+        self._connection.execute(sql,
+                                 username=username,
+                                 role=pg_role,
+                                 password=password)
         if description:
-            self._connection.execute(
-                'comment on role {username} is %s'.format(username=username), description
-            )
+            sql = text('comment on role :username is :description')
+            self._connection.execute(sql,
+                                     username=username,
+                                     description=description)
 
     def drop_users(self, users):
         # type: (Iterable[str]) -> None
         for username in users:
-            self._connection.execute('drop role {username}'.format(
-                username=escape_pg_identifier(self._connection, username)))
+            sql = text('drop role :username')
+            self._connection.execute(sql,
+                                     username=escape_pg_identifier(self._connection, username))
 
     def grant_role(self, role, users):
         # type: (str, Iterable[str]) -> None


### PR DESCRIPTION
### Reason for this pull request
Removes unescaped SQL string formatting.
...


### Proposed changes
Use SQLAlchemy expression language to replace String.format syntax as shown [here](https://docs.sqlalchemy.org/en/13/core/tutorial.html#using-textual-sql).
- 
- 



 - [x] Closes #464 
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
