### PR TITLE
Bugsquash19: product list with tab option

### DIFF
--- a/datacube/scripts/product.py
+++ b/datacube/scripts/product.py
@@ -138,13 +138,14 @@ def _write_tab(products):
         echo('No products discovered :(')
         return
 
-    echo(df.to_string(columns=('id', 'name', 'description', 'ancillary_quality',
-                               'product_type', 'gqa_abs_iterative_mean_xy',
-                               'gqa_ref_source', 'sat_path',
-                               'gqa_iterative_stddev_xy', 'time', 'sat_row',
-                               'orbit', 'gqa', 'instrument', 'gqa_abs_xy', 'crs',
-                               'resolution', 'tile_size', 'spatial_dimensions'),
-                      justify='left'))
+    output_columns=('id', 'name', 'description', 'ancillary_quality',
+                    'product_type', 'gqa_abs_iterative_mean_xy',
+                    'gqa_ref_source', 'sat_path',
+                    'gqa_iterative_stddev_xy', 'time', 'sat_row',
+                    'orbit', 'gqa', 'instrument', 'gqa_abs_xy', 'crs',
+                    'resolution', 'tile_size', 'spatial_dimensions')
+
+    echo(df.to_string(columns=[col for col in output_columns if col in df.columns],justify='left',index=False))
 
 
 def _default_lister(products):

--- a/datacube/scripts/product.py
+++ b/datacube/scripts/product.py
@@ -144,8 +144,9 @@ def _write_tab(products):
                     'gqa_iterative_stddev_xy', 'time', 'sat_row',
                     'orbit', 'gqa', 'instrument', 'gqa_abs_xy', 'crs',
                     'resolution', 'tile_size', 'spatial_dimensions')
-
-    echo(df.to_string(columns=[col for col in output_columns if col in df.columns],justify='left',index=False))
+    # If the intersection of desired columns with available columns is empty, just use whatever IS in df
+    output_columns=tuple(col for col in output_columns if col in df.columns) or df.columns
+    echo(df.to_string(columns=output_columns,justify='left',index=False))
 
 
 def _default_lister(products):


### PR DESCRIPTION
Bug Squash 2019: refs #623 
- Updated product.py so that if any of the (hard-coded) output columns don't exist in the data, it omits that column instead of crashing
- Handled potential case where *none* of the desired output columns exist in the data (it just prints whatever is in the data)
