### PR TITLE
remove dependency `singledispatch`

### DIFF
--- a/datacube/scripts/search_tool.py
+++ b/datacube/scripts/search_tool.py
@@ -12,7 +12,7 @@ from functools import partial
 import click
 from dateutil import tz
 from psycopg2._range import Range
-from singledispatch import singledispatch
+from functools import singledispatch
 
 from datacube.ui import click as ui
 from datacube.ui.click import CLICK_SETTINGS

--- a/docs/conda-requirements.yml
+++ b/docs/conda-requirements.yml
@@ -119,7 +119,6 @@ dependencies:
   - recommonmark=0.5.0=py_0
   - requests=2.22.0=py37_0
   - setuptools=41.0.1=py37_0
-  - singledispatch=3.4.0.3=py37_0
   - six=1.12.0=py37_0
   - snowballstemmer=1.9.0=py_0
   - snuggs=1.4.6=py_0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -78,7 +78,6 @@ regex==2017.7.28
 requests==2.20.1
 s3transfer==0.2.0
 SharedArray==2.0.4
-singledispatch==3.4.0.3
 snuggs==1.4.1
 SQLAlchemy==1.3.1
 toolz==0.9.0

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,6 @@ setup(
         'python-dateutil',
         'pyyaml',
         'rasterio>=1.0.2',  # Multi-band re-project fixed in that version
-        'singledispatch',
         'sqlalchemy',
         'toolz',
         'xarray>=0.9',  # >0.9 fixes most problems with `crs` attributes being lost


### PR DESCRIPTION
### Reason for this pull request
One less dependency on things pre-3.5.


### Proposed changes
Remove package `singledispatch` as a dependency. The package is a backport of `functools.singledispatch` for python < 3.4.
