### PR TITLE
test env docker fixes

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -83,11 +83,13 @@ COPY ./dist/datacube-*tar.gz /conf/
 
 RUN mkdir -p /wheels \
   && echo "GDAL==$(gdal-config --version)" > /tmp/constraints.txt \
-  && find /conf -type f -name 'datacube-*tar.gz' >> /tmp/constraints.txt \
+  && find /conf -type f -name 'datacube-*tar.gz' | head -1 >> /tmp/constraints.txt \
+  && cat /tmp/constraints.txt \
   && pip wheel \
   --no-cache \
   --no-cache-dir \
   --wheel-dir=/wheels \
+  --find-links=/conf/ \
   --constraint=/tmp/constraints.txt \
   --requirement=/conf/requirements.txt \
   && rm /tmp/constraints.txt \

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,10 +1,10 @@
 # boto3
-boto3==1.10.42
-botocore==1.13.42
-python-dateutil==2.8.0
+boto3==1.10.46
+botocore==1.13.46
+python-dateutil==2.8.1
 
 # every new version finds new errors, so we pin it
-pylint==1.8.4
+pylint==2.4.4
 
 # for packaging
 wheel


### PR DESCRIPTION
### Reason for this pull request

When building test environment inside Docker we want to use currently checked out datacube source code as a source of requirements. Instead datacube was pulled from pypi, so older possibly out of date set of dependencies would be installed. This PR forces use of local `datacube` package.

Also bump versions of pinned requirements for `boto` related libs and for `pylint`
