### PR TITLE
Do not require product if datasets are supplied (#852)

### DIFF
--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -255,6 +255,17 @@ def check_load_via_dss(index):
     assert (xx1.blue != -999).any()
     assert (xx1.blue == xx2.blue).all()
 
+    xx2 = dc.load(datasets=iter(dss), measurements=['blue'])
+    assert xx1.blue.shape
+    assert (xx1.blue != -999).any()
+    assert (xx1.blue == xx2.blue).all()
+
+    with pytest.raises(ValueError):
+        dc.load(measurements=['blue'])
+
+    with pytest.raises(DeprecationWarning):
+        dc.load(product='ls5_nbar_albers', stack=True)
+
 
 def check_legacy_open(index):
     from datacube.api.core import Datacube

--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -105,6 +105,7 @@ def test_end_to_end(clirunner, index, testdata_dir, ingest_configs, datacube_env
 
     check_open_with_dc(index)
     check_open_with_grid_workflow(index)
+    check_load_via_dss(index)
 
     if datacube_env_name == "s3aio_env":
         check_legacy_open(index)
@@ -239,6 +240,20 @@ def check_open_with_grid_workflow(index):
 
     dataset_cell = gw.load(tile)
     assert all(m in dataset_cell for m in ['blue', 'green', 'red', 'nir', 'swir1', 'swir2'])
+
+
+def check_load_via_dss(index):
+    from datacube.api.core import Datacube
+    dc = Datacube(index=index)
+
+    dss = dc.find_datasets(product='ls5_nbar_albers')
+    assert len(dss) > 0
+
+    xx1 = dc.load(product='ls5_nbar_albers', measurements=['blue'])
+    xx2 = dc.load(datasets=dss, measurements=['blue'])
+    assert xx1.blue.shape
+    assert (xx1.blue != -999).any()
+    assert (xx1.blue == xx2.blue).all()
 
 
 def check_legacy_open(index):


### PR DESCRIPTION
### Reason for this pull request

Do not demand duplicate information fro user when using `dc.load(.., datasets=dss,..)`

 - [x] Closes #852
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
