### PR TITLE
Support RGB(A) images better

### DIFF
--- a/datacube/testutils/io.py
+++ b/datacube/testutils/io.py
@@ -331,7 +331,7 @@ def rio_slurp(fname, *args, **kw):
         return rio_slurp_read(fname, *args, **kw)
 
 
-def rio_slurp_xarray(fname, *args, **kw):
+def rio_slurp_xarray(fname, *args, rgb='auto', **kw):
     """
     Dispatches to either:
 
@@ -354,8 +354,16 @@ def rio_slurp_xarray(fname, *args, **kw):
         else:
             im, mm = rio_slurp_read(fname, *args, **kw)
 
+    if im.ndim == 3:
+        dims = ('band', *mm.gbox.dims)
+        if rgb and im.shape[0] in (3, 4):
+            im = im.transpose([1, 2, 0])
+            dims = tuple(dims[i] for i in [1, 2, 0])
+    else:
+        dims = mm.gbox.dims
+
     return DataArray(im,
-                     dims=mm.gbox.dims,
+                     dims=dims,
                      coords=xr_coords(mm.gbox),
                      attrs=dict(
                          crs=mm.gbox.crs,

--- a/datacube/utils/cog.py
+++ b/datacube/utils/cog.py
@@ -60,6 +60,11 @@ def _write_cog(pix: np.ndarray,
         nbands = 1
         band = 1  # type: Any
     elif pix.ndim == 3:
+        if pix.shape[:2] == geobox.shape:
+            pix = pix.transpose([2, 0, 1])
+        elif pix.shape[-2:] != geobox.shape:
+            raise ValueError('GeoBox shape does not match image shape')
+
         nbands, h, w = pix.shape
         band = tuple(i for i in range(1, nbands + 1))
     else:

--- a/datacube/utils/xarray_geoextensions.py
+++ b/datacube/utils/xarray_geoextensions.py
@@ -38,8 +38,12 @@ def _get_crs(obj):
     else:
         data_array = obj
 
-    # Assumption: spatial dimensions are always the last 2)
-    spatial_dims = data_array.dims[-2:]
+    # Assumption: (... y,x) or (...y,x,band)
+    if data_array.dims[-1] == 'band':
+        spatial_dims = data_array.dims[-3:-1]
+    else:
+        spatial_dims = data_array.dims[-2:]
+
     crs_set = set(data_array[d].attrs.get('crs', None) for d in spatial_dims)
     crs = None
     if len(crs_set) > 1:

--- a/tests/test_utils_cog.py
+++ b/tests/test_utils_cog.py
@@ -175,3 +175,6 @@ def test_cog_rgba(tmpdir):
     assert(yy.geobox == rgba.geobox)
     assert(yy.shape == rgba.shape)
     np.testing.assert_array_equal(yy.values, rgba.values)
+
+    with pytest.raises(ValueError):
+        _write_cog(rgba.values[1:, :, :], rgba.geobox, ':mem:')


### PR DESCRIPTION
RGB(A) images have extra dimension y,x,band instead of just y,x
Deal with that case better in:

- `.geobox` accessor while figuring out spatial dimensions
- `.write_cog` need to transpose to be (band, y,x)
- `.rio_slurp` need to transpose back to (y,x,band)

