### PR TITLE
Fix datacube cli not reading config from env vars

### DIFF
--- a/datacube/ui/click.py
+++ b/datacube/ui/click.py
@@ -181,7 +181,7 @@ def pass_config(f):
     def new_func(*args, **kwargs):
         obj = click.get_current_context().obj
 
-        paths = obj.get('config_files') or config.DEFAULT_CONF_PATHS
+        paths = obj.get('config_files', None)
         # If the user is overriding the defaults
         specific_environment = obj.get('config_environment')
 


### PR DESCRIPTION
- LocalConfig.find ignore env vars if file list is supplied
- ui.click supplies file lists even if user didn't specify extra files

Resolution: pass None to LocalConfig.find(paths=None) if user didn't request any
extra config files to indicate that defaults should be used.

If user did supply extra paths, then we should not fallback to env so current
behaviour inside LocalConfig.find should remain the same: only fallback to env
if everything is set to defaults.
