### PR TITLE
various fixes for 1.8

### DIFF
--- a/datacube/storage/_base.py
+++ b/datacube/storage/_base.py
@@ -108,7 +108,6 @@ class BandInfo:
         self.units = mp.units
         self.crs = ds.crs
         self.transform = ds.transform
-        self.center_time = ds.center_time
         self.format = ds.format
         self.driver_data = _extract_driver_data(ds)
 

--- a/datacube/storage/_hdf5.py
+++ b/datacube/storage/_hdf5.py
@@ -1,0 +1,2 @@
+from threading import RLock
+HDF5_LOCK = RLock()

--- a/datacube/storage/_rio.py
+++ b/datacube/storage/_rio.py
@@ -3,6 +3,7 @@
 Driver implementation for Rasterio based reader.
 """
 import logging
+import warnings
 import contextlib
 from contextlib import contextmanager
 from threading import RLock
@@ -187,6 +188,11 @@ class RasterioDataSource(DataSource):
                     lock.release()
 
                 if override:
+                    warnings.warn(f"""Broken/missing geospatial data was found in file:
+"{self.filename}"
+Will use approximate metadata for backwards compatibility reasons (#673).
+This behaviour is deprecated. Future versions will raise an error.""",
+                                  category=DeprecationWarning)
                     yield OverrideBandDataSource(band, nodata=nodata, crs=crs, transform=transform, lock=lock)
                 else:
                     yield BandDataSource(band, nodata=nodata, lock=lock)

--- a/datacube/storage/_rio.py
+++ b/datacube/storage/_rio.py
@@ -174,10 +174,6 @@ class RasterioDataSource(DataSource):
                     override = True
                     crs = self.get_crs()
 
-                # The [1.0a1-1.0a8] releases of rasterio had a bug that means it
-                # cannot read multiband data into a numpy array during reprojection
-                # We override it here to force the reading and reprojection into separate steps
-                # TODO: Remove when we no longer care about those versions of rasterio
                 bandnumber = self.get_bandnumber(src)
                 band = rasterio.band(src, bandnumber)
                 nodata = src.nodatavals[band.bidx-1] if src.nodatavals[band.bidx-1] is not None else self.nodata

--- a/datacube/storage/_rio.py
+++ b/datacube/storage/_rio.py
@@ -18,9 +18,9 @@ from datacube.utils.math import num2numpy
 from datacube.utils import uri_to_local_path, get_part_from_uri, is_vsipath
 from datacube.utils.rio import activate_from_config
 from . import DataSource, GeoRasterReader, RasterShape, RasterWindow, BandInfo
+from ._hdf5 import HDF5_LOCK
 
 _LOG = logging.getLogger(__name__)
-_HDF5_LOCK = RLock()
 
 
 def _rasterio_crs_wkt(src):
@@ -215,7 +215,7 @@ class RasterDatasetDataSource(RasterioDataSource):
         self._hdf = _is_hdf(band.format)
         self._part = get_part_from_uri(band.uri)
         filename = _url2rasterio(band.uri, band.format, band.layer)
-        lock = _HDF5_LOCK if self._hdf else None
+        lock = HDF5_LOCK if self._hdf else None
         super(RasterDatasetDataSource, self).__init__(filename, nodata=band.nodata, lock=lock)
 
     def get_bandnumber(self, src=None) -> Optional[int]:

--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -423,6 +423,9 @@ class Geometry(object):
     union = _wrap_binary_geom(ogr.Geometry.Union)
 
     def __init__(self, geo, crs=None):
+        if isinstance(crs, str):
+            crs = CRS(crs)
+
         self.crs = crs
         self._geom = Geometry._geom_makers[geo['type']](geo['coordinates'])
 

--- a/datacube/utils/masking.py
+++ b/datacube/utils/masking.py
@@ -119,7 +119,8 @@ def valid_data_mask(data):
 
     nodata = data.attrs.get('nodata', None)
 
-    return xarray.apply_ufunc(lambda xx: valid_mask(xx, nodata), data, dask='parallelized',
+    return xarray.apply_ufunc(valid_mask, data, nodata,
+                              dask='parallelized',
                               output_dtypes=[numpy.bool])
 
 

--- a/tests/drivers/test_rio_reader.py
+++ b/tests/drivers/test_rio_reader.py
@@ -15,7 +15,6 @@ from datacube.drivers.rio._reader import (
     _rio_band_idx,
     _roi_to_window,
 )
-from datacube.utils import datetime_to_seconds_since_1970
 from datacube.testutils.geom import SAMPLE_WKT_WITHOUT_AUTHORITY, epsg3857
 from datacube.testutils.iodriver import (
     NetCDF, GeoTIFF, mk_band, mk_rio_driver, open_reader
@@ -76,7 +75,6 @@ def test_rd_internals_bidx(data_folder):
                  timestamp=datetime.utcfromtimestamp(1),
                  layer='a')
     assert bi.uri.endswith('multi_doc.nc')
-    assert datetime_to_seconds_since_1970(bi.center_time) == 1
 
     rio_fname = _rio_uri(bi)
     assert rio_fname.startswith('NETCDF:')

--- a/tests/storage/test_base.py
+++ b/tests/storage/test_base.py
@@ -44,7 +44,6 @@ def test_band_info():
     assert binfo.crs is None
     assert binfo.units == 'K'
     assert binfo.nodata == 33
-    assert binfo.center_time == ds.center_time
     assert binfo.uri == 'file:///tmp/b.tiff'
     assert binfo.format == ds.format
     assert binfo.driver_data is None

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -519,9 +519,10 @@ class TestRasterDataReading(object):
         transform = Affine(0.01, 0.0, 111.975,
                            0.0, 0.01, -9.975)
         data_source = RasterFileDataSource(no_crs_gdal_path, bandnumber=1, nodata=nodata, crs=crs, transform=transform)
-        with data_source.open() as src:
-            dest1 = src.read()
-            assert dest1.shape == (10, 10)
+        with pytest.warns(DeprecationWarning):
+            with data_source.open() as src:
+                dest1 = src.read()
+                assert dest1.shape == (10, 10)
 
 
 @pytest.fixture

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -69,6 +69,11 @@ def test_geobox_simple():
 
     assert (t == "some random thing") is False
 
+    # ensure GeoBox accepts string CRS
+    assert isinstance(geometry.GeoBox(4000, 4000,
+                                      Affine(0.00025, 0.0, 151.0, 0.0, -0.00025, -29.0),
+                                      'epsg:4326').crs, CRS)
+
 
 def test_props():
     crs = epsg4326
@@ -107,6 +112,9 @@ def test_props():
     assert 'Point' in str(pt)
     assert bool(pt) is True
     assert pt.__nonzero__() is True
+
+    # check "CRS as string is converted to class automatically"
+    assert isinstance(geometry.point(3, 4, 'epsg:3857').crs, geometry.CRS)
 
 
 def test_tests():

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -140,7 +140,7 @@ def test_load_data_cbk(tmpdir):
 
 
 def test_hdf5_lock_release_on_failure():
-    from datacube.storage._rio import RasterDatasetDataSource, _HDF5_LOCK
+    from datacube.storage._rio import RasterDatasetDataSource, HDF5_LOCK
     from datacube.storage import BandInfo
 
     band = dict(name='xx',
@@ -158,7 +158,7 @@ def test_hdf5_lock_release_on_failure():
         with src.open():
             assert False and "Did not expect to get here"
 
-    assert not _HDF5_LOCK._is_owned()
+    assert not HDF5_LOCK._is_owned()
 
 
 def test_rio_slurp(tmpdir):


### PR DESCRIPTION
- Accept string CRS when constructing Geometry objects
- Don't die on Ctrl-C in `product add`
- Add deprecation warning when using approximate metadata when file is missing geo referencing data (#673)
- Remove `.center_time` from `BandInfo`
- Grab hdf5 lock when writing as well as reading
- Catch more read failures when `skip_broken_datasets=True`, should now catch missing uris errors.
- Remove more dead code



 - [x] Closes #749 
 - [x] Closes #857 
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes