### PR TITLE
fix issue #888

### DIFF
--- a/datacube/virtual/impl.py
+++ b/datacube/virtual/impl.py
@@ -843,10 +843,8 @@ def reproject_band(band, geobox, resampling, dims, dask_chunks=None):
     dask_name = 'warp_{name}-{token}'.format(name=band.name, token=uuid.uuid4().hex)
     dependencies = [band.data]
 
-    if not all(k in dask_chunks for k in geobox.dims):
-        spatial_chunks = geobox.shape
-    else:
-        spatial_chunks = tuple(dask_chunks[k] for k in geobox.dims)
+    spatial_chunks = tuple(dask_chunks.get(k, geobox.shape[i])
+                           for i, k in enumerate(geobox.dims))
 
     gt = GeoboxTiles(geobox, spatial_chunks)
     new_layer = {}

--- a/datacube/virtual/impl.py
+++ b/datacube/virtual/impl.py
@@ -843,7 +843,11 @@ def reproject_band(band, geobox, resampling, dims, dask_chunks=None):
     dask_name = 'warp_{name}-{token}'.format(name=band.name, token=uuid.uuid4().hex)
     dependencies = [band.data]
 
-    spatial_chunks = tuple(dask_chunks[k] for k in geobox.dims)
+    if not all(k in dask_chunks for k in geobox.dims):
+        spatial_chunks = geobox.shape
+    else:
+        spatial_chunks = tuple(dask_chunks[k] for k in geobox.dims)
+
     gt = GeoboxTiles(geobox, spatial_chunks)
     new_layer = {}
 


### PR DESCRIPTION
### Reason for this pull request
Virtual product reproject erroneously assumes the `dask_chunks` settings will always include spatial chunking.

### Proposed changes
- No spatial chunking specified does not trigger `KeyError`


 - [X] Closes Issue #888
