### PR TITLE
fix virtual product no uri error

### DIFF
--- a/datacube/virtual/impl.py
+++ b/datacube/virtual/impl.py
@@ -342,7 +342,8 @@ class Product(VirtualProduct):
                      "query for {} returned another product {}".format(self._product, query.product))
 
         # find the datasets
-        datasets = dc.index.datasets.search(**query.search_terms)
+        datasets = (dataset for dataset in dc.index.datasets.search(**query.search_terms) if dataset.uris)
+
         if query.geopolygon is not None:
             datasets = select_datasets_inside_polygon(datasets, query.geopolygon)
 


### PR DESCRIPTION
### Reason for this pull request
Virtual product load mechanism does not ensure that the datasets have location. The usual `dc.load` does.

### Proposed changes
Throw away datasets with no location.