### PR TITLE
Fix test docker again

### DIFF
--- a/.github/workflows/docker-test-runner.yml
+++ b/.github/workflows/docker-test-runner.yml
@@ -51,12 +51,12 @@ jobs:
           twine
 
     # This is just to get dependencies right, we do not keep datacube in the final image
-    - name: Build datacube source distribution
+    - name: Build datacube wheel
       run: |
         mkdir -p ./docker/dist/
         find ./docker/dist/ -type f -delete
 
-        python setup.py sdist --dist-dir ./docker/dist/
+        python setup.py bdist_wheel --dist-dir ./docker/dist/
         ls -lh ./docker/dist/
         twine check ./docker/dist/*
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,12 +6,14 @@ FROM ${ORG}/geobase:wheels${V_BASE} as env_builder
 ENV LC_ALL C.UTF-8
 
 COPY requirements.txt /conf/requirements.txt
-COPY ./dist/datacube-*tar.gz /conf/
+COPY ./dist/datacube-*.whl /conf/
 
 RUN find /wheels -type f -name '*whl' > /tmp/constraints.txt \
-  && find /conf -type f -name 'datacube-*tar.gz' | head -1 >> /tmp/constraints.txt \
+  && find /conf -type f -name 'datacube-*.whl' | head -1 >> /tmp/constraints.txt \
   && mkdir -p /wheels-tmp \
+  && echo "Constraints:" \
   && cat /tmp/constraints.txt \
+  && echo "..." \
   && pip3 wheel \
      --no-cache \
      --no-cache-dir \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,6 +25,7 @@ RUN find /wheels -type f -name '*whl' > /tmp/constraints.txt \
   && rm /tmp/constraints.txt \
   && find /wheels-tmp/ -type f -name "datacube-*whl" -delete \
   && ls -lh /wheels-tmp/ \
+  && rm -rf /root/.cache/pip \
   && echo "================================================================================" \
   && find /wheels-tmp/ -type f -name "*whl" > /tmp/reqs.txt \
 # make env root:users with write permissions for group
@@ -33,7 +34,9 @@ RUN find /wheels -type f -name '*whl' > /tmp/constraints.txt \
   && chgrp users /env \
   && chmod g+s /env \
   && env-build-tool new_no_index /tmp/reqs.txt /env /wheels-tmp ) \
-  && rm -rf /wheels-tmp
+  && rm -rf /wheels-tmp \
+  && rm -rf /root/.cache/pip \
+  && echo done
 
 
 #################################################################################


### PR DESCRIPTION
### Reason for this pull request

Test docker build process was not picking up latest datcube dependencies as it was pulling datacube from pypi instead of using checkout. 


### Proposed changes

Build wheel version of datacube and push that into docker, this seems to make it work with --constraint option.


 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
