### PR TITLE
Documentation enhancements for virtual product transformations

### DIFF
--- a/datacube/virtual/transformations.py
+++ b/datacube/virtual/transformations.py
@@ -39,11 +39,19 @@ def selective_apply(data, apply_to=None, key_map=None, value_map=None):
 
 class MakeMask(Transformation):
     """
-    Create a mask that would only keep pixels for which the measurement with `mask_measurement_name`
-    of the `product` satisfies `flags`.
+    Create a mask that would only keep pixels for which the specified measurement
+    satisfies `flags` specification.
+
+    Alias in recipe: ``make_mask``.
     """
 
     def __init__(self, mask_measurement_name, flags):
+        """
+        Initialize transformation.
+
+        :param mask_measurement_name: the name of the measurement to turn into a boolean mask
+        :param flags: a dictionary of flag value specifications for the ``flags_definition`` of that measurement
+        """
         self.mask_measurement_name = mask_measurement_name
         self.flags = flags
 
@@ -68,8 +76,22 @@ class MakeMask(Transformation):
 
 
 class ApplyMask(Transformation):
+    """
+    Apply a boolean mask to other measurements.
+
+    Alias in recipe: ``apply_mask``.
+    """
     def __init__(self, mask_measurement_name, apply_to=None,
                  preserve_dtype=True, fallback_dtype='float32', dilation=0):
+        """
+        Initialize transformation.
+
+        :param mask_measurement_name: the measurement name of the boolean mask
+        :param apply_to: list of names of measurements to apply the mask to
+        :param preserve_dtype: whether to cast back to original ``dtype`` after masking
+        :param fallback_dtype: default ``dtype`` for masked measurements
+        :param dilation: the dilation to apply to mask in pixels
+        """
         self.mask_measurement_name = mask_measurement_name
         self.apply_to = apply_to
         self.preserve_dtype = preserve_dtype
@@ -124,7 +146,18 @@ class ApplyMask(Transformation):
 
 
 class ToFloat(Transformation):
+    """
+    Convert measurements to floats and mask invalid data.
+
+    Alias in recipe: ``to_float``.
+    """
     def __init__(self, apply_to=None, dtype='float32'):
+        """
+        Initialize transformation.
+
+        :param apply_to: list of names of measurements to apply conversion to
+        :param dtype: default ``dtype`` for conversion
+        """
         self.apply_to = apply_to
         self.dtype = dtype
 
@@ -147,7 +180,17 @@ class ToFloat(Transformation):
 
 
 class Rename(Transformation):
+    """
+    Rename measurements.
+
+    Alias in recipe: ``rename``.
+    """
     def __init__(self, measurement_names):
+        """
+        Initialize transformation.
+
+        :param measurement_names: a dictionary mapping original names to new names
+        """
         self.measurement_names = measurement_names
 
     def measurements(self, input_measurements):
@@ -167,7 +210,17 @@ class Rename(Transformation):
 
 
 class Select(Transformation):
+    """
+    Keep only specified measurements.
+
+    Alias in recipe: ``select``.
+    """
     def __init__(self, measurement_names):
+        """
+        Initialize transformation.
+
+        :param measurement_names: list of measurements to keep
+        """
         self.measurement_names = measurement_names
 
     def measurements(self, input_measurements):
@@ -253,7 +306,38 @@ class EvaluateTree(lark.Transformer):
 
 
 class Expressions(Transformation):
+    """
+    Calculate measurements on-the-fly using arithmetic expressions.
+
+    Alias in recipe: ``expressions``. For example,
+
+    .. code-block:: yaml
+
+       transform: expressions
+       output:
+           ndvi:
+               formula: (nir - red) / (nir + red)
+
+       input:
+           product: example_surface_reflectance_product
+           measurements: [nir, red]
+
+    """
     def __init__(self, output, masked=True):
+        """
+        Initialize transformation.
+
+        :param output:
+            A dictionary mapping output measurement names to specifications.
+            That specification can be one of:
+
+            - a measurement name from the input product in which case it is copied over
+            - a dictionary containing a ``formula``,
+              and optionally a ``dtype``, a new ``nodata`` value, and a ``units`` specification
+
+        :param masked:
+            Defaults to ``True``. If set to ``False``, the inputs and outputs are not masked for no data.
+        """
         self.output = output
         self.masked = masked
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -18,7 +18,7 @@ v1.8rc (???)
 - Deprecated ``datacube.helpers.write_geotiff``, use ``datacube.utils.cog.write_cog`` for similar functionality
 - Deprecated ``datacube.storage.masking``, moved to ``datacube.utils.masking``
 - Changed geo-registration mechanics for arrays returned by ``dc.load``. (:pull:`899`, :issue:`837`)
-
+- Migrate geometry and CRS backends from ``osgeo.ogr`` and ``osgeo.osr`` to ``shapely`` and ``pyproj`` respectively (:pull:`880`)
 
 v1.7.0 (16 May 2019)
 ====================
@@ -118,10 +118,10 @@ v1.6.0 (23 August 2018)
 - Updates when indexing data with `datacube dataset add` (See :pull:`485`, :issue:`451` and :issue:`480`)
 
 
-  - Allow indexing without lineage :option:`datacube dataset add --ignore-lineage`
+  - Allow indexing without lineage `datacube dataset add --ignore-lineage`
   - Removed the `--sources-policy=skip|verify|ensure`. Instead use
     `--[no-]auto-add-lineage` and `--[no-]verify-lineage`
-  - New option :option:`datacube dataset add --exclude-product` ``<name>``
+  - New option `datacube dataset add --exclude-product` ``<name>``
     allows excluding some products from auto-matching
 
 - Preliminary API for indexing datasets (:pull:`511`)
@@ -298,8 +298,8 @@ Bug Fixes
  - Allow creation of :class:`datacube.utils.geometry.Geometry` objects from 3d
    representations. The Z axis is simply thrown away.
 
- - The :option:`datacube --config_file` option has been renamed to
-   :option:`datacube --config`, which is shorter and more consistent with the
+ - The `datacube --config_file` option has been renamed to
+   `datacube --config`, which is shorter and more consistent with the
    other options. The old name can still be used for now.
 
  - Fix a severe performance regression when extracting and reprojecting a small

--- a/docs/dev/api/virtual-products.rst
+++ b/docs/dev/api/virtual-products.rst
@@ -86,7 +86,7 @@ PQ products (``ls7_pq_albers`` and ``ls8_pq_albers``):
 The virtual product ``cloud_free_ls_nbar`` can now be used to load cloud-free SR imagery. The dataflow for loading the
 data reflects the tree structure of the recipe:
 
-.. image:: ../diagrams/cloud_free.svg
+.. image:: ../../diagrams/cloud_free.svg
 
 
 Combinators
@@ -128,7 +128,7 @@ for a ``collate`` node has the form:
 
 Observations from different sensors get interlaced:
 
-.. image:: ../diagrams/collate.svg
+.. image:: ../../diagrams/collate.svg
 
 Optionally, the source product of a pixel can be captured by introducing another measurement in the loaded data
 that consists of the index of the source product:
@@ -170,12 +170,17 @@ where the ``settings`` are keyword arguments to the initializer of the transform
 
 ODC has a (growing) set of built-in transformations:
 
-- ``make_mask``
-- ``apply_mask``
-- ``to_float``
-- ``rename``
-- ``select``
-- ``expressions``
+.. currentmodule:: datacube.virtual.transformations
+
+.. autosummary::
+   :toctree: generate/
+
+   Expressions
+   MakeMask
+   ApplyMask
+   ToFloat
+   Rename
+   Select
 
 For more information on transformations, see :ref:`user-defined-virtual-product-transforms`.
 
@@ -195,7 +200,7 @@ The form of the recipe is:
 
 Observations without corresponding entries in the other products will get dropped.
 
-.. image:: ../diagrams/juxtapose.svg
+.. image:: ../../diagrams/juxtapose.svg
 
 
 5. ``aggregate``
@@ -260,7 +265,7 @@ Currently, virtual products also provide a ``load(dc, **query)`` method that rou
 However, this method exists only to facilitate code migration, and its extensive use is not recommended. It implements
 the pipeline:
 
-.. image:: ../diagrams/virtual_product_load.svg
+.. image:: ../../diagrams/virtual_product_load.svg
 
 For advanced use cases, the intermediate objects ``VirtualDatasetBag`` and ``VirtualDatasetBox`` may be directly manipulated.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,7 +60,7 @@ and  related data from multiple satellite and other acquisition systems.
 
    dev/api/index.rst
    dev/setup/index.rst
-   dev/virtual-products.rst
+   dev/api/virtual-products.rst
    architecture/index.rst
    about/release_process.rst
 


### PR DESCRIPTION
### Reason for this pull request
We had virtual product documentation before, but the build-in transformations did not have documentation of their own. Especially the `expressions` transformation is useful enough to warrant documentation.

### Proposed changes
Fix that.