### PR TITLE
fix most of pyproj performance regression

### DIFF
--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -218,20 +218,20 @@ class CRS(object):
     def __repr__(self):
         return "CRS('%s')" % self.crs_str
 
-    def __eq__(self, other):
-        if hasattr(other, '_crs') and other._crs is self._crs:
+    def __eq__(self, other)->bool:
+        if not isinstance(other, CRS):
+            try:
+                other = CRS(other)
+            except:
+                return False
+
+        if self._crs is other._crs:
             return True
 
-        if isinstance(other, CRS):
-            if self.epsg is not None and other.epsg is not None:
-                return self.epsg == other.epsg
-            return self._crs == other._crs
+        if self.epsg is not None and other.epsg is not None:
+            return self.epsg == other.epsg
 
-
-        crs_str = _guess_crs_str(other)
-        if crs_str is None:
-            return False
-        return self._crs == CRS(crs_str)._crs
+        return self._crs == other._crs
 
     def __ne__(self, other):
         return not (self == other)

--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -84,7 +84,7 @@ def _make_crs_transform(from_crs, to_crs, always_xy):
     return Transformer.from_crs(from_crs, to_crs, always_xy=always_xy).transform
 
 
-def _guess_crs_str(crs_spec):
+def _guess_crs_str(crs_spec: Any)->Optional[str]:
     """
     Returns a string representation of the crs spec.
     Returns `None` if it does not understand the spec.
@@ -128,7 +128,7 @@ class CRS(object):
     def __setstate__(self, state):
         self.__init__(state['crs_str'])
 
-    def to_wkt(self, pretty=False, version=None):
+    def to_wkt(self, pretty: bool = False, version: Optional[WktVersion] = None)->str:
         """
         WKT representation of the CRS
 
@@ -140,7 +140,7 @@ class CRS(object):
         return self._crs.to_wkt(pretty=pretty, version=version)
 
     @property
-    def wkt(self):
+    def wkt(self)->str:
         return self.to_wkt(version="WKT1_GDAL")
 
     def to_epsg(self)->Optional[int]:
@@ -168,21 +168,21 @@ class CRS(object):
         return self._crs.ellipsoid.inverse_flattening
 
     @property
-    def geographic(self):
+    def geographic(self)->bool:
         """
         :type: bool
         """
         return self._crs.is_geographic
 
     @property
-    def projected(self):
+    def projected(self)->bool:
         """
         :type: bool
         """
         return self._crs.is_projected
 
     @property
-    def dimensions(self):
+    def dimensions(self)->Tuple[str, str]:
         """
         List of dimension names of the CRS.
         The ordering of the names is intended to reflect the `numpy` array axis order of the loaded raster.
@@ -198,7 +198,7 @@ class CRS(object):
         raise ValueError('Neither projected nor geographic')  # pragma: no cover
 
     @property
-    def units(self):
+    def units(self)->Tuple[str, str]:
         """
         List of dimension units of the CRS.
         The ordering of the units is intended to reflect the `numpy` array axis order of the loaded raster.
@@ -214,13 +214,13 @@ class CRS(object):
 
         raise ValueError('Neither projected nor geographic')  # pragma: no cover
 
-    def __str__(self):
+    def __str__(self)->str:
         return self.crs_str
 
     def __hash__(self):
         return hash(self.to_wkt())
 
-    def __repr__(self):
+    def __repr__(self)->str:
         return "CRS('%s')" % self.crs_str
 
     def __eq__(self, other)->bool:
@@ -238,7 +238,7 @@ class CRS(object):
 
         return self._crs == other._crs
 
-    def __ne__(self, other):
+    def __ne__(self, other)->bool:
         return not (self == other)
 
     def transformer_to_crs(self, other, always_xy=True):

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -31,7 +31,7 @@ from datacube.utils.geometry._base import (
     geobox_intersection_conservative,
     geobox_union_conservative,
     _guess_crs_str,
-    ensure_2d,
+    force_2d,
 )
 from datacube.testutils.geom import (
     epsg4326,
@@ -1181,7 +1181,7 @@ def test_base_internals():
     assert _guess_crs_str(no_epsg_crs) == no_epsg_crs.to_wkt()
 
     gjson_bad = {'type': 'a', 'coordinates': [1, [2, 3, 4]]}
-    assert ensure_2d(gjson_bad) == {'type': 'a', 'coordinates': [1, [2, 3]]}
+    assert force_2d(gjson_bad) == {'type': 'a', 'coordinates': [1, [2, 3]]}
 
     with pytest.raises(ValueError):
-        ensure_2d({'type': 'a', 'coordinates': [set("not a valid element")]})
+        force_2d({'type': 'a', 'coordinates': [set("not a valid element")]})


### PR DESCRIPTION
### Reason for this pull request
Severe performance regression for `dc.find_datasets` after PR #880 


### Proposed changes
- cache pyproj `Transformer` objects
- cached EPSG property (not yet implemented)