### PR TITLE
Fix for groupby sorting

### DIFF
--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -27,8 +27,9 @@ from pandas import to_datetime as pandas_to_datetime
 import numpy as np
 
 
-from ..model import Range
+from ..model import Range, Dataset
 from ..utils import geometry, datetime_to_seconds_since_1970
+from ..utils.dates import normalise_dt
 
 _LOG = logging.getLogger(__name__)
 
@@ -156,19 +157,23 @@ def query_geopolygon(geopolygon=None, **kwargs):
     return geopolygon
 
 
+def _extract_time_from_ds(ds: Dataset) -> datetime.datetime:
+    return normalise_dt(ds.center_time)
+
+
 def query_group_by(group_by='time', **kwargs):
     if not isinstance(group_by, str):
         return group_by
 
     time_grouper = GroupBy(dimension='time',
-                           group_by_func=lambda ds: ds.center_time,
+                           group_by_func=_extract_time_from_ds,
                            units='seconds since 1970-01-01 00:00:00',
-                           sort_key=lambda ds: ds.center_time)
+                           sort_key=_extract_time_from_ds)
 
     solar_day_grouper = GroupBy(dimension='time',
                                 group_by_func=solar_day,
                                 units='seconds since 1970-01-01 00:00:00',
-                                sort_key=lambda ds: ds.center_time)
+                                sort_key=_extract_time_from_ds)
 
     group_by_map = {
         None: time_grouper,

--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -2,7 +2,7 @@ import functools
 import itertools
 import math
 from collections import namedtuple, OrderedDict
-from typing import Tuple, Iterable, List, Union, Optional, Any, Callable, Mapping, Hashable, Dict
+from typing import Tuple, Iterable, List, Union, Optional, Any, Callable, Hashable, Dict
 from collections.abc import Sequence
 from distutils.version import LooseVersion
 
@@ -943,7 +943,7 @@ class GeoBox:
             attrs['crs'] = str(crs)
 
         coords = dict((n, _coord_to_xr(n, c, **attrs))
-                      for n, c in coords.items()) # type: Dict[Hashable, xr.DataArray]
+                      for n, c in coords.items())  # type: Dict[Hashable, xr.DataArray]
 
         if with_crs and crs is not None:
             coords[spatial_ref] = _mk_crs_coord(crs, spatial_ref)

--- a/datacube/utils/uris.py
+++ b/datacube/utils/uris.py
@@ -14,19 +14,6 @@ URL_RE = re.compile(r'\A\s*[\w\d\+]+://')
 def is_url(url_str: str) -> bool:
     """
     Check if url_str tastes like a url (starts with blah://)
-
-    >>> is_url('file:///etc/blah')
-    True
-    >>> is_url('http://greg.com/greg.txt')
-    True
-    >>> is_url('s3:///etc/blah')
-    True
-    >>> is_url('gs://data/etc/blah.yaml')
-    True
-    >>> is_url('/etc/blah')
-    False
-    >>> is_url('C:/etc/blah')
-    False
     """
     try:
         return URL_RE.match(url_str) is not None

--- a/datacube/utils/uris.py
+++ b/datacube/utils/uris.py
@@ -222,10 +222,12 @@ def register_scheme(*schemes):
     urllib.parse.uses_params.extend(schemes)
 
 
-# s3:// not recognised by python by default
-#  without this `urljoin` might be broken for s3 urls
-register_scheme('s3')
-
-# gs:// not recognised by python by default
-#  without this `urljoin` might be broken for google storage urls
-register_scheme('gs')
+# `urljoin`, that we use for relative path computation, needs to know which url
+# schemes support relative offsets. By default only well known types are
+# understood. So here we register more common blob store url protocols.
+register_scheme(
+    's3',         # `s3://...`      -- AWS S3 Object Store
+    'gs',         # `gs://...`      -- Google Cloud Storage
+    'wasb',       # `wasb[s]://...` -- Windows Azure Storage Blob
+    'wasbs'
+)

--- a/tests/api/test_core.py
+++ b/tests/api/test_core.py
@@ -73,7 +73,7 @@ def test_dask_chunks():
 
     sources = xr.DataArray(coords['time'],
                            coords=coords,
-                           dims=coords.keys())
+                           dims=list(coords))
     geobox = AlbersGS.tile_geobox((0, 0))[:6, :7]
 
     assert geobox.dimensions == ('y', 'x')

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -227,6 +227,19 @@ def test_ops():
     assert all(p.crs == poly_2_parts.crs for p in pp)
 
 
+def test_to_crs():
+    poly = geometry.polygon([(0, 0), (0, 5), (10, 5)], epsg4326)
+    assert poly.crs is epsg4326
+    assert poly.to_crs(epsg3857).crs is epsg3857
+    assert poly.to_crs('EPSG:3857').crs == 'EPSG:3857'
+    assert poly.to_crs('EPSG:3857', 0.1).crs == epsg3857
+
+    poly = geometry.polygon([(0, 0), (0, 5), (10, 5)], None)
+    assert poly.crs is None
+    with pytest.raises(ValueError):
+        poly.to_crs(epsg3857)
+
+
 def test_bbox_union():
     b1 = BoundingBox(0, 1, 10, 20)
     b2 = BoundingBox(5, 6, 11, 22)

--- a/tests/test_utils_other.py
+++ b/tests/test_utils_other.py
@@ -107,6 +107,8 @@ def test_uri_to_local_path():
 @pytest.mark.parametrize("base", [
     "s3://foo",
     "gs://foo",
+    "wasb://foo",
+    "wasbs://foo",
     "/vsizip//vsicurl/https://host.tld/some/path",
 ])
 def test_uri_resolve(base):
@@ -511,6 +513,8 @@ def test_testutils_geobox():
     ("test.bar", False),
     ("s3://mybucket/objname.tiff", True),
     ("gs://mybucket/objname.tiff", True),
+    ("wasb://mybucket/objname.tiff", True),
+    ("wasbs://mybucket/objname.tiff", True),
     ("ftp://host.name/filename.txt", True),
     ("https://host.name.com/path/file.txt", True),
     ("http://host.name.com/path/file.txt", True),


### PR DESCRIPTION
### Reason for this pull request

When grouping datasets by time/solar day, dataset order is determined by timestamp, python can only sort timestamps if they all have timezone info or all don't, so grouping fails when datasets have different styles of timestamp.

### Proposed changes

Normalise timestamps into UTC timezone and remove timezone info after that. Timestamps without timezone information are assumed to be in UTC already.

Also includes another test for geometry code that was missed yesterday and other minor stylistic fixes.

Also adding support for Azure Windows Blob storage urls #912 

 - [x] Closes #906
-  [x] Closes #912 
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes