### PR TITLE
Allow a 'license' field in products

### DIFF
--- a/datacube/model/schema/dataset-type-schema.yaml
+++ b/datacube/model/schema/dataset-type-schema.yaml
@@ -12,6 +12,11 @@ properties:
         oneOf:
             - type: string
             - "$ref": "metadata-type-schema.yaml"
+    license:
+        title: Product license
+        description: Either a SPDX License identifier, 'various' or 'proprietary'
+        type: string
+        pattern: '^[\w\-.+]+$'
     metadata:
         type: object
     storage:

--- a/docs/config_samples/dataset_types/dsm1sv10.yaml
+++ b/docs/config_samples/dataset_types/dsm1sv10.yaml
@@ -1,6 +1,7 @@
 name: dsm1sv10
 description: DSM 1sec Version 1.0
 metadata_type: eo
+license: proprietary
 
 metadata:
     platform:

--- a/docs/ops/product.rst
+++ b/docs/ops/product.rst
@@ -3,8 +3,8 @@
 Product Definition
 ******************
 
-Product description document defines some of the metadata common to all the datasets belonging to the products.
-It also describes the measurements that product has and some of the properties of the measurements.
+A product definition document describes the measurements and common metadata
+for a collection of datasets.
 
 .. highlight:: language
 
@@ -19,6 +19,12 @@ description
 
 metadata_type
     Name of the :ref:`metadata-type-definition`
+
+license
+    The license of the data.
+
+    This is either a SPDX License identifier (eg 'CC-BY-SA-4.0') or
+    'various' or 'proprietary'
 
 metadata
     Dictionary containing bits of metadata common to all the datasets in the product.

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -154,6 +154,7 @@ def ls5_telem_doc(ga_metadata_type):
     return {
         "name": "ls5_telem_test",
         "description": 'LS5 Test',
+        "license": "CC-BY-4.0",
         "metadata": {
             "platform": {
                 "code": "LANDSAT_5"


### PR DESCRIPTION
This makes conversion to Stac easier, as the license field is required in Stac collections.

Eg.
```yaml
name: ga_ls5t_ard_3
description: Landsat 5 TM ARD, GA Collection 3
metadata_type: eo3_landsat_ard

license: CC-BY-4.0

... etc
```

It follows the same format, document location and jsonschema regex as the Stac standard, except our field is currently optional for backward compatibility.

> license: REQUIRED. Collection's license(s), either a SPDX License identifier, various if multiple licenses apply or proprietary for all other cases.

From: https://github.com/radiantearth/stac-spec/blob/2dc002400da3064a7ef4d2190fa8339d27aa2acf/collection-spec/collection-spec.md#collection-fields

Also:
- Added it to a product within the integration-tests. It fails without the schema patch.
- Added to the docs and example.
