### PR TITLE
Simpler test dependencies

### DIFF
--- a/docker/assets/with_bootstrap
+++ b/docker/assets/with_bootstrap
@@ -62,7 +62,7 @@ if [ -e "${env}/bin/activate" ]; then
         source "${env}/bin/activate"
 
         if [ -e "./setup.py" ]; then
-            pip install -e '.[test,celery,s3,performance,distributed]'
+            pip install -e '.[test,cf,celery,s3,performance,distributed]'
         fi
 
         if [ -e "./tests/drivers/fail_drivers" ]; then

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -20,4 +20,4 @@ twine
 
 psycopg2 --no-binary=psycopg2
 
-datacube[test,celery,s3,performance,distributed]
+datacube[test,cf,celery,s3,performance,distributed]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,9 +63,10 @@ project = u'Open Data Cube'
 # built documents.
 #
 # The short X.Y version.
-version = "FIXME"
+version = "1.8"
 # The full version, including alpha/beta/rc tags.
-release = version
+# FIXME: obtain real version by running git
+release = version+"-FIXME"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.extlinks',
     'sphinx.ext.mathjax',
+    'sphinx_click.ext',
     'sphinxcontrib.plantuml',
     'click_utils',
     'sphinx.ext.napoleon',

--- a/docs/dev/api/index.rst
+++ b/docs/dev/api/index.rst
@@ -323,7 +323,7 @@ Masking
 
    masking.rst
 
-.. currentmodule:: datacube.storage
+.. currentmodule:: datacube.utils
 
 .. autosummary::
 

--- a/docs/dev/api/masking.rst
+++ b/docs/dev/api/masking.rst
@@ -6,7 +6,7 @@ Bit Masking
 Masking No Data Values
 ----------------------
 
-.. currentmodule:: datacube.storage
+.. currentmodule:: datacube.utils
 
 .. automethod:: masking.mask_invalid_data
 
@@ -45,7 +45,7 @@ How to Define Meanings on Measurements
 How to Create Masks within code
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. currentmodule:: datacube.storage
+.. currentmodule:: datacube.utils
 
 .. automethod:: masking.describe_variable_flags
 .. automethod:: masking.make_mask

--- a/docs/rtd-requirements.txt
+++ b/docs/rtd-requirements.txt
@@ -2,8 +2,10 @@ affine==2.3.0
 alabaster==0.7.12
 attrs==19.3.0
 Babel==2.8.0
+bcrypt==3.1.7
 cachetools==4.1.0
 certifi==2020.4.5.1
+cffi==1.14.0
 cftime==1.1.1.2
 chardet==3.0.4
 click==7.1.1
@@ -11,6 +13,7 @@ click-plugins==1.1.1
 cligj==0.5.0
 cloudpickle==1.3.0
 commonmark==0.9.1
+cryptography==2.9
 dask==2.14.0
 distributed==2.14.0
 docutils==0.16
@@ -18,7 +21,7 @@ HeapDict==1.0.1
 idna==2.9
 imagesize==1.2.0
 importlib-metadata==1.6.0
-Jinja2==2.11.1
+Jinja2==2.11.2
 jsonschema==3.2.0
 lark-parser==0.8.5
 MarkupSafe==1.1.1
@@ -27,10 +30,13 @@ netCDF4==1.5.3
 numpy==1.18.2
 packaging==20.3
 pandas==1.0.3
+paramiko==2.7.1
 pbr==5.4.5
 psutil==5.7.0
 psycopg2==2.8.5
+pycparser==2.20
 Pygments==2.6.1
+PyNaCl==1.3.0
 pyparsing==2.4.7
 pyproj==2.6.0
 pyrsistent==0.16.0
@@ -46,7 +52,9 @@ six==1.14.0
 snowballstemmer==2.0.0
 snuggs==1.4.7
 sortedcontainers==2.1.0
-Sphinx==3.0.0
+Sphinx==3.0.1
+sphinx-click==2.3.2
+sphinx-rtd-theme==0.4.3
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==1.0.3
@@ -55,11 +63,13 @@ sphinxcontrib-plantuml==0.18
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
 SQLAlchemy==1.3.16
+sshtunnel==0.1.5
 tblib==1.6.0
 toml==0.10.0
 toolz==0.10.0
 tornado==6.0.4
-urllib3==1.25.8
+tqdm==4.45.0
+urllib3==1.25.9
 xarray==0.15.1
 zict==2.0.0
 zipp==3.1.0

--- a/integration_tests/test_celery_runner.py
+++ b/integration_tests/test_celery_runner.py
@@ -7,7 +7,7 @@ import subprocess
 import pytest
 import sys
 
-from datacube import _celery_runner as cr
+cr = pytest.importorskip("datacube._celery_runner")
 
 PORT = 29374
 PASS = 'dfhksdjh23iuervao'

--- a/setup.py
+++ b/setup.py
@@ -36,14 +36,14 @@ extras_require = {
     'cf': ['compliance-checker>=4.0.0'],
 }
 
-extras_require['dev'] = sum([extras_require[k] for k in [
+extras_require['dev'] = sorted(set(sum([extras_require[k] for k in [
     'test',
     'doc',
     'replicas',
     'performance',
     's3',
     'distributed',
-]], [])
+]], [])))
 
 # An 'all' option, following ipython naming conventions.
 extras_require['all'] = sorted(set(sum(extras_require.values(), [])))

--- a/setup.py
+++ b/setup.py
@@ -13,12 +13,22 @@ tests_require = [
     'pytest-httpserver',
     'moto',
 ]
+doc_require = [
+    'Sphinx',
+    'sphinx_rtd_theme',
+    'sphinx-click',
+    'sphinxcontrib-plantuml',  # `apt-get install -y plantuml`
+    'recommonmark',
+    # version related dependencies
+    'setuptools',
+    'setuptools_scm[toml]',
+]
 
 extras_require = {
     'performance': ['ciso8601', 'bottleneck'],
     'interactive': ['matplotlib', 'fiona'],
     'distributed': ['distributed', 'dask[distributed]'],
-    'doc': ['Sphinx', 'setuptools'],
+    'doc': doc_require,
     'replicas': ['paramiko', 'sshtunnel', 'tqdm'],
     'celery': ['celery>=4', 'redis'],
     's3': ['boto3'],

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 from setuptools import setup, find_packages
 
 tests_require = [
-    'compliance-checker>=4.0.0',
     'hypothesis',
     'mock',
     'pycodestyle',
@@ -24,6 +23,7 @@ extras_require = {
     'celery': ['celery>=4', 'redis'],
     's3': ['boto3'],
     'test': tests_require,
+    'cf': ['compliance-checker>=4.0.0'],
 }
 # An 'all' option, following ipython naming conventions.
 extras_require['all'] = sorted(set(sum(extras_require.values(), [])))

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,16 @@ extras_require = {
     'test': tests_require,
     'cf': ['compliance-checker>=4.0.0'],
 }
+
+extras_require['dev'] = sum([extras_require[k] for k in [
+    'test',
+    'doc',
+    'replicas',
+    'performance',
+    's3',
+    'distributed',
+]], [])
+
 # An 'all' option, following ipython naming conventions.
 extras_require['all'] = sorted(set(sum(extras_require.values(), [])))
 


### PR DESCRIPTION
### Reason for this pull request

Make it easier for new developers to get started with the code base

### Proposed changes

1. Exclude netcdf cf compliance checker from `test` option as it can be a little bit tricky to install.
2. Update `doc` option to include all the needed packages for building docs
3. Add `dev` option which is like `all` but with a little bit fewer dependencies
4. Some fixes in `docs/*` -- re-enable click and add more dependencies for generating docs for "replicas" cli tool, fix masking location.
5. Protect celery test from failing everything when celery is not installed

```
pip install '.[dev]'
```




 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
