### PR TITLE
Feat/catalog enhancements

### DIFF
--- a/datacube/virtual/catalog.py
+++ b/datacube/virtual/catalog.py
@@ -16,7 +16,13 @@ class UnappliedTransform:
         self.recipe = recipe
 
     def __call__(self, input):
-        return self.name_resolver.construct(**self.recipe, input=input)
+        if isinstance(self.recipe, Mapping):
+            return self.name_resolver.construct(**self.recipe, input=input)
+
+        output = input
+        for subtransform in reversed(self.recipe):
+            output = dict(**subtransform, input=output)
+        return self.name_resolver.construct(**output)
 
     def __repr__(self):
         return yaml.dump(self.recipe, Dumper=SafeDumper,

--- a/datacube/virtual/catalog.py
+++ b/datacube/virtual/catalog.py
@@ -3,6 +3,24 @@ Catalog of virtual products.
 """
 
 from collections.abc import Mapping
+from itertools import chain
+
+import yaml
+
+from datacube.model.utils import SafeDumper
+
+
+class UnappliedTransform:
+    def __init__(self, name_resolver, recipe):
+        self.name_resolver = name_resolver
+        self.recipe = recipe
+
+    def __call__(self, input):
+        return self.name_resolver.construct(**self.recipe, input=input)
+
+    def __repr__(self):
+        return yaml.dump(self.recipe, Dumper=SafeDumper,
+                         default_flow_style=False, indent=2)
 
 
 class Catalog(Mapping):
@@ -13,21 +31,39 @@ class Catalog(Mapping):
     def __init__(self, name_resolver, contents):
         self.name_resolver = name_resolver
         self.contents = contents
+        common = set(self._names('products')) & set(self._names('transforms'))
+        assert not common, f"common names found in products and transforms {common}"
 
-    def __getitem__(self, product_name):
+    def _names(self, section):
+        """ List of names under a section (products or transforms). """
+        if section not in self.contents:
+            return []
+        return list(self.contents[section])
+
+    def __getitem__(self, name):
         """
-        Look up virtual product by name.
+        Looks up a virtual product or transform by name.
+        Returns `None` is not found.
         """
-        return self.name_resolver.construct(**self.contents['products'][product_name]['recipe'])
+        if name in self._names('products'):
+            return self.name_resolver.construct(**self.contents['products'][name]['recipe'])
+        if name in self._names('transforms'):
+            return UnappliedTransform(self.name_resolver, self.contents['transforms'][name]['recipe'])
+
+        # raising a `KeyError` here stops autocompletion from working
+        return None
+
+    def __getattr__(self, name):
+        return self[name]
 
     def __len__(self):
-        return len(self.contents['products'])
+        return len(self._names('products')) + len(self._names('transforms'))
 
     def __iter__(self):
-        return iter(self.contents['products'])
+        return chain(iter(self._names('products')), iter(self._names('transforms')))
 
-    def describe(self, product_name):
+    def __dir__(self):
         """
-        Section describing the product in the catalog.
+        Override to provide autocompletion of products and transforms.
         """
-        return self.contents['products'][product_name]
+        return sorted(dir(Mapping) + list(self.__dict__) + self._names('products') + self._names('transforms'))

--- a/datacube/virtual/transformations.py
+++ b/datacube/virtual/transformations.py
@@ -116,7 +116,7 @@ class ApplyMask(Transformation):
 
     def compute(self, data):
         mask = data[self.mask_measurement_name]
-        rest = data.drop(self.mask_measurement_name)
+        rest = data.drop_vars([self.mask_measurement_name])
 
         def dilate(array):
             """Dilation e.g. for the mask"""
@@ -229,9 +229,9 @@ class Select(Transformation):
                 if key in self.measurement_names}
 
     def compute(self, data):
-        return data.drop([measurement
-                          for measurement in data.data_vars
-                          if measurement not in self.measurement_names])
+        return data.drop_vars([measurement
+                               for measurement in data.data_vars
+                               if measurement not in self.measurement_names])
 
 
 def formula_parser():

--- a/docs/dev/api/virtual-products.rst
+++ b/docs/dev/api/virtual-products.rst
@@ -168,6 +168,26 @@ where the ``settings`` are keyword arguments to the initializer of the transform
        def measurements(self, input_measurements):
            """ Dict[str, Measurement] -> Dict[str, Measurement] """
 
+Alternatively, for a chain of transforms to be applied sequentially, the recipe can take the form:
+
+.. code-block:: text
+
+    {'transform': [<unapplied-transformation-1>,
+                   <unapplied-transformation-2>,
+                   ...,
+                   <unapplied-transformation-N>],
+     'input': <input-virtual-product>}
+
+where each of the unapplied transformations has the form:
+
+.. code-block:: text
+
+    {'transform': <transformation-class>,
+     **settings}
+
+where the ``input`` is omitted. The transformations are applied to the common ``input`` in reverse order,
+as in the familiar case of function application.
+
 ODC has a (growing) set of built-in transformations:
 
 .. currentmodule:: datacube.virtual.transformations


### PR DESCRIPTION
### Reason for this pull request
It is becoming increasingly common in virtual product catalogs to apply similar transformations to multiple products. The UX for this could be better.

### Proposed changes
- Enable specifying chains of transformations to be applied one after. Without this the yaml recipes for indentation of long chains of transformations become unwieldy. 
- Enable transformations to be specified separately from products that do not specify their input products so that abstraction is encouraged. Also sharing recipes of transformations among products become easier.
- Enable autocompletion of product and transform names as attributes of the catalog object. Helps discovery, also helps applying transforms to products.
- Add documentation for chains of transformations.

 - [X] Tests added / passed