### PR TITLE
Virtual product catalog support for defining transforms

### DIFF
--- a/datacube/virtual/catalog.py
+++ b/datacube/virtual/catalog.py
@@ -3,6 +3,24 @@ Catalog of virtual products.
 """
 
 from collections.abc import Mapping
+from itertools import chain
+
+import yaml
+
+from datacube.model.utils import SafeDumper
+
+
+class UnappliedTransform:
+    def __init__(self, name_resolver, recipe):
+        self.name_resolver = name_resolver
+        self.recipe = recipe
+
+    def __call__(self, input):
+        return self.name_resolver.construct(**self.recipe, input=input)
+
+    def __repr__(self):
+        return yaml.dump(self.recipe, Dumper=SafeDumper,
+                         default_flow_style=False, indent=2)
 
 
 class Catalog(Mapping):
@@ -13,21 +31,39 @@ class Catalog(Mapping):
     def __init__(self, name_resolver, contents):
         self.name_resolver = name_resolver
         self.contents = contents
+        common = set(self._names('products')) & set(self._names('transforms'))
+        assert not common, f"common names found in products and transforms {common}"
 
-    def __getitem__(self, product_name):
+    def _names(self, section):
+        """ List of names under a section (products or transforms). """
+        if section not in self.contents:
+            return []
+        return list(self.contents[section])
+
+    def __getitem__(self, name):
         """
-        Look up virtual product by name.
+        Looks up a virtual product or transform by name.
+        Returns `None` if not found.
         """
-        return self.name_resolver.construct(**self.contents['products'][product_name]['recipe'])
+        if name in self._names('products'):
+            return self.name_resolver.construct(**self.contents['products'][name]['recipe'])
+        if name in self._names('transforms'):
+            return UnappliedTransform(self.name_resolver, self.contents['transforms'][name]['recipe'])
+
+        # raising a `KeyError` here stops autocompletion from working
+        return None
+
+    def __getattr__(self, name):
+        return self[name]
 
     def __len__(self):
-        return len(self.contents['products'])
+        return len(self._names('products')) + len(self._names('transforms'))
 
     def __iter__(self):
-        return iter(self.contents['products'])
+        return chain(iter(self._names('products')), iter(self._names('transforms')))
 
-    def describe(self, product_name):
+    def __dir__(self):
         """
-        Section describing the product in the catalog.
+        Override to provide autocompletion of products and transforms.
         """
-        return self.contents['products'][product_name]
+        return sorted(dir(Mapping) + list(self.__dict__) + self._names('products') + self._names('transforms'))


### PR DESCRIPTION
### Reason for this pull request
It is becoming increasingly common in virtual product catalogs to apply similar transformations to multiple products. The UX for this could be better.


### Proposed changes
- Enable transformations to be specified separately from products that do not specify their input products so that abstraction is encouraged. Also sharing recipes of transformations among products become easier.
- Enable autocompletion of product and transform names as attributes of the catalog object. Helps discovery, also helps applying transforms to products.
