### PR TITLE
Various minor cleanups/addition in geometry

### DIFF
--- a/check-code.sh
+++ b/check-code.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Convenience script for running Travis-like checks.
+# Convenience script for running CI-like checks.
 
 set -eu
 set -x
@@ -15,18 +15,27 @@ if [ "${1:-}" == "--with-docker" ]; then
     fi
 
     exec docker run $ti \
+         -e SKIP_STYLE_CHECK="${SKIP_STYLE_CHECK:-no}" \
          -v $(pwd):/src/datacube-core \
          opendatacube/datacube-tests:latest \
          $0 $@
 fi
 
-pycodestyle tests integration_tests examples --max-line-length 120
-
-pylint -j 2 --reports no datacube datacube_apps
+if [ "${SKIP_STYLE_CHECK:-no}" != "yes" ]; then
+    pycodestyle tests integration_tests examples --max-line-length 120
+    pylint -j 2 --reports no datacube datacube_apps
+fi
 
 # Run tests, taking coverage.
 # Users can specify extra folders as arguments.
-pytest -r a --cov datacube --doctest-ignore-import-errors --durations=5 datacube tests datacube_apps $@
+pytest -r a \
+       --cov datacube \
+       --doctest-ignore-import-errors \
+       --durations=5 \
+       datacube \
+       tests \
+       datacube_apps \
+       $@
 
 set +x
 

--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -412,7 +412,7 @@ class Geometry:
 
     @property
     def coords(self) -> CoordList:
-        return self.geom.coords
+        return list(self.geom.coords)
 
     @property
     def points(self) -> CoordList:

--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -444,6 +444,10 @@ class Geometry:
         return self.geom.wkt
 
     @property
+    def __array_interface__(self):
+        return self.geom.__array_interface__
+
+    @property
     def __geo_interface__(self):
         return self.geom.__geo_interface__
 

--- a/docker/assets/with_bootstrap
+++ b/docker/assets/with_bootstrap
@@ -38,7 +38,7 @@ launch_db () {
         groupmod --gid "${target_gid}" odc
         usermod --gid "${target_gid}" --uid "${target_uid}" odc
         chown -R odc:odc /home/odc/
-        exec sudo -u odc -H bash "$0" "$@"
+        exec sudo -u odc -E -H bash "$0" "$@"
     }
 }
 

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -2,7 +2,6 @@ Docker for running test suite
 =============================
 
 - Pushed to docker hub as `opendatacube/datacube-tests`
-- Based on `osgeo/gdal:ubuntu-small-3.0.2`
 
 Example Use:
 

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -172,3 +172,12 @@ def test_solar_day():
         solar_day(ds)
 
     assert 'Cannot compute solar_day: dataset is missing spatial info' in str(e.value)
+
+
+@pytest.mark.xfail(True, reason="Queries that pass antimeridian do not work")
+def test_dateline_query_building():
+    lon = Query(x=(618300, 849000),
+                y=(-1876800, -1642500),
+                crs='EPSG:32660').search_terms['lon']
+
+    assert lon.begin < 180 < lon.end

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -591,48 +591,8 @@ def test_geobox_xr_coords():
 
 
 def test_wrap_dateline():
-    sinus_crs = geometry.CRS("""PROJCS["unnamed",
-                           GEOGCS["Unknown datum based upon the custom spheroid",
-                           DATUM["Not specified (based on custom spheroid)", SPHEROID["Custom spheroid",6371007.181,0]],
-                           PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]],
-                           PROJECTION["Sinusoidal"],
-                           PARAMETER["longitude_of_center",0],
-                           PARAMETER["false_easting",0],
-                           PARAMETER["false_northing",0],
-                           UNIT["Meter",1]]""")
     albers_crs = epsg3577
     geog_crs = epsg4326
-
-    wrap = geometry.polygon([(12231455.716333, -5559752.598333),
-                             (12231455.716333, -4447802.078667),
-                             (13343406.236, -4447802.078667),
-                             (13343406.236, -5559752.598333),
-                             (12231455.716333, -5559752.598333)], crs=sinus_crs)
-    wrapped = wrap.to_crs(geog_crs)
-    assert wrapped.type == 'Polygon'
-    wrapped = wrap.to_crs(geog_crs, wrapdateline=True)
-    # assert wrapped.type == 'MultiPolygon' TODO: these cases are quite hard to implement.
-    # hopefully GDAL's CutGeometryOnDateLineAndAddToMulti will be available through py API at some point
-
-    wrap = geometry.polygon([(13343406.236, -5559752.598333),
-                             (13343406.236, -4447802.078667),
-                             (14455356.755667, -4447802.078667),
-                             (14455356.755667, -5559752.598333),
-                             (13343406.236, -5559752.598333)], crs=sinus_crs)
-    wrapped = wrap.to_crs(geog_crs)
-    assert wrapped.type == 'Polygon'
-    wrapped = wrap.to_crs(geog_crs, wrapdateline=True)
-    # assert wrapped.type == 'MultiPolygon' TODO: same as above
-
-    wrap = geometry.polygon([(14455356.755667, -5559752.598333),
-                             (14455356.755667, -4447802.078667),
-                             (15567307.275333, -4447802.078667),
-                             (15567307.275333, -5559752.598333),
-                             (14455356.755667, -5559752.598333)], crs=sinus_crs)
-    wrapped = wrap.to_crs(geog_crs)
-    assert wrapped.type == 'Polygon'
-    wrapped = wrap.to_crs(geog_crs, wrapdateline=True)
-    # assert wrapped.type == 'MultiPolygon' TODO: same as above
 
     wrap = geometry.polygon([(3658653.1976781483, -4995675.379595791),
                              (4025493.916030875, -3947239.249752495),
@@ -645,6 +605,42 @@ def test_wrap_dateline():
     wrapped = wrap.to_crs(geog_crs, wrapdateline=True)
     assert wrapped.type == 'MultiPolygon'
     assert not wrapped.intersects(geometry.line([(0, -90), (0, 90)], crs=geog_crs))
+
+
+@pytest.mark.xfail(True, reason="Wrap dateline not working in these cases")
+@pytest.mark.parametrize("pts", [
+    [(12231455.716333, -5559752.598333),
+     (12231455.716333, -4447802.078667),
+     (13343406.236, -4447802.078667),
+     (13343406.236, -5559752.598333),
+     (12231455.716333, -5559752.598333)],
+    [(13343406.236, -5559752.598333),
+     (13343406.236, -4447802.078667),
+     (14455356.755667, -4447802.078667),
+     (14455356.755667, -5559752.598333),
+     (13343406.236, -5559752.598333)],
+    [(14455356.755667, -5559752.598333),
+     (14455356.755667, -4447802.078667),
+     (15567307.275333, -4447802.078667),
+     (15567307.275333, -5559752.598333),
+     (14455356.755667, -5559752.598333)],
+])
+def test_wrap_dateline_sinusoidal(pts):
+    sinus_crs = geometry.CRS("""PROJCS["unnamed",
+                           GEOGCS["Unknown datum based upon the custom spheroid",
+                           DATUM["Not specified (based on custom spheroid)", SPHEROID["Custom spheroid",6371007.181,0]],
+                           PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]],
+                           PROJECTION["Sinusoidal"],
+                           PARAMETER["longitude_of_center",0],
+                           PARAMETER["false_easting",0],
+                           PARAMETER["false_northing",0],
+                           UNIT["Meter",1]]""")
+
+    wrap = geometry.polygon(pts, crs=sinus_crs)
+    wrapped = wrap.to_crs(epsg4326)
+    assert wrapped.type == 'Polygon'
+    wrapped = wrap.to_crs(epsg4326, wrapdateline=True)
+    assert wrapped.type == 'MultiPolygon'  # fails here
 
 
 def test_3d_geometry_converted_to_2d_geometry():

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -212,6 +212,10 @@ def test_ops():
     with pytest.raises(TypeError):
         pt.interpolate(3)
 
+    # test array interface
+    assert line.__array_interface__ is not None
+    assert np.array(line).shape == (3, 2)
+
     # test simplify
     poly = geometry.polygon([(0, 0), (0, 5), (10, 5)], epsg4326)
     assert poly.simplify(100) == poly

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -207,6 +207,7 @@ def test_ops():
     pt = line.interpolate(1)
     assert pt.crs is line.crs
     assert pt.coords[0] == (0, 1)
+    assert isinstance(pt.coords, list)
 
     with pytest.raises(TypeError):
         pt.interpolate(3)


### PR DESCRIPTION
- Match implementation to signature for `Geometry.coords|points`
- Expose `__array_interface__` of the shapely geometry
- Cleanup `check-code.sh` script and allow skipping style checks
- Cleanup in test docker
- Add `xfail` test for `to_crs(..., wrapdetiline=True)`
- Add `xfail` test for Query construction across `lon=180`