### PR TITLE
Expose more shapely operators on Geometry class

### DIFF
--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -429,6 +429,14 @@ class Geometry:
         return Geometry(self.geom.boundary, self.crs)
 
     @property
+    def exterior(self) -> 'Geometry':
+        return Geometry(self.geom.exterior, self.crs)
+
+    @property
+    def interiors(self) -> List['Geometry']:
+        return [Geometry(g, self.crs) for g in self.geom.interiors]
+
+    @property
     def centroid(self) -> 'Geometry':
         return Geometry(self.geom.centroid, self.crs)
 

--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -1,6 +1,7 @@
 import functools
 import itertools
 import math
+import array
 from collections import namedtuple, OrderedDict
 from typing import Tuple, Iterable, List, Union, Optional, Any, Callable, Hashable, Dict
 from collections.abc import Sequence
@@ -455,6 +456,10 @@ class Geometry:
     @property
     def area(self) -> float:
         return self.geom.area
+
+    @property
+    def xy(self) -> Tuple[array.array, array.array]:
+        return self.geom.xy
 
     @property
     def convex_hull(self) -> 'Geometry':

--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -390,6 +390,28 @@ class Geometry:
     def union(self, other: 'Geometry') -> 'Geometry':
         return self.union(other)
 
+    @wrap_shapely
+    def __and__(self, other: 'Geometry') -> 'Geometry':
+        return self.__and__(other)
+
+    @wrap_shapely
+    def __or__(self, other: 'Geometry') -> 'Geometry':
+        return self.__or__(other)
+
+    @wrap_shapely
+    def __xor__(self, other: 'Geometry') -> 'Geometry':
+        return self.__xor__(other)
+
+    @wrap_shapely
+    def __sub__(self, other: 'Geometry') -> 'Geometry':
+        return self.__sub__(other)
+
+    def svg(self) -> str:
+        return self.geom.svg()
+
+    def _repr_svg_(self) -> str:
+        return self.geom._repr_svg_()
+
     @property
     def type(self) -> str:
         return self.geom.type

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -232,6 +232,18 @@ def test_ops():
     assert all(p.crs == poly_2_parts.crs for p in pp)
 
 
+def test_shapely_wrappers():
+    poly = geometry.polygon([(0, 0), (0, 5), (10, 5)], epsg4326)
+
+    assert isinstance(poly.svg(), str)
+    assert isinstance(poly._repr_svg_(), str)
+
+    assert (poly | poly) == poly
+    assert (poly & poly) == poly
+    assert (poly ^ poly).is_empty
+    assert (poly - poly).is_empty
+
+
 def test_to_crs():
     poly = geometry.polygon([(0, 0), (0, 5), (10, 5)], epsg4326)
     assert poly.crs is epsg4326

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -246,6 +246,11 @@ def test_shapely_wrappers():
     assert with_hole.interiors[0].crs == with_hole.crs
     assert poly.exterior.crs == poly.crs
 
+    x, y = poly.exterior.xy
+    assert len(x) == len(y)
+    assert x.typecode == y.typecode
+    assert x.typecode == 'd'
+
     assert (poly | poly) == poly
     assert (poly & poly) == poly
     assert (poly ^ poly).is_empty

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -259,10 +259,19 @@ def test_shapely_wrappers():
 
 def test_to_crs():
     poly = geometry.polygon([(0, 0), (0, 5), (10, 5)], epsg4326)
+    num_points = 3
     assert poly.crs is epsg4326
     assert poly.to_crs(epsg3857).crs is epsg3857
     assert poly.to_crs('EPSG:3857').crs == 'EPSG:3857'
     assert poly.to_crs('EPSG:3857', 0.1).crs == epsg3857
+
+    # test that by default segmentation happens
+    # +1 is because exterior loops back to start point
+    assert len(poly.to_crs(epsg3857).exterior.xy[0]) > num_points + 1
+
+    # test that +inf disables segmentation
+    # +1 is because exterior loops back to start point
+    assert len(poly.to_crs(epsg3857, float('+inf')).exterior.xy[0]) == num_points + 1
 
     poly = geometry.polygon([(0, 0), (0, 5), (10, 5)], None)
     assert poly.crs is None

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -273,6 +273,13 @@ def test_to_crs():
     # +1 is because exterior loops back to start point
     assert len(poly.to_crs(epsg3857, float('+inf')).exterior.xy[0]) == num_points + 1
 
+    # test the segmentation works on multi-polygons
+    mpoly = (geometry.box(0, 0, 1, 3, 'EPSG:4326') |
+             geometry.box(2, 4, 3, 6, 'EPSG:4326'))
+
+    assert mpoly.type == 'MultiPolygon'
+    assert mpoly.to_crs(epsg3857).type == 'MultiPolygon'
+
     poly = geometry.polygon([(0, 0), (0, 5), (10, 5)], None)
     assert poly.crs is None
     with pytest.raises(ValueError):

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -238,6 +238,14 @@ def test_shapely_wrappers():
     assert isinstance(poly.svg(), str)
     assert isinstance(poly._repr_svg_(), str)
 
+    with_hole = poly.buffer(1) - poly
+    assert len(poly.interiors) == 0
+    assert len(with_hole.interiors) == 1
+    assert isinstance(with_hole.interiors, list)
+    assert isinstance(with_hole.interiors[0], geometry.Geometry)
+    assert with_hole.interiors[0].crs == with_hole.crs
+    assert poly.exterior.crs == poly.crs
+
     assert (poly | poly) == poly
     assert (poly & poly) == poly
     assert (poly ^ poly).is_empty


### PR DESCRIPTION
- Expose a bunch of set oeprators
- Expose `svg` and `_repr_svg_` (for notebook display)
- Change `.to_crs`
  - no segmentation if resolution is infirnite
  - segment before "chopping along dateline" not after

