### PR TITLE
Working driver metadata storage and retrieval.

### DIFF
--- a/datacube/scripts/ingest.py
+++ b/datacube/scripts/ingest.py
@@ -282,13 +282,13 @@ def ingest_work(config, source_type, output_type, tile, tile_index):
         'complevel': 9,
     }
 
-    storage_metadata = driver.write_dataset_to_storage(nudata, file_path,
-                                                       global_attributes=global_attributes,
-                                                       variable_params=variable_params,
-                                                       storage_config=config['storage'])
+    driver_data = driver.write_dataset_to_storage(nudata, file_path,
+                                                  global_attributes=global_attributes,
+                                                  variable_params=variable_params,
+                                                  storage_config=config['storage'])
 
-    if (storage_metadata is not None) and len(storage_metadata) > 0:
-        datasets.attrs['storage_metadata'] = storage_metadata
+    if (driver_data is not None) and len(driver_data) > 0:
+        datasets.attrs['driver_data'] = driver_data
 
     _LOG.info('Finished task %s', tile_index)
 
@@ -300,12 +300,12 @@ def _index_datasets(index, results):
     for datasets in results:
         extra_args = {}
         # datasets is an xarray.DataArray
-        if 'storage_metadata' in datasets.attrs:
-            extra_args['storage_metadata'] = datasets.attrs['storage_metadata']
+        if 'driver_data' in datasets.attrs:
+            extra_args['driver_data'] = datasets.attrs['driver_data']
 
         for dataset in datasets.values:
-            if 'storage_metadata' in extra_args:
-                dataset.metadata_doc['storage_metadata'] = extra_args['storage_metadata']
+            if 'driver_data' in extra_args:
+                dataset.metadata_doc['driver_data'] = extra_args['driver_data']
             index.datasets.add(dataset, with_lineage=False, **extra_args)
             n += 1
     return n

--- a/datacube/scripts/ingest.py
+++ b/datacube/scripts/ingest.py
@@ -304,6 +304,8 @@ def _index_datasets(index, results):
             extra_args['storage_metadata'] = datasets.attrs['storage_metadata']
 
         for dataset in datasets.values:
+            if 'storage_metadata' in extra_args:
+                dataset.metadata_doc['storage_metadata'] = extra_args['storage_metadata']
             index.datasets.add(dataset, with_lineage=False, **extra_args)
             n += 1
     return n

--- a/datacube/storage/_base.py
+++ b/datacube/storage/_base.py
@@ -42,10 +42,7 @@ def _get_band_and_layer(b: Dict[str, Any]) -> Tuple[Optional[int], Optional[str]
 
 
 def _extract_driver_data(ds: Dataset) -> Optional[Any]:
-    if 'storage_metadata' in ds.metadata_doc:
-        return ds.metadata_doc['storage_metadata']
-    else:
-        return None
+    return ds.metadata_doc.get('driver_data', None)
 
 def measurement_paths(ds: Dataset) -> Dict[str, str]:
     """

--- a/datacube/storage/_base.py
+++ b/datacube/storage/_base.py
@@ -42,11 +42,10 @@ def _get_band_and_layer(b: Dict[str, Any]) -> Tuple[Optional[int], Optional[str]
 
 
 def _extract_driver_data(ds: Dataset) -> Optional[Any]:
-    dd = getattr(ds, 'driver_data', None)
-    if dd is None:
-        dd = getattr(ds, 's3_metadata', None)  # TODO: change CSIRO driver to populate `driver_data`
-    return dd
-
+    if 'storage_metadata' in ds.metadata_doc:
+        return ds.metadata_doc['storage_metadata']
+    else:
+        return None
 
 def measurement_paths(ds: Dataset) -> Dict[str, str]:
     """

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -19,6 +19,7 @@ v1.8rc (???)
 - Deprecated ``datacube.storage.masking``, moved to ``datacube.utils.masking``
 - Changed geo-registration mechanics for arrays returned by ``dc.load``. (:pull:`899`, :issue:`837`)
 - Migrate geometry and CRS backends from ``osgeo.ogr`` and ``osgeo.osr`` to ``shapely`` and ``pyproj`` respectively (:pull:`880`)
+- Driver metadata storage and retrieval. (:pull:`931`)
 
 v1.7.0 (16 May 2019)
 ====================

--- a/docs/architecture/driver.rst
+++ b/docs/architecture/driver.rst
@@ -67,6 +67,8 @@ Example code to implement a reader driver
     class AbstractDataSource(object):  # Same interface as before
         ...
 
+Driver specific metadata will be present in ``BandInfo.driver_data`` if saved during ``write_dataset_to_storage``
+
 Example Pickle Based Driver
 ---------------------------
 
@@ -118,6 +120,8 @@ Example code to implement a writer driver
                                      **kwargs):
             ...
             return {}  # Can return extra metadata to be saved in the index with the dataset
+
+Extra metadata will be saved into the database and loaded into ``BandInfo`` during a load operation.
 
 NetCDF Writer Driver
 --------------------


### PR DESCRIPTION
### Working driver metadata storage and retrieval.

Storage of driver metadata during ingest and loading via BandInfo was partially implemented.
This PR addresses this.


### Proposed changes

- Store metadata from `write_dataset_to_storage` in `ingest.py`
- Load into `BandInfo.driver_data` and made available to the Reader Driver during a `dc.load`

 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
