### PR TITLE
Access configuration via `.get(key, fallback)` interface in simple_replica code

### DIFF
--- a/datacube_apps/simple_replica.py
+++ b/datacube_apps/simple_replica.py
@@ -112,7 +112,8 @@ class DatacubeReplicator(object):
         self.tunnel = SSHTunnelForwarder(
             self.remote_host,
             ssh_username=self.remote_user,
-            remote_bind_address=(self.remote_dc_config.db_hostname, int(self.remote_dc_config.db_port)))
+            remote_bind_address=(self.remote_dc_config.get('db_hostname', '127.0.0.1'),
+                                 int(self.remote_dc_config.get('db_port', 5432))))
         self.tunnel.start()
 
         # pylint: disable=protected-access


### PR DESCRIPTION
I don't know when `LocalConfig` class exposed attribute access via `.db_hostname`,
but it doesn't now.

 - [x] Closes #938
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
