### PR TITLE
Simplify eo3 detection: use only $schema

### DIFF
--- a/docs/ops/dataset_documents.rst
+++ b/docs/ops/dataset_documents.rst
@@ -15,6 +15,9 @@ Traditionally :ref:`dataset-metadata-doc-eo` format was used to capture
 information about individual datasets. However there are a number of issues with
 this format, hence deprecation and move to :ref:`dataset-metadata-doc-eo3`.
 
+The format is determined by ODC using the ``$schema`` field in the document.
+Include an eo3 ``$schema`` for eo3 documents. If no schema field exists, it
+is treated as the older ``eo`` format.
 
 .. _dataset-metadata-doc-eo3:
 
@@ -39,10 +42,10 @@ EO3 is an intermediate format before we move to something more standard like `ST
 
    # Product name
    product:
-     name: landsat8
+     name: landsat8_example_product
 
    # Native CRS, assumed to be the same across all bands
-   crs: "EPSG:32660"
+   crs: "epsg:32660"
 
    # Optional GeoJSON object in the units of native CRS.
    # Defines a polygon such that, all valid pixels across all bands
@@ -82,13 +85,13 @@ EO3 is an intermediate format before we move to something more standard like `ST
    # Dataset properties, prefer STAC standard names here
    # Timestamp is the only compulsory field here
    properties:
-     datetime: '2020-01-01T07:02:54.188Z'  # Use UTC
+     datetime: 2020-01-01T07:02:54.188Z  # Use UTC
      # When recording time range use these names
      #   dtr:start_datetime:
      #   dtr:end_datetime:
 
      odc:file_format: GeoTIFF
-     odc:processing_datetime: '2020-01-01T07:02:54.188Z'
+     odc:processing_datetime: 2020-01-01T07:02:54.188Z
 
    # Lineage only references UUIDs of direct source datasets
    # Mapping name:str -> [UUID]
@@ -99,6 +102,11 @@ Elements ``shape`` and ``transform`` can be obtained from the output of ``rio
 info <image-file>``. ``shape`` is basically ``height, width`` tuple and
 ``transform`` captures a linear mapping from pixel space to projected space
 encoded in a row-major order:
+
+A command-line tool to validate eo3 documents called ``eo3-validate`` is available
+in the `eodatasets3 library <https://github.com/GeoscienceAustralia/eo-datasets>`_,
+ as well as optional tools to write these files more easily.
+
 
 .. code-block::
 

--- a/integration_tests/data/dataset_add/datasets_eo3.yml
+++ b/integration_tests/data/dataset_add/datasets_eo3.yml
@@ -1,8 +1,14 @@
 ---
+$schema: https://schemas.opendatacube.org/dataset
 id: 7d41a4d0-2ab3-4da1-a010-ef48662ae8ef
-product: EO3
+product:
+  name: eo3_test
 
-crs: "EPSG:3857"
+crs: "epsg:3857"
+properties:
+    datetime: 2020-04-20 00:26:43Z
+    odc:processing_datetime: 2020-05-16 10:56:18Z
+
 grids:
     default:
        shape: [100, 200]
@@ -12,12 +18,19 @@ lineage:
   bc:
     - fb077e47-f62e-5869-9bd1-03584c2d7380
     - 13d3d75a-1d90-5ec0-8b86-e8be78275660
----
-# crossing lon=180
-id: f884df9b-4458-47fd-a9d2-1a52a2db8a1a
-product: EO3
 
-crs: "EPSG:32660"
+---
+# Crossing lon=180
+$schema: https://schemas.opendatacube.org/dataset
+id: f884df9b-4458-47fd-a9d2-1a52a2db8a1a
+product:
+  name: eo3_test
+
+crs: "epsg:32660"
+properties:
+    datetime: 2020-04-20 00:26:43Z
+    odc:processing_datetime: 2020-05-16 10:56:18Z
+
 grids:
     default:
        shape: [7811, 7691]

--- a/integration_tests/data/dataset_add/products.yml
+++ b/integration_tests/data/dataset_add/products.yml
@@ -47,4 +47,5 @@ name: EO3
 description: test product EO3
 metadata_type: eo3_minimal
 metadata:
-  product: EO3
+    product:
+        name: eo3_test


### PR DESCRIPTION
We know that all eo3 documents have a schema if they pass the validator tool, and all older datasets have no schema. So instead of heuristics, we can just use the `$schema` field to detect if it's eo3.

It also now rejects unknown schemas. Several of us have indexed eo3 documents accidentally recently, which ODC-1.7 quietly accepts despite not supporting eo3. It's friendlier to reject them immediately, and leaves room to match a Stac Item or Eo4 schema in the future.

- [x] Tests updated