### PR TITLE
Remove support for older schemas

### DIFF
--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -6,6 +6,7 @@ Core SQL schema settings.
 import logging
 
 from sqlalchemy import MetaData
+from sqlalchemy.engine import Engine
 from sqlalchemy.schema import CreateSchema
 
 from datacube.drivers.postgres.sql import TYPES_INIT_SQL, pg_exists, pg_column_exists, escape_pg_identifier
@@ -117,72 +118,46 @@ def database_exists(engine):
     return has_schema(engine, engine)
 
 
-def schema_is_latest(engine):
+def schema_is_latest(engine: Engine) -> bool:
     """
-    Over the lifetime of ODC there have been a couple of schema updates. For now we don't
-    version the schema, but we do need to check we're running against the latest.
+    Is the current schema up-to-date?
 
-    We may have a versioned schema in the future.
-    For now, we know updates have been applied if certain objects exist.
+    This is run when a new connection is established to see if it's compatible.
+
+    It should be runnable by unprivileged users. If it returns false, their
+    connection will be rejected and they will be told to get an administrator
+    to apply updates.
+
+    See the ``update_schema()`` function below for actually applying the updates.
     """
-    # We may have versioned schema in the future.
-    # For now, we know updates have been applied if certain objects exist,
+    # In lieu of a versioned schema, we typically check by seeing if one of the objects
+    # from the change exists.
+    #
+    # Eg.
+    #     return pg_column_exists(engine, schema_qualified('dataset_location'), 'archived')
+    #
+    # ie. Does the 'archived' column exist? If so, we know the related schema was applied.
 
-    location_first_index = 'ix_{schema}_dataset_location_dataset_ref'.format(schema=SCHEMA_NAME)
-
-    has_dataset_source_update = not pg_exists(engine, schema_qualified('uq_dataset_source_dataset_ref'))
-    has_uri_searches = pg_exists(engine, schema_qualified(location_first_index))
-    has_dataset_location = pg_column_exists(engine, schema_qualified('dataset_location'), 'archived')
-    return has_dataset_source_update and has_uri_searches and has_dataset_location
+    # No schema changes recently. Everything is perfect.
+    return True
 
 
-def update_schema(engine):
+def update_schema(engine: Engine):
     """
-    Instead of versioning our schema, this function ensures we are running against the latest
-    version of the database schema.
+    Check and apply any missing schema changes to the database.
+
+    This is run by an administrator.
+
+    See the `schema_is_latest()` function above: this should apply updates
+    that it requires.
     """
-    is_unification = pg_exists(engine, schema_qualified('dataset_type'))
-    if not is_unification:
-        raise ValueError('Pre-unification database cannot be updated.')
+    # This will typically check if something exists (like a newly added column), and
+    # run the SQL of the change inside a single transaction.
 
-    # Removal of surrogate key from dataset_source: it makes the table larger for no benefit.
-    if pg_exists(engine, schema_qualified('uq_dataset_source_dataset_ref')):
-        _LOG.info('Applying surrogate-key update')
-        engine.execute("""
-        begin;
-          alter table {schema}.dataset_source drop constraint pk_dataset_source;
-          alter table {schema}.dataset_source drop constraint uq_dataset_source_dataset_ref;
-          alter table {schema}.dataset_source add constraint pk_dataset_source primary key(dataset_ref, classifier);
-          alter table {schema}.dataset_source drop column id;
-        commit;
-        """.format(schema=SCHEMA_NAME))
-        _LOG.info('Completed surrogate-key update')
-
-    # float8range is needed if the user uses the double-range field type.
-    if not engine.execute("SELECT 1 FROM pg_type WHERE typname = 'float8range'").scalar():
-        engine.execute(TYPES_INIT_SQL)
-
-    if not pg_column_exists(engine, schema_qualified('dataset_location'), 'archived'):
-        _LOG.info('Applying dataset_location.archived update')
-        engine.execute("""
-          alter table {schema}.dataset_location add column archived TIMESTAMP WITH TIME ZONE
-          """.format(schema=SCHEMA_NAME))
-        _LOG.info('Completed dataset_location.archived update')
-
-    # Update uri indexes to allow dataset search-by-uri.
-    if not pg_exists(engine, schema_qualified('ix_{schema}_dataset_location_dataset_ref'.format(schema=SCHEMA_NAME))):
-        _LOG.info('Applying uri-search update')
-        engine.execute("""
-        begin;
-          -- Add a separate index by dataset.
-          create index ix_{schema}_dataset_location_dataset_ref on {schema}.dataset_location (dataset_ref);
-
-          -- Replace (dataset, uri) index with (uri, dataset) index.
-          alter table {schema}.dataset_location add constraint uq_dataset_location_uri_scheme unique (uri_scheme, uri_body, dataset_ref);
-          alter table {schema}.dataset_location drop constraint uq_dataset_location_dataset_ref;
-        commit;
-        """.format(schema=SCHEMA_NAME))
-        _LOG.info('Completed uri-search update')
+    # Empty, as no schema changes have been made recently.
+    # -> If you need to write one, look at the Git history of this
+    #    function for some examples.
+    return
 
 
 def _ensure_role(engine, name, inherits_from=None, add_user=False, create_db=False):

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -21,7 +21,9 @@ v1.8rc (???)
 - Migrate geometry and CRS backends from ``osgeo.ogr`` and ``osgeo.osr`` to ``shapely`` and ``pyproj`` respectively (:pull:`880`)
 - Driver metadata storage and retrieval. (:pull:`931`)
 - Support EO3 style datasets in ``datacube dataset add`` (:pull:`929`, :issue:`864`)
-
+- Removed migration support from datacube releases before 1.1.5.
+    If you still run a datacube before 1.1.5 (from 2016 or older), you will need to update it
+    using ODC 1.7 first, before coming to 1.8.
 
 v1.7.0 (16 May 2019)
 ====================


### PR DESCRIPTION
The most recent of these schema updates is from early 2017 (datacube 1.1.5): 2986a677ff77573e3effa42a9d06a3fff39cc7b3

Anyone that has not already applied these updates must still be running `datacube < 1.1.5`, and I strongly suspect has already lost backwards compatibility in other ways.

Removing these will save a few query round-trips on each `dc = Datacube()` initialisation.
