### PR TITLE
Install doc building dependencies in test docker #934

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -58,6 +58,9 @@ RUN apt-get update \
   sudo \
   # git is needed for sdist|bdist_wheel
   git \
+  # for docs
+  make \
+  graphviz \
   && rm -rf /var/lib/apt/lists/*
 
 # if using binary rasterio package, to support https

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -4,11 +4,11 @@ dkr := $(image_name):$(image_tag)
 
 all: docker
 
-dist/datacube.tar.gz: ../setup.py
-	(cd .. && python3 setup.py sdist --dist-dir ./docker/dist/)
-	(cd dist && find . -type f -exec ln -sf '{}' datacube.tar.gz ';')
+dist/datacube.whl: ../setup.py
+	(cd .. && python3 setup.py bdist_wheel --dist-dir ./docker/dist/)
+	(cd dist && find . -type f -name "datacube*whl" -exec ln -sf '{}' datacube.whl ';')
 
-docker: dist/datacube.tar.gz
+docker: dist/datacube.whl
 	@echo Building $(dkr)
 	docker build -t $(dkr) .
 

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -11,6 +11,7 @@ wrapt==1.11.2
 
 # every new version finds new errors, so we pin it
 pylint==2.4.4
+pycodestyle==2.5.0
 
 # for packaging
 wheel
@@ -20,4 +21,4 @@ twine
 
 psycopg2 --no-binary=psycopg2
 
-datacube[test,cf,celery,s3,performance,distributed]
+datacube[all]


### PR DESCRIPTION
### Reason for this pull request

Adds `make` and `sphinx` libs. This won't build complete docs as `apt-get install -y pluntuml` is missing, but this is still useful with only small increase in docker image size.


 - [x] Closes #934 
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
