### PR TITLE
Only verify lineage if doc is not eo3

### DIFF
--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -9,7 +9,7 @@ from datacube.model import Dataset
 from datacube.utils import changes, InvalidDocException, SimpleDocNav, jsonify_document
 from datacube.model.utils import dedup_lineage, remap_lineage_doc, flatten_datasets
 from datacube.utils.changes import get_doc_changes
-from .eo3 import prep_eo3
+from .eo3 import prep_eo3, is_doc_eo3
 
 
 class BadMatch(Exception):
@@ -152,7 +152,7 @@ def dataset_resolver(index,
         if missing_lineage and fail_on_missing_lineage:
             return None, "Following lineage datasets are missing from DB: %s" % (','.join(missing_lineage))
 
-        if verify_lineage:
+        if verify_lineage and not is_doc_eo3(main_ds.doc):
             bad_lineage = []
 
             for uuid in lineage_uuids:

--- a/integration_tests/test_dataset_add.py
+++ b/integration_tests/test_dataset_add.py
@@ -255,7 +255,7 @@ def test_dataset_add(dataset_add_configs, index_empty, clirunner):
     assert 'WARNING --auto-match option is deprecated' in r.output
 
     # test dataset add eo3
-    r = clirunner(['dataset', 'add', '--no-verify-lineage', p.datasets_eo3])
+    r = clirunner(['dataset', 'add', p.datasets_eo3])
     assert r.exit_code == 0
 
     ds_eo3 = load_dataset_definition(p.datasets_eo3)


### PR DESCRIPTION
### Reason for this pull request

By default `datacube dataset add ...` performs lineage verification on eo3 documents which raises an error because eo3 documents don't contain info about linked datasets. See: #956 

### Proposed changes

- check is document is eo3 in `resolve` and perform check if its not eo3 and verify lineage is true

 - [ ] Closes #956 
 - [ ] Tests added / passed (I didn't see many tests in `tests/index` but im happy to add tests for this)
