### PR TITLE
update product page to eo3 plus new example product yaml

### DIFF
--- a/docs/config_samples/dataset_types/landsat8_example_product.yaml
+++ b/docs/config_samples/dataset_types/landsat8_example_product.yaml
@@ -28,7 +28,7 @@ measurements:
       units: 'bit_index'
       flags_definition:
         pixel_qa:
-          bits: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]
+          bits: [0,1,2,3,4,5,6,7,8,9,10,11]
           description: Level 2 pixel quality band 
           values:
             1: Fill

--- a/docs/config_samples/dataset_types/landsat8_example_product.yaml
+++ b/docs/config_samples/dataset_types/landsat8_example_product.yaml
@@ -5,9 +5,6 @@ metadata_type: eo3
 metadata:
     product:
         name: landsat8_example_product
-    properties:
-        eo:instrument: OLI_TIRS
-        eo:platform: landsat-8
 
 measurements:
     - name: 'red'

--- a/docs/config_samples/dataset_types/landsat8_example_product.yaml
+++ b/docs/config_samples/dataset_types/landsat8_example_product.yaml
@@ -1,0 +1,48 @@
+name: landsat8_example_product
+description: Landsat 8 example product
+metadata_type: eo3
+
+metadata:
+    product:
+        name: landsat8_example_product
+    properties:
+        eo:instrument: OLI_TIRS
+        eo:platform: landsat-8
+
+measurements:
+    - name: 'red'
+      aliases: [band_4, sr_band4]
+      dtype: int16
+      nodata: -9999
+      units: 'reflectance'
+    - name: 'blue'
+      aliases: [band_2, sr_band2]
+      dtype: int16
+      nodata: -9999
+      units: 'reflectance'
+    - name: 'pixel_qa'
+      aliases: [pixel_quality, level2_qa]
+      dtype: uint16
+      nodata: 1
+      units: 'bit_index'
+      flags_definition:
+        pixel_qa:
+          bits: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]
+          description: Level 2 pixel quality band
+          values:
+            1: Fill
+            2: Clear
+            4: Water
+            8: Cloud shadow
+            16: Snow
+            32: Cloud
+            64: Cloud Confidence Low Bit
+            128: Cloud Confidence High Bit
+            256: Cirrus Confidence Low Bit
+            512: Cirrus Confidence High Bit
+            1024: Terrain Occlusion
+            2048: Unused
+            4096: Unused
+            8192: Unused
+            16384: Unused
+            32786: Unused

--- a/docs/config_samples/dataset_types/landsat8_example_product.yaml
+++ b/docs/config_samples/dataset_types/landsat8_example_product.yaml
@@ -5,6 +5,10 @@ metadata_type: eo3
 metadata:
     product:
         name: landsat8_example_product
+    # Alternatively, include specific items to match
+    # properties:
+        # eo:instrument: OLI_TIRS
+        # eo:platform: landsat-8
 
 measurements:
     - name: 'red'
@@ -25,7 +29,7 @@ measurements:
       flags_definition:
         pixel_qa:
           bits: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]
-          description: Level 2 pixel quality band
+          description: Level 2 pixel quality band 
           values:
             1: Fill
             2: Clear
@@ -38,8 +42,20 @@ measurements:
             256: Cirrus Confidence Low Bit
             512: Cirrus Confidence High Bit
             1024: Terrain Occlusion
-            2048: Unused
-            4096: Unused
-            8192: Unused
-            16384: Unused
-            32786: Unused
+            2048: Unused  # Be careful of repeated names which could confuse the masking code
+        # Alternatively or additionally, use the bit on/off method
+        fill:
+          bits: 0
+          description: No data
+          values: {0: false, 1: true}
+        clear:
+          bits: 1
+          description: Clear
+          values: {0: no_clear_land, 1: clear_land}
+        # ...
+        cloud_confidence:
+          bits: [6, 7]
+          description: Cloud confidence
+          values: {0: none, 1: low, 2: medium, 3: high}
+        # ...
+            

--- a/docs/ops/product.rst
+++ b/docs/ops/product.rst
@@ -32,6 +32,15 @@ metadata
     It is used during indexing to match datasets to their products. That is, the keys and values defined
     here must also be in the :ref:`dataset-metadata-doc`.
 
+    In the above example, ``product: name`` would match a specific product.
+    
+    Alternatively one could include specific items to match such as::
+
+        metadata:
+            properties:
+                eo:instrument: OLI_TIRS
+                eo:platform: landsat-8
+
 storage (optional)
     Describes some of common storage attributes of all the datasets. While optional defining this will make
     product data easier to access and use.

--- a/docs/ops/product.rst
+++ b/docs/ops/product.rst
@@ -33,13 +33,6 @@ metadata
     here must also be in the :ref:`dataset-metadata-doc`.
 
     In the above example, ``product: name`` would match a specific product.
-    
-    Alternatively one could include specific items to match such as::
-
-        metadata:
-            properties:
-                eo:instrument: OLI_TIRS
-                eo:platform: landsat-8
 
 storage (optional)
     Describes some of common storage attributes of all the datasets. While optional defining this will make

--- a/docs/ops/product.rst
+++ b/docs/ops/product.rst
@@ -8,7 +8,7 @@ for a collection of datasets.
 
 .. highlight:: language
 
-.. literalinclude:: ../config_samples/dataset_types/dsm1sv10.yaml
+.. literalinclude:: ../config_samples/dataset_types/landsat_example_product.yaml
    :language: yaml
 
 name
@@ -29,7 +29,8 @@ license
 metadata
     Dictionary containing bits of metadata common to all the datasets in the product.
 
-    It is used during indexing to match datasets to their products.
+    It is used during indexing to match datasets to their products. That is, the keys and values defined
+    here must also be in the :ref:`dataset-metadata-doc`.
 
 storage (optional)
     Describes some of common storage attributes of all the datasets. While optional defining this will make
@@ -43,7 +44,8 @@ storage (optional)
         Use ``latitude``, ``longitude`` if the projection is geographic and ``x``, ``y`` otherwise
 
 measurements
-    List of measurements in this product
+    List of measurements in this product. The measurement names defined here need to match 1:1 with the measurement
+    key names defined in the :ref:`dataset-metadata-doc`.
 
     name
          Name of the measurement


### PR DESCRIPTION
### Reason for this pull request

Update the docs/ops/product definition page to an eo3 example. The new landsat8_example_product.yaml file is intended to (partly) match the eo3 dataset example in the following page.


### Proposed changes

- change product yaml referenced in the page
- add clarifications for product-dataset matching to metadata and measurements descriptions
- (likely a fairly minor contrib that doesn't require tests nor whats_new but please advise if otherwise)

 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
