### PR TITLE
Allow safe product license changes

### DIFF
--- a/datacube/index/_products.py
+++ b/datacube/index/_products.py
@@ -127,6 +127,7 @@ class ProductResource(object):
 
         updates_allowed = {
             ('description',): changes.allow_any,
+            ('license',): changes.allow_any,
             ('metadata_type',): changes.allow_any,
 
             # You can safely make the match rules looser but not tighter.


### PR DESCRIPTION
'License' was a new field added in ODC 1.8.0 for products, but it wasn't added to the safe-change-list, so `datacube product update` (and related API) currently block all additions/changes to it as unsafe changes.

Changing a license will not break ODC's schema, so I think license should be considered a safe change, just like changing the description of a product.

This is particularly timely because we want to encourage people to add licenses to products that currently have no license. License is a required field for Stac compatiblity, and Stac converters such as ODC Explorer don't pass validation without it.