### PR TITLE
Remove extra quotes in ensured_db code fixes #968

### DIFF
--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -85,7 +85,7 @@ def ensure_db(engine, with_permissions=True):
             raise
         finally:
             if with_permissions:
-                c.execute('set role "{}"'.format(quoted_user))
+                c.execute('set role {}'.format(quoted_user))
 
     if with_permissions:
         _LOG.info('Adding role grants.')


### PR DESCRIPTION
In `ensure_db` variable `quoted_user` already has quotes, so don't add more.


 - [x] Closes #968
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
