### PR TITLE
Fix exception in `datacube dataset update` for numeric keys

### DIFF
--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -265,7 +265,7 @@ class DatasetResource(object):
 
         return not bad_changes, good_changes, bad_changes
 
-    def update(self, dataset, updates_allowed=None):
+    def update(self, dataset: Dataset, updates_allowed=None):
         """
         Update dataset metadata and location
         :param Dataset dataset: Dataset to update
@@ -287,7 +287,7 @@ class DatasetResource(object):
             _LOG.warning("Unsafe change in %s from %r to %r", _readable_offset(offset), old_val, new_val)
 
         if not can_update:
-            raise ValueError("Unsafe changes at " + (
+            raise ValueError(f"Unsafe changes in {dataset.id}: " + (
                 ", ".join(
                     _readable_offset(offset)
                     for offset, _, _ in unsafe_changes

--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -10,7 +10,7 @@ from uuid import UUID
 
 from datacube.model import Dataset, DatasetType
 from datacube.model.utils import flatten_datasets
-from datacube.utils import jsonify_document, changes, cached_property
+from datacube.utils import jsonify_document, _readable_offset, changes, cached_property
 from datacube.utils.changes import get_doc_changes
 from . import fields
 
@@ -280,17 +280,21 @@ class DatasetResource(object):
             _LOG.info("No changes detected for dataset %s", dataset.id)
             return dataset
 
-        if not can_update:
-            full_message = "Unsafe changes at " + ", ".join(".".join(offset) for offset, _, _ in unsafe_changes)
-            raise ValueError(full_message)
-
-        _LOG.info("Updating dataset %s", dataset.id)
-
         for offset, old_val, new_val in safe_changes:
-            _LOG.info("Safe change from %r to %r", old_val, new_val)
+            _LOG.info("Safe change in %s from %r to %r", _readable_offset(offset), old_val, new_val)
 
         for offset, old_val, new_val in unsafe_changes:
-            _LOG.info("Unsafe change from %r to %r", old_val, new_val)
+            _LOG.warning("Unsafe change in %s from %r to %r", _readable_offset(offset), old_val, new_val)
+
+        if not can_update:
+            raise ValueError("Unsafe changes at " + (
+                ", ".join(
+                    _readable_offset(offset)
+                    for offset, _, _ in unsafe_changes
+                )
+            ))
+
+        _LOG.info("Updating dataset %s", dataset.id)
 
         product = self.types.get_by_name(dataset.type.name)
         with self._db.begin() as transaction:

--- a/datacube/index/_metadata_types.py
+++ b/datacube/index/_metadata_types.py
@@ -111,7 +111,7 @@ class MetadataTypeResource(object):
             _LOG.info("Safe change in %s from %r to %r", _readable_offset(offset), old_val, new_val)
 
         for offset, old_val, new_val in bad_changes:
-            _LOG.info("Unsafe change in %s from %r to %r", _readable_offset(offset), old_val, new_val)
+            _LOG.warning("Unsafe change in %s from %r to %r", _readable_offset(offset), old_val, new_val)
 
         return allow_unsafe_updates or not bad_changes, good_changes, bad_changes
 
@@ -137,9 +137,12 @@ class MetadataTypeResource(object):
             return self.get_by_name(metadata_type.name)
 
         if not can_update:
-            full_message = "Unsafe changes at " + ", ".join(".".join(map(str, offset))
-                                                            for offset, _, _ in unsafe_changes)
-            raise ValueError(full_message)
+            raise ValueError("Unsafe changes at " + (
+                ", ".join(
+                    _readable_offset(offset)
+                    for offset, _, _ in unsafe_changes
+                )
+            ))
 
         _LOG.info("Updating metadata type %s", metadata_type.name)
 

--- a/datacube/index/_metadata_types.py
+++ b/datacube/index/_metadata_types.py
@@ -115,7 +115,7 @@ class MetadataTypeResource(object):
 
         return allow_unsafe_updates or not bad_changes, good_changes, bad_changes
 
-    def update(self, metadata_type, allow_unsafe_updates=False, allow_table_lock=False):
+    def update(self, metadata_type: MetadataType, allow_unsafe_updates=False, allow_table_lock=False):
         """
         Update a metadata type from the document. Unsafe changes will throw a ValueError by default.
 
@@ -137,7 +137,7 @@ class MetadataTypeResource(object):
             return self.get_by_name(metadata_type.name)
 
         if not can_update:
-            raise ValueError("Unsafe changes at " + (
+            raise ValueError(f"Unsafe changes in {metadata_type.name}: " + (
                 ", ".join(
                     _readable_offset(offset)
                     for offset, _, _ in unsafe_changes

--- a/datacube/index/_products.py
+++ b/datacube/index/_products.py
@@ -148,7 +148,7 @@ class ProductResource(object):
             _LOG.info("Safe change in %s from %r to %r", _readable_offset(offset), old_val, new_val)
 
         for offset, old_val, new_val in bad_changes:
-            _LOG.info("Unsafe change in %s from %r to %r", _readable_offset(offset), old_val, new_val)
+            _LOG.warning("Unsafe change in %s from %r to %r", _readable_offset(offset), old_val, new_val)
 
         return allow_unsafe_updates or not bad_changes, good_changes, bad_changes
 
@@ -176,13 +176,12 @@ class ProductResource(object):
             return self.get_by_name(product.name)
 
         if not can_update:
-            full_message = "Unsafe changes at " + (
+            raise ValueError("Unsafe changes at " + (
                 ", ".join(
                     _readable_offset(offset)
                     for offset, _, _ in unsafe_changes
                 )
-            )
-            raise ValueError(full_message)
+            ))
 
         _LOG.info("Updating product %s", product.name)
 

--- a/datacube/index/_products.py
+++ b/datacube/index/_products.py
@@ -152,7 +152,7 @@ class ProductResource(object):
 
         return allow_unsafe_updates or not bad_changes, good_changes, bad_changes
 
-    def update(self, product, allow_unsafe_updates=False, allow_table_lock=False):
+    def update(self, product: DatasetType, allow_unsafe_updates=False, allow_table_lock=False):
         """
         Update a product. Unsafe changes will throw a ValueError by default.
 
@@ -176,7 +176,7 @@ class ProductResource(object):
             return self.get_by_name(product.name)
 
         if not can_update:
-            raise ValueError("Unsafe changes at " + (
+            raise ValueError(f"Unsafe changes in {product.name}: " + (
                 ", ".join(
                     _readable_offset(offset)
                     for offset, _, _ in unsafe_changes


### PR DESCRIPTION
The `dataset update` command threw an exception when one of the unsafe changes was a numeric key:

```python
File "/g/data/v10/public/modules/dea/20200526/lib/python3.6/site-packages/datacube/index/_datasets.py", line 284, in <genexpr>
    full_message = "Unsafe changes at " + ", ".join(".".join(offset) for offset, _, _ in unsafe_changes)
TypeError: sequence item 2: expected str instance, int found
```

This fixes that, and updates the `product update`, `metadata update` and `dataset update` commands to display document changes more consistently with each-other.

Other minor issues fixed:
- It now tells you which document the error occurred in (since we often have multiple documents in one yaml)
- The unsafe value changes are now shown as warnings so that they display by default without needing to rerun the command with higher verbosity.

Issues not yet fixed:

It's a pain to make changes to a multi-document yaml. I wish I could tell it "update the ODC to match my whole yaml", without having to pick apart which inner-documents need updating and which need adding. Are we sure `add` and `update` need to be mutually exclusive?

(An example of multi-doc yamls are DEA's [metadata-types and products](https://github.com/GeoscienceAustralia/digitalearthau/tree/develop/digitalearthau/config))