### PR TITLE
Prepare for 1.8.2 release

### DIFF
--- a/datacube/model/schema/dataset-type-schema.yaml
+++ b/datacube/model/schema/dataset-type-schema.yaml
@@ -45,7 +45,7 @@ patternProperties:
 
 definitions:
     dtype:
-        enum: ["float16", "float32", "float64", "int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"]
+        enum: ["float16", "float32", "float64", "int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64", "complex64", "complex128"]
     measurement:
         type: object
         properties:

--- a/datacube/model/schema/ingestor-config-type-schema.yaml
+++ b/datacube/model/schema/ingestor-config-type-schema.yaml
@@ -88,7 +88,7 @@ additionalProperties: true
 
 definitions:
     dtype:
-        enum: ["float16", "float32", "float64", "int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"]
+        enum: ["float16", "float32", "float64", "int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64", "complex64", "complex128"]
     measurement:
         type: object
         properties:

--- a/datacube/utils/aws/__init__.py
+++ b/datacube/utils/aws/__init__.py
@@ -11,9 +11,27 @@ from urllib.request import urlopen
 from urllib.parse import urlparse
 from typing import Optional, Dict, Tuple, Any, Union, IO
 from datacube.utils.generic import thread_local_cache
+from ..rio import configure_s3_access
 
 ByteRange = Union[slice, Tuple[int, int]]       # pylint: disable=invalid-name
 MaybeS3 = Optional[botocore.client.BaseClient]  # pylint: disable=invalid-name
+
+__all__ = (
+    "s3_url_parse",
+    "s3_fmt_range",
+    "s3_client",
+    "s3_open",
+    "s3_fetch",
+    "s3_dump",
+    "ec2_metadata",
+    "ec2_current_region",
+    "botocore_default_region",
+    "auto_find_region",
+    "get_creds_with_retry",
+    "mk_boto_session",
+    "get_aws_settings",
+    "configure_s3_access",
+)
 
 
 def _fetch_text(url: str, timeout: float = 0.1) -> Optional[str]:

--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -355,6 +355,15 @@ class SimpleDocNav(object):
     def sources_path(self):
         return self._sources_path
 
+    @property
+    def location(self):
+        return self._doc.get('location', None)
+
+    def without_location(self):
+        if self.location is None:
+            return self
+        return SimpleDocNav(toolz.dissoc(self._doc, 'location'))
+
 
 def _set_doc_offset(offset, document, value):
     """

--- a/datacube/utils/py.py
+++ b/datacube/utils/py.py
@@ -68,5 +68,7 @@ def sorted_items(d, key=None, reverse=False):
     :param bool reverse: If True return in descending order instead of default ascending
 
     """
+    if d is None:
+        return []
     key = toolz.first if key is None else toolz.comp(key, toolz.first)
     return sorted(d.items(), key=key, reverse=reverse)

--- a/datacube/utils/rio/_rio.py
+++ b/datacube/utils/rio/_rio.py
@@ -161,28 +161,32 @@ def configure_s3_access(profile=None,
                         cloud_defaults=True,
                         client=None,
                         **gdal_opts):
-    """ Credentialize for S3 bucket access.
+    """ Credentialize for S3 bucket access or configure public access.
 
     This function obtains credentials for S3 access and passes them on to
     processing threads, either local or on dask cluster.
 
-    @returns credentials object or None if `aws_unsigned=True`
 
-    NOTE: if credentials are STS based they will eventually expire, currently
-    this case is not handled very well, reads will just start failing
-    eventually and will never recover.
+    .. note::
+
+       if credentials are STS based they will eventually expire, currently
+       this case is not handled very well, reads will just start failing
+       eventually and will never recover.
 
     :param profile:        AWS profile name to use
     :param region_name:    Default region_name to use if not configured for a given/default AWS profile
-    :param aws_unsigned:   if True don't bother with credentials when reading from S3
-    :param requester_pays: needed when accessing requester pays buckets
+    :param aws_unsigned:   If ``True`` don't bother with credentials when reading from S3
+    :param requester_pays: Needed when accessing requester pays buckets
 
     :param cloud_defaults: Assume files are in the cloud native format, i.e. no side-car files, disables
                            looking for side-car files, makes things faster but won't work for files
                            that do have side-car files with extra metadata.
 
-    :param client:         Dask distributed `Client` instance, if supplied apply settings on the dask cluster
-                           rather than locally
+    :param client:         Dask distributed ``dask.Client`` instance, if supplied apply settings on the
+                           dask cluster rather than locally.
+    :param gdal_opts:      Any other option to pass to GDAL environment setup
+
+    :returns: credentials object or ``None`` if ``aws_unsigned=True``
     """
     from datacube.utils.aws import get_aws_settings
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -5,8 +5,8 @@
 What's New
 **********
 
-v1.8.2 (??)
-===========
+v1.8.2 (10 July 2020)
+=====================
 
 - Fix regressions in ``.geobox`` (:pull:`982`)
 - Expand list of supported ``dtype``s to include complex values (:pull:`989`)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -5,6 +5,11 @@
 What's New
 **********
 
+v1.8.2 (??)
+===========
+
+- Can now specify dataset location directly in the yaml document (:issue:`990`, :pull:`989`)
+
 v1.8.1 (2 July 2020)
 ====================
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,7 +8,10 @@ What's New
 v1.8.2 (??)
 ===========
 
+- Fix regressions in ``.geobox`` (:pull:`982`)
+- Expand list of supported ``dtype``s to include complex values (:pull:`989`)
 - Can now specify dataset location directly in the yaml document (:issue:`990`, :pull:`989`)
+- Better error reporting in ``datacube dataset update`` (:pull:`983`)
 
 v1.8.1 (2 July 2020)
 ====================

--- a/docs/dev/api/index.rst
+++ b/docs/dev/api/index.rst
@@ -420,6 +420,7 @@ AWS Utilities
    mk_boto_session
    ec2_current_region
    ec2_metadata
+   configure_s3_access
 
 
 

--- a/docs/dev/api/index.rst
+++ b/docs/dev/api/index.rst
@@ -333,8 +333,8 @@ Multi-geometry ops
    clip_lon180
    chop_along_antimeridian
 
-Tools
------
+Other Utilities
+---------------
 
 .. autosummary::
    :toctree: generate/

--- a/docs/ops/dataset_documents.rst
+++ b/docs/ops/dataset_documents.rst
@@ -82,6 +82,9 @@ EO3 is an intermediate format before we move to something more standard like `ST
         path: some.nc
         layer: some_var  # str: netcdf variable to read
 
+   # optional dataset location (useful for public datasets)
+   location: https://landsatonaws.com/L8/099/072/LC08_L1GT_099072_20200523_20200523_01_RT/metadata.yaml
+
    # Dataset properties, prefer STAC standard names here
    # Timestamp is the only compulsory field here
    properties:

--- a/integration_tests/data/dataset_add/datasets_eo3.yml
+++ b/integration_tests/data/dataset_add/datasets_eo3.yml
@@ -4,6 +4,8 @@ id: 7d41a4d0-2ab3-4da1-a010-ef48662ae8ef
 product:
   name: eo3_test
 
+location: "http://example.com/a.yml"
+
 crs: "epsg:3857"
 properties:
     datetime: 2020-04-20 00:26:43Z

--- a/tests/test_utils_docs.py
+++ b/tests/test_utils_docs.py
@@ -284,6 +284,11 @@ A:..:0
     assert len(fv['E']) == 1
     assert set(fv.keys()) == set('ABCDE')
 
+    leaf = SimpleNamespace(id='N', sources=None)
+    out = []
+    traverse_datasets(leaf, visitor, out=out)
+    assert out == ["N:..:0"]
+
 
 def test_simple_doc_nav():
     """

--- a/tests/test_utils_other.py
+++ b/tests/test_utils_other.py
@@ -300,6 +300,8 @@ def test_sorted_items():
     remap = dict(c=0, a=1, b=2)
     assert ''.join(k for k, _ in sorted_items(aa, key=lambda x: remap[x])) == 'cab'
 
+    assert sorted_items(None) == []
+
 
 def test_default_base_dir(monkeypatch):
     def set_pwd(p):


### PR DESCRIPTION
### Reason for this pull request

`1.8.1` had a regression in `.geobox`. It only applies to re-injected CRS data, but example notebooks do that, so this has been fixed and we need to make a new release soon. Getting some easy fixes in before that.


### Proposed changes

- Extend allowed dtype enum with `complex64`, `complex128`
- Be robust when traversing lineage
- Understand `location` field in dataset document
- Document `configure_s3_access` in the api docs
- Some other documentation tweaks

 - [x] Closes #988
 - [x] Closes #990
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
