### PR TITLE
When creating s3 client with creds ignore AWS_UNSIGNED

### DIFF
--- a/datacube/utils/aws/__init__.py
+++ b/datacube/utils/aws/__init__.py
@@ -268,7 +268,10 @@ def s3_client(profile: Optional[str] = None,
 
     """
     if aws_unsigned is None:
-        aws_unsigned = _aws_unsigned_check_env()
+        if creds is None:
+            aws_unsigned = _aws_unsigned_check_env()
+        else:
+            aws_unsigned = False
 
     if aws_unsigned:
         cfg.update(signature_version=botocore.UNSIGNED)

--- a/datacube/utils/dask.py
+++ b/datacube/utils/dask.py
@@ -239,7 +239,8 @@ def pmap(func: Any,
 
 
 def _save_blob_to_file(data: Union[bytes, str],
-                       fname: str) -> Tuple[str, bool]:
+                       fname: str,
+                       with_deps=None) -> Tuple[str, bool]:
     if isinstance(data, str):
         data = data.encode('utf8')
 
@@ -257,8 +258,10 @@ def _save_blob_to_s3(data: Union[bytes, str],
                      profile: Optional[str] = None,
                      creds: Optional[ReadOnlyCredentials] = None,
                      region_name: Optional[str] = None,
+                     with_deps=None,
                      **kw) -> Tuple[str, bool]:
     from botocore.errorfactory import ClientError
+
     try:
         s3 = s3_client(profile=profile,
                        creds=creds,
@@ -302,7 +305,7 @@ def save_blob_to_file(data,
        the same path as calling code.
 
     """
-    return _save_blob_to_file_delayed(data, fname)
+    return _save_blob_to_file_delayed(data, fname, with_deps=with_deps)
 
 
 def save_blob_to_s3(data,
@@ -335,4 +338,5 @@ def save_blob_to_s3(data,
                                     profile=profile,
                                     creds=creds,
                                     region_name=region_name,
+                                    with_deps=with_deps,
                                     **kw)


### PR DESCRIPTION
### Reason for this pull request

Fix regression in `s3_client` construction introduced when adding s3 unsigned access. If `creds=` are supplied from outside then of course you want signed requests no matter what `AWS_UNSIGNED` says.

also fixes `with_deps=` argument handling in `.utils.dask.save_blob..` functions.


 - [x] Closes #995 
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes