### PR TITLE
Fix for failure to load data if dataset format is missing

### DIFF
--- a/datacube/drivers/readers.py
+++ b/datacube/drivers/readers.py
@@ -62,7 +62,7 @@ def reader_drivers() -> List[str]:
     return rdr_cache().drivers()
 
 
-def choose_datasource(band: 'BandInfo') -> DatasourceFactory:
+def choose_datasource(band: BandInfo) -> DatasourceFactory:
     """Returns appropriate `DataSource` class (or a constructor method) for loading
     given `dataset`.
 

--- a/datacube/storage/_base.py
+++ b/datacube/storage/_base.py
@@ -104,9 +104,9 @@ class BandInfo:
         self.units = mp.units
         self.crs = ds.crs
         self.transform = ds.transform
-        self.format = ds.format
+        self.format = ds.format or ''
         self.driver_data = _extract_driver_data(ds)
 
     @property
     def uri_scheme(self) -> str:
-        return urlparse(self.uri).scheme
+        return urlparse(self.uri).scheme or ''

--- a/tests/storage/test_base.py
+++ b/tests/storage/test_base.py
@@ -64,3 +64,13 @@ def test_band_info():
     ds.uris = None
     with pytest.raises(ValueError):
         BandInfo(ds, 'a')
+
+    ds_none_fmt = mk_sample_dataset(bands,
+                                    uri='file:///tmp/datataset.yml',
+                                    format=None)
+    assert ds_none_fmt.format is None
+    assert BandInfo(ds_none_fmt, 'a').format == ''
+
+    ds = mk_sample_dataset(bands, uri='/not/a/uri')
+    band = BandInfo(ds, 'a')
+    assert(band.uri_scheme is '')

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -23,6 +23,12 @@ def test_new_datasource_fallback():
     assert rdr is not None
     assert isinstance(rdr, RasterDatasetDataSource)
 
+    # check that None format works
+    band = BandInfo(mk_sample_dataset(bands, 'file:///file', format=None), 'green')
+    rdr = new_datasource(band)
+    assert rdr is not None
+    assert isinstance(rdr, RasterDatasetDataSource)
+
 
 def test_reader_drivers():
     available_drivers = reader_drivers()


### PR DESCRIPTION
### Reason for this pull request

Fix for #998.

### Proposed changes

- When constructing `BandInfo` object detect missing dataset `format` and substitute with empty string, this way all the places where we assume that `band.format` is a string will work even when `ds.format` was missing.
- When computing `.uri_scheme` make sure to always return a string (`... or ''` essentially)

 - [x] Closes #998
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
