### PR TITLE
Clearer error messages for archive, restore commands

### DIFF
--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -64,7 +64,7 @@ class DatasetResource(object):
         self._db = db
         self.types = dataset_type_resource
 
-    def get(self, id_, include_sources=False):
+    def get(self, id_: Union[str, UUID], include_sources=False):
         """
         Get dataset by id
 
@@ -332,7 +332,7 @@ class DatasetResource(object):
         """
         Mark datasets as archived
 
-        :param list[UUID] ids: list of dataset ids to archive
+        :param Iterable[UUID] ids: list of dataset ids to archive
         """
         with self._db.begin() as transaction:
             for id_ in ids:


### PR DESCRIPTION
A user asked for help on Slack because `datacube dataset archive` was throwing an `AttributeError`. This turned out to be because one of the UUIDs provided on the command-line was unknown by datacube.

This adds a friendlier error message for both `archive` and the `restore` commands.

There's also some clean-up of types to fix some warnings in the affected methods.

(Note that the error message is output via `stdout` to be consistent with the rest of the commands.)
