### PR TITLE
Go directly to rasterio.DatasetReader instead of rasterio.open

### DIFF
--- a/datacube/storage/_rio.py
+++ b/datacube/storage/_rio.py
@@ -10,6 +10,7 @@ from threading import RLock
 import numpy as np
 from affine import Affine
 import rasterio
+import rasterio.path
 from urllib.parse import urlparse
 from typing import Optional, Iterator
 
@@ -160,7 +161,8 @@ class RasterioDataSource(DataSource):
 
         try:
             _LOG.debug("opening %s", self.filename)
-            with rasterio.open(self.filename, sharing=False) as src:
+            with rasterio.DatasetReader(rasterio.path.parse_path(str(self.filename)),
+                                        sharing=False) as src:
                 override = False
 
                 transform = src.transform


### PR DESCRIPTION
`rasterio.open` tries to be smart about environment setup even if user didn't
activate environment, it also deals with ro vs rw modes. Since we always open in
ro mode and always activate credentialed environment we can skip directly to
DatasetReader class and avoid credentialization bugs in rasterio.

### Reason for this pull request

major slow-down in sandbox are caused by rasterio misguided attempts at credentialization on every file open even when public reads are enabled.

https://github.com/GeoscienceAustralia/dea-sandbox/issues/121


 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
