### PR TITLE
Fix partial gridspec

### DIFF
--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -487,6 +487,10 @@ class DatasetType:
         gs_params = {name: extract_point(name)
                      for name in ('tile_size', 'resolution', 'origin')}
 
+        complete = all(gs_params[k] is not None for k in ('tile_size', 'resolution'))
+        if not complete:
+            return None
+
         return GridSpec(crs=crs, **gs_params)
 
     def canonical_measurement(self, measurement: str) -> str:

--- a/docs/ops/product.rst
+++ b/docs/ops/product.rst
@@ -36,14 +36,26 @@ metadata
 
 storage (optional)
     Describes some of common storage attributes of all the datasets. While optional defining this will make
-    product data easier to access and use.
+    product data easier to access and use. This only applies to products that have data arranged on a regular
+    grid, for example ingested products are like that.
 
     crs
-        Coordinate reference system common to all the datasets in the product. 'EPSG:<code>' or WKT string.
+        Coordinate reference system common to all the datasets in the product. ``'EPSG:<code>'`` or WKT string.
 
     resolution
         Resolution of the data of all the datasets in the product specified in projection units.
-        Use ``latitude``, ``longitude`` if the projection is geographic and ``x``, ``y`` otherwise
+        Use ``latitude``, ``longitude`` if the projection is geographic and ``x``, ``y`` otherwise.
+
+    tile_size
+        Size of the tiles for the data to be stored in specified in projection units. Use ``latitude`` and ``longitude``
+        if the projection is geographic, otherwise use ``x`` and ``y``.
+
+    origin
+        Coordinates of the bottom-left or top-left corner of the ``(0,0)`` tile specified in projection units. If
+        coordinates are for top-left corner, ensure that the ``latitude`` or ``y`` dimension of ``tile_size`` is
+        negative so tile indexes count downward. Use ``latitude`` and ``longitude`` if the projection is geographic,
+        otherwise use ``x`` and ``y``.
+
 
 measurements
     List of measurements in this product. The measurement names defined here need to match 1:1 with the measurement

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -111,6 +111,11 @@ def test_product_dimensions():
     assert product.grid_spec is not None
     assert product.dimensions == ('time', 'y', 'x')
 
+    partial_storage = product.definition['storage']
+    partial_storage.pop('tile_size')
+    product = mk_sample_product('tt', storage=partial_storage)
+    assert product.grid_spec is None
+
 
 def test_product_scale_factor():
     product = mk_sample_product('test', measurements=[dict(name='red',


### PR DESCRIPTION
### Reason for this pull request

Disallow partial GridSpec construction. There is no gridspec unless all compulsory components are configured.


### Proposed changes

- Do not construct GridSpec if any of `resolution`, `crs` or `tile_size` are missing or misconfigured
- Add documentation for compulsory `storage` components

Possible gotchas: people might be using partial gridspec as load hint (see #1011) without defining `tile_size`, `dc.load` will stop working for them after this fix. The work around would be to add dummy `tile_size` and update product definition.

 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
