### PR TITLE
Implement load hints for product spec #1011

### DIFF
--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -518,11 +518,18 @@ class DatasetType:
     def _extract_load_hints(self) -> Optional[Dict[str, Any]]:
         _load = self.definition.get('load')
         if _load is None:
-            # TODO: support partial "storage" definition with a warning
-            #       if storage object exists but gridspec is None
-            #           take crs and resolution from storage
-            #           warn user that this is no longer supported mode
-            return None
+            # Check for partial "storage" definition
+            storage = self.definition.get('storage', {})
+
+            if 'crs' in storage and 'resolution' in storage:
+                if 'tile_size' in storage:
+                    # Fully defined GridSpec, ignore it
+                    return None
+
+                # TODO: warn user to use `load:` instead of `storage:`??
+                _load = storage
+            else:
+                return None
 
         crs = geometry.CRS(_load['crs'])
 

--- a/datacube/model/schema/dataset-type-schema.yaml
+++ b/datacube/model/schema/dataset-type-schema.yaml
@@ -21,6 +21,8 @@ properties:
         type: object
     storage:
         "$ref": "#/definitions/storage"
+    load:
+        "$ref": "#/definitions/load"
     measurements:
         type: array
         additionalProperties: false
@@ -128,4 +130,17 @@ definitions:
                 type: object
             driver:
                 type: string
+        additionalProperties: false
+    load:
+        type: object
+        properties:
+            crs:
+                type: string
+            resolution:
+                type: object
+            align:
+                type: object
+        required:
+          - crs
+          - resolution
         additionalProperties: false

--- a/datacube/testutils/__init__.py
+++ b/datacube/testutils/__init__.py
@@ -157,7 +157,8 @@ def mk_sample_product(name,
                       measurements=('red', 'green', 'blue'),
                       with_grid_spec=False,
                       metadata_type=None,
-                      storage=None):
+                      storage=None,
+                      load=None):
 
     if storage is None and with_grid_spec is True:
         storage = {'crs': 'EPSG:3577',
@@ -199,6 +200,9 @@ def mk_sample_product(name,
 
     if storage is not None:
         definition['storage'] = storage
+
+    if load is not None:
+        definition['load'] = load
 
     return DatasetType(metadata_type, definition)
 

--- a/docs/ops/product.rst
+++ b/docs/ops/product.rst
@@ -34,6 +34,25 @@ metadata
 
     In the above example, ``product: name`` would match a specific product.
 
+load (optional)
+    Define default projections and resolution to use when loading data from this
+    product. User supplied load options take precedence over settings configured
+    here.
+
+    crs
+        Coordinate reference system to use as a fallback when loading data from this product. ``'EPSG:<code>'`` or WKT string.
+
+    resolution.{x,y}
+        Default resolution to use during ``dc.load(..)`` specified in projection units.
+        Use ``latitude``, ``longitude`` if the projection is geographic and ``x``, ``y`` otherwise.
+
+    align.{x,y} (optional)
+        By default pixel grid is aligned such that pixel boundaries fall on
+        ``x,y`` axis. This option allows to translate pixel grid. For example,
+        to ensure that pixel center of a 30m pixel grid is coincidental with
+        ``0,0`` use ``align:{x:15,y:15}``.
+
+
 storage (optional)
     Describes some of common storage attributes of all the datasets. While optional defining this will make
     product data easier to access and use. This only applies to products that have data arranged on a regular

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -196,6 +196,19 @@ def test_product_load_hints():
     assert product.default_resolution == (-10, 10)
     assert product.default_crs == geometry.CRS('EPSG:3857')
 
+    # check for fallback into partially defined `storage:`
+    # no resolution -- no hints
+    product = mk_sample_product('test', storage=dict(
+        crs='EPSG:3857'))
+    assert product.grid_spec is None
+    assert product.load_hints() == {}
+
+    # check misspelled load hints
+    product = mk_sample_product('test_product',
+                                load=dict(crs='epsg:4326',
+                                          resolution={'longtude': 1.2, 'latitude': -1.1}))
+    assert product.load_hints() == {}
+
 
 def test_measurement():
     # Can create a measurement

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -183,6 +183,19 @@ def test_product_load_hints():
         with pytest.raises(InvalidDocException):
             DatasetType.validate(doc)
 
+    # check GridSpec leakage doesn't happen for fully defined gridspec
+    product = mk_sample_product('test', with_grid_spec=True)
+    assert product.grid_spec is not None
+    assert product.load_hints() == {}
+
+    # check for fallback into partially defined `storage:`
+    product = mk_sample_product('test', storage=dict(
+        crs='EPSG:3857',
+        resolution={'x': 10, 'y': -10}))
+    assert product.grid_spec is None
+    assert product.default_resolution == (-10, 10)
+    assert product.default_crs == geometry.CRS('EPSG:3857')
+
 
 def test_measurement():
     # Can create a measurement


### PR DESCRIPTION
### Reason for this pull request

Implement load hints on product spec.


### Proposed changes

- Accept `load.{crs,resolution,align}` section in product that configured default crs and resolution to use when loading data from this product


 - [x] Closes #1011
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
