### PR TITLE
Document resampling strategy and overviews

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -203,8 +203,8 @@ class Datacube(object):
             To reproject or resample the data, supply the ``output_crs``, ``resolution``, ``resampling`` and ``align``
             fields.
 
-            By default, the resampling method is 'nearest'. However, any stored overview layers may be used
-            when down-sampling, which may (completely or partially) override the choice of resampling method.
+            By default, the resampling method is 'nearest'. However any stored overview layers may be used
+            when down-sampling, which may override (or hybridise) the choice of resampling method.
 
             To reproject data to 25m resolution for EPSG:3577::
 

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -203,6 +203,9 @@ class Datacube(object):
             To reproject or resample the data, supply the ``output_crs``, ``resolution``, ``resampling`` and ``align``
             fields.
 
+            By default, the resampling method is 'nearest'. However, any stored overview layers may be used
+            when down-sampling, which may (completely or partially) override the choice of resampling method.
+
             To reproject data to 25m resolution for EPSG:3577::
 
                 dc.load(product='ls5_nbar_albers', x=(148.15, 148.2), y=(-35.15, -35.2), time=('1990', '1991'),


### PR DESCRIPTION
Apparently if stored overviews exist then they will be used, and therefore any subsequent choice of resampling strategy may in effect be silently overridden when down-sampling. 

Consequently, for some applications (depending on the individual data file), it may be inappropriate to allow the API to perform the resampling.