### PR TITLE
Make sure product name, id and description take precedence #1023

### DIFF
--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -587,12 +587,11 @@ class DatasetType:
         """
         Convert to a dictionary representation of the available fields
         """
-        row = {
-            'id': self.id,
-            'name': self.name,
-            'description': self.definition['description'],
-        }
-        row.update(self.fields)
+        row = dict(**self.fields)
+        row.update(id=self.id,
+                   name=self.name,
+                   description=self.definition['description'])
+
         if self.grid_spec is not None:
             row.update({
                 'crs': str(self.grid_spec.crs),


### PR DESCRIPTION
### Reason for this pull request

If metadata definition contains search field named `id,name,description` then they would alias product's id name and description as returned by `.list_products` (#1023)


### Proposed changes

- In case of ambiguity prefer field from product definition and not from metadata.

 - [x] Closes #1023 
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes
