### PR TITLE
Add cloud_cover to default EO3

### DIFF
--- a/datacube/index/default-metadata-types.yaml
+++ b/datacube/index/default-metadata-types.yaml
@@ -43,6 +43,12 @@ dataset:
       offset: [properties, 'dea:dataset_maturity']
       indexed: false
 
+    cloud_cover:
+      description: Cloud cover percentage [0, 100]
+      type: double
+      offset: [properties, 'eo:cloud_cover']
+      indexed: false
+
     time:
       description: Acquisition time range
       type: datetime-range

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -10,6 +10,7 @@ v1.8.4 (???)
 
 - Removed example and contributed notebooks from the repository. Better notebook_ examples exist.
 - Removed datacube_apps, as these are not used and not maintained.
+- Add `cloud_cover` to EO3 metadata
 
 .. _notebooks: https://github.com/GeoscienceAustralia/dea-notebooks/
 


### PR DESCRIPTION
### Reason for this pull request

Cloud cover is a very useful field to search by. It's better to have it in, and not use it, than to not have it available at all.

The bigger picture is that we should really allow arbitrary filtering by properties, but that's for later.

**Note**: there's no way to apply this change aside from manually... should we ensure that init does a metadata update?

### Proposed changes

- Add `cloud_cover` to EO3, which means you can use `dc.load(product="example", cloud_cover=(0, 10))` to load data with 0-10% cloud cover

 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes
