### PR TITLE
Pin celery below version 5 (#1037)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ extras_require = {
     'distributed': ['distributed', 'dask[distributed]'],
     'doc': doc_require,
     'replicas': ['paramiko', 'sshtunnel', 'tqdm'],
-    'celery': ['celery>=4', 'redis'],
+    'celery': ['celery>=4,<5', 'redis'],
     's3': ['boto3'],
     'test': tests_require,
     'cf': ['compliance-checker>=4.0.0'],


### PR DESCRIPTION
### Reason for this pull request

Celery 5 is out, and it breaks datacube-core executor classes.

### Proposed changes

Best is to just delete all those "executor" classes and remove dependency on celery and redis (#1037), but in the meantime we must at least declare constraints on Celery version.

 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
