### PR TITLE
Test docker for ubuntu 20.04/python 3.8

### DIFF
--- a/.github/workflows/docker-test-runner.yml
+++ b/.github/workflows/docker-test-runner.yml
@@ -20,7 +20,6 @@ on:
 env:
   ORG: opendatacube
   IMAGE: datacube-tests
-  BUILDER_TAG: _build_cache
   DOCKER_USER: gadockersvc
 
 
@@ -60,24 +59,9 @@ jobs:
         ls -lh ./docker/dist/
         twine check ./docker/dist/*
 
-    - name: Pull docker cache
-      run: |
-        docker pull ${ORG}/${IMAGE}:latest         || true
-        docker pull ${ORG}/${IMAGE}:${BUILDER_TAG} || true
-
     - name: Build Test Runner Docker
       run: |
-        # build and cache first stage (env_builder)
         docker build \
-          --target env_builder \
-          --cache-from ${ORG}/${IMAGE}:${BUILDER_TAG} \
-          --tag        ${ORG}/${IMAGE}:${BUILDER_TAG} \
-          ./docker/
-
-        # now build second stage making sure first stage is from cache
-        docker build \
-          --cache-from ${ORG}/${IMAGE}:${BUILDER_TAG} \
-          --cache-from ${ORG}/${IMAGE}:latest \
           --tag        ${ORG}/${IMAGE}:latest \
           ./docker/
 
@@ -94,7 +78,6 @@ jobs:
         if [ -n "${{ secrets.DockerPassword }}" ]; then
            echo "Login to DockerHub as ${DOCKER_USER}"
            echo "${{ secrets.DockerPassword }}" | docker login -u "${DOCKER_USER}" --password-stdin
-           docker push ${ORG}/${IMAGE}:${BUILDER_TAG}
            docker push ${ORG}/${IMAGE}:latest
         else
            echo "Set DockerPassword secret to push to docker"

--- a/.github/workflows/docker-test-runner.yml
+++ b/.github/workflows/docker-test-runner.yml
@@ -62,14 +62,15 @@ jobs:
     - name: Build Test Runner Docker
       run: |
         docker build \
-          --tag        ${ORG}/${IMAGE}:latest \
+          --tag ${ORG}/${IMAGE}:latest \
           ./docker/
 
     - name: Verify Docker Image
       run: |
         ./check-code.sh --with-docker integration_tests
 
-    - name: DockerHub Push
+    - name: DockerHub Login
+      id: dkr
       if: |
         github.event_name == 'push' && (
           github.ref == 'refs/heads/develop'
@@ -78,7 +79,36 @@ jobs:
         if [ -n "${{ secrets.DockerPassword }}" ]; then
            echo "Login to DockerHub as ${DOCKER_USER}"
            echo "${{ secrets.DockerPassword }}" | docker login -u "${DOCKER_USER}" --password-stdin
-           docker push ${ORG}/${IMAGE}:latest
+           echo "::set-output name=logged_in::yes"
         else
            echo "Set DockerPassword secret to push to docker"
         fi
+
+    - name: DockerHub Push
+      if: |
+        github.event_name == 'push' && (
+          github.ref == 'refs/heads/develop'
+          ) && steps.dkr.outputs.logged_in == 'yes'
+      run: |
+        if [ -n "${{ secrets.DockerPassword }}" ]; then
+           docker push ${ORG}/${IMAGE}:latest
+        fi
+
+    - name: Build Test Runner Docker (20.04 with python 3.8)
+      run: |
+        docker build \
+          --build-arg V_BASE=-3.1.3 \
+          --build-arg V_PG=12 \
+          --tag ${ORG}/${IMAGE}:py38 \
+          ./docker/
+
+    - name: DockerHub Push
+      if: |
+        github.event_name == 'push' && (
+          github.ref == 'refs/heads/develop'
+          ) && steps.dkr.outputs.logged_in == 'yes'
+      run: |
+        if [ -n "${{ secrets.DockerPassword }}" ]; then
+           docker push ${ORG}/${IMAGE}:py38
+        fi
+

--- a/.github/workflows/docker-test-runner.yml
+++ b/.github/workflows/docker-test-runner.yml
@@ -27,6 +27,12 @@ jobs:
   docker:
     runs-on: ubuntu-latest
 
+    strategy:
+      max-parallel: 2
+      matrix:
+        python-version: [3.6, 3.8]
+
+
     steps:
     - uses: actions/checkout@v1
       with:
@@ -35,7 +41,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: '3.6'
+        python-version: ${{ matrix.python-version }}
 
     # This is just to get dependencies right, we do not keep datacube in the final image
     - name: Install packaging dependencies
@@ -60,10 +66,21 @@ jobs:
         twine check ./docker/dist/*
 
     - name: Build Test Runner Docker
+      id: build
       run: |
-        docker build \
-          --tag ${ORG}/${IMAGE}:latest \
-          ./docker/
+        if [ "${{ matrix.python-version }}" == "3.8" ]; then
+          echo ::set-output name=docker_image::${ORG}/${IMAGE}:py38
+          docker build \
+            --build-arg V_BASE=-3.1.3 \
+            --build-arg V_PG=12 \
+            --tag ${ORG}/${IMAGE}:py38 \
+            ./docker/
+        else
+          echo ::set-output name=docker_image::${ORG}/${IMAGE}:latest
+          docker build \
+              --tag ${ORG}/${IMAGE}:latest \
+              ./docker/
+        fi
 
     - name: Verify Docker Image
       run: |
@@ -91,24 +108,5 @@ jobs:
           ) && steps.dkr.outputs.logged_in == 'yes'
       run: |
         if [ -n "${{ secrets.DockerPassword }}" ]; then
-           docker push ${ORG}/${IMAGE}:latest
+           docker push "${{ steps.build.outputs.docker_image }}"
         fi
-
-    - name: Build Test Runner Docker (20.04 with python 3.8)
-      run: |
-        docker build \
-          --build-arg V_BASE=-3.1.3 \
-          --build-arg V_PG=12 \
-          --tag ${ORG}/${IMAGE}:py38 \
-          ./docker/
-
-    - name: DockerHub Push
-      if: |
-        github.event_name == 'push' && (
-          github.ref == 'refs/heads/develop'
-          ) && steps.dkr.outputs.logged_in == 'yes'
-      run: |
-        if [ -n "${{ secrets.DockerPassword }}" ]; then
-           docker push ${ORG}/${IMAGE}:py38
-        fi
-

--- a/datacube/utils/cog.py
+++ b/datacube/utils/cog.py
@@ -67,8 +67,6 @@ def _write_cog(pix: np.ndarray,
         blocksize = 512
     if ovr_blocksize is None:
         ovr_blocksize = blocksize
-    if overview_levels is None:
-        overview_levels = [2 ** i for i in range(1, 6)]
     if overview_resampling is None:
         overview_resampling = "nearest"
 
@@ -89,6 +87,12 @@ def _write_cog(pix: np.ndarray,
 
     assert geobox.shape == (h, w)
 
+    if overview_levels is None:
+        if min(w, h) < 512:
+            overview_levels = []
+        else:
+            overview_levels = [2 ** i for i in range(1, 6)]
+
     if fname != ":mem:":
         path = check_write_path(
             fname, overwrite
@@ -97,7 +101,7 @@ def _write_cog(pix: np.ndarray,
     resampling = rasterio.enums.Resampling[overview_resampling]
 
     if (blocksize % 16) != 0:
-        warnings.warn(f"Block size must be a multiple of 16, will be adjusted")
+        warnings.warn("Block size must be a multiple of 16, will be adjusted")
 
     rio_opts = dict(
         width=w,

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,7 +54,7 @@ FROM ${ORG}/geobase:runner${V_BASE}
 # Set the locale, this is required for some of the Python packages
 ENV LC_ALL C.UTF-8
 RUN apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing --no-install-recommends \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing --no-install-recommends --allow-change-held-packages \
   # datacube tests need redis
   redis-server \
   # include db for running tests

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,7 @@
 ##
 ARG ORG=opendatacube
 ARG V_BASE=-3.0.4
+ARG V_PG=10
 FROM ${ORG}/geobase:wheels${V_BASE} as env_builder
 
 # Set the locale, this is required for some of the Python packages
@@ -58,8 +59,8 @@ RUN apt-get update \
   redis-server \
   # include db for running tests
   postgresql \
-  postgresql-client-10 \
-  postgresql-10 \
+  postgresql-client-${V_PG} \
+  postgresql-${V_PG} \
   # to become test user
   sudo \
   # git is needed for sdist|bdist_wheel
@@ -75,7 +76,7 @@ RUN mkdir -p /etc/pki/tls/certs \
 
 # prep db
 RUN  install --owner postgres --group postgres -D -d /var/run/postgresql /srv/postgresql \
-  && sudo -u postgres "/usr/lib/postgresql/10/bin/initdb" -D "/srv/postgresql" --auth-host=md5 --encoding=UTF8
+  && sudo -u postgres "$(find /usr/lib/postgresql/ -type f -name initdb)" -D "/srv/postgresql" --auth-host=md5 --encoding=UTF8
 
 RUN groupadd --gid 1000 odc \
   && useradd --gid 1000 \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,7 +48,7 @@ RUN find /wheels -type f -name '*whl' > /tmp/constraints.txt \
 #################################################################################
 # Runner stage
 #################################################################################
-FROM opendatacube/geobase:runner${V_BASE}
+FROM ${ORG}/geobase:runner${V_BASE}
 
 # Set the locale, this is required for some of the Python packages
 ENV LC_ALL C.UTF-8

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -12,6 +12,10 @@ docker: dist/datacube.whl
 	@echo Building $(dkr)
 	docker build -t $(dkr) .
 
+docker-next: dist/datacube.whl
+	@echo Building $(dkr) '(next)'
+	docker build -t $(dkr) --build-arg V_BASE=-3.1.3 --build-arg V_PG=12  .
+
 check:
 	@docker run --rm -ti \
   -v "$$(dirname $$(pwd))":/src/datacube-core \

--- a/docker/assets/with_bootstrap
+++ b/docker/assets/with_bootstrap
@@ -3,7 +3,7 @@
 launch_db () {
     local pgdata="${1:-/srv/postgresql}"
     local dbuser="${2:-odc}"
-    local bin=/usr/lib/postgresql/10/bin
+    local bin=$(find /usr/lib/postgresql/ -type d -name bin)
 
     [ -e "${pgdata}/PG_VERSION" ] || {
         sudo -u postgres "${bin}/initdb" -D "${pgdata}" --auth-host=md5 --encoding=UTF8

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -4,6 +4,9 @@ botocore==1.13.46
 python-dateutil==2.8.1
 moto==1.3.14
 idna==2.8
+# maybe also boto?
+python-jose==3.2.0
+ecdsa==0.14.1
 
 # something wrong with time axis handling in xarray with pandas==1.1.1
 pandas==1.0.5

--- a/tests/test_utils_cog.py
+++ b/tests/test_utils_cog.py
@@ -89,7 +89,7 @@ def test_cog_file_dask(tmpdir):
     assert dask.is_dask_collection(xx)
 
     path = pp / "cog.tif"
-    ff = write_cog(xx, path)
+    ff = write_cog(xx, path, overview_levels=[2, 4])
     assert isinstance(ff, Delayed)
     assert path.exists() is False
     assert ff.compute() == path


### PR DESCRIPTION
### Reason for this pull request

There is now experimental `geobase` image based on ubuntu 20.04 with python3.8. This PR makes changes to test docker to support that new image as optional base, building test docker image for 18.04 is still possible from the same docker file.

### Proposed changes

- Build test docker against both `-3.0.4` and `-3.1.3` geobase images
- Some minor changes to write_cog -- be smarter about picking default overview levels for smaller outputs



 - [ ] Closes #xxxx
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
