### PR TITLE
Update test runner to also test python 3.8 on ubuntu 20.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,12 +15,16 @@ on:
       - '!docs/**'
       - '!contrib/**'
 
-env:
-  DKR: opendatacube/datacube-tests:latest
-
 jobs:
   main:
     runs-on: ubuntu-latest
+
+    strategy:
+      max-parallel: 2
+      matrix:
+        docker_image:
+          - opendatacube/datacube-tests:latest
+          - opendatacube/datacube-tests:py38
 
     steps:
     - uses: actions/checkout@v1
@@ -33,15 +37,20 @@ jobs:
         push_dea=no
         push_pypi=no
         push_test_pypi=no
+        primary=no
+
+        if [ "${{ matrix.docker_image }}" == "opendatacube/datacube-tests:latest" ]; then
+           primary=yes
+        fi
 
         case "${GITHUB_REF}" in
         "refs/heads/develop")
-             push_dea=yes
+             push_dea=${primary}
              ;;
         "refs/tags/"*)
-             push_pypi=yes
-             push_test_pypi=yes
-             push_dea=yes
+             push_pypi=${primary}
+             push_test_pypi=${primary}
+             push_dea=${primary}
              ;;
         "refs/heads/"*)
              ;;
@@ -51,20 +60,20 @@ jobs:
              ;;
         esac
 
-        for x in push_pypi push_test_pypi push_dea; do
+        for x in primary push_pypi push_test_pypi push_dea; do
            echo "::set-output name=${x}::${!x}"
         done
 
     - name: Pull Docker
       run: |
-        docker pull ${DKR}
+        docker pull "${{ matrix.docker_image }}"
 
     - name: Build Packages
       run: |
         cat <<EOF | docker run --rm -i  \
                   -v $(pwd):/src/datacube-core \
                   -e SKIP_DB=yes \
-                  ${DKR} bash -
+                  ${{ matrix.docker_image }} bash -
         python setup.py bdist_wheel sdist
         ls -lh ./dist/
         twine check ./dist/*
@@ -75,7 +84,7 @@ jobs:
         docker run --rm  \
           -v $(pwd):/src/datacube-core \
           -e SKIP_DB=yes \
-          ${DKR} \
+          ${{ matrix.docker_image }} \
           pycodestyle tests integration_tests examples --max-line-length 120
 
     - name: Lint Code
@@ -83,14 +92,14 @@ jobs:
         docker run --rm  \
           -v $(pwd):/src/datacube-core \
           -e SKIP_DB=yes \
-          ${DKR} \
+          ${{ matrix.docker_image }} \
           pylint -j 2 --reports no datacube
 
     - name: Run Tests
       run: |
         docker run --rm  \
           -v $(pwd):/src/datacube-core \
-          ${DKR} \
+          ${{ matrix.docker_image }} \
           pytest -r a \
             --cov datacube \
             --cov-report=xml \
@@ -122,7 +131,7 @@ jobs:
           docker run --rm  \
             -v $(pwd):/src/datacube-core \
             -e SKIP_DB=yes \
-            ${DKR} \
+            ${{ matrix.docker_image }} \
             twine upload \
               --verbose \
               --non-interactive \
@@ -146,7 +155,7 @@ jobs:
           docker run --rm  \
             -v $(pwd):/src/datacube-core \
             -e SKIP_DB=yes \
-            ${DKR} \
+            ${{ matrix.docker_image }} \
             twine upload \
               --verbose \
               --non-interactive \
@@ -162,6 +171,7 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PyPiToken }}
 
     - name: Upload coverage to Codecov
+      if: steps.cfg.outputs.primary == 'yes'
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CodeCovToken }}

--- a/tests/test_utils_cog.py
+++ b/tests/test_utils_cog.py
@@ -19,8 +19,10 @@ from datacube.testutils.io import native_load, rio_slurp_xarray, rio_slurp
 from datacube.utils.cog import write_cog, to_cog, _write_cog
 
 
-def gen_test_data(prefix, dask=False):
+def gen_test_data(prefix, dask=False, shape=None):
     w, h, dtype, nodata, ndw = 96, 64, 'int16', -999, 7
+    if shape is not None:
+        h, w = shape
 
     aa = mk_test_image(w, h, dtype, nodata, nodata_width=ndw)
 
@@ -101,9 +103,13 @@ def test_cog_file_dask(tmpdir):
     assert yy.nodata == xx.nodata
 
 
-def test_cog_mem(tmpdir):
+@pytest.mark.parametrize("shape", [
+    None,
+    (1024, 512)
+])
+def test_cog_mem(tmpdir, shape):
     pp = Path(str(tmpdir))
-    xx, ds = gen_test_data(pp)
+    xx, ds = gen_test_data(pp, shape=shape)
 
     # write to memory 1
     bb = write_cog(xx, ":mem:")


### PR DESCRIPTION
### Reason for this pull request

Run test suite in two configurations
- Ubuntu 18.04, Python 3.6, GDAL 3.0.4, Postgresql 10 (original)
- Ubuntu 20.04, Python 3.8, GDAL 3.1.3, Postgresql 12 (new one added)

also includes tweaks to cog writing test suite to increase test coverage. Coverage gone down after changing overview handling for smaller images.

 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
