### PR TITLE
Add 'az' to registered schemes

### DIFF
--- a/datacube/utils/uris.py
+++ b/datacube/utils/uris.py
@@ -33,6 +33,7 @@ def vsi_join(base: str, path: str) -> str:
 
         Basically just base/path, but taking care of trailing `/` in base
     """
+
     return base.rstrip('/') + '/' + path
 
 
@@ -229,5 +230,6 @@ register_scheme(
     's3',         # `s3://...`      -- AWS S3 Object Store
     'gs',         # `gs://...`      -- Google Cloud Storage
     'wasb',       # `wasb[s]://...` -- Windows Azure Storage Blob
-    'wasbs'
+    'wasbs',
+    'az',
 )

--- a/datacube/utils/uris.py
+++ b/datacube/utils/uris.py
@@ -33,7 +33,6 @@ def vsi_join(base: str, path: str) -> str:
 
         Basically just base/path, but taking care of trailing `/` in base
     """
-
     return base.rstrip('/') + '/' + path
 
 


### PR DESCRIPTION
### Reason for this pull request

Add support for 'vsiaz' urls. This is somewhat redundant as public azure blobs are readable by HTTPS by default. This will be required for non-public blobs that require authetication credentials.

I have confirmed that SAS Token authentication method with a nightly build of GDAL (not supported until version 3.2), for now only AZURE_STORAGE_ACCESS_KEY will work. For more details see here: https://gdal.org/user/virtual_file_systems.html

This is also dependant upon a future release of rasterio https://github.com/mapbox/rasterio/pull/1906 (tested with an identically patched rasterio/path.py)


### Proposed changes
Add 'az' to registered schemes 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
