### PR TITLE
Add new erosion param to virtual products "ApplyMask"

### DIFF
--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -11,6 +11,7 @@ v1.8.4 (???)
 - Removed example and contributed notebooks from the repository. Better `notebook examples`_ exist.
 - Removed datacube_apps, as these are not used and not maintained.
 - Add ``cloud_cover`` to EO3 metadata
+- Add ``erosion`` functionality to Virtual products' ``ApplyMask`` to supplement existing ``dilation`` functionality (:pull:`1049`)
 
 .. _`notebook examples`: https://github.com/GeoscienceAustralia/dea-notebooks/
 


### PR DESCRIPTION
### Reason for this pull request
The `ApplyMask` transformation in Virtual products currently includes a "dilation" parameter that allows the user to dilate (i.e. expand) cloud mask layers prior to applying then to satellite imagery.

Being able to also "erode" (shrink) cloud masking data before dilating it would effectively enable a ["morphological opening" operation](https://scikit-image.org/docs/dev/api/skimage.morphology.html#skimage.morphology.binary_opening). This can be extremely useful for removing false positives in `fmask` data, such as those that occur along narrow but bright coastal features (beaches) or urban areas.

### Proposed changes
This PR adds an additional "erosion" parameter to the `ApplyMask` transformation so that users can apply erosion either independently, or in combination with the existing "dilation" functionality.

In addition, I have removed the custom dilation function and replaced it with the implementation in `skimage.morphology`. This also simplifies the creation of a disk-like structure object (disk) and is a little faster than the current approach.

I have tested the new code out on the `Frequently_used_code` Virtually products notebook, and the results are comparable. Original:
![original](https://user-images.githubusercontent.com/17680388/100575359-04fbf500-3330-11eb-8af0-f1de20092532.JPG)

Updated approach: 

![image](https://user-images.githubusercontent.com/17680388/100575343-fb728d00-332f-11eb-9869-254e4ec42fcf.png)


 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
