### PR TITLE
Fix issue 1047: fix numeric precision issues in `box_overlap` when pi…

### DIFF
--- a/datacube/utils/geometry/tools.py
+++ b/datacube/utils/geometry/tools.py
@@ -458,8 +458,8 @@ def box_overlap(src_shape, dst_shape, ST, tol):
             x = round(x)
         return x
 
-    ty = _round_to_near_int(ty, tol[0])
-    tx = _round_to_near_int(tx, tol[1])
+    ty = _round_to_near_int(ty, tol)
+    tx = _round_to_near_int(tx, tol)
 
     s0, d0 = compute_axis_overlap(src_shape[0], dst_shape[0], sy, ty)
     s1, d1 = compute_axis_overlap(src_shape[1], dst_shape[1], sx, tx)
@@ -635,9 +635,7 @@ def compute_reproject_roi(src, dst, tol=0.05, padding=None, align=None):
         is_st = is_affine_st(tr.linear)
 
         if tight_ok and is_st:
-            # Calculate tolerance in source space scaled by resolution
-            tolerance = tuple(abs(tol*res) for res in src.resolution)
-            roi_src, roi_dst = box_overlap(src.shape, dst.shape, tr.back.linear, tolerance)
+            roi_src, roi_dst = box_overlap(src.shape, dst.shape, tr.back.linear, tol)
         else:
             padding = 1 if padding is None else padding
             roi_src, roi_dst = compute_roi(src, dst, tr, 2, padding, align)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -12,6 +12,7 @@ v1.8.4 (???)
 - Removed datacube_apps, as these are not used and not maintained.
 - Add ``cloud_cover`` to EO3 metadata
 - Add ``erosion`` functionality to Virtual products' ``ApplyMask`` to supplement existing ``dilation`` functionality (:pull:`1049`)
+- Fix numeric precision issues in ``compute_reproject_roi`` when pixel size is small. (:issue:`1047`)
 
 .. _`notebook examples`: https://github.com/GeoscienceAustralia/dea-notebooks/
 


### PR DESCRIPTION
### Fix issue #1047 

`compute_reproject_roi(geobox, geobox[roi])` should result with `src_roi == roi` every time.

Sometimes it has an extra pixel when the geobox has
- tiny pixels
- oddly sized alignment. 

### Proposed changes

- Snap translation `t` to nearest integer if it's close to an integer in `box_overlap`


 - [x] Closes #1047 
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
