### PR TITLE
Fix docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,44 +7,20 @@
 ARG ORG=opendatacube
 ARG V_BASE=-3.0.4
 ARG V_PG=10
-FROM ${ORG}/geobase:wheels${V_BASE} as env_builder
+FROM ${ORG}/geobase:builder${V_BASE} as env_builder
 
 # Set the locale, this is required for some of the Python packages
 ENV LC_ALL C.UTF-8
 
+COPY assets/mkenv /usr/bin/
+COPY constraints.txt /conf/constraints.txt
 COPY requirements.txt /conf/requirements.txt
 COPY ./dist/datacube-*.whl /conf/
 
-RUN find /wheels -type f -name '*whl' > /tmp/constraints.txt \
-  && find /conf -type f -name 'datacube-*.whl' | head -1 >> /tmp/constraints.txt \
-  && mkdir -p /wheels-tmp \
-  && echo "Constraints:" \
-  && cat /tmp/constraints.txt \
-  && echo "..." \
-  && pip3 wheel \
-     --no-cache \
-     --no-cache-dir \
-     --wheel-dir=/wheels-tmp \
-     --find-links=/wheels/ \
-     --find-links=/conf/ \
-     --constraint=/tmp/constraints.txt \
-     --requirement=/conf/requirements.txt \
-  && rm /tmp/constraints.txt \
-  && find /wheels-tmp/ -type f -name "datacube-*whl" -delete \
-  && ls -lh /wheels-tmp/ \
-  && rm -rf /root/.cache/pip \
-  && echo "================================================================================" \
-  && find /wheels-tmp/ -type f -name "*whl" > /tmp/reqs.txt \
-# make env root:users with write permissions for group
-  && (umask 002 \
-  && mkdir -p /env \
-  && chgrp users /env \
-  && chmod g+s /env \
-  && env-build-tool new_no_index /tmp/reqs.txt /env /wheels-tmp ) \
+RUN mkenv \
   && rm -rf /wheels-tmp \
   && rm -rf /root/.cache/pip \
   && echo done
-
 
 #################################################################################
 # Runner stage

--- a/docker/assets/mkenv
+++ b/docker/assets/mkenv
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -o errexit
+set -o noclobber
+set -o pipefail
+set -o nounset
+
+# Download all the wheels needed to install datacube[all]
+mkdir -p /wheels-tmp
+find /conf -type f -name 'datacube-*.whl' | head -1 | awk '{print $1"[all]"}' > /tmp/requirements-dc.txt
+echo "GDAL==$(gdal-config --version)" > /tmp/constraints-gdal.txt
+cat /tmp/requirements-dc.txt
+pip3 wheel \
+  --no-cache \
+  --no-cache-dir \
+  --wheel-dir=/wheels-tmp \
+  --requirement=/conf/requirements.txt \
+  --constraint=/conf/constraints.txt \
+  --requirement=/tmp/requirements-dc.txt \
+  --constraint=/tmp/constraints-gdal.txt
+# remove datacube wheel itself as we don't want it to be installed, only requirements of datacube
+find /wheels-tmp/ -type f -name "datacube-*whl" -delete
+
+# make env root:users with write permissions for group
+umask 002
+mkdir -p /env
+chgrp users /env
+chmod g+s /env
+
+python3 -m venv /env
+/env/bin/pip install --upgrade pip setuptools wheel
+# install all downloaded wheels
+/env/bin/pip install \
+             --no-cache-dir \
+             --no-index \
+             --find-links=/wheels-tmp/ \
+             /wheels-tmp/*whl

--- a/docker/constraints.txt
+++ b/docker/constraints.txt
@@ -1,0 +1,31 @@
+# boto3
+boto3==1.10.46
+botocore==1.13.46
+python-dateutil==2.8.1
+moto==1.3.14
+idna==2.8
+# maybe also boto?
+python-jose==3.2.0
+ecdsa==0.14.1
+
+# something wrong with time axis handling in xarray with pandas==1.1.1
+pandas==1.1.2
+xarray==0.16.1
+
+# astroid needs certain version of wrapt
+astroid==2.3.3
+wrapt==1.11.2
+
+# every new version finds new errors, so we pin it
+pylint==2.4.4
+pycodestyle==2.5.0
+
+# for packaging
+setuptools>=42
+setuptools_scm>=3.4
+
+# celery is failing tests, so pinning to known working
+celery==4.4.7
+
+# 3 series needs more recent PROJ than what we have
+pyproj==2.6.*

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,34 +1,11 @@
-# boto3
-boto3==1.10.46
-botocore==1.13.46
-python-dateutil==2.8.1
-moto==1.3.14
-idna==2.8
-# maybe also boto?
-python-jose==3.2.0
-ecdsa==0.14.1
-
-# something wrong with time axis handling in xarray with pandas==1.1.1
-pandas==1.0.5
-xarray==0.16.0
-
-# astroid needs certain version of wrapt
-astroid==2.3.3
-wrapt==1.11.2
-
-# every new version finds new errors, so we pin it
-pylint==2.4.4
-pycodestyle==2.5.0
-
 # for packaging
 wheel
 setuptools>=42
 setuptools_scm[toml]>=3.4
 twine
 
-psycopg2 --no-binary=psycopg2
-
-datacube[all]
-
-# celery is failing tests, so pinning to known working
-celery==4.4.7
+#no binary flags
+--no-binary=pyproj,\
+ shapely,\
+ rasterio,\
+ netcdf4

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -6,6 +6,7 @@ twine
 
 #no binary flags
 --no-binary=pyproj,\
- shapely,\
- rasterio,\
- netcdf4
+shapely,\
+rasterio,\
+fiona,\
+netcdf4


### PR DESCRIPTION
### Reason for this pull request

`pip` no longer supports files in `--constraint` files, see here for details:

https://github.com/opendatacube/geobase/issues/45

We were using this "feature" (now removed) to force installation of locally compiled wheels that were cached in the `:wheels` image. This no longer works with newest `pip`.

### Proposed changes

1. Use `pip wheel` to download/compile all the wheels needed to install datacube
    - Force compilation of geo libs with `--no-binary` flag
2. Install all the wheels (except for datacube wheel) from the folder, using `--no-index` install mode


 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
