### PR TITLE
Simplify dependencies, use mock from stdlib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ from setuptools import setup, find_packages
 
 tests_require = [
     'hypothesis',
-    'mock',
     'pycodestyle',
     'pylint',
     'pytest',

--- a/tests/api/test_grid_workflow.py
+++ b/tests/api/test_grid_workflow.py
@@ -6,7 +6,7 @@ import pytest
 import numpy
 from datacube.model import GridSpec
 from datacube.utils import geometry
-from mock import MagicMock
+from unittest.mock import MagicMock
 import uuid
 
 
@@ -17,7 +17,7 @@ class PickableMock(MagicMock):
 
 def test_gridworkflow():
     """ Test GridWorkflow with padding option. """
-    from mock import MagicMock
+    from unittest.mock import MagicMock
     import datetime
 
     # ----- fake a datacube -----
@@ -123,7 +123,7 @@ def test_gridworkflow():
     fakedataset.type.lookup_measurements.return_value = {'dummy': measurement}
     fakedataset2.type = fakedataset.type
 
-    from mock import patch
+    from unittest.mock import patch
     with patch('datacube.api.core.Datacube.load_data') as loader:
 
         data = GridWorkflow.load(tile)
@@ -157,7 +157,7 @@ def test_gridworkflow_with_time_depth():
     """Test GridWorkflow with time series.
     Also test `Tile` methods `split` and `split_by_time`
     """
-    from mock import MagicMock
+    from unittest.mock import MagicMock
     import datetime
 
     fakecrs = geometry.CRS('EPSG:4326')

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -23,7 +23,7 @@ def test_datetime_to_timestamp():
 
 
 def test_query_kwargs():
-    from mock import MagicMock
+    from unittest.mock import MagicMock
 
     mock_index = MagicMock()
     mock_index.datasets.get_field_names = lambda: {u'product', u'lat', u'sat_path', 'type_id', u'time', u'lon',

--- a/tests/api/test_virtual.py
+++ b/tests/api/test_virtual.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 import warnings
 
 import pytest
-import mock
+from unittest import mock
 import numpy
 
 from datacube.model import DatasetType, MetadataType, Dataset, GridSpec

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from contextlib import contextmanager
 
-import mock
+from unittest import mock
 import numpy as np
 import pytest
 import rasterio.warp

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import math
 import numpy as np
-from mock import MagicMock
+from unittest.mock import MagicMock
 from affine import Affine
 import pytest
 from pytest import approx

--- a/tests/test_utils_aws.py
+++ b/tests/test_utils_aws.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2015-2020 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import pytest
-import mock
+from unittest import mock
 import json
 import botocore
 from botocore.credentials import ReadOnlyCredentials

--- a/tests/test_utils_rio.py
+++ b/tests/test_utils_rio.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2015-2020 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import pytest
-import mock
+from unittest import mock
 import os
 
 from datacube.testutils import write_files


### PR DESCRIPTION
Change to import mock from unittest.mock, which has been available in
the standard library since Python 3.3, well below our minimum.

 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
