### PR TITLE
Fix slow cli archive for datasets

### DIFF
--- a/check-code.sh
+++ b/check-code.sh
@@ -38,7 +38,7 @@ pytest -r a \
 
 set +x
 
-# Optinally validate example yaml docs.
+# Optionally validate example yaml docs.
 if which yamllint;
 then
     set -x

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -333,6 +333,15 @@ class PostgresDbAPI(object):
             )
         )
 
+    def exists_dataset(self, dataset_ids):
+        return self._connection.execute(
+            DATASET.select(
+                DATASET.c.id.label('id')
+            ).where(
+                DATASET.c.id.in_(dataset_ids)
+            )
+        ).fetchall()
+
     def restore_dataset(self, dataset_id):
         self._connection.execute(
             DATASET.update().where(

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -335,11 +335,7 @@ class PostgresDbAPI(object):
 
     def exists_dataset(self, dataset_ids):
         return self._connection.execute(
-            DATASET.select(
-                [DATASET.c.id.label('id')]
-            ).where(
-                DATASET.c.id.in_(dataset_ids)
-            )
+            select([DATASET.c.id]).where(DATASET.c.id.in_(dataset_ids))
         ).fetchall()
 
     def restore_dataset(self, dataset_id):

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -333,11 +333,6 @@ class PostgresDbAPI(object):
             )
         )
 
-    def exists_dataset(self, dataset_ids):
-        return self._connection.execute(
-            select([DATASET.c.id]).where(DATASET.c.id.in_(dataset_ids))
-        ).fetchall()
-
     def restore_dataset(self, dataset_id):
         self._connection.execute(
             DATASET.update().where(

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -336,7 +336,7 @@ class PostgresDbAPI(object):
     def exists_dataset(self, dataset_ids):
         return self._connection.execute(
             DATASET.select(
-                DATASET.c.id.label('id')
+                [DATASET.c.id.label('id')]
             ).where(
                 DATASET.c.id.in_(dataset_ids)
             )

--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -348,10 +348,10 @@ class DatasetResource(object):
         Check if a dataset exists by UUID
 
         :param List[str] ids: list of dataset ids to check existence
-        :rtype set[Union[str, UUID]]
+        :rtype set[str]
         """
         with self._db.begin() as transaction:
-            return transaction.exists_dataset(ids)
+            return [str(row.id) for row in transaction.exists_dataset(ids)]
 
     def restore(self, ids):
         """

--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -343,6 +343,16 @@ class DatasetResource(object):
             for id_ in ids:
                 transaction.archive_dataset(id_)
 
+    def exists(self, ids):
+        """
+        Check if a dataset exists by UUID
+
+        :param List[str] ids: list of dataset ids to check existence
+        :rtype set[Union[str, UUID]]
+        """
+        with self._db.begin() as transaction:
+            return transaction.exists_dataset(ids)
+
     def restore(self, ids):
         """
         Mark datasets as not archived

--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -8,7 +8,7 @@ API for dataset indexing, access and search.
 import logging
 import warnings
 from collections import namedtuple
-from typing import Any, Iterable, Set, Tuple, Union, List, Optional
+from typing import Iterable, Tuple, Union, List, Optional
 from uuid import UUID
 
 from datacube.model import Dataset, DatasetType

--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -343,16 +343,6 @@ class DatasetResource(object):
             for id_ in ids:
                 transaction.archive_dataset(id_)
 
-    def exists(self, ids):
-        """
-        Check if a dataset exists by UUID
-
-        :param List[str] ids: list of dataset ids to check existence
-        :rtype set[str]
-        """
-        with self._db.begin() as transaction:
-            return [str(row.id) for row in transaction.exists_dataset(ids)]
-
     def restore(self, ids):
         """
         Mark datasets as not archived

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -475,7 +475,7 @@ def archive_cmd(index: Index, archive_derived: bool, dry_run: bool, ids: List[st
         for dataset_id, exists in datasets_for_archive.items():
             if not exists:
                 click.echo(f'No dataset found with id: {dataset_id}')
-        sys.exit(0)
+        sys.exit(-1)
 
     derived_datasets = []
     if archive_derived:

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -471,7 +471,7 @@ def _get_derived_set(index: Index, id_: str) -> Set[Dataset]:
 def archive_cmd(index: Index, archive_derived: bool, dry_run: bool, ids: List[str]):
     datasets_for_archive = index.datasets.exists(ids)
 
-    non_existent_datasets = list(set(ids) - set(datasets_for_archive))
+    non_existent_datasets = list(set(datasets_for_archive) - set(ids))
     if non_existent_datasets:
         for dataset in non_existent_datasets:
             click.echo(f'No dataset found with id: {dataset}')

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -469,13 +469,13 @@ def _get_derived_set(index: Index, id_: str) -> Set[Dataset]:
 @click.argument('ids', nargs=-1)
 @ui.pass_index()
 def archive_cmd(index: Index, archive_derived: bool, dry_run: bool, ids: List[str]):
-    datasets_for_archive = index.datasets.exists(ids)
+    datasets_for_archive = {dataset_id: exists for dataset_id, exists in zip(ids, index.datasets.bulk_has(ids))}
 
-    non_existent_datasets = list(set(datasets_for_archive) - set(ids))
-    if non_existent_datasets:
-        for dataset in non_existent_datasets:
-            click.echo(f'No dataset found with id: {dataset}')
-        sys.exit(-1)
+    if False in datasets_for_archive.values():
+        for dataset_id, exists in datasets_for_archive.items():
+            if not exists:
+                click.echo(f'No dataset found with id: {dataset_id}')
+        sys.exit(0)
 
     derived_datasets = []
     if archive_derived:
@@ -483,7 +483,7 @@ def archive_cmd(index: Index, archive_derived: bool, dry_run: bool, ids: List[st
         # Get the UUID of our found derived datasets
         derived_datasets = [derived.id for derived_dataset in derived_datasets for derived in derived_dataset]
 
-    all_datasets = derived_datasets + datasets_for_archive
+    all_datasets = derived_datasets + [uuid for uuid in datasets_for_archive.keys()]
 
     for dataset in all_datasets:
         click.echo(f'Archiving dataset: {dataset}')

--- a/integration_tests/index/test_search.py
+++ b/integration_tests/index/test_search.py
@@ -958,7 +958,7 @@ def test_cli_info(index: Index,
     assert len(yaml_docs) == 1
 
     # We output properties in order for readability:
-    output_lines = [l for l in output.splitlines() if not l.startswith('indexed:')]
+    output_lines = [line for line in output.splitlines() if not line.startswith('indexed:')]
     assert output_lines == [
         "id: " + str(pseudo_ls8_dataset.id),
         'product: ls8_telemetry',


### PR DESCRIPTION
### Reason for this pull request

This PR should resolve https://github.com/opendatacube/datacube-core/issues/1048 by skipping heavy bootstrapping of the `DatasetResource` object and just querying for UUIDs in the database.

This should also partly solve;

https://github.com/opendatacube/datacube-core/issues/1029

I've not been able to test this completely on a large dataset. 

 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
