### PR TITLE
Fixed incorrect variable name and some typos.

### DIFF
--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -566,7 +566,7 @@ class DatasetType:
                 dim_name = extra_dim.get('dimension')
                 if len(extra_dimension_values.get(dim_name)) != len(extra_dim.get('alias_map')):
                     raise ValueError(
-                        f"alias_map should be the same length as extra_dimention "
+                        f"alias_map should be the same length as extra_dimensions "
                         f"{dim_name} values in the product definition"
                     )
 
@@ -577,7 +577,7 @@ class DatasetType:
                 spectral_definition_map = extra_dim.get('spectral_definition_map')
                 if len(extra_dimension_values.get(dim_name)) != len(spectral_definition_map):
                     raise ValueError(
-                        f"spectral_definition_map should be the same length as extra_dimention "
+                        f"spectral_definition_map should be the same length as extra_dimensions "
                         f"{dim_name} values in the product definition"
                     )
 
@@ -595,7 +595,7 @@ class DatasetType:
                 if m_name in measurement_names:
                     raise ValueError(
                         f"Trying to generate measurement {m_name} from 3D measurement "
-                        f"{m.get('name')}, but it already defined in the product definition"
+                        f"{m.get('name')}, but it is already defined in the product definition"
                     )
                 if m_name in duplicates_names:
                     raise ValueError(f"Found duplicate measurement name {m_name} in 3D measurement {m.get('name')}")
@@ -606,7 +606,7 @@ class DatasetType:
                 for alias in aliases:
                     if alias in duplicates_aliases:
                         raise ValueError(f"Found duplicate alias {alias} in 3D measurement {m.get('name')}")
-                    duplicates_names.add(alias)
+                    duplicates_aliases.add(alias)
 
     def canonical_measurement(self, measurement: str) -> str:
         """ resolve measurement alias into canonical name


### PR DESCRIPTION
### Reason for this pull request
The check for duplicate aliases in 3D product definitions was not working as it used the `duplicates_names` instead of the `duplicates_aliases` variable.
Some of the error messages had small typos.

### Proposed changes
- Fixed incorrect var name in border case checks.
- Fixed typos in error messages.

 - [X] Closes #1070 
 - [X] Tests added / passed
 - [X] Fully documented, including `docs/about/whats_new.rst` for all changes

Please delete branch after merging.

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
