### PR TITLE
removes the codecov token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -176,7 +176,6 @@ jobs:
       if: steps.cfg.outputs.primary == 'yes'
       uses: codecov/codecov-action@v1
       with:
-        token: ${{ secrets.CodeCovToken }}
         file: ./coverage.xml
         fail_ci_if_error: false
 


### PR DESCRIPTION
### Reason for this pull request

A CodeCov token not required for public repositories uploading from Travis, CircleCI, AppVeyor, Azure Pipelines or GitHub Actions

The existing CodeCov token will be regenerated


### Proposed changes
Remove the CodeCov secret and remove from the codecov-action
 - [x] Fixes a security compromise
 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
