### PR TITLE
Fix 1085 nodata nan

### DIFF
--- a/.github/workflows/docker-test-runner.yml
+++ b/.github/workflows/docker-test-runner.yml
@@ -84,7 +84,15 @@ jobs:
 
     - name: Verify Docker Image
       run: |
+        # Make sure we test docker image we built
+        if [[ "${{ steps.build.outputs.docker_image }}" != "opendatacube/datacube-tests:latest" ]]; then
+            docker tag "${{ steps.build.outputs.docker_image }}" opendatacube/datacube-tests:latest
+        fi
+
         ./check-code.sh --with-docker integration_tests
+
+        echo "Verify that twine is installed"
+        docker run --rm opendatacube/datacube-tests:latest twine --version
 
     - name: DockerHub Login
       id: dkr

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,11 @@ jobs:
                   ${{ matrix.docker_image }} bash -
         python setup.py bdist_wheel sdist
         ls -lh ./dist/
-        twine check ./dist/*
+        if hash twine 2> /dev/null ; then
+           twine check ./dist/*
+        else
+           echo "WARNING: twine is missing from the docker!"
+        fi
         EOF
 
     - name: Check Code Style

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -453,7 +453,14 @@ class DatasetType:
         Dictionary of measurements in this product
         """
         if self._canonical_measurements is None:
-            self._canonical_measurements = OrderedDict((m['name'], Measurement(**m))
+            def fix_nodata(m):
+                nodata = m.get('nodata', None)
+                if isinstance(nodata, str):
+                    m = dict(**m)
+                    m['nodata'] = float(nodata)
+                return m
+
+            self._canonical_measurements = OrderedDict((m['name'], Measurement(**fix_nodata(m)))
                                                        for m in self.definition.get('measurements', []))
         return self._canonical_measurements
 

--- a/docker/assets/mkenv
+++ b/docker/assets/mkenv
@@ -6,16 +6,10 @@ set -o pipefail
 set -o nounset
 
 # Download/compile all the wheels needed to install datacube[all]
+# plus libs specified in /conf/requirements.txt
 mkdir -p /tmp/wheels
 find /conf -type f -name 'datacube-*.whl' | head -1 | awk '{print $1"[all]"}' > /tmp/requirements-dc.txt
-cat <<EOF >> /tmp/requirements-dc.txt
---no-binary=rasterio
---no-binary=fiona
---no-binary=shapely
---no-binary=pyproj
---no-binary=netcdf4
---no-binary=h5py
-EOF
+cat /conf/requirements.txt >> /tmp/requirements-dc.txt
 
 cat /tmp/requirements-dc.txt
 env-build-tool wheels /tmp/requirements-dc.txt /conf/constraints.txt /tmp/wheels
@@ -29,4 +23,4 @@ find /tmp/wheels/ -type f -name '*whl' | \
 
 # make env root:users with write permissions for group
 umask 002
-env-build-tool new_no_index /tmp/requirements-test-env.txt /env /tmp/wheels
+env-build-tool new_no_index /tmp/requirements-test-env.txt /conf/constraints.txt /env /tmp/wheels

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -3,10 +3,3 @@ wheel
 setuptools>=42
 setuptools_scm[toml]>=3.4
 twine
-
-#no binary flags
---no-binary=pyproj,\
-shapely,\
-rasterio,\
-fiona,\
-netcdf4

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -124,6 +124,27 @@ def test_product_dimensions():
     assert product.grid_spec is None
 
 
+def test_product_nodata_nan():
+    # When storing .nan to JSON in DB it becomes a string with value "NaN"
+    # Make sure it is converted back to real NaN
+    product = mk_sample_product('test', measurements=[dict(name='_nan',
+                                                           dtype='float32',
+                                                           nodata='NaN'),
+                                                      dict(name='_inf',
+                                                           dtype='float32',
+                                                           nodata='Infinity'),
+                                                      dict(name='_neg_inf',
+                                                           dtype='float32',
+                                                           nodata='-Infinity'),
+                                                      ])
+    for m in product.measurements.values():
+        assert isinstance(m.nodata, float)
+
+    assert numpy.isnan(product.measurements['_nan'].nodata)
+    assert product.measurements['_inf'].nodata == numpy.inf
+    assert product.measurements['_neg_inf'].nodata == -numpy.inf
+
+
 def test_product_scale_factor():
     product = mk_sample_product('test', measurements=[dict(name='red',
                                                            scale_factor=33,

--- a/tests/test_utils_rio.py
+++ b/tests/test_utils_rio.py
@@ -182,5 +182,9 @@ def test_rio_configure_aws_access(monkeypatch, without_aws_env, dask_client):
     assert 'AWS_REGION' in ee
     assert 'AWS_SESSION_TOKEN' not in ee
 
-    ee = client.submit(get_rio_env, sanitize=False).result()
+    def _activate_and_get(sanitize=True):
+        activate_from_config()
+        return get_rio_env(sanitize=sanitize)
+
+    ee = client.submit(_activate_and_get, sanitize=False).result()
     assert ee == ee_local


### PR DESCRIPTION
### Reason for this pull request

Properly handle `nodata=NaN` case in the product. See #1085 for details.


### Proposed changes

- Detect string values inside `nodata` fields of the measurement dictionary and parse them to `float`
- Also fixes docker building and testing
- Also fixes rio test that started failing with newer version of Dask or python.



 - [x] Closes #1085 
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
