### PR TITLE
Add docstring for skip_broken_datasets

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -281,6 +281,10 @@ class Datacube(object):
             Optional. If this is a non-empty list of :class:`datacube.model.Dataset` objects, these will be loaded
             instead of performing a database lookup.
 
+        :param bool skip_broken_datasets:
+            Optional. If this is True, then don't break when failing to load a broken dataset.
+            Default is False.
+
         :param int limit:
             Optional. If provided, limit the maximum number of datasets
             returned. Useful for testing and debugging.


### PR DESCRIPTION
### Reason for this pull request

Undocumented feature


### Proposed changes

- document the feature `skip_broken_datasets` for `dc.load()`

 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes
