### PR TITLE
Fix an issue with SQL Alchemy's API changing, resulting in a warning

### DIFF
--- a/datacube/drivers/postgres/_connections.py
+++ b/datacube/drivers/postgres/_connections.py
@@ -123,7 +123,9 @@ class PostgresDb(object):
 
     @property
     def url(self) -> str:
-        return self._engine.url.create()
+        if hasattr(self._engine.url, 'create'):
+            return self._engine.url.create()
+        return str(self._engine.url)
 
     @staticmethod
     def get_db_username(config):

--- a/datacube/drivers/postgres/_connections.py
+++ b/datacube/drivers/postgres/_connections.py
@@ -123,7 +123,7 @@ class PostgresDb(object):
 
     @property
     def url(self) -> str:
-        return self._engine.url
+        return self._engine.url.create()
 
     @staticmethod
     def get_db_username(config):


### PR DESCRIPTION
### Reason for this pull request

Creating a `Datacube` object is raising a warning:

>/env/lib/python3.6/site-packages/datacube/drivers/postgres/_connections.py:87: SADeprecationWarning: Calling URL() directly is deprecated and will be disabled in a future release.  The public constructor for URL is now the URL.create() method.

Looks like it's from here: https://github.com/sqlalchemy/sqlalchemy/blob/master/lib/sqlalchemy/engine/url.py#L87

### Proposed changes

- Change the way we create a DB connection

 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
