### PR TITLE
Address SQLAlchemy API change warnings

### DIFF
--- a/datacube/drivers/postgres/_connections.py
+++ b/datacube/drivers/postgres/_connections.py
@@ -80,8 +80,9 @@ class PostgresDb(object):
     @classmethod
     def create(cls, hostname, database, username=None, password=None, port=None,
                application_name=None, validate=True, pool_timeout=60):
+        mk_url = getattr(EngineUrl, 'create', EngineUrl)
         engine = cls._create_engine(
-            EngineUrl(
+            mk_url(
                 'postgresql',
                 host=hostname, database=database, port=port,
                 username=username, password=password,

--- a/datacube/drivers/postgres/_connections.py
+++ b/datacube/drivers/postgres/_connections.py
@@ -123,7 +123,7 @@ class PostgresDb(object):
         )
 
     @property
-    def url(self) -> str:
+    def url(self) -> EngineUrl:
         return self._engine.url
 
     @staticmethod


### PR DESCRIPTION
### Reason for this pull request

SQLAlchemy now wants `URL.create(...)` instead of just `URL(...)`, but we probably want to support older versions too for now.


### Proposed changes

- Call `URL.create(...)` if available, else use old syntax `URL(...)`
- Also fix `.url` property type annotation it's not a `str` it's `URL`


 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
