### PR TITLE
Add examples/io_plugin to test docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,6 @@
 .circleci
 .github
 .travis
-examples
 integration_tests
 
 # Byte-compiled / optimized / DLL files

--- a/datacube/ui/click.py
+++ b/datacube/ui/click.py
@@ -150,9 +150,9 @@ verbose_option = click.option('--verbose', '-v', count=True, callback=_init_logg
 logfile_option = click.option('--log-file', multiple=True, callback=_add_logfile,
                               is_eager=True, expose_value=False, help="Specify log file")
 #: pylint: disable=invalid-name
-config_option = click.option('--config', '--config_file', '-C', multiple=True, default='', callback=_set_config,
+config_option = click.option('--config', '--config_file', '-C', multiple=True, default=[], callback=_set_config,
                              expose_value=False)
-config_option_exposed = click.option('--config', '--config_file', '-C', multiple=True, default='', callback=_set_config)
+config_option_exposed = click.option('--config', '--config_file', '-C', multiple=True, default=[], callback=_set_config)
 
 environment_option = click.option('--env', '-E', callback=_set_environment,
                                   expose_value=False)
@@ -285,7 +285,7 @@ def _setup_executor(ctx, param, value):
 
 executor_cli_options = click.option('--executor',  # type: ignore
                                     type=(click.Choice(list(EXECUTOR_TYPES)), str),
-                                    default=('serial', None),
+                                    default=['serial', None],
                                     help="Run parallelized, either locally or distributed. eg:\n"
                                          "--executor multiproc 4 (OR)\n"
                                          "--executor distributed 10.0.0.8:8888",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -76,6 +76,7 @@ RUN --mount=type=bind,from=env_builder,target=/b \
     --mount=type=cache,target=/home/odc/.cache/pip,uid=1000,gid=1000 \
     (cd /src && tar c . ) | (cd /code && tar x) \
     && /env/bin/python -m pip install -e '/code/[all]' --no-index --find-links=/b/wheels \
+    && /env/bin/python -m pip install -e /code/examples/io_plugin --no-index --find-links=/b/wheels \
     && /env/bin/python -m pip install -e /code/tests/drivers/fail_drivers --no-index --find-links=/b/wheels
 
 USER root

--- a/docker/assets/with_bootstrap
+++ b/docker/assets/with_bootstrap
@@ -76,6 +76,7 @@ if [ -e "${env}/bin/activate" ]; then
         [[ -e /code/datacube.egg-info ]] || {
             python -m pip install -e /code --no-deps
             python -m pip install -e /code/tests/drivers/fail_drivers --no-deps
+            python -m pip install -e /code/examples/io_plugin --no-deps
         }
 
         [ -n "${GDAL_DATA:-}" ] || {


### PR DESCRIPTION
### Reason for this pull request

Recent changes to test docker resulted in missing examples/io_plugin installation, and some plugin related tests rely on those being installed during testing for maximum coverage.

### Proposed changes

Make sure `examples/io_plugin` are installed in edit mode in the test docker.
Also fix click>=8 incompatibilities

 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
