### PR TITLE
Fix UUID parsing (#1029)

### DIFF
--- a/datacube/ui/expression.py
+++ b/datacube/ui/expression.py
@@ -55,7 +55,7 @@ search_grammar = r"""
     YEAR: DIGIT ~ 4
     MONTH: DIGIT ~ 1..2
     DAY: DIGIT ~ 1..2
-    SIMPLE_STRING: /[a-zA-Z][\w._-]*/
+    SIMPLE_STRING: /[a-zA-Z][\w._-]*/ | /[0-9]+[\w_-][\w._-]*/
     URL_STRING: /[a-z0-9+.-]+:\/\/([:\/\w._-])*/
     UUID: HEXDIGIT~8 "-" HEXDIGIT~4 "-" HEXDIGIT~4 "-" HEXDIGIT~4 "-" HEXDIGIT~12
 

--- a/datacube/ui/expression.py
+++ b/datacube/ui/expression.py
@@ -43,7 +43,7 @@ search_grammar = r"""
           | ESCAPED_STRING -> string
           | SIMPLE_STRING -> simple_string
           | URL_STRING -> url_string
-
+          | UUID -> simple_string
 
     ?date_range: date -> single_date
                | "[" date "," date "]" -> date_pair
@@ -57,12 +57,14 @@ search_grammar = r"""
     DAY: DIGIT ~ 1..2
     SIMPLE_STRING: /[a-zA-Z][\w._-]*/
     URL_STRING: /[a-z0-9+.-]+:\/\/([:\/\w._-])*/
+    UUID: HEXDIGIT~8 "-" HEXDIGIT~4 "-" HEXDIGIT~4 "-" HEXDIGIT~4 "-" HEXDIGIT~12
 
 
     %import common.ESCAPED_STRING
     %import common.SIGNED_NUMBER
     %import common.INT
     %import common.DIGIT
+    %import common.HEXDIGIT
     %import common.CNAME
     %import common.WS
     %ignore WS

--- a/tests/ui/test_expression_parsing.py
+++ b/tests/ui/test_expression_parsing.py
@@ -7,7 +7,6 @@ from dateutil.tz import tzutc
 
 from datacube.model import Range
 from datacube.ui import parse_expressions
-import pytest
 
 
 def test_parse_empty_str():
@@ -15,12 +14,12 @@ def test_parse_empty_str():
     assert q == {}
 
 
-@pytest.mark.xfail(
-    True,
-    reason="Parsing UUIDs without string quotes doesn't work when uuid starts with a digit",
-)
 def test_id_search():
     q = parse_expressions("id = 26931d17-7a4e-4b55-98e7-d6777fb61df6")
+    assert q['id'] == "26931d17-7a4e-4b55-98e7-d6777fb61df6"
+
+    q = parse_expressions('id = "26931d17-7a4e-4b55-98e7-d6777fb61df6"')
+    assert q['id'] == "26931d17-7a4e-4b55-98e7-d6777fb61df6"
 
 
 def test_between_expression():

--- a/tests/ui/test_expression_parsing.py
+++ b/tests/ui/test_expression_parsing.py
@@ -22,6 +22,13 @@ def test_id_search():
     assert q['id'] == "26931d17-7a4e-4b55-98e7-d6777fb61df6"
 
 
+def test_simple_string():
+    q = parse_expressions("region_code = 56KKD", "i=10", "f=10.3")
+    assert q['region_code'] == '56KKD'
+    assert q['i'] == 10
+    assert q['f'] == 10.3
+
+
 def test_between_expression():
     q = parse_expressions('time in [2014, 2015]')
     assert 'time' in q

--- a/tests/ui/test_expression_parsing.py
+++ b/tests/ui/test_expression_parsing.py
@@ -7,11 +7,20 @@ from dateutil.tz import tzutc
 
 from datacube.model import Range
 from datacube.ui import parse_expressions
+import pytest
 
 
 def test_parse_empty_str():
     q = parse_expressions('')
     assert q == {}
+
+
+@pytest.mark.xfail(
+    True,
+    reason="Parsing UUIDs without string quotes doesn't work when uuid starts with a digit",
+)
+def test_id_search():
+    q = parse_expressions("id = 26931d17-7a4e-4b55-98e7-d6777fb61df6")
 
 
 def test_between_expression():


### PR DESCRIPTION
### Reason for this pull request

Do not require quoted strings for UUIDs that start with a digit

```bash
datacube dataset search id = "26931d17-7a4e-4b55-98e7-d6777fb61df6" # works
datacube dataset search id = 26931d17-7a4e-4b55-98e7-d6777fb61df6 # didn't work, now does
```

### Proposed changes

- Define UUID value in the grammar, that then fixes parsing.
- Parse inputs like `55ABC` as strings

 - [x] Closes #1029 
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
