### PR TITLE
The Python Modules Index in the Docs isn't working

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -34,8 +34,8 @@ plantuml_diags: $(SVG_FILES)
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 livehtml:
-	sphinx-autobuild -b html --host 0.0.0.0 --port 8123 --ignore "*_tmp_*" --ignore "*_old_*" --watch "../datacube" --ignore "_build/*" --ignore "dev/api/generate/*" $(SPHINXOPTS) . $(BUILDDIR)/html
+	sphinx-autobuild -b html --host 0.0.0.0 --port 8123 --watch "../datacube" --re-ignore "dev/api/generate/.*\.rst" $(SPHINXOPTS) . $(BUILDDIR)/html
 
 clean:
 	rm -rf _build/
-	rm -rf dev/api/generate/
+	rm -rf dev/api/generate/*

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -616,7 +616,7 @@ v1.1.17 Happy Festivus Continues (12 January 2017)
 
  - Added more operations to the geometry utils
 
- - Updated :ref:`recipes` to use geometry utils
+ - Updated `recipes` to use geometry utils
 
  - Enabled Windows CI (python 3 only)
 
@@ -667,7 +667,7 @@ v1.1.13 Black Goat (15 November 2016)
 
   - Merged several bug-fixes from CEOS-SEO branch
 
-  - Added Polygon Drill recipe to :ref:`recipes`
+  - Added Polygon Drill recipe to `recipes`
 
 v1.1.12 Unnamed Unknown (1 November 2016)
 =========================================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,7 +66,7 @@ release = version+"-FIXME"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = []
+exclude_patterns = ['README.rst']
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 add_function_parentheses = True
@@ -82,6 +82,7 @@ autosummary_generate = True
 
 extlinks = {'issue': ('https://github.com/opendatacube/datacube-core/issues/%s', 'issue '),
             'pull': ('https://github.com/opendatacube/datacube-core/pulls/%s', 'PR ')}
+
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),

--- a/docs/dev/api/index.rst
+++ b/docs/dev/api/index.rst
@@ -6,6 +6,8 @@ API reference
 
 .. currentmodule:: datacube
 
+.. py:module:: datacube
+
 .. highlight:: python
 
 For examples on how to use the API, check out the `example Jupyter notebooks
@@ -59,6 +61,8 @@ for example, to pre-filter the available datasets before loading.
 
 .. _grid-workflow-class:
 
+.. py:module:: datacube.api
+
 Grid Processing API
 ===================
 
@@ -85,6 +89,8 @@ Grid Processing API Internals
    GridWorkflow.group_into_cells
    GridWorkflow.tile_sources
 
+.. py:module:: datacube.model
+
 Internal Data Model
 ===================
 
@@ -101,6 +107,7 @@ Internal Data Model
    Range
 
 
+.. py:module:: datacube.index
 
 Database Index API
 ==================
@@ -230,6 +237,8 @@ Database Index Connections
 Dataset to Product Matching
 ---------------------------
 
+.. py:module:: datacube.index.hl
+
 .. currentmodule:: datacube.index.hl
 
 .. autosummary::
@@ -237,6 +246,9 @@ Dataset to Product Matching
    :toctree: generate/
 
    Doc2Dataset
+
+
+.. py:module:: datacube.utils.geometry
 
 Geometry Utilities
 ==================
@@ -372,6 +384,9 @@ Other Utilities
    rio_reproject
 
 
+
+.. py:module:: datacube.utils
+
 Masking
 =======
 
@@ -389,6 +404,8 @@ Masking
    masking.make_mask
 
 
+.. py:module:: datacube.utils.cog
+
 Writing Image Files
 ===================
 
@@ -400,6 +417,8 @@ Writing Image Files
    write_cog
    to_cog
 
+
+.. py:module:: datacube.utils.aws
 
 AWS Utilities
 =============
@@ -424,6 +443,7 @@ AWS Utilities
    configure_s3_access
 
 
+.. py:module:: datacube.utils.dask
 
 Dask Utilities
 ==============
@@ -441,6 +461,7 @@ Dask Utilities
    save_blob_to_s3
 
 
+.. currentmodule:: datacube.api.query
 
 Query Class
 ===========
@@ -454,6 +475,7 @@ Query Class
    solar_day
    solar_offset
 
+.. currentmodule:: datacube.api.config
 
 User Configuration
 ==================

--- a/docs/dev/api/masking.rst
+++ b/docs/dev/api/masking.rst
@@ -1,5 +1,7 @@
 .. _bit-masking:
 
+.. py:module:: datacube.utils.masking
+
 Bit Masking
 ===========
 
@@ -45,7 +47,6 @@ How to Define Meanings on Measurements
 How to Create Masks within code
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. currentmodule:: datacube.utils
 
 .. automethod:: masking.describe_variable_flags
 .. automethod:: masking.make_mask

--- a/docs/ops/windows.rst
+++ b/docs/ops/windows.rst
@@ -4,14 +4,18 @@ Microsoft Windows
 
 Miniconda
 ~~~~~~~~~
+
 1. Download and install Miniconda using the following instructions https://conda.io/projects/conda/en/latest/user-guide/install/windows.html
 
 2. Open the Anaconda Prompt from the Start Menu to execute the following commands.
 
 .. include:: conda_base.rst 
 
-The Datacube package and associated requirement packages are now installed and can be used in the Anaconda Prompt by activating the `cubeenv` environment. 
-e.g. 
+The Open Datacube package and it's requirements are now installed. Use them by
+activating the `cubeenv` environment from the Anaconda Prompt.
+
+.. code:: bash
+
     conda activate cubenv
    
 Manual Installation (Fallback)

--- a/docs/user/ecosystem.rst
+++ b/docs/user/ecosystem.rst
@@ -14,7 +14,7 @@ See :ref:`jupyter-notebooks` for some examples.
 
 
 Open Web Services
-----------------
+-----------------
 
 The datacube-ows_ server allows users to interact with
 an Open Data Cube instance using client software

--- a/docs/user/intro.rst
+++ b/docs/user/intro.rst
@@ -50,6 +50,6 @@ See the following sections for more introductory information:
 
 .. toctree::
 
-   user/deployments.rst
-   user/ecosystem.rst
-   user/notebooks.rst
+   deployments.rst
+   ecosystem.rst
+   notebooks.rst


### PR DESCRIPTION
### Expected behaviour
This page has a list of all the Python modules in Core https://datacube-core.readthedocs.io/en/latest/py-modindex.html

### Actual behaviour

It does not!

### Steps to reproduce the behaviour

