### PR TITLE
New Feature: Search by URI from the Command Line

### DIFF
--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -420,7 +420,7 @@ class DatasetResource(object):
         Find datasets that exist at the given URI
 
         :param uri: search uri
-        :param str mode: 'exact' or 'prefix'
+        :param str mode: 'exact' or 'prefix' or None to guess
         :return:
         """
         with self._db.connect() as connection:

--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -420,7 +420,7 @@ class DatasetResource(object):
         Find datasets that exist at the given URI
 
         :param uri: search uri
-        :param str mode: 'exact' or 'prefix' or None to guess
+        :param str mode: 'exact', 'prefix' or None (to guess)
         :return:
         """
         with self._db.connect() as connection:

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -478,11 +478,11 @@ def uri_search_cmd(index: Index, paths: List[str], search_mode):
         # This is what the API expects. I think it should be changed.
         search_mode = None
     for path in paths:
-        dss = list(index.datasets.get_datasets_for_location(uri_resolve(base=path), mode=search_mode))
-        if not dss:
-            print(f"Not found in index: {path}")
-        for ds in dss:
-            print(ds)
+        datasets = list(index.datasets.get_datasets_for_location(uri_resolve(base=path), mode=search_mode))
+        if not datasets:
+            _LOG.info(f"Not found in index: {path}")
+        for dataset in datasets:
+            print(dataset)
 
 
 @dataset_cmd.command('archive', help="Archive datasets")

--- a/datacube/utils/uris.py
+++ b/datacube/utils/uris.py
@@ -167,7 +167,7 @@ def normalise_path(p: Union[str, pathlib.Path],
     return norm(base / p)
 
 
-def uri_resolve(base: str, path: Optional[str]) -> str:
+def uri_resolve(base: str, path: Optional[str] = None) -> str:
     """
     path                  -- if path is a uri or /vsi.* style path
     Path(path).as_uri()   -- if path is absolute filename

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -15,6 +15,7 @@ v1.8.4 (???)
 - Fix numeric precision issues in ``compute_reproject_roi`` when pixel size is small. (:issue:`1047`)
 - Follow up fix to (:issue:`1047`) to round scale to nearest integer if very close.
 - Add support for 3D Datasets. (:pull:`1099`)
+- New feature: search by URI from the command line ``datacube dataset uri-search``.
 - Added new "license" and "description" properties to `DatasetType` to enable easier access to product information. (:pull:`1143`, :pull:`1144`)
 - Revised the ``Datacube.list_products`` function to produce a simpler and more useful product list table (:pull:`1145`)
 - Add new ``dataset_predicate`` param to ``dc.load`` and ``dc.find_datasets`` for more flexible temporal filtering (e.g. loading data for non-contiguous time ranges such as specific months or seasons over multiple years). (:pull:`1148`, :pull:`1156`)

--- a/tests/test_utils_other.py
+++ b/tests/test_utils_other.py
@@ -134,11 +134,6 @@ def test_uri_resolve(base):
     if not is_vsipath(base):
         assert uri_resolve(base + '/some/dir/file.txt', 'relative/path') == base + '/some/dir/relative/path'
 
-def test_uri_resolve_more():
-    base_path = ''
-
-
-
 
 def test_pick_uri():
     f, s, h = ('file://a', 's3://b', 'http://c')

--- a/tests/test_utils_other.py
+++ b/tests/test_utils_other.py
@@ -117,7 +117,6 @@ def test_uri_to_local_path():
     "wasb://foo",
     "wasbs://foo",
     "/vsizip//vsicurl/https://host.tld/some/path",
-    "/absolute/path",
 ])
 def test_uri_resolve(base):
     abs_path = '/abs/path/to/something'

--- a/tests/test_utils_other.py
+++ b/tests/test_utils_other.py
@@ -117,6 +117,7 @@ def test_uri_to_local_path():
     "wasb://foo",
     "wasbs://foo",
     "/vsizip//vsicurl/https://host.tld/some/path",
+    "/absolute/path",
 ])
 def test_uri_resolve(base):
     abs_path = '/abs/path/to/something'
@@ -132,6 +133,11 @@ def test_uri_resolve(base):
 
     if not is_vsipath(base):
         assert uri_resolve(base + '/some/dir/file.txt', 'relative/path') == base + '/some/dir/relative/path'
+
+def test_uri_resolve_more():
+    base_path = ''
+
+
 
 
 def test_pick_uri():


### PR DESCRIPTION
### Reason for this pull request

It's currently quite difficult to find out whether a given URI is indexed inside an ODC Datacube. It's possible to search by a URI using the Python API, but not from the command line.

While it is possible to search by Dataset ID, we have had some cases where new data has overwritten old data, and we no longer have a record of the Dataset ID in the filesystem or S3 bucket, only in the database, which makes this feature extremely useful.


### Proposed changes

- Add `datacube dataset uri-search` command line feature.



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
