### PR TITLE
Add license as new DatasetType property

### DIFF
--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -434,6 +434,10 @@ class DatasetType:
         return self.definition['name']
 
     @property
+    def license(self) -> str:
+        return self.definition.get("license", None)
+
+    @property
     def managed(self) -> bool:
         return self.definition.get('managed', False)
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -15,6 +15,7 @@ v1.8.4 (???)
 - Fix numeric precision issues in ``compute_reproject_roi`` when pixel size is small. (:issue:`1047`)
 - Follow up fix to (:issue:`1047`) to round scale to nearest integer if very close.
 - Add support for 3D Datasets. (:pull:`1099`)
+- Added new "license" property to `DatasetType` to enable easier access to product license information. (:pull:`1142`)
 
 .. _`notebook examples`: https://github.com/GeoscienceAustralia/dea-notebooks/
 


### PR DESCRIPTION


### Reason for this pull request
Declaring licenses for products helps the user map out the usability of the product for specific purposes.

This PR adds a new property to DatasetType which allows license information to be more easily accessed programmatically, thereby partially contributing to #1141.

### Proposed changes
This PR adds a new property to DatasetType which allows license information to be more easily accessed programmatically, thereby partially contributing to #1141.

 - [x] Contibutes to #1141
 - [ ] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
