### PR TITLE
Add description as new DatasetType property

### DIFF
--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -434,6 +434,10 @@ class DatasetType:
         return self.definition['name']
 
     @property
+    def description(self) -> str:
+        return self.definition.get("description", None)
+
+    @property
     def license(self) -> str:
         return self.definition.get("license", None)
 
@@ -675,7 +679,8 @@ class DatasetType:
         row = dict(**self.fields)
         row.update(id=self.id,
                    name=self.name,
-                   description=self.definition['description'])
+                   license=self.license,
+                   description=self.description)
 
         if self.grid_spec is not None:
             row.update({

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -15,7 +15,7 @@ v1.8.4 (???)
 - Fix numeric precision issues in ``compute_reproject_roi`` when pixel size is small. (:issue:`1047`)
 - Follow up fix to (:issue:`1047`) to round scale to nearest integer if very close.
 - Add support for 3D Datasets. (:pull:`1099`)
-- Added new "license" property to `DatasetType` to enable easier access to product license information. (:pull:`1142`)
+- Added new "license" and "description" properties to `DatasetType` to enable easier access to product information. (:pull:`1143`, :pull:`1144`)
 
 .. _`notebook examples`: https://github.com/GeoscienceAustralia/dea-notebooks/
 


### PR DESCRIPTION
### Proposed changes
Similar to #1143, this PR adds "description" from the product definition to a new property in `DatasetType`. This will make it easier to access programatically.

I've also used this change to simplify the `to_dict` functionality, and ensured that both of the new properties to the dict (e.g. `license` and `description`).

 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
