### PR TITLE
Update `dc.list_products` to provide more useful summary of products

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -1,6 +1,6 @@
 # This file is part of the Open Data Cube, see https://opendatacube.org for more information
 #
-# Copyright (c) 2015-2020 ODC Contributors
+# Copyright (c) 2015-2021 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import uuid
 import collections.abc
@@ -135,7 +135,7 @@ class Datacube(object):
 
         # Return pandas dataframe with each product as a row
         import pandas
-        return pandas.DataFrame(rows, columns=cols).set_index('name')
+        return pandas.DataFrame(rows, columns=cols).set_index('name', drop=False)
 
     def list_measurements(self, show_archived=False, with_pandas=True):
         """

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -90,7 +90,7 @@ class Datacube(object):
 
         self.index = index
 
-    def list_products(self, with_pandas=True, dataset_count=True):
+    def list_products(self, with_pandas=True, dataset_count=False):
         """
         List all products in the datacube. This will produce a ``pandas.DataFrame``
         or list of dicts containing useful information about each product, including:
@@ -107,7 +107,8 @@ class Datacube(object):
 
         :param bool dataset_count:
             Return a "dataset_count" column containing the number of datasets
-            for each product. This can be disabled to reduce run time.
+            for each product. This can take several minutes on large datacubes.
+            Defaults to False.
 
         :return: A table or list of every product in the datacube.
         :rtype: pandas.DataFrame or list(dict)

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -125,9 +125,19 @@ class Datacube(object):
                 for pr in self.index.products.get_all()]
 
         # Optionally compute dataset count for each product and add to row/cols
-        if dataset_count:
-            counts = [count[1] for count in self.index.datasets.count_by_product()]
-            rows = [row + [col] for row, col in zip(rows, counts)]
+        # Product lists are sorted by product name to ensure 1:1 match
+        if dataset_count:            
+           
+            # Load counts
+            counts = [(p.name, c) for p, c in self.index.datasets.count_by_product()]
+            
+            # Sort both rows and counts by product name
+            from operator import itemgetter
+            rows = sorted(rows, key=itemgetter(0))
+            counts = sorted(counts, key=itemgetter(0))
+            
+            # Add sorted count to each existing row
+            rows = [row + [count[1]] for row, count in zip(rows, counts)]
             cols = cols + ['dataset_count']
 
         # If pandas not requested, return list of dicts

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -90,25 +90,52 @@ class Datacube(object):
 
         self.index = index
 
-    def list_products(self, show_archived=False, with_pandas=True):
+    def list_products(self, with_pandas=True, dataset_count=True):
         """
-        List products in the datacube
+        List all products in the datacube. This will produce a ``pandas.DataFrame``
+        or list of dicts containing useful information about each product, including:
 
-        :param show_archived: include products that have been archived.
-        :param with_pandas: return the list as a Pandas DataFrame, otherwise as a list of dict.
+            'name'
+            'description'
+            'license'
+            'default_crs'
+            'default_resolution'
+            'dataset_count' (optional)
+
+        :param bool with_pandas:
+            Return the list as a Pandas DataFrame. If False, return a list of dicts.
+
+        :param bool dataset_count:
+            Return a "dataset_count" column containing the number of datasets
+            for each product. This can be disabled to reduce run time.
+
+        :return: A table or list of every product in the datacube.
         :rtype: pandas.DataFrame or list(dict)
         """
-        rows = [product.to_dict() for product in self.index.products.get_all()]
-        if not with_pandas:
-            return rows
+        # Read properties from each datacube product
+        cols = [
+            'name',
+            'description',
+            'license',
+            'default_crs',
+            'default_resolution',
+        ]
+        rows = [[getattr(pr, col, None) for col in cols]
+                for pr in self.index.products.get_all()]
 
+        # Optionally compute dataset count for each product and add to row/cols
+        if dataset_count:
+            counts = [count[1] for count in self.index.datasets.count_by_product()]
+            rows = [row + [col] for row, col in zip(rows, counts)]
+            cols = cols + ['dataset_count']
+
+        # If pandas not requested, return list of dicts
+        if not with_pandas:
+            return [dict(zip(cols, row)) for row in rows]
+
+        # Return pandas dataframe with each product as a row
         import pandas
-        keys = set(k for r in rows for k in r)
-        main_cols = ['id', 'name', 'description']
-        grid_cols = ['crs', 'resolution', 'tile_size', 'spatial_dimensions']
-        other_cols = list(keys - set(main_cols) - set(grid_cols))
-        cols = main_cols + other_cols + grid_cols
-        return pandas.DataFrame(rows, columns=cols).set_index('id')
+        return pandas.DataFrame(rows, columns=cols).set_index('name')
 
     def list_measurements(self, show_archived=False, with_pandas=True):
         """

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -16,6 +16,7 @@ v1.8.4 (???)
 - Follow up fix to (:issue:`1047`) to round scale to nearest integer if very close.
 - Add support for 3D Datasets. (:pull:`1099`)
 - Added new "license" and "description" properties to `DatasetType` to enable easier access to product information. (:pull:`1143`, :pull:`1144`)
+- Revised the ``Datacube.list_products`` function to produce a simpler and more useful product list table (:pull:`1145`)
 
 .. _`notebook examples`: https://github.com/GeoscienceAustralia/dea-notebooks/
 


### PR DESCRIPTION
### Reason for this pull request
When we run this to produce a list of products in a datacube:
```
dc.list_products()
```
We get a giant table with a column for every single unique field in every product in a datacube (e.g. see image below), defined by the code here: https://github.com/opendatacube/datacube-core/blob/develop/datacube/api/core.py#L106-L111
```
main_cols = ['id', 'name', 'description']
grid_cols = ['crs', 'resolution', 'tile_size', 'spatial_dimensions']
other_cols = list(keys - set(main_cols) - set(grid_cols))
```
![image](https://user-images.githubusercontent.com/17680388/123737486-5b410e80-d8e6-11eb-91aa-ac3c2f3c2656.png)

This ends up being really unwieldy and unusable, especially as the vast majority of those columns contain no data (as we no longer ingest data into standard grids, and most products have unique metadata/"other" fields). 

We also do not have access to several important product properties, such as license (see #1141) and default CRS and resolution.

### Proposed changes
This PR significantly revises `dc.list_products` to generate a simpler but more useful table:
![image](https://user-images.githubusercontent.com/17680388/123737664-b541d400-d8e6-11eb-9490-0477315ab4a5.png)

This includes `'name', 'description', 'license', 'default_crs', 'default_resolution'` fields, as well as a new `dataset_count` field that reports the number of datasets for each product (this can be turned off using the `dataset_count` param).

This also changes the `pandas.DataFrame` table index to `'name'` (instead of the internal `'id'`) so that users can more easily access info about specific products, e.g.: 
```
product_df = dc.list_products()
product_df.loc[['s2_l2a', 's1_rtc']]
```
![image](https://user-images.githubusercontent.com/17680388/123738320-eff83c00-d8e7-11eb-867c-5d9d27ce072c.png)

**Backwards compatibility**
This change will have no effect on users who previously ran `dc.list_products()` purely to inspect available products. However, the change from `'id'` to `'name'` as the `pandas.DataFrame` table index may cause code to break if users are expecting the original structure, for example:
```
product_df = dc.list_products()
product_df.set_index('name')  # user attempts to set 'name' to index

>>> KeyError: "None of ['name'] are in the columns"
```


 - [x] Closes #1141
 - [ ] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
