### PR TITLE
Fix bug in query building in the case where the value is 2 char string

### DIFF
--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -246,8 +246,14 @@ def _values_to_search(**kwargs):
         if key.lower() in ('time', 't'):
             search['time'] = _time_to_search_dims(value)
         elif key not in ['latitude', 'lat', 'y'] + ['longitude', 'lon', 'x']:
-            if isinstance(value, collections.abc.Sequence) and len(value) == 2:
+            # If it's not a string, but is a sequence of length 2, then it's a Range
+            if (
+                not isinstance(value, str)
+                and isinstance(value, collections.abc.Sequence)
+                and len(value) == 2
+            ):
                 search[key] = Range(*value)
+            # All other cases are default
             else:
                 search[key] = value
     return search

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -208,3 +208,8 @@ def test_dateline_query_building():
                 crs='EPSG:32660').search_terms['lon']
 
     assert lon.begin < 180 < lon.end
+
+
+def test_query_issue_1146():
+    q = Query(k='AB')
+    assert q.search['k'] == 'AB'


### PR DESCRIPTION
Fixes an issue with query building for strings of length 2

### Reason for this pull request

Minimal reproducer:

```
from datacube.api.query import Query
print(Query(region_code='AB'))
```

### Proposed changes

- Tweak the logic around identifying a range of values in a sequence

 - [x] Closes #1146 
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
