### PR TITLE
Add new `dataset_predicate` param to `dc.load` for more flexible temporal filtering

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -319,7 +319,8 @@ class Datacube(object):
         :param function dataset_predicate:
             Optional. A function that can be passed to restrict loaded datasets. A predicate function should
             take a `datacube.model.Dataset` object (e.g. as returned from `dc.find_datasets`) and return a boolean.
-            For example, the following predicate function would only return True for datasets acquired in January::
+            For example, loaded data could be filtered to January observations only by passing the following 
+            predicate function that returns True for datasets acquired in January::
                 def filter_jan(dataset): return dataset.time.begin.month == 1
 
         :param int limit:

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -15,7 +15,8 @@ v1.8.4 (???)
 - Fix numeric precision issues in ``compute_reproject_roi`` when pixel size is small. (:issue:`1047`)
 - Follow up fix to (:issue:`1047`) to round scale to nearest integer if very close.
 - Add support for 3D Datasets. (:pull:`1099`)
-- Added new "license" and "description" properties to `DatasetType` to enable easier access to product information. (:pull:`1143`, :pull:`1144`)
+- Add new "license" and "description" properties to `DatasetType` to enable easier access to product information. (:pull:`1143`, :pull:`1144`)
+- Add new ``dataset_predicate`` param to ``dc.load`` for more flexible temporal filtering (e.g. loading data for non-contiguous time ranges such as specific months or seasons over multiple years). (:pull:`1148`)
 
 .. _`notebook examples`: https://github.com/GeoscienceAustralia/dea-notebooks/
 


### PR DESCRIPTION
### Reason for this pull request
The ability to query data from discrete, non-contiguous time ranges (e.g. for specific months or seasons over multiple years) has been a frequently requested ODC feature (e.g. see #868 and [here](https://gis.stackexchange.com/questions/402115/temporal-subsetting-of-landsat-collection-using-select-months-using-open-data-cu/402116#402116), plus multiple undocumented Slack queries). This can be extremely useful for analysing specific environmental conditions consistently over time, e.g. dry seasons in northern Australia, or Spring growing seasons in agricultural regions.

Previously, the only way this could be achieved is to use the `dc.find_datasets()` method to list available datasets, then remove items from this list before loading them via the `datasets` param in `dc.load`. This adds significant overhead to simple analyses, and can be overwhelming to new users who have only just mastered `dc.load` itself.

Recently, the `dea-tools` `load_ard` function and ODC Virtual Products have introduced a "predicate" param that allows users to easily filter data prior to loading. This would be powerful functionality to have in `dc.load` as well.

### Proposed changes
This PR adds a new `dataset_predicate` parameter to `dc.load`. This allows users to filter data prior to load using a simple predicate function. For example, the user could filter to only January observations across a multi-year period using the following syntax:

```
query = {
    "x": (153.45, 153.47),
    "y": (-28.90, -28.92),
    "time": ("2018", "2020"),
    "output_crs": "EPSG:3577",
    "resolution": (-10, 10),
    "group_by": "solar_day",
}

# Predicate function that returns true if month is Jan
def filter_jan(dataset):
    return dataset.time.begin.month == 1

# Specify using `dataset_predicate` param
ds = dc.load(
    product="s2a_ard_granule",
    measurements="nbart_red",
    dataset_predicate=filter_jan,
    dask_chunks={},
    **query
)
```
![image](https://user-images.githubusercontent.com/17680388/124232628-428a6000-db55-11eb-9b85-4275b014d851.png)


 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes


