### PR TITLE
More dataset predicate refactors

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -338,13 +338,13 @@ class Datacube(object):
             raise ValueError("Must specify a product or supply datasets")
 
         if datasets is None:
-            datasets = self.find_datasets(product=product, like=like, ensure_location=True, **query)
+            datasets = self.find_datasets(product=product,
+                                          like=like,
+                                          ensure_location=True,
+                                          dataset_predicate=dataset_predicate,
+                                          **query)
         elif isinstance(datasets, collections.abc.Iterator):
             datasets = list(datasets)
-
-        # If a predicate function is provided, use this to filter datasets before load
-        if dataset_predicate:
-            datasets = [dataset for dataset in datasets if dataset_predicate(dataset)]
 
         if len(datasets) == 0:
             return xarray.Dataset()
@@ -402,13 +402,14 @@ class Datacube(object):
         """
         return list(self.find_datasets_lazy(**search_terms))
 
-    def find_datasets_lazy(self, limit=None, ensure_location=False, **kwargs):
+    def find_datasets_lazy(self, limit=None, ensure_location=False, dataset_predicate=None, **kwargs):
         """
         Find datasets matching query.
 
         :param kwargs: see :class:`datacube.api.query.Query`
         :param ensure_location: only return datasets that have locations
         :param limit: if provided, limit the maximum number of datasets returned
+        :param dataset_predicate: an optional predicate to filter datasets
         :return: iterator of datasets
         :rtype: __generator[:class:`datacube.model.Dataset`]
 
@@ -426,6 +427,10 @@ class Datacube(object):
 
         if ensure_location:
             datasets = (dataset for dataset in datasets if dataset.uris)
+
+        # If a predicate function is provided, use this to filter datasets before load
+        if dataset_predicate is not None:
+            datasets = (dataset for dataset in datasets if dataset_predicate(dataset))
 
         return datasets
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -16,7 +16,7 @@ v1.8.4 (???)
 - Follow up fix to (:issue:`1047`) to round scale to nearest integer if very close.
 - Add support for 3D Datasets. (:pull:`1099`)
 - Add new "license" and "description" properties to `DatasetType` to enable easier access to product information. (:pull:`1143`, :pull:`1144`)
-- Add new ``dataset_predicate`` param to ``dc.load`` for more flexible temporal filtering (e.g. loading data for non-contiguous time ranges such as specific months or seasons over multiple years). (:pull:`1148`)
+- Add new ``dataset_predicate`` param to ``dc.find_datasets`` for more flexible temporal filtering (e.g. loading data for non-contiguous time ranges such as specific months or seasons over multiple years). (:pull:`1148`, :pull:`1156`)
 
 .. _`notebook examples`: https://github.com/GeoscienceAustralia/dea-notebooks/
 

--- a/tests/api/test_virtual.py
+++ b/tests/api/test_virtual.py
@@ -229,7 +229,7 @@ def dc():
         result.center_time = center_time
         return result
 
-    def search(*args, **kwargs):
+    def find_datasets(*args, **kwargs):
         product = kwargs['product']
         if product == 'ls8_nbar_albers':
             return [example_dataset(product, ids[0], datetime(2014, 2, 7, 23, 57, 26)),
@@ -245,7 +245,7 @@ def dc():
 
     result.index.products.get_all = lambda: [example_product(x) for x in PRODUCT_LIST]
     result.index.products.get_by_name = example_product
-    result.index.datasets.search = search
+    result.find_datasets = find_datasets
     return result
 
 


### PR DESCRIPTION
### Reason for this pull request
The dataset predicate option is better suited in `Datacube.find_datasets`, so moving it there.
Virtual product then does not need to implement it again.