### PR TITLE
Iam authentication

### DIFF
--- a/datacube/config.py
+++ b/datacube/config.py
@@ -202,8 +202,8 @@ def parse_env_params() -> Dict[str, str]:
     # Handle environment vars that cannot fit in the DB URL
     non_url_params = {}
     iam_auth = os.environ.get('DATACUBE_IAM_AUTHENTICATION')
-    if iam_auth is not None and iam_auth.tolower() in ['y', 'yes']:
-        non_url_params["iam_authentication"] = iam_auth
+    if iam_auth is not None and iam_auth.lower() in ['y', 'yes']:
+        non_url_params["iam_authentication"] = True
         iam_auth_timeout = os.environ.get('DATACUBE_IAM_TIMEOUT')
         if iam_auth_timeout:
             non_url_params["iam_timeout"] = int(iam_auth_timeout)

--- a/datacube/config.py
+++ b/datacube/config.py
@@ -199,25 +199,25 @@ def parse_env_params() -> Dict[str, str]:
     - Else look for DB_HOSTNAME, DB_USERNAME, DB_PASSWORD, DB_DATABASE
     - Return {} otherwise
     """
+    # Handle environment vars that cannot fit in the DB URL
     non_url_params = {}
     iam_auth = os.environ.get('DATACUBE_IAM_AUTHENTICATION')
     if iam_auth is not None and iam_auth.tolower() in ['y', 'yes']:
         non_url_params["iam_authentication"] = iam_auth
         iam_auth_timeout = os.environ.get('DATACUBE_IAM_TIMEOUT')
         if iam_auth_timeout:
-            non_url_params["iam_authentication_timeout"] = int(iam_auth_timeout)
+            non_url_params["iam_timeout"] = int(iam_auth_timeout)
 
+    # Handle environment vars that may fit in the DB URL
     db_url = os.environ.get('DATACUBE_DB_URL', None)
     if db_url is not None:
         params = parse_connect_url(db_url)
-        params.update(non_url_params)
-        return params
-
-    raw_params = {k: os.environ.get('DB_{}'.format(k.upper()), None)
-                  for k in DB_KEYS}
-    params = {k: v
-              for k, v in raw_params.items()
-              if v is not None and v != ""}
+    else:
+        raw_params = {k: os.environ.get('DB_{}'.format(k.upper()), None)
+                      for k in DB_KEYS}
+        params = {k: v
+                  for k, v in raw_params.items()
+                  if v is not None and v != ""}
     params.update(non_url_params)
     return params
 

--- a/datacube/drivers/postgres/_connections.py
+++ b/datacube/drivers/postgres/_connections.py
@@ -80,8 +80,8 @@ class PostgresDb(object):
             config.get('db_port', DEFAULT_DB_PORT),
             application_name=app_name,
             validate=validate_connection,
-            iam_rds_auth=bool(config.get("db_iam_rds_auth", DEFAULT_IAM_AUTH)),
-            iam_rds_timeout=int(config.get("db_iam_rds_timeout", DEFAULT_IAM_TIMEOUT)),
+            iam_rds_auth=bool(config.get("db_iam_authentication", DEFAULT_IAM_AUTH)),
+            iam_rds_timeout=int(config.get("db_iam_timeout", DEFAULT_IAM_TIMEOUT)),
             pool_timeout=int(config.get('db_connection_timeout', 60)),
             # pass config?
         )

--- a/datacube/drivers/postgres/_connections.py
+++ b/datacube/drivers/postgres/_connections.py
@@ -21,12 +21,13 @@ from time import clock_gettime, CLOCK_REALTIME
 from typing import Callable, Optional, Union
 
 from sqlalchemy import event, create_engine, text
+from sqlalchemy.engine import Engine
 from sqlalchemy.engine.url import URL as EngineUrl
 
 import datacube
 from datacube.index.exceptions import IndexSetupError
 from datacube.utils import jsonify_document
-from datacube.utils.aws import obtain_new_IAM_auth_token
+from datacube.utils.aws import obtain_new_iam_auth_token
 
 from . import _api
 from . import _core
@@ -126,7 +127,7 @@ class PostgresDb(object):
         )
 
         if os.environ.get("ODC_IAM_RDS_AUTHENTICATION", "") in ("Y", "y", "YES", "yes", "Yes"):
-            handle_dynamic_token_authentication(engine, obtain_new_IAM_auth_token, timeout=600, url=url)
+            handle_dynamic_token_authentication(engine, obtain_new_iam_auth_token, timeout=600, url=url)
 
         return engine
 
@@ -252,7 +253,7 @@ class PostgresDb(object):
         return "PostgresDb<engine={!r}>".format(self._engine)
 
 
-def handle_dynamic_token_authentication(engine: "sqlalchemy.engine.Engine",
+def handle_dynamic_token_authentication(engine: Engine,
                                         new_token: Callable[..., str],
                                         timeout: Union[float, int] = 600,
                                         **kwargs) -> None:

--- a/datacube/utils/aws/__init__.py
+++ b/datacube/utils/aws/__init__.py
@@ -13,7 +13,7 @@ from botocore.session import Session
 import time
 from urllib.request import urlopen
 from urllib.parse import urlparse
-from sqlachemy.engine.url import URL
+from sqlalchemy.engine.url import URL
 
 from typing import Optional, Dict, Tuple, Any, Union, IO
 from datacube.utils.generic import thread_local_cache

--- a/datacube/utils/aws/__init__.py
+++ b/datacube/utils/aws/__init__.py
@@ -13,6 +13,8 @@ from botocore.session import Session
 import time
 from urllib.request import urlopen
 from urllib.parse import urlparse
+from sqlachemy.engine.url import URL
+
 from typing import Optional, Dict, Tuple, Any, Union, IO
 from datacube.utils.generic import thread_local_cache
 from ..rio import configure_s3_access
@@ -440,7 +442,7 @@ def get_aws_settings(profile: Optional[str] = None,
                  requester_pays=requester_pays), creds)
 
 
-def obtain_new_IAM_auth_token(url: str, region_name: str = "auto", profile_name: Optional[str] = None) -> str:
+def obtain_new_iam_auth_token(url: URL, region_name: str = "auto", profile_name: Optional[str] = None) -> str:
     try:
         # Boto3 is not core requirement
         from boto3.session import Session as Boto3Session

--- a/datacube/utils/aws/__init__.py
+++ b/datacube/utils/aws/__init__.py
@@ -447,6 +447,6 @@ def obtain_new_IAM_auth_token(url: str, region_name: str = "auto", profile_name:
     except ImportError:
         raise ValueError("boto3 is not available")
     session = Boto3Session(profile_name=profile_name)
-    client = session.client("rds")
+    client = session.client("rds", region_name=region_name)
     return client.generate_db_auth_token(DBHostname=url.host, Port=url.port, DBUsername=url.username,
                                          Region=region_name)

--- a/datacube/utils/aws/__init__.py
+++ b/datacube/utils/aws/__init__.py
@@ -443,11 +443,9 @@ def get_aws_settings(profile: Optional[str] = None,
 
 
 def obtain_new_iam_auth_token(url: URL, region_name: str = "auto", profile_name: Optional[str] = None) -> str:
-    try:
-        # Boto3 is not core requirement
-        from boto3.session import Session as Boto3Session
-    except ImportError:
-        raise ValueError("boto3 is not available")
+    # Boto3 is not core requirement, but ImportError is probably the right exception to throw anyway.
+    from boto3.session import Session as Boto3Session
+
     session = Boto3Session(profile_name=profile_name)
     client = session.client("rds", region_name=region_name)
     return client.generate_db_auth_token(DBHostname=url.host, Port=url.port, DBUsername=url.username,

--- a/datacube/utils/aws/__init__.py
+++ b/datacube/utils/aws/__init__.py
@@ -438,3 +438,15 @@ def get_aws_settings(profile: Optional[str] = None,
                  aws_secret_access_key=cc.secret_key,
                  aws_session_token=cc.token,
                  requester_pays=requester_pays), creds)
+
+
+def obtain_new_IAM_auth_token(url: str, region_name: str = "auto", profile_name: Optional[str] = None) -> str:
+    try:
+        # Boto3 is not core requirement
+        from boto3.session import Session as Boto3Session
+    except ImportError:
+        raise ValueError("boto3 is not available")
+    session = Boto3Session(profile_name=profile_name)
+    client = session.client("rds")
+    return client.generate_db_auth_token(DBHostname=url.host, Port=url.port, DBUsername=url.username,
+                                         Region=region_name)

--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -1389,16 +1389,12 @@ def lonlat_bounds(geom: Geometry,
     if geom.crs.geographic:
         return geom.boundingbox
 
-    if geom.type in ('Polygon', 'MultiPolygon'):
-        geom = geom.exterior
-
     if resolution is not None and math.isfinite(resolution):
         geom = geom.segmented(resolution)
 
-    xx, yy = geom.to_crs('EPSG:4326', resolution=math.inf).xy
-    xx_range = min(xx), max(xx)
-    yy_range = min(yy), max(yy)
+    bbox = geom.to_crs('EPSG:4326', resolution=math.inf).boundingbox
 
+    xx_range = bbox.range_x
     if mode == "safe":
         # If range in Longitude is more than 180 then it's probably wrapped
         # around 180 (X-360 for X > 180), so we add back 360 but only for X<0
@@ -1406,18 +1402,17 @@ def lonlat_bounds(geom: Geometry,
         # a globe, so we need to check for that too, but this is not yet
         # implemented...
 
-        span_x = xx_range[1] - xx_range[0]
-        if span_x > 180:
+        if bbox.span_x > 180:
             # TODO: check the case when input geometry spans >180 region.
             #       For now we assume "smaller" geometries not too close
             #       to poles.
-            xx_ = [x + 360 if x < 0 else x for x in xx]
+            xx_ = [x + 360 if x < 0 else x for x in bbox.range_x]
             xx_range_ = min(xx_), max(xx_)
             span_x_ = xx_range_[1] - xx_range_[0]
-            if span_x_ < span_x:
+            if span_x_ < bbox.span_x:
                 xx_range = xx_range_
 
-    return BoundingBox.from_xy(xx_range, yy_range)
+    return BoundingBox.from_xy(xx_range, bbox.range_y)
 
 
 def assign_crs(xx: Union[xr.DataArray, xr.Dataset],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -125,7 +125,9 @@ def _clear_cfg_env(monkeypatch):
               'DB_HOSTNAME',
               'DB_PORT',
               'DB_USERNAME',
-              'DB_PASSWORD'):
+              'DB_PASSWORD',
+              'DATACUBE_IAM_AUTHENTICATION',
+              'DATACUBE_IAM_TIMEOUT'):
         monkeypatch.delenv(e, raising=False)
 
 
@@ -140,6 +142,10 @@ def test_parse_env(monkeypatch):
         return parse_env_params()
 
     assert check_env() == {}
+    assert check_env(DATACUBE_IAM_AUTHENTICATION="yes",
+                     DATACUBE_IAM_TIMEOUT='666') == dict(
+        iam_authentication=True,
+        iam_timeout=666)
     assert check_env(DATACUBE_DB_URL='postgresql:///db') == dict(
         hostname='',
         database='db'

--- a/tests/test_dynamic_db_passwd.py
+++ b/tests/test_dynamic_db_passwd.py
@@ -20,9 +20,11 @@ def next_token(base):
 
 
 def test_dynamic_password():
-    url = URL.create('postgresql',
+    url = URL.create(
+                    'postgresql',
                     host="fake_host", database="fake_database", port=6543,
-                    username="fake_username", password="fake_password")
+                    username="fake_username", password="fake_password"
+    )
     engine = PostgresDb._create_engine(url)
     counter[0] = 0
     last_base[0] = None

--- a/tests/test_dynamic_db_passwd.py
+++ b/tests/test_dynamic_db_passwd.py
@@ -1,0 +1,25 @@
+import pytest
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.engine.url import URL
+
+from datacube.drivers.postgres._connections import PostgresDb, handle_dynamic_token_authentication
+
+counter = [0]
+last_base = [None]
+def next_token(base):
+    counter[0] = counter[0] + 1
+    last_base[0] = base
+    return f"{base}{counter[0]}"
+
+def test_dynamic_password():
+    url = URL.create('postgresql',
+        host="fake_host", database="fake_database", port=6543,
+        username="fake_username", password="fake_password")
+    engine = PostgresDb._create_engine(url)
+    counter[0] = 0
+    last_base[0] = None
+    handle_dynamic_token_authentication(engine, next_token, base="password")
+    with pytest.raises(OperationalError):
+        conn = engine.connect()
+    assert counter[0] == 1
+    assert last_base[0] == "password"

--- a/tests/test_dynamic_db_passwd.py
+++ b/tests/test_dynamic_db_passwd.py
@@ -21,8 +21,8 @@ def next_token(base):
 
 def test_dynamic_password():
     url = URL.create('postgresql',
-        host="fake_host", database="fake_database", port=6543,
-        username="fake_username", password="fake_password")
+                    host="fake_host", database="fake_database", port=6543,
+                    username="fake_username", password="fake_password")
     engine = PostgresDb._create_engine(url)
     counter[0] = 0
     last_base[0] = None

--- a/tests/test_dynamic_db_passwd.py
+++ b/tests/test_dynamic_db_passwd.py
@@ -1,15 +1,23 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2020 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.engine.url import URL
 
 from datacube.drivers.postgres._connections import PostgresDb, handle_dynamic_token_authentication
 
+
 counter = [0]
 last_base = [None]
+
+
 def next_token(base):
     counter[0] = counter[0] + 1
     last_base[0] = base
     return f"{base}{counter[0]}"
+
 
 def test_dynamic_password():
     url = URL.create('postgresql',

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1541,6 +1541,22 @@ def test_lonlat_bounds():
     with pytest.raises(ValueError):
         geometry.lonlat_bounds(geometry.box(0, 0, 1, 1, None))
 
+    multi = {
+        "type": "MultiPolygon",
+        "coordinates": [
+            [[[174, 52], [174, 53], [175, 53], [174, 52]]],
+            [[[168, 54], [167, 55], [167, 54], [168, 54]]]
+        ]
+    }
+
+    multi_geom = geometry.Geometry(multi, "epsg:4326")
+    multi_geom_projected = multi_geom.to_crs('epsg:32659', math.inf)
+
+    ll_bounds = geometry.lonlat_bounds(multi_geom)
+    ll_bounds_projected = geometry.lonlat_bounds(multi_geom_projected)
+
+    assert ll_bounds == approx(ll_bounds_projected)
+
 
 @pytest.mark.xfail(True, reason="Bounds computation for large geometries in safe mode is broken")
 def test_lonalt_bounds_more_than_180():

--- a/tests/test_utils_aws.py
+++ b/tests/test_utils_aws.py
@@ -272,4 +272,3 @@ def test_obtain_new_iam_token(monkeypatch, without_aws_env):
     with moto.mock_iam():
         token = obtain_new_IAM_auth_token(url)
         assert isinstance(token, str)
-

--- a/tests/test_utils_aws.py
+++ b/tests/test_utils_aws.py
@@ -270,5 +270,5 @@ def test_obtain_new_iam_token(monkeypatch, without_aws_env):
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "fake-key-id")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "fake-secret")
     with moto.mock_iam():
-        token = obtain_new_IAM_auth_token(url, region='us-west-1')
+        token = obtain_new_IAM_auth_token(url, region_name='us-west-1')
         assert isinstance(token, str)

--- a/tests/test_utils_aws.py
+++ b/tests/test_utils_aws.py
@@ -270,5 +270,5 @@ def test_obtain_new_iam_token(monkeypatch, without_aws_env):
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "fake-key-id")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "fake-secret")
     with moto.mock_iam():
-        token = obtain_new_IAM_auth_token(url)
+        token = obtain_new_IAM_auth_token(url, region='us-west-1')
         assert isinstance(token, str)

--- a/tests/test_utils_aws.py
+++ b/tests/test_utils_aws.py
@@ -23,7 +23,7 @@ from datacube.utils.aws import (
     s3_fetch,
     s3_head_object,
     _s3_cache_key,
-    obtain_new_IAM_auth_token,
+    obtain_new_iam_auth_token,
 )
 
 
@@ -270,5 +270,5 @@ def test_obtain_new_iam_token(monkeypatch, without_aws_env):
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "fake-key-id")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "fake-secret")
     with moto.mock_iam():
-        token = obtain_new_IAM_auth_token(url, region_name='us-west-1')
+        token = obtain_new_iam_auth_token(url, region_name='us-west-1')
         assert isinstance(token, str)


### PR DESCRIPTION
### Reason for this pull request

Cloud ops want to be able to authenticate to RDS databases using IAM authentication

### Proposed changes

1. Utility function in `utils/aws/__init__.py` to obtain a new IAM authentication token.
2. Hook in Postgresql driver to register a `do_connect` event on newly instantiated SQLAlchemy engines, to obtain a new IAM token every 10 minutes.

Written so as to easily support other dynamic password-generation frameworks.

To use: Set Environment Variable `$ODC_IAM_RDS_AUTHENTICATION` to 'yes'.