### PR TITLE
Iam authentication (attempt 2)

### DIFF
--- a/datacube/config.py
+++ b/datacube/config.py
@@ -202,8 +202,8 @@ def parse_env_params() -> Dict[str, str]:
     # Handle environment vars that cannot fit in the DB URL
     non_url_params = {}
     iam_auth = os.environ.get('DATACUBE_IAM_AUTHENTICATION')
-    if iam_auth is not None and iam_auth.tolower() in ['y', 'yes']:
-        non_url_params["iam_authentication"] = iam_auth
+    if iam_auth is not None and iam_auth.lower() in ['y', 'yes']:
+        non_url_params["iam_authentication"] = True
         iam_auth_timeout = os.environ.get('DATACUBE_IAM_TIMEOUT')
         if iam_auth_timeout:
             non_url_params["iam_timeout"] = int(iam_auth_timeout)

--- a/datacube/config.py
+++ b/datacube/config.py
@@ -199,25 +199,25 @@ def parse_env_params() -> Dict[str, str]:
     - Else look for DB_HOSTNAME, DB_USERNAME, DB_PASSWORD, DB_DATABASE
     - Return {} otherwise
     """
+    # Handle environment vars that cannot fit in the DB URL
     non_url_params = {}
     iam_auth = os.environ.get('DATACUBE_IAM_AUTHENTICATION')
     if iam_auth is not None and iam_auth.tolower() in ['y', 'yes']:
         non_url_params["iam_authentication"] = iam_auth
         iam_auth_timeout = os.environ.get('DATACUBE_IAM_TIMEOUT')
         if iam_auth_timeout:
-            non_url_params["iam_authentication_timeout"] = int(iam_auth_timeout)
+            non_url_params["iam_timeout"] = int(iam_auth_timeout)
 
+    # Handle environment vars that may fit in the DB URL
     db_url = os.environ.get('DATACUBE_DB_URL', None)
     if db_url is not None:
         params = parse_connect_url(db_url)
-        params.update(non_url_params)
-        return params
-
-    raw_params = {k: os.environ.get('DB_{}'.format(k.upper()), None)
-                  for k in DB_KEYS}
-    params = {k: v
-              for k, v in raw_params.items()
-              if v is not None and v != ""}
+    else:
+        raw_params = {k: os.environ.get('DB_{}'.format(k.upper()), None)
+                      for k in DB_KEYS}
+        params = {k: v
+                  for k, v in raw_params.items()
+                  if v is not None and v != ""}
     params.update(non_url_params)
     return params
 

--- a/datacube/drivers/postgres/_connections.py
+++ b/datacube/drivers/postgres/_connections.py
@@ -80,8 +80,8 @@ class PostgresDb(object):
             config.get('db_port', DEFAULT_DB_PORT),
             application_name=app_name,
             validate=validate_connection,
-            iam_rds_auth=bool(config.get("db_iam_rds_auth", DEFAULT_IAM_AUTH)),
-            iam_rds_timeout=int(config.get("db_iam_rds_timeout", DEFAULT_IAM_TIMEOUT)),
+            iam_rds_auth=bool(config.get("db_iam_authentication", DEFAULT_IAM_AUTH)),
+            iam_rds_timeout=int(config.get("db_iam_timeout", DEFAULT_IAM_TIMEOUT)),
             pool_timeout=int(config.get('db_connection_timeout', 60)),
             # pass config?
         )

--- a/datacube/drivers/postgres/_connections.py
+++ b/datacube/drivers/postgres/_connections.py
@@ -21,12 +21,13 @@ from time import clock_gettime, CLOCK_REALTIME
 from typing import Callable, Optional, Union
 
 from sqlalchemy import event, create_engine, text
+from sqlalchemy.engine import Engine
 from sqlalchemy.engine.url import URL as EngineUrl
 
 import datacube
 from datacube.index.exceptions import IndexSetupError
 from datacube.utils import jsonify_document
-from datacube.utils.aws import obtain_new_IAM_auth_token
+from datacube.utils.aws import obtain_new_iam_auth_token
 
 from . import _api
 from . import _core
@@ -126,7 +127,7 @@ class PostgresDb(object):
         )
 
         if os.environ.get("ODC_IAM_RDS_AUTHENTICATION", "") in ("Y", "y", "YES", "yes", "Yes"):
-            handle_dynamic_token_authentication(engine, obtain_new_IAM_auth_token, timeout=600, url=url)
+            handle_dynamic_token_authentication(engine, obtain_new_iam_auth_token, timeout=600, url=url)
 
         return engine
 
@@ -252,7 +253,7 @@ class PostgresDb(object):
         return "PostgresDb<engine={!r}>".format(self._engine)
 
 
-def handle_dynamic_token_authentication(engine: "sqlalchemy.engine.Engine",
+def handle_dynamic_token_authentication(engine: Engine,
                                         new_token: Callable[..., str],
                                         timeout: Union[float, int] = 600,
                                         **kwargs) -> None:

--- a/datacube/utils/aws/__init__.py
+++ b/datacube/utils/aws/__init__.py
@@ -13,7 +13,7 @@ from botocore.session import Session
 import time
 from urllib.request import urlopen
 from urllib.parse import urlparse
-from sqlachemy.engine.url import URL
+from sqlalchemy.engine.url import URL
 
 from typing import Optional, Dict, Tuple, Any, Union, IO
 from datacube.utils.generic import thread_local_cache

--- a/datacube/utils/aws/__init__.py
+++ b/datacube/utils/aws/__init__.py
@@ -13,6 +13,8 @@ from botocore.session import Session
 import time
 from urllib.request import urlopen
 from urllib.parse import urlparse
+from sqlachemy.engine.url import URL
+
 from typing import Optional, Dict, Tuple, Any, Union, IO
 from datacube.utils.generic import thread_local_cache
 from ..rio import configure_s3_access
@@ -440,7 +442,7 @@ def get_aws_settings(profile: Optional[str] = None,
                  requester_pays=requester_pays), creds)
 
 
-def obtain_new_IAM_auth_token(url: str, region_name: str = "auto", profile_name: Optional[str] = None) -> str:
+def obtain_new_iam_auth_token(url: URL, region_name: str = "auto", profile_name: Optional[str] = None) -> str:
     try:
         # Boto3 is not core requirement
         from boto3.session import Session as Boto3Session

--- a/datacube/utils/aws/__init__.py
+++ b/datacube/utils/aws/__init__.py
@@ -447,6 +447,6 @@ def obtain_new_IAM_auth_token(url: str, region_name: str = "auto", profile_name:
     except ImportError:
         raise ValueError("boto3 is not available")
     session = Boto3Session(profile_name=profile_name)
-    client = session.client("rds")
+    client = session.client("rds", region_name=region_name)
     return client.generate_db_auth_token(DBHostname=url.host, Port=url.port, DBUsername=url.username,
                                          Region=region_name)

--- a/datacube/utils/aws/__init__.py
+++ b/datacube/utils/aws/__init__.py
@@ -443,11 +443,9 @@ def get_aws_settings(profile: Optional[str] = None,
 
 
 def obtain_new_iam_auth_token(url: URL, region_name: str = "auto", profile_name: Optional[str] = None) -> str:
-    try:
-        # Boto3 is not core requirement
-        from boto3.session import Session as Boto3Session
-    except ImportError:
-        raise ValueError("boto3 is not available")
+    # Boto3 is not core requirement, but ImportError is probably the right exception to throw anyway.
+    from boto3.session import Session as Boto3Session
+
     session = Boto3Session(profile_name=profile_name)
     client = session.client("rds", region_name=region_name)
     return client.generate_db_auth_token(DBHostname=url.host, Port=url.port, DBUsername=url.username,

--- a/datacube/utils/aws/__init__.py
+++ b/datacube/utils/aws/__init__.py
@@ -438,3 +438,15 @@ def get_aws_settings(profile: Optional[str] = None,
                  aws_secret_access_key=cc.secret_key,
                  aws_session_token=cc.token,
                  requester_pays=requester_pays), creds)
+
+
+def obtain_new_IAM_auth_token(url: str, region_name: str = "auto", profile_name: Optional[str] = None) -> str:
+    try:
+        # Boto3 is not core requirement
+        from boto3.session import Session as Boto3Session
+    except ImportError:
+        raise ValueError("boto3 is not available")
+    session = Boto3Session(profile_name=profile_name)
+    client = session.client("rds")
+    return client.generate_db_auth_token(DBHostname=url.host, Port=url.port, DBUsername=url.username,
+                                         Region=region_name)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -21,6 +21,7 @@ v1.8.4 (???)
 - Add new ``dataset_predicate`` param to ``dc.load`` and ``dc.find_datasets`` for more flexible temporal filtering (e.g. loading data for non-contiguous time ranges such as specific months or seasons over multiple years). (:pull:`1148`, :pull:`1156`)
 - Fix to ``GroupBy`` to ensure output output axes are correctly labelled when sorting observations using ``sort_key`` (:pull:`1157`)
 - ``GroupBy`` is now its own class to allow easier custom grouping and sorting of data (:pull:`1157`)
+- add support for IAM authentication for RDS databases in AWS. (:pull:`1168`)
 
 .. _`notebook examples`: https://github.com/GeoscienceAustralia/dea-notebooks/
 

--- a/docs/ops/config.rst
+++ b/docs/ops/config.rst
@@ -68,6 +68,23 @@ Example:
     [staging]
     db_hostname: staging.dea.ga.gov.au
 
+    ## An AWS environment, using RDS ##
+    [aws_rds]
+    # Point database to an RDS server on AWS.
+    db_hostname: your.rds.server.name
+    db_username: your_rds_username
+    db_database: your_rds_db
+
+    # Choose an authentication option:
+
+    # 1. password authentication, as documented above
+    # db_password: Ungue55able$ecRet
+
+    # 2. IAM Authentication
+    # iam_authentication: yes
+    #
+    # Token timeout in seconds.  Defaults to 600 (10 minutes)
+    # iam_timeout: 750
 
 Note that the ``staging`` environment only specifies the hostname, all other
 fields will use default values (database ``datacube``, current username,
@@ -98,7 +115,7 @@ It is possible to configure datacube with a single environment variable:
 inside a docker image. The format of the URL is the same as used by SQLAclchemy:
 ``postgresql://user:password@host:port/database``. Only the ``database`` parameter
 is required. Note that ``password`` is url encoded, so it can contain special
-characters. 
+characters.
 
 For more information refer to the `SQLAlchemy database URLs documentation
 <https://docs.sqlalchemy.org/en/13/core/engines.html#database-urls>`_.
@@ -118,8 +135,14 @@ Examples:
 
 
 It is also possible to use separate environment variables for each component of
-the connection URL. The recognised environment variables are 
+the connection URL. The recognised environment variables are
 ``DB_HOSTNAME``, ``DB_PORT``, ``DB_USERNAME``, ``DB_PASSWORD`` and ``DB_DATABASE``.
+
+AWS IAM authentication for RDS can also be activated by setting the
+``DATACUBE_IAM_AUTHENTICATION`` environment variable to ``'y'`` or  ``'yes'``.
+The IAM token timeout can be tuned by setting the ``DATACUBE_IAM_TIMEOUT``
+environment variable to a value in seconds.  Default is 600 (i.e. 10 minutes).
+
 
 Types of Indexes
 ================

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -125,7 +125,9 @@ def _clear_cfg_env(monkeypatch):
               'DB_HOSTNAME',
               'DB_PORT',
               'DB_USERNAME',
-              'DB_PASSWORD'):
+              'DB_PASSWORD',
+              'DATACUBE_IAM_AUTHENTICATION',
+              'DATACUBE_IAM_TIMEOUT'):
         monkeypatch.delenv(e, raising=False)
 
 
@@ -140,6 +142,10 @@ def test_parse_env(monkeypatch):
         return parse_env_params()
 
     assert check_env() == {}
+    assert check_env(DATACUBE_IAM_AUTHENTICATION="yes",
+                     DATACUBE_IAM_TIMEOUT='666') == dict(
+        iam_authentication=True,
+        iam_timeout=666)
     assert check_env(DATACUBE_DB_URL='postgresql:///db') == dict(
         hostname='',
         database='db'

--- a/tests/test_dynamic_db_passwd.py
+++ b/tests/test_dynamic_db_passwd.py
@@ -20,9 +20,11 @@ def next_token(base):
 
 
 def test_dynamic_password():
-    url = URL.create('postgresql',
+    url = URL.create(
+                    'postgresql',
                     host="fake_host", database="fake_database", port=6543,
-                    username="fake_username", password="fake_password")
+                    username="fake_username", password="fake_password"
+    )
     engine = PostgresDb._create_engine(url)
     counter[0] = 0
     last_base[0] = None

--- a/tests/test_dynamic_db_passwd.py
+++ b/tests/test_dynamic_db_passwd.py
@@ -1,0 +1,25 @@
+import pytest
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.engine.url import URL
+
+from datacube.drivers.postgres._connections import PostgresDb, handle_dynamic_token_authentication
+
+counter = [0]
+last_base = [None]
+def next_token(base):
+    counter[0] = counter[0] + 1
+    last_base[0] = base
+    return f"{base}{counter[0]}"
+
+def test_dynamic_password():
+    url = URL.create('postgresql',
+        host="fake_host", database="fake_database", port=6543,
+        username="fake_username", password="fake_password")
+    engine = PostgresDb._create_engine(url)
+    counter[0] = 0
+    last_base[0] = None
+    handle_dynamic_token_authentication(engine, next_token, base="password")
+    with pytest.raises(OperationalError):
+        conn = engine.connect()
+    assert counter[0] == 1
+    assert last_base[0] == "password"

--- a/tests/test_dynamic_db_passwd.py
+++ b/tests/test_dynamic_db_passwd.py
@@ -21,8 +21,8 @@ def next_token(base):
 
 def test_dynamic_password():
     url = URL.create('postgresql',
-        host="fake_host", database="fake_database", port=6543,
-        username="fake_username", password="fake_password")
+                    host="fake_host", database="fake_database", port=6543,
+                    username="fake_username", password="fake_password")
     engine = PostgresDb._create_engine(url)
     counter[0] = 0
     last_base[0] = None

--- a/tests/test_dynamic_db_passwd.py
+++ b/tests/test_dynamic_db_passwd.py
@@ -1,15 +1,23 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2020 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.engine.url import URL
 
 from datacube.drivers.postgres._connections import PostgresDb, handle_dynamic_token_authentication
 
+
 counter = [0]
 last_base = [None]
+
+
 def next_token(base):
     counter[0] = counter[0] + 1
     last_base[0] = base
     return f"{base}{counter[0]}"
+
 
 def test_dynamic_password():
     url = URL.create('postgresql',

--- a/tests/test_utils_aws.py
+++ b/tests/test_utils_aws.py
@@ -272,4 +272,3 @@ def test_obtain_new_iam_token(monkeypatch, without_aws_env):
     with moto.mock_iam():
         token = obtain_new_IAM_auth_token(url)
         assert isinstance(token, str)
-

--- a/tests/test_utils_aws.py
+++ b/tests/test_utils_aws.py
@@ -270,5 +270,5 @@ def test_obtain_new_iam_token(monkeypatch, without_aws_env):
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "fake-key-id")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "fake-secret")
     with moto.mock_iam():
-        token = obtain_new_IAM_auth_token(url, region='us-west-1')
+        token = obtain_new_IAM_auth_token(url, region_name='us-west-1')
         assert isinstance(token, str)

--- a/tests/test_utils_aws.py
+++ b/tests/test_utils_aws.py
@@ -270,5 +270,5 @@ def test_obtain_new_iam_token(monkeypatch, without_aws_env):
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "fake-key-id")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "fake-secret")
     with moto.mock_iam():
-        token = obtain_new_IAM_auth_token(url)
+        token = obtain_new_IAM_auth_token(url, region='us-west-1')
         assert isinstance(token, str)

--- a/tests/test_utils_aws.py
+++ b/tests/test_utils_aws.py
@@ -23,7 +23,7 @@ from datacube.utils.aws import (
     s3_fetch,
     s3_head_object,
     _s3_cache_key,
-    obtain_new_IAM_auth_token,
+    obtain_new_iam_auth_token,
 )
 
 
@@ -270,5 +270,5 @@ def test_obtain_new_iam_token(monkeypatch, without_aws_env):
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "fake-key-id")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "fake-secret")
     with moto.mock_iam():
-        token = obtain_new_IAM_auth_token(url, region_name='us-west-1')
+        token = obtain_new_iam_auth_token(url, region_name='us-west-1')
         assert isinstance(token, str)


### PR DESCRIPTION
### Reason for this pull request

Cloud ops want to be able to authenticate to RDS databases using IAM authentication

Note: Branch for #1162 got tangled between my rebases and github's merges.  This is a new PR with the same commits, but a cleaned up git history.  (This PR also addresses @jeremyh's comments on the previous PR)

### Proposed changes

*  Utility function in utils/aws/__init__.py to obtain a new IAM authentication token.
*  Hook in Postgresql driver to register a do_connect event on newly instantiated SQLAlchemy engines, to obtain a new IAM token every 10 minutes.

Written so as to easily support other dynamic password-generation frameworks.

To use: Set Environment Variable $ODC_IAM_RDS_AUTHENTICATION to 'yes'.