### PR TITLE
Doc fixes and import loop fixes

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -205,8 +205,7 @@ class Datacube(object):
                 product_type='ndvi'
 
             The ``measurements`` argument is a list of measurement names, as listed in :meth:`list_measurements`.
-            If not provided, all measurements for the product will be returned.
-            ::
+            If not provided, all measurements for the product will be returned. ::
 
                 measurements=['red', 'nir', 'swir2']
 
@@ -225,7 +224,7 @@ class Datacube(object):
                 x=(1516200, 1541300), y=(-3867375, -3867350), crs='EPSG:3577'
 
             The ``time`` dimension can be specified using a tuple of datetime objects or strings with
-            `YYYY-MM-DD hh:mm:ss` format. Data will be loaded inclusive of the start and finish times. E.g::
+            ``YYYY-MM-DD hh:mm:ss`` format. Data will be loaded inclusive of the start and finish times. E.g::
 
                 time=('2000-01-01', '2001-12-31')
                 time=('2000-01', '2001-12')
@@ -274,19 +273,18 @@ class Datacube(object):
                         resampling='cubic'
                 )
 
+
         :param str product:
             The product to be loaded.
 
-        :param measurements:
+        :param list(str) measurements:
             Measurements name or list of names to be included, as listed in :meth:`list_measurements`.
             These will be loaded as individual ``xr.DataArray`` variables in the output ``xarray.Dataset`` object.
 
             If a list is specified, the measurements will be returned in the order requested.
             By default all available measurements are included.
 
-        :type measurements: list(str), optional
-
-        :param **query:
+        :param \*\*query:
             Search parameters for products and dimension ranges as described above.
             For example: ``'x', 'y', 'time', 'crs'``.
 
@@ -308,13 +306,17 @@ class Datacube(object):
             The resampling method to use if re-projection is required. This could be a string or
             a dictionary mapping band name to resampling mode. When using a dict use ``'*'`` to
             indicate "apply to all other bands", for example ``{'*': 'cubic', 'fmask': 'nearest'}`` would
-            use `cubic` for all bands except ``fmask`` for which `nearest` will be used.
+            use ``cubic`` for all bands except ``fmask`` for which ``nearest`` will be used.
 
-            Valid values are: ``'nearest', 'cubic', 'bilinear', 'cubic_spline', 'lanczos', 'average',
-            'mode', 'gauss',  'max', 'min', 'med', 'q1', 'q3'``
+            Valid values are: ::
+
+              'nearest', 'average', 'bilinear', 'cubic', 'cubic_spline',
+              'lanczos', 'mode', 'gauss',  'max', 'min', 'med', 'q1', 'q3'
 
             Default is to use ``nearest`` for all bands.
-            .. seealso:: :meth:`load_data`
+
+            .. seealso::
+               :meth:`load_data`
 
         :param (float,float) align:
             Load data such that point 'align' lies on the pixel boundary.
@@ -330,8 +332,8 @@ class Datacube(object):
             for more information.
 
         :param xarray.Dataset like:
-            Use the output of a previous ``datacube.load()`` to load data into the same spatial grid and
-            resolution (i.e. ``.GeoBox``).
+            Use the output of a previous :meth:`load()` to load data into the same spatial grid and
+            resolution (i.e. :class:`datacube.utils.geometry.GeoBox`).
             E.g.::
 
                 pq = dc.load(product='ls5_pq_albers', like=nbar_dataset)
@@ -356,21 +358,26 @@ class Datacube(object):
 
         :param function dataset_predicate:
             Optional. A function that can be passed to restrict loaded datasets. A predicate function should
-            take a `datacube.model.Dataset` object (e.g. as returned from `dc.find_datasets`) and return a boolean.
+            take a :class:`datacube.model.Dataset` object (e.g. as returned from :meth:`find_datasets`) and return a boolean.
             For example, loaded data could be filtered to January observations only by passing the following
             predicate function that returns True for datasets acquired in January::
+
                 def filter_jan(dataset): return dataset.time.begin.month == 1
 
         :param int limit:
             Optional. If provided, limit the maximum number of datasets
             returned. Useful for testing and debugging.
 
-        :param progress_cbk: Int, Int -> None
-            if supplied will be called for every file read with `files_processed_so_far, total_files`. This is
+        :param progress_cbk:
+            ``Int, Int -> None``,
+            if supplied will be called for every file read with ``files_processed_so_far, total_files``. This is
             only applicable to non-lazy loads, ignored when using dask.
 
-        :return: Requested data in a :class:`xarray.Dataset`
-        :rtype: :class:`xarray.Dataset`
+        :return:
+            Requested data in a :class:`xarray.Dataset`
+
+        :rtype:
+            :class:`xarray.Dataset`
         """
         if product is None and datasets is None:
             raise ValueError("Must specify a product or supply datasets")

--- a/datacube/storage/_load.py
+++ b/datacube/storage/_load.py
@@ -23,7 +23,8 @@ from datacube.utils.math import invalid_mask
 from datacube.utils.geometry import GeoBox, roi_is_empty
 from datacube.model import Measurement
 from datacube.drivers._types import ReaderDriver
-from . import DataSource, BandInfo
+from ..drivers.datasource import DataSource
+from ._base import BandInfo
 
 _LOG = logging.getLogger(__name__)
 

--- a/datacube/storage/_rio.py
+++ b/datacube/storage/_rio.py
@@ -21,7 +21,8 @@ from datacube.utils import geometry
 from datacube.utils.math import num2numpy
 from datacube.utils import uri_to_local_path, get_part_from_uri, is_vsipath
 from datacube.utils.rio import activate_from_config
-from . import DataSource, GeoRasterReader, RasterShape, RasterWindow, BandInfo
+from ..drivers.datasource import DataSource, GeoRasterReader, RasterShape, RasterWindow
+from ._base import BandInfo
 from ._hdf5 import HDF5_LOCK
 
 _LOG = logging.getLogger(__name__)

--- a/datacube/utils/aws/__init__.py
+++ b/datacube/utils/aws/__init__.py
@@ -6,18 +6,18 @@
 Helper methods for working with AWS
 """
 import os
+import time
+import functools
 import botocore
 import botocore.session
 from botocore.credentials import Credentials, ReadOnlyCredentials
 from botocore.session import Session
-import time
 from urllib.request import urlopen
 from urllib.parse import urlparse
 from sqlalchemy.engine.url import URL
 
 from typing import Optional, Dict, Tuple, Any, Union, IO
 from datacube.utils.generic import thread_local_cache
-from ..rio import configure_s3_access
 
 ByteRange = Union[slice, Tuple[int, int]]       # pylint: disable=invalid-name
 MaybeS3 = Optional[botocore.client.BaseClient]  # pylint: disable=invalid-name
@@ -450,3 +450,56 @@ def obtain_new_iam_auth_token(url: URL, region_name: str = "auto", profile_name:
     client = session.client("rds", region_name=region_name)
     return client.generate_db_auth_token(DBHostname=url.host, Port=url.port, DBUsername=url.username,
                                          Region=region_name)
+
+
+def configure_s3_access(profile=None,
+                        region_name="auto",
+                        aws_unsigned=False,
+                        requester_pays=False,
+                        cloud_defaults=True,
+                        client=None,
+                        **gdal_opts):
+    """ Credentialize for S3 bucket access or configure public access.
+
+    This function obtains credentials for S3 access and passes them on to
+    processing threads, either local or on dask cluster.
+
+
+    .. note::
+
+       if credentials are STS based they will eventually expire, currently
+       this case is not handled very well, reads will just start failing
+       eventually and will never recover.
+
+    :param profile:        AWS profile name to use
+    :param region_name:    Default region_name to use if not configured for a given/default AWS profile
+    :param aws_unsigned:   If ``True`` don't bother with credentials when reading from S3
+    :param requester_pays: Needed when accessing requester pays buckets
+
+    :param cloud_defaults: Assume files are in the cloud native format, i.e. no side-car files, disables
+                           looking for side-car files, makes things faster but won't work for files
+                           that do have side-car files with extra metadata.
+
+    :param client:         Dask distributed ``dask.Client`` instance, if supplied apply settings on the
+                           dask cluster rather than locally.
+    :param gdal_opts:      Any other option to pass to GDAL environment setup
+
+    :returns: credentials object or ``None`` if ``aws_unsigned=True``
+    """
+    from ..rio import set_default_rio_config
+
+    aws, creds = get_aws_settings(profile=profile,
+                                  region_name=region_name,
+                                  aws_unsigned=aws_unsigned,
+                                  requester_pays=requester_pays)
+
+    if client is None:
+        set_default_rio_config(aws=aws, cloud_defaults=cloud_defaults, **gdal_opts)
+    else:
+        client.register_worker_callbacks(
+            functools.partial(set_default_rio_config,
+                              aws=aws,
+                              cloud_defaults=cloud_defaults,
+                              **gdal_opts))
+
+    return creds

--- a/datacube/utils/rio/_rio.py
+++ b/datacube/utils/rio/_rio.py
@@ -6,7 +6,6 @@
 """
 import threading
 from types import SimpleNamespace
-import functools
 import rasterio
 from rasterio.session import AWSSession, DummySession
 import rasterio.env
@@ -158,54 +157,28 @@ def set_default_rio_config(aws=None, cloud_defaults=False, **kwargs):
                                epoch=_CFG.epoch + 1)
 
 
-def configure_s3_access(profile=None,
-                        region_name="auto",
-                        aws_unsigned=False,
-                        requester_pays=False,
-                        cloud_defaults=True,
-                        client=None,
-                        **gdal_opts):
-    """ Credentialize for S3 bucket access or configure public access.
-
-    This function obtains credentials for S3 access and passes them on to
-    processing threads, either local or on dask cluster.
 
 
-    .. note::
-
-       if credentials are STS based they will eventually expire, currently
-       this case is not handled very well, reads will just start failing
-       eventually and will never recover.
-
-    :param profile:        AWS profile name to use
-    :param region_name:    Default region_name to use if not configured for a given/default AWS profile
-    :param aws_unsigned:   If ``True`` don't bother with credentials when reading from S3
-    :param requester_pays: Needed when accessing requester pays buckets
-
-    :param cloud_defaults: Assume files are in the cloud native format, i.e. no side-car files, disables
-                           looking for side-car files, makes things faster but won't work for files
-                           that do have side-car files with extra metadata.
-
-    :param client:         Dask distributed ``dask.Client`` instance, if supplied apply settings on the
-                           dask cluster rather than locally.
-    :param gdal_opts:      Any other option to pass to GDAL environment setup
-
-    :returns: credentials object or ``None`` if ``aws_unsigned=True``
+def configure_s3_access(
+    profile=None,
+    region_name="auto",
+    aws_unsigned=False,
+    requester_pays=False,
+    cloud_defaults=True,
+    client=None,
+    **gdal_opts
+):
     """
-    from datacube.utils.aws import get_aws_settings
+    Use :meth:`datacube.utils.aws.configure_s3_access` instead.
+    """
+    from datacube.utils.aws import configure_s3_access
 
-    aws, creds = get_aws_settings(profile=profile,
-                                  region_name=region_name,
-                                  aws_unsigned=aws_unsigned,
-                                  requester_pays=requester_pays)
-
-    if client is None:
-        set_default_rio_config(aws=aws, cloud_defaults=cloud_defaults, **gdal_opts)
-    else:
-        client.register_worker_callbacks(
-            functools.partial(set_default_rio_config,
-                              aws=aws,
-                              cloud_defaults=cloud_defaults,
-                              **gdal_opts))
-
-    return creds
+    return configure_s3_access(
+        profile=profile,
+        region_name=region_name,
+        aws_unsigned=aws_unsigned,
+        requester_pays=requester_pays,
+        cloud_defaults=cloud_defaults,
+        client=client,
+        **gdal_opts
+    )

--- a/docs/architecture/index.rst
+++ b/docs/architecture/index.rst
@@ -5,7 +5,7 @@ Architecture Guide
 .. toctree::
    :maxdepth: 2
 
-  intro.rst
-  data_model.rst
-  data_loading.rst
-  driver.rst
+   intro.rst
+   data_model.rst
+   data_loading.rst
+   driver.rst

--- a/docs/dev/api/index.rst
+++ b/docs/dev/api/index.rst
@@ -61,9 +61,8 @@ for example, to pre-filter the available datasets before loading.
 
 .. include:: load_3d_dataset.rst
 
-.. _grid-workflow-class:
-
 .. py:module:: datacube.api
+.. _grid-workflow-class:
 
 Grid Processing API
 ===================

--- a/docs/dev/api/masking.rst
+++ b/docs/dev/api/masking.rst
@@ -1,6 +1,5 @@
-.. _bit-masking:
-
 .. py:module:: datacube.utils.masking
+.. _bit-masking:
 
 Bit Masking
 ===========

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,9 +29,6 @@ and related data from multiple sources.
 .. toctree::
 
    user/intro.rst
-   user/deployments.rst
-   user/notebooks.rst
-   user/ecosystem.rst
 
 
 .. toctree::

--- a/docs/ops/prepare_scripts.rst
+++ b/docs/ops/prepare_scripts.rst
@@ -6,7 +6,7 @@ Dataset Preparation Scripts
 ***************************
 
 .. note::
-  
+
   Much of the below content is not updated and has not been tested recently.
 
 
@@ -133,7 +133,7 @@ To view an example of how to `index Sentinel-2 data from S3`_ check out the docu
 available in the datacube-dataset-config_ repository.
 
 .. _`index Sentinel-2 data from S3`: https://github.com/opendatacube/datacube-dataset-config/blob/master/sentinel-2-l2a-cogs.md
-.. _datacube-datset-config: https://github.com/opendatacube/datacube-dataset-config/
+.. _datacube-dataset-config: https://github.com/opendatacube/datacube-dataset-config/
 
 Custom Prepare Scripts
 ======================

--- a/docs/user/ecosystem.rst
+++ b/docs/user/ecosystem.rst
@@ -18,7 +18,7 @@ Open Web Services
 
 The datacube-ows_ server allows users to interact with
 an Open Data Cube instance using client software
-(for example, Desktop GIS like QGIS, or a web mapping library like Leaflet or Terria), 
+(for example, Desktop GIS like QGIS, or a web mapping library like Leaflet or Terria),
 through the use of Web Map Service (WMS) and Web Coverage Service (WCS) standards from the Open Goespatial Consortium.
 
 
@@ -45,7 +45,7 @@ See the `Digital Earth Australia Explorer`_ for an example deployment showing th
 Cube in a Box
 -------------
 
-_`Cube in a Box` provides everything needed to get up and running quickly with Open Data Cube inside
+`Cube in a Box`_ provides everything needed to get up and running quickly with Open Data Cube inside
 an Amazon Web Services Environment.
 
 .. _`Cube in a Box`: https://github.com/opendatacube/cube-in-a-box
@@ -65,7 +65,7 @@ producing datasets that are packaged completely.
 Data Cube Statistician
 ----------------------
 
-_`Data Cube Statistician` is a framework of tools for generating statistical summaries of large collections of Earth Observation Imagery
+`Data Cube Statistician`_ is a framework of tools for generating statistical summaries of large collections of Earth Observation Imagery
 managed in an Open Datacube Instance. It is a spiritual successor to `datacube-stats`_, but intended to run in a
 cloud environment rather than on a High Performance Computer (HPC). It has already run at continental scale to produce annual geomedian
 summaries of all of Africa based on Sentinel-2 data. It is still under development, including adding support
@@ -73,6 +73,8 @@ for processing sibling products, eg. Water Observations together with Surface Re
 
 .. _`Data Cube Statistician`: https://github.com/opendatacube/odc-tools/tree/develop/libs/stats
 
+
+.. _datacube-stats:
 
 Data Cube Stats
 ---------------


### PR DESCRIPTION
### Reason for this pull request

- Address warnings in documentation building
- Remove duplicate toc entries (#1166)
- Address import loops

### Proposed changes

- Some of RST typo fixes
- Remove import loop in datacube.storage
- Relocate `configure_s3_access` to `.utils.aws.` (canonical location in the docs)

 - [x] Closes #1166
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
