### PR TITLE
Fix import problems on Windows

### DIFF
--- a/datacube/drivers/postgres/_connections.py
+++ b/datacube/drivers/postgres/_connections.py
@@ -17,7 +17,6 @@ import logging
 import os
 import re
 from contextlib import contextmanager
-from time import clock_gettime, CLOCK_REALTIME
 from typing import Callable, Optional, Union
 
 from sqlalchemy import event, create_engine, text
@@ -272,6 +271,8 @@ def handle_dynamic_token_authentication(engine: Engine,
     @event.listens_for(engine, "do_connect")
     def override_new_connection(dialect, conn_rec, cargs, cparams):
         # Handle IAM authentication
+        from time import clock_gettime, CLOCK_REALTIME
+
         now = clock_gettime(CLOCK_REALTIME)
         if now - last_token_time[0] > timeout:
             last_token[0] = new_token(**kwargs)

--- a/datacube/drivers/postgres/_connections.py
+++ b/datacube/drivers/postgres/_connections.py
@@ -271,6 +271,8 @@ def handle_dynamic_token_authentication(engine: Engine,
     @event.listens_for(engine, "do_connect")
     def override_new_connection(dialect, conn_rec, cargs, cparams):
         # Handle IAM authentication
+        # Importing here because the function `clock_gettime` is not available on Windows
+        # which shouldn't be a problem, because boto3 auth is mostly used on AWS.
         from time import clock_gettime, CLOCK_REALTIME
 
         now = clock_gettime(CLOCK_REALTIME)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -9,7 +9,10 @@ What's New
 v1.8.5 (???)
 =======================
 
-- ???
+- Fix unguarded dependencies on boto libraries (:pull:`1174`, :issue:`1172`)
+- Various documentation fixes (:pull:`1175`)
+- Address import problems on Windows due to use of Unix only functions (:issue:`1176`)
+
 
 v1.8.4 (6 August 2021)
 =======================


### PR DESCRIPTION
### Reason for this pull request

`time.clock_gettime` is not available on Windows.

### Proposed changes

Delay import until it's needed. This code is likely to be used from AWS running on Linux, so no need to provide cross-platform solution, simply delaying import should do.



 - [x] Closes #1176 
 - [ ] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
