### PR TITLE
Make GeoBox class hashable

### DIFF
--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -1065,6 +1065,9 @@ class GeoBox:
     def __bool__(self) -> bool:
         return not self.is_empty()
 
+    def __hash__(self):
+        return hash((*self.shape, self.crs, self.affine))
+
     @property
     def transform(self) -> Affine:
         return self.affine

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -73,7 +73,6 @@ def test_pickleable():
 
 
 def test_geobox_simple():
-    from affine import Affine
     t = geometry.GeoBox(4000, 4000,
                         Affine(0.00025, 0.0, 151.0, 0.0, -0.00025, -29.0),
                         epsg4326)
@@ -98,6 +97,14 @@ def test_geobox_simple():
     assert isinstance(geometry.GeoBox(4000, 4000,
                                       Affine(0.00025, 0.0, 151.0, 0.0, -0.00025, -29.0),
                                       'epsg:4326').crs, CRS)
+
+    # Check GeoBox class is hashable
+    t_copy = GeoBox(t.width, t.height, t.transform, t.crs)
+    t_other = GeoBox(t.width+1, t.height, t.transform, t.crs)
+    assert t_copy is not t
+    assert t == t_copy
+    assert len(set([t, t, t_copy])) == 1
+    assert len(set([t, t_copy, t_other])) == 2
 
 
 def test_props():


### PR DESCRIPTION
### Reason for this pull request

Quick change before release. `GeoBox` class is currently non-hashable, but there is no good reason why it shouldn't be hashable.

### Proposed changes

Add `__hash__` method that returns hash of `.shape, .transform and .crs`.


 - [ ] Closes #xxxx
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
