### PR TITLE
Document stalebot and the pinned tag in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -14,3 +14,7 @@
 
 * Which ``datacube --version`` are you using?
 * What datacube deployment/enviornment are you running against?
+
+
+> **Note:** Stale issues will be automatically closed after a period of six months with no activity. 
+> To ensure critical issues are not closed, tag them with the Github `pinned` tag .


### PR DESCRIPTION
### Reason for this pull request
The stalebot has caused issues over the years by closing important issues which have not been actioned due to resourcing constraints: https://github.com/opendatacube/governance/issues/31

This is particularly an issue as the solution to preventing stalebot from closing issues (i.e. adding the `pinned` tag) is not documented anywhere prominently in this repo.

### Proposed changes
As discussed in the 7 Sep 2021 ODC Steering Committee Meeting, this PR adds a note to the issue template which warns users that issues will be closed if they have no activity for six months, and instructs users how to avoid this using the `pinned` tag:

> **Note:** Stale issues will be automatically closed after a period of six months with no activity. 
> To ensure critical issues are not closed, tag them with the Github `pinned` tag .