### PR TITLE
Clean up `datacube dataset` cli help text

### DIFF
--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -7,6 +7,7 @@ import datetime
 import logging
 import sys
 from collections import OrderedDict
+from textwrap import dedent
 from typing import Iterable, Mapping, MutableMapping, Any, List, Set
 
 import click
@@ -142,7 +143,7 @@ def load_datasets_for_update(doc_stream, index):
                     'you can supply several by repeating this option with a new product name'),
               multiple=True)
 @click.option('--auto-match', '-a', help="Deprecated don't use it, it's a no-op",
-              is_flag=True, default=False)
+              is_flag=True, default=False, hidden=True)
 @click.option('--auto-add-lineage/--no-auto-add-lineage', is_flag=True, default=True,
               help=('Default behaviour is to automatically add lineage datasets if they are missing from the database, '
                     'but this can be disabled if lineage is expected to be present in the DB, '
@@ -237,11 +238,13 @@ def parse_update_rules(keys_that_can_change):
 @click.option('--location-policy',
               type=click.Choice(['keep', 'archive', 'forget']),
               default='keep',
-              help='''What to do with previously recorded dataset location
-'keep' - keep as alternative location [default]
-'archive' - mark as archived
-'forget' - remove from the index
-''')
+              help=dedent('''
+              What to do with previously recorded dataset location(s)
+              
+              \b
+              - 'keep': keep as alternative location [default]
+              - 'archive': mark as archived
+              - 'forget': remove from the index'''))
 @click.argument('dataset-paths', nargs=-1)
 @ui.pass_index()
 def update_cmd(index, keys_that_can_change, dry_run, location_policy, dataset_paths):

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -5,6 +5,10 @@
 What's New
 **********
 
+v1.8.next
+=========
+
+- Trivial fixes to CLI help output (:pull:`1197`)
 
 v1.8.5 (18 August 2021)
 =======================


### PR DESCRIPTION
- better formatting of --location-policy options
- don't list deprecated options in help text, it's untidy

### Reason for this pull request

`datacube dataset` help texts looked untidy, this makes them marginally better.


### Proposed changes
- better formatting of `datacube dataset update --location-policy` help

Before:
```
  --location-policy [keep|archive|forget]                                                                                                                                                                                                                                                   
                                  What to do with previously recorded dataset                                                                                                                                                                                                               
                                  location 'keep' - keep as alternative                                                                                                                                                                                                                     
                                  location [default] 'archive' - mark as                                                                                                                                                                                                                    
                                  archived 'forget' - remove from the index                
```

After:
```
  --location-policy [keep|archive|forget]
                                  What to do with previously recorded dataset
                                  location
                                  
                                  - 'keep': keep as alternative location [default]
                                  - 'archive': mark as archived
                                  - 'forget': remove from the index
```

- don't list deprecated options in help text, it's untidy

Before:
```
-a, --auto-match                Deprecated don't use it, it's a no-op
```

After: Not listed, merely ignored.

- [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
