### PR TITLE
Delete archived datasets

### DIFF
--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -344,6 +344,16 @@ class PostgresDbAPI(object):
 
     def delete_dataset(self, dataset_id):
         self._connection.execute(
+            DATASET_LOCATION.delete().where(
+                DATASET_LOCATION.c.dataset_ref == dataset_id
+            )
+        )
+        self._connection.execute(
+            DATASET_SOURCE.delete().where(
+                DATASET_SOURCE.c.dataset_ref == dataset_id
+            )
+        )
+        self._connection.execute(
             DATASET.delete().where(
                 DATASET.c.id == dataset_id
             )

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -306,6 +306,22 @@ class PostgresDbAPI(object):
             )
         ).fetchall()
 
+    def all_dataset_ids(self, archived: bool):
+        query = select(
+            DATASET.c.id
+        ).select_from(
+            DATASET
+        )
+        if archived:
+            query = query.where(
+                DATASET.c.archived != None
+            )
+        else:
+            query = query.where(
+                DATASET.c.archived == None
+            )
+        return self._connection.execute(query).fetchall()
+
     def insert_dataset_source(self, classifier, dataset_id, source_dataset_id):
         try:
             r = self._connection.execute(

--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -5,23 +5,23 @@
 """
 API for dataset indexing, access and search.
 """
+import json
 import logging
 import warnings
 from collections import namedtuple
 from typing import Iterable, Tuple, Union, List, Optional
 from uuid import UUID
 
+from sqlalchemy import select, func
+
+from datacube.drivers.postgres._fields import SimpleDocField, DateDocField
+from datacube.drivers.postgres._schema import DATASET
 from datacube.model import Dataset, DatasetType
+from datacube.model.fields import Field
 from datacube.model.utils import flatten_datasets
 from datacube.utils import jsonify_document, _readable_offset, changes, cached_property
 from datacube.utils.changes import get_doc_changes
 from . import fields
-
-import json
-from datacube.drivers.postgres._fields import SimpleDocField, DateDocField
-from datacube.drivers.postgres._schema import DATASET
-from sqlalchemy import select, func
-from datacube.model.fields import Field
 
 _LOG = logging.getLogger(__name__)
 
@@ -352,6 +352,16 @@ class DatasetResource(object):
         with self._db.begin() as transaction:
             for id_ in ids:
                 transaction.restore_dataset(id_)
+
+    def purge(self, ids: Iterable[UUID]):
+        """
+        Delete archived datasets
+
+        :param ids: iterable of dataset ids to purge
+        """
+        with self._db.begin() as transaction:
+            for id_ in ids:
+                transaction.delete_dataset(id_)
 
     def get_field_names(self, product_name=None):
         """

--- a/datacube/index/_datasets.py
+++ b/datacube/index/_datasets.py
@@ -363,6 +363,19 @@ class DatasetResource(object):
             for id_ in ids:
                 transaction.delete_dataset(id_)
 
+    def get_all_dataset_ids(self, archived: bool):
+        """
+        Get list of all dataset IDs based only on archived status
+
+        This will be very slow and inefficient for large databases, and is really
+        only intended for small and/or experimental databases.
+
+        :param archived:
+        :rtype: list[str]
+        """
+        with self._db.begin() as transaction:
+            return [str(dsid[0]) for dsid in transaction.all_dataset_ids(archived)]
+
     def get_field_names(self, product_name=None):
         """
         Get the list of possible search fields for a Product

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -602,4 +602,4 @@ def purge_cmd(index: Index, dry_run: bool, all: bool, ids: List[str]):
         # Perform purge
         index.datasets.purge(datasets_for_archive.keys())
 
-    click.echo('Completed dataset archival.')
+    click.echo('Completed dataset purge.')

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -566,7 +566,7 @@ def restore_cmd(index: Index, restore_derived: bool, derived_tolerance_seconds: 
 @dataset_cmd.command('purge', help="Purge archived datasets")
 @click.option('--dry-run', help="Don't archive. Display datasets that would get archived",
               is_flag=True, default=False)
-@click.option('--all', help="Ignore id list - purge all archived datasets",
+@click.option('--all', help="Ignore id list - purge all archived datasets  (warning: VERY slow on large databases)",
               is_flag=True, default=False)
 @click.argument('ids', nargs=-1)
 @ui.pass_index()

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -34,7 +34,8 @@ plantuml_diags: $(SVG_FILES)
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 livehtml:
-	sphinx-autobuild -b html --host 0.0.0.0 --port 8123 --watch "../datacube" --re-ignore "dev/api/generate/.*\.rst" $(SPHINXOPTS) . $(BUILDDIR)/html
+#	sphinx-autobuild -b html --host 0.0.0.0 --port 8123 --watch "../datacube" --re-ignore "dev/api/generate/.*\.rst" $(SPHINXOPTS) . $(BUILDDIR)/html
+	sphinx-autobuild -b html --host 0.0.0.0 --port 8123 --watch "../datacube" --ignore build/ --ignore dev/api/generate $(SPHINXOPTS) . $(BUILDDIR)/html
 
 clean:
 	rm -rf _build/

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,7 +8,14 @@ What's New
 v1.8.next
 =========
 
-- Added ``dataset purge`` command for hard deletion of archived datasets. Added ``--all`` option to dataset archive, restore and purge commands. (:pull:`1199`)
+- Added ``dataset purge`` command for hard deletion of archived datasets. 
+  ``--all`` option deletes all archived datasets.  (N.B. will fail if there
+  are unarchived datasets that depend on the archived datasets.)  
+
+  ``--all`` option also added to ``dataset archive`` and ``dataset restore`` 
+  commands, to archive all unarchived datasets, and restore all archived
+  datasets, respectively.  
+  (:pull:`1199`)
 - Trivial fixes to CLI help output (:pull:`1197`)
 
 v1.8.5 (18 August 2021)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,7 @@ What's New
 v1.8.next
 =========
 
+- Added ``dataset purge`` command for hard deletion of archived datasets. Added ``--all`` option to dataset archive, restore and purge commands. (:pull:`1199`)
 - Trivial fixes to CLI help output (:pull:`1197`)
 
 v1.8.5 (18 August 2021)

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -146,11 +146,11 @@ def test_purge_datasets(index, initialised_postgres_db, local_config, default_me
     indexed_dataset = index.datasets.get(_telemetry_uuid)
     assert indexed_dataset.is_archived
 
-    clirunner(['dataset', 'purge', '--dry-run', _telemetry_uuid])
+    clirunner(['dataset', 'purge', '--dry-run', str(_telemetry_uuid)])
     indexed_dataset = index.datasets.get(_telemetry_uuid)
     assert indexed_dataset.is_archived
 
-    clirunner(['dataset', 'purge', _telemetry_uuid])
+    clirunner(['dataset', 'purge', str(_telemetry_uuid)])
     assert index.datasets.get(_telemetry_uuid) is None
 
 


### PR DESCRIPTION
Add click CLI api option `datacube dataset purge` to delete archived datasets.

Takes a list of dataset IDs, checks that they all exist and are archived, and deletes them.

Options:

`--dry-run`: Perform checks but do not actually delete datasets.
`--all`: Ignore list of IDs (if provided) and delete ALL archived datasets.

I've also added the `--all` flag to the `dataset archive` and `dataset restore` commands.
