### PR TITLE
Change product finding to handle lists of products

### DIFF
--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -99,12 +99,12 @@ class Query(object):
             # Retrieve known keys for extra dimensions
             known_dim_keys = set()
             if product is not None:
-                datacube_product = index.products.get_by_name(product)
-                if datacube_product is not None:
-                    known_dim_keys.update(datacube_product.extra_dimensions.dims.keys())
+                datacube_products = index.products.search(product=product)
             else:
-                for datacube_product in index.products.get_all():
-                    known_dim_keys.update(datacube_product.extra_dimensions.dims.keys())
+                datacube_products = index.products.get_all()
+
+            for datacube_product in datacube_products:
+                known_dim_keys.update(datacube_product.extra_dimensions.dims.keys())
 
             remaining_keys -= known_dim_keys
 

--- a/datacube/index/_products.py
+++ b/datacube/index/_products.py
@@ -331,7 +331,12 @@ class ProductResource(object):
         """
 
         def _listify(v):
-            return v if isinstance(v, list) else [v]
+            if isinstance(v, tuple):
+                return list(v)
+            elif isinstance(v, list):
+                return v
+            else:
+                return [v]
 
         for type_ in self.get_all():
             remaining_matchable = query.copy()

--- a/integration_tests/index/test_search.py
+++ b/integration_tests/index/test_search.py
@@ -32,6 +32,8 @@ from datacube.model import Range
 
 from datacube.testutils import load_dataset_definition
 
+from datacube import Datacube
+
 
 @pytest.fixture
 def pseudo_ls8_type(index, ga_metadata_type):
@@ -1179,6 +1181,19 @@ def test_csv_structure(clirunner, pseudo_ls8_type, ls5_telem_type,
     assert len(lines) == 3
 
     assert lines[0] == _EXPECTED_OUTPUT_HEADER
+
+
+def test_query_dataset_multi_product(index: Index, ls5_dataset_w_children: Dataset):
+    # We have one ls5 level1 and its child nbar
+    dc = Datacube(index)
+
+    # Can we query a single product name?
+    datasets = dc.find_datasets(product='ls5_nbar_scene')
+    assert len(datasets) == 1
+
+    # Can we query multiple products?
+    datasets = dc.find_datasets(product=['ls5_nbar_scene', 'ls5_level1_scene'])
+    assert len(datasets) == 2
 
 
 def _cli_csv_search(args, clirunner):

--- a/integration_tests/index/test_search.py
+++ b/integration_tests/index/test_search.py
@@ -1195,6 +1195,10 @@ def test_query_dataset_multi_product(index: Index, ls5_dataset_w_children: Datas
     datasets = dc.find_datasets(product=['ls5_nbar_scene', 'ls5_level1_scene'])
     assert len(datasets) == 2
 
+    # Can we query multiple products in a tuple
+    datasets = dc.find_datasets(product=('ls5_nbar_scene', 'ls5_level1_scene'))
+    assert len(datasets) == 2
+
 
 def _cli_csv_search(args, clirunner):
     # Do a CSV search from the cli, returning results as a list of dictionaries

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -15,6 +15,12 @@ from datacube.utils import parse_time
 from datacube.utils.geometry import CRS
 
 
+@pytest.fixture
+def mock_index():
+    from unittest.mock import MagicMock
+    return MagicMock()
+
+
 def test_datetime_to_timestamp():
     assert _datetime_to_timestamp((1990, 1, 7)) == 631670400
     assert _datetime_to_timestamp(datetime.datetime(1990, 1, 7)) == 631670400
@@ -22,10 +28,7 @@ def test_datetime_to_timestamp():
     assert _datetime_to_timestamp('1990-01-07T00:00:00.0Z') == 631670400
 
 
-def test_query_kwargs():
-    from unittest.mock import MagicMock
-
-    mock_index = MagicMock()
+def test_query_kwargs(mock_index):
     mock_index.datasets.get_field_names = lambda: {u'product', u'lat', u'sat_path', 'type_id', u'time', u'lon',
                                                    u'orbit', u'instrument', u'sat_row', u'platform', 'metadata_type',
                                                    u'gsi', 'type', 'id'}
@@ -213,3 +216,8 @@ def test_dateline_query_building():
 def test_query_issue_1146():
     q = Query(k='AB')
     assert q.search['k'] == 'AB'
+
+
+def test_query_multiple_products(mock_index):
+    q = Query(index=mock_index, product=['ls5_nbar_albers', 'ls7_nbar_albers'])
+    assert q.product == ['ls5_nbar_albers', 'ls7_nbar_albers']


### PR DESCRIPTION
### Reason for this pull request

Searching for datasets by including a list of products is possible, this makes it accessible using the normal query method.

### Proposed changes

- Use `index.products.search(product=product)` to find products. Tested with a string or a list of strings locally.

 - [x] Closes https://github.com/opendatacube/odc-tools/issues/366
 - [x] Tests added / passed.  NOT A GOOD TEST. ANY IDEAS ON A BETTER ONE?
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes
