### PR TITLE
Replace for g in geom with for g in geom.geoms, to squash Shapely war…

### DIFF
--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -605,7 +605,7 @@ class Geometry:
                 return type(geom)(geom)  # clone without changes
 
             if geom.type in ['GeometryCollection', 'MultiPolygon', 'MultiLineString']:
-                return type(geom)([segmentize_shapely(g) for g in geom])
+                return type(geom)([segmentize_shapely(g) for g in geom.geoms])
 
             if geom.type in ['LineString', 'LinearRing']:
                 return type(geom)(densify(list(geom.coords), resolution))


### PR DESCRIPTION
…ning

### Reason for this pull request

New versions of Shapely (> 1.8?) have been raising a warning:
>ShapelyDeprecationWarning: Iteration over multi-part geometries is deprecated and will be removed in Shapely 2.0. Use the `geoms` property to access the constituent parts of a multi-part geometry.

### Proposed changes

- Replace use of `for g in geom` with `for g in geom.geoms` as recommended by Shapely

 - [ ] Closes #xxxx
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
