### PR TITLE
Prefer WKT over EPSG when guessing crs strings

### DIFF
--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -141,12 +141,13 @@ def _guess_crs_str(crs_spec: Any) -> Optional[str]:
     if isinstance(crs_spec, dict):
         crs_spec = _CRS.from_dict(crs_spec)
 
+    if hasattr(crs_spec, 'to_wkt'):
+        return crs_spec.to_wkt()
     if hasattr(crs_spec, 'to_epsg'):
         epsg = crs_spec.to_epsg()
         if epsg is not None:
             return 'EPSG:{}'.format(crs_spec.to_epsg())
-    if hasattr(crs_spec, 'to_wkt'):
-        return crs_spec.to_wkt()
+
     return None
 
 

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -949,7 +949,7 @@ def test_crs():
 
     crs2 = CRS(crs)
     assert crs2 == crs
-    assert crs.proj is crs2.proj
+    assert crs.proj == crs2.proj
 
     assert epsg4326.valid_region == geometry.box(-180, -90, 180, 90, epsg4326)
     assert epsg3857.valid_region.crs == epsg4326
@@ -1475,7 +1475,7 @@ def test_crs_hash():
 
 
 def test_base_internals():
-    assert _guess_crs_str(CRS("epsg:3577")) == 'EPSG:3577'
+    assert _guess_crs_str(CRS("epsg:3577")) == epsg3577.to_wkt()
     no_epsg_crs = CRS(SAMPLE_WKT_WITHOUT_AUTHORITY)
     assert _guess_crs_str(no_epsg_crs) == no_epsg_crs.to_wkt()
 


### PR DESCRIPTION
### Reason for this pull request

Extracting EPSG code from a CRS that doesn't have one is slow and causes significant performance impacts when loading large file/band counts. 


### Proposed changes

- Swap the order of the .to_epsg and .to_wkt checks

This requires a few minor changes in the tests since 'EPSG:xxxxx' CRS strings will be converted into the equivalent WKT string.

 - [ ] Closes #1222
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes
