### PR TITLE
Update test docker numpy and netcdf4

### DIFF
--- a/docker/constraints.in
+++ b/docker/constraints.in
@@ -17,8 +17,8 @@ jsonschema
 lark-parser>=0.6.7
 matplotlib
 moto
-netcdf4
-numpy
+netcdf4>=1.5.8
+numpy>=1.22.2
 psycopg2
 pycodestyle
 pylint

--- a/docker/constraints.txt
+++ b/docker/constraints.txt
@@ -215,13 +215,13 @@ msgpack==1.0.2
     # via distributed
 munch==2.5.0
     # via fiona
-netcdf4==1.5.6
+netcdf4==1.5.8
     # via
     #   -r constraints.in
     #   compliance-checker
 networkx==2.5.1
     # via cfn-lint
-numpy==1.20.3
+numpy==1.22.2
     # via
     #   -r constraints.in
     #   bottleneck


### PR DESCRIPTION
### Reason for this pull request

Bump versions of numpy and netcdf4.

When `pip` inside `geobase` compiles `netcdf4` wheels it uses some numpy version and not the version that will be installed eventually. Bumping numpy solves the problem for now, but proper solution is to ensure that all wheels like netcdf4 are compiled against the same version of numpy as will be installed.

or switch over to conda based test setup like what's done in `odc-stac` and `odc-tools` and don't bother with docker building and all the complexities this brings.


 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
