### PR TITLE
Index api consistency

### DIFF
--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -469,14 +469,13 @@ class AbstractDatasetResource(ABC):
         """
 
     @abstractmethod
-    def get_derived(self, id_: UUID) -> Iterable[Dataset]:
+    def get_derived(self, id_: DSID) -> Iterable[Dataset]:
         """
         Get all datasets derived from a dataset
 
         :param id_: dataset id
         :rtype: list[Dataset]
         """
-        # TODO: Upgrade to DSID (requires changes to existing index driver)
 
     @abstractmethod
     def has(self, id_: DSID) -> bool:

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -584,7 +584,7 @@ class AbstractDatasetResource(ABC):
         """
 
     @abstractmethod
-    def get_all_dataset_ids(self, archived: bool) -> Iterable[str]:
+    def get_all_dataset_ids(self, archived: bool) -> Iterable[UUID]:
         """
         Get all dataset IDs based only on archived status
 
@@ -594,7 +594,6 @@ class AbstractDatasetResource(ABC):
         :param archived: If true, return all archived datasets, if false, all unarchived datatsets
         :return: Iterable of dataset ids
         """
-        # TODO: Should return Iterable[UUID] for API consistency - requires changes to default index driver
 
     @abstractmethod
     def get_field_names(self, product_name: Optional[str] = None) -> Iterable[str]:

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -374,10 +374,10 @@ class DatasetResource(AbstractDatasetResource):
         only intended for small and/or experimental databases.
 
         :param archived:
-        :rtype: list[str]
+        :rtype: list[UUID]
         """
         with self._db.begin() as transaction:
-            return [str(dsid[0]) for dsid in transaction.all_dataset_ids(archived)]
+            return [dsid[0] for dsid in transaction.all_dataset_ids(archived)]
 
     def get_field_names(self, product_name=None):
         """

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -116,9 +116,11 @@ class DatasetResource(AbstractDatasetResource):
         """
         Get all derived datasets
 
-        :param UUID id_: dataset id
+        :param Union[str,UUID] id_: dataset id
         :rtype: list[Dataset]
         """
+        if not isinstance(id_, UUID):
+            id_ = UUID(id_)
         with self._db.connect() as connection:
             return [
                 self._make(result, full_info=True)

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -9,6 +9,7 @@ import sys
 from collections import OrderedDict
 from textwrap import dedent
 from typing import Iterable, Mapping, MutableMapping, Any, List, Set
+from uuid import UUID
 
 import click
 import yaml
@@ -452,7 +453,7 @@ def search_cmd(index, limit, f, expressions):
     )
 
 
-def _get_derived_set(index: Index, id_: str) -> Set[Dataset]:
+def _get_derived_set(index: Index, id_: UUID) -> Set[Dataset]:
     """
     Get a single flat set of all derived datasets.
     (children, grandchildren, great-grandchildren...)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update -y \
         python3-dev python3-distutils python3-pip \
         build-essential \
         postgresql \
+        redis-server \
         postgresql-client-${V_PG} \
         postgresql-${V_PG} \
         sudo make graphviz \

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,7 @@ What's New
 v1.8.next
 =========
 
+- Regularise some minor API inconsistencies and restore redis-server to Docker image. (:pull:`1234`)
 - Move (default) postgres driver-specific files from `datacube.index` to `datacube.index.postgres`.
   `datacube.index.Index` is now an alias for the abstract base class index interface definition
   rather than postgres driver-specific implementation of that interface. (:pull:`1231`)
@@ -16,7 +17,7 @@ v1.8.next
 - Migrate test docker image from `datacube/geobase` to `osgeo/gdal`. (:pull:`1233`)
 - Separate index driver interface definition from default index driver implementation. (:pull:`1226`)
 - Prefer WKT over EPSG when guessing CRS strings. (:pull:`1223`)
-- Updates install docs. (:pull:`1208`, :pull:`1212`, :pull:`1215`)
+- Updates install docs. (:pull:`1208`, :pull:`1212`, :pull:`1215`, :pull:`1218`)
 - Tweak to segmented in geometry to suppress Shapely warning. (:pull:`1207`)
 
 v1.8.6 (30 September 2021)


### PR DESCRIPTION
### Reason for this pull request

1. API inconsistencies were identified during work on #1226.
2. redis-server was left out of Docker build in #1233, bypassing celery tests.

### Proposed changes

1. Regularise API inconsistencies
2. Add redis-server to docker image to allow celery tests to run

Note: The celery integration depends on ancient and security-compromised version of celery.  The general consensus seems to be that it is useless and nobody uses it, but I need to consult more widely before removing it all together.