### PR TITLE
Null template index driver

### DIFF
--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2015-2022 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import datetime
+from pathlib import Path
 
 from abc import ABC, abstractmethod
 from typing import (Any, Iterable, Iterator,
@@ -12,6 +13,7 @@ from uuid import UUID
 
 from datacube.model import Dataset, MetadataType, Range
 from datacube.model import DatasetType as Product
+from datacube.utils import read_documents
 from datacube.utils.changes import AllowPolicy, Change, Offset
 
 
@@ -63,6 +65,12 @@ class AbstractUserResource(ABC):
         List all database users
         :return: Iterable of (role, username, description) tuples
         """
+
+_DEFAULT_METADATA_TYPES_PATH = Path(__file__).parent.joinpath('default-metadata-types.yaml')
+
+def default_metadata_type_docs():
+    """A list of the bare dictionary format of default :class:`datacube.model.MetadataType`"""
+    return [doc for (path, doc) in read_documents(_DEFAULT_METADATA_TYPES_PATH)]
 
 
 class AbstractMetadataTypeResource(ABC):
@@ -937,3 +945,4 @@ class AbstractIndexDriver(ABC):
                                definition: dict
                               ) -> MetadataType:
         pass
+

--- a/datacube/index/null/__init__.py
+++ b/datacube/index/null/__init__.py
@@ -1,0 +1,7 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2022 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""
+Module
+"""

--- a/datacube/index/null/_datasets.py
+++ b/datacube/index/null/_datasets.py
@@ -1,0 +1,116 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2020 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+from typing import Iterable, Union, Optional
+from uuid import UUID
+
+from datacube.index.abstract import AbstractDatasetResource
+from datacube.model import Dataset, DatasetType
+
+
+class DatasetResource(AbstractDatasetResource):
+    def __init__(self, product_resource):
+        self.types = product_resource
+
+    def get(self, id_: Union[str, UUID], include_sources=False):
+        return None
+
+    def bulk_get(self, ids):
+        return []
+
+    def get_derived(self, id_):
+        return []
+
+    def has(self, id_):
+        return False
+
+    def bulk_has(self, ids_):
+        return [False for id in ids_]
+
+    def add(self, dataset: Dataset,
+            with_lineage: Optional[bool] = None,
+            **kwargs) -> Dataset:
+        return NotImplementedError()
+
+    def search_product_duplicates(self, product: DatasetType, *args):
+        return []
+
+    def can_update(self, dataset, updates_allowed=None):
+        return NotImplementedError()
+
+    def update(self, dataset: Dataset, updates_allowed=None):
+        return NotImplementedError()
+
+    def archive(self, ids):
+        return NotImplementedError()
+
+    def restore(self, ids):
+        return NotImplementedError()
+
+    def purge(self, ids: Iterable[UUID]):
+        return NotImplementedError()
+
+    def get_all_dataset_ids(self, archived: bool):
+        return []
+
+    def get_field_names(self, product_name=None):
+        return []
+
+    def get_locations(self, id_):
+        return []
+
+    def get_archived_locations(self, id_):
+        return []
+
+    def get_archived_location_times(self, id_):
+        return []
+
+    def add_location(self, id_, uri):
+        return NotImplementedError()
+
+    def get_datasets_for_location(self, uri, mode=None):
+        return []
+
+    def remove_location(self, id_, uri):
+        return NotImplementedError()
+
+    def archive_location(self, id_, uri):
+        return NotImplementedError()
+
+    def restore_location(self, id_, uri):
+        return NotImplementedError()
+
+    def search_by_metadata(self, metadata):
+        return []
+
+    def search(self, limit=None, **query):
+        return []
+
+    def search_by_product(self, **query):
+        return []
+
+    def search_returning(self, field_names, limit=None, **query):
+        return []
+
+    def count(self, **query):
+        return 0
+
+    def count_by_product(self, **query):
+        return []
+
+    def count_by_product_through_time(self, period, **query):
+        return []
+
+    def count_product_through_time(self, period, **query):
+        return []
+
+    def search_summaries(self, **query):
+        return []
+
+    def get_product_time_bounds(self, product: str):
+        raise NotImplementedError()
+
+    # pylint: disable=redefined-outer-name
+    def search_returning_datasets_light(self, field_names: tuple, custom_offsets=None, limit=None, **query):
+        return []

--- a/datacube/index/null/_datasets.py
+++ b/datacube/index/null/_datasets.py
@@ -31,25 +31,25 @@ class DatasetResource(AbstractDatasetResource):
     def add(self, dataset: Dataset,
             with_lineage: Optional[bool] = None,
             **kwargs) -> Dataset:
-        return NotImplementedError()
+        raise NotImplementedError()
 
     def search_product_duplicates(self, product: DatasetType, *args):
         return []
 
     def can_update(self, dataset, updates_allowed=None):
-        return NotImplementedError()
+        raise NotImplementedError()
 
     def update(self, dataset: Dataset, updates_allowed=None):
-        return NotImplementedError()
+        raise NotImplementedError()
 
     def archive(self, ids):
-        return NotImplementedError()
+        raise NotImplementedError()
 
     def restore(self, ids):
-        return NotImplementedError()
+        raise NotImplementedError()
 
     def purge(self, ids: Iterable[UUID]):
-        return NotImplementedError()
+        raise NotImplementedError()
 
     def get_all_dataset_ids(self, archived: bool):
         return []
@@ -67,19 +67,19 @@ class DatasetResource(AbstractDatasetResource):
         return []
 
     def add_location(self, id_, uri):
-        return NotImplementedError()
+        raise NotImplementedError()
 
     def get_datasets_for_location(self, uri, mode=None):
         return []
 
     def remove_location(self, id_, uri):
-        return NotImplementedError()
+        raise NotImplementedError()
 
     def archive_location(self, id_, uri):
-        return NotImplementedError()
+        raise NotImplementedError()
 
     def restore_location(self, id_, uri):
-        return NotImplementedError()
+        raise NotImplementedError()
 
     def search_by_metadata(self, metadata):
         return []

--- a/datacube/index/null/_metadata_types.py
+++ b/datacube/index/null/_metadata_types.py
@@ -1,0 +1,40 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2022 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from datacube.index.abstract import AbstractMetadataTypeResource
+from datacube.model import MetadataType
+
+
+class MetadataTypeResource(AbstractMetadataTypeResource):
+    def __init__(self):
+        pass
+
+    def from_doc(self, definition):
+        raise NotImplementedError
+
+    def add(self, metadata_type, allow_table_lock=False):
+        raise NotImplementedError
+
+    def can_update(self, metadata_type, allow_unsafe_updates=False):
+        raise NotImplementedError
+
+    def update(self, metadata_type: MetadataType, allow_unsafe_updates=False, allow_table_lock=False):
+        raise NotImplementedError
+
+    def update_document(self, definition, allow_unsafe_updates=False):
+        raise NotImplementedError
+
+    def get_unsafe(self, id_):
+        raise KeyError(id_)
+
+    def get_by_name_unsafe(self, name):
+        raise KeyError(name)
+
+    def check_field_indexes(self, allow_table_lock=False, rebuild_all=None,
+                            rebuild_views=False, rebuild_indexes=False):
+        raise NotImplementedError
+
+    def get_all(self):
+        return []

--- a/datacube/index/null/_products.py
+++ b/datacube/index/null/_products.py
@@ -1,0 +1,44 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2022 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+from datacube.index.abstract import AbstractProductResource
+from datacube.model import DatasetType
+
+from typing import Iterable
+
+_LOG = logging.getLogger(__name__)
+
+
+class ProductResource(AbstractProductResource):
+    def __init__(self, metadata_type_resource):
+        self.metadata_type_resource = metadata_type_resource
+
+    def add(self, product, allow_table_lock=False):
+        raise NotImplementedError()
+
+    def can_update(self, product, allow_unsafe_updates=False):
+        raise NotImplementedError()
+
+    def update(self, product: DatasetType, allow_unsafe_updates=False, allow_table_lock=False):
+        raise NotImplementedError()
+
+    def update_document(self, definition, allow_unsafe_updates=False, allow_table_lock=False):
+        raise NotImplementedError()
+
+    def get_unsafe(self, id_):  # type: ignore
+        raise KeyError(id_)
+
+    def get_by_name_unsafe(self, name):  # type: ignore
+        raise KeyError(name)
+
+    def get_with_fields(self, field_names):
+        return []
+
+    def search_robust(self, **query):
+        return []
+
+    def get_all(self) -> Iterable[DatasetType]:
+        return []

--- a/datacube/index/null/_users.py
+++ b/datacube/index/null/_users.py
@@ -20,4 +20,4 @@ class UserResource(AbstractUserResource):
         raise NotImplementedError()
 
     def list_users(self) -> Iterable[Tuple[str, str, str]]:
-        raise NotImplementedError()
+        return []

--- a/datacube/index/null/_users.py
+++ b/datacube/index/null/_users.py
@@ -1,0 +1,23 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2020 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+from typing import Iterable, Optional, Tuple
+from datacube.index.abstract import AbstractUserResource
+
+class UserResource(AbstractUserResource):
+    def __init__(self) -> None:
+        pass
+
+    def grant_role(self, role: str, *usernames: str) -> None:
+        raise NotImplementedError()
+
+    def create_user(self, username: str, password: str,
+                    role: str, description: Optional[str] = None) -> None:
+        raise NotImplementedError()
+
+    def delete_user(self, *usernames: str) -> None:
+        raise NotImplementedError()
+
+    def list_users(self) -> Iterable[Tuple[str, str, str]]:
+        raise NotImplementedError()

--- a/datacube/index/null/index.py
+++ b/datacube/index/null/index.py
@@ -1,0 +1,82 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2022 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+from datacube.index.null._datasets import DatasetResource  # type: ignore
+from datacube.index.null._metadata_types import MetadataTypeResource
+from datacube.index.null._products import ProductResource
+from datacube.index.null._users import UserResource
+from datacube.index.abstract import AbstractIndex, AbstractIndexDriver
+from datacube.model import MetadataType
+
+_LOG = logging.getLogger(__name__)
+
+
+class Index(AbstractIndex):
+    """
+    (Sub-)Minimal (non-)implementation of the Index API.
+    """
+
+    def __init__(self) -> None:
+        self._users = UserResource()
+        self._metadata_types = MetadataTypeResource()
+        self._products = ProductResource(self.metadata_types)
+        self._datasets = DatasetResource(self.products)
+
+    @property
+    def users(self) -> UserResource:
+        return self._users
+
+    @property
+    def metadata_types(self) -> MetadataTypeResource:
+        return self._metadata_types
+
+    @property
+    def products(self) -> ProductResource:
+        return self._products
+
+    @property
+    def datasets(self) -> DatasetResource:
+        return self._datasets
+
+    @property
+    def url(self) -> str:
+        return "null"
+
+    @classmethod
+    def from_config(cls, config, application_name=None, validate_connection=True):
+        return cls()
+
+    @classmethod
+    def get_dataset_fields(cls, doc):
+        return {}
+
+    def init_db(self, with_default_types=True, with_permissions=True):
+        return True
+
+    def close(self):
+        pass
+
+    def __repr__(self):
+        return "Index<null>"
+
+
+class NullIndexDriver(AbstractIndexDriver):
+    @staticmethod
+    def connect_to_index(config, application_name=None, validate_connection=True):
+        return Index.from_config(config, application_name, validate_connection)
+
+    @staticmethod
+    def metadata_type_from_doc(definition: dict) -> MetadataType:
+        """
+        :param definition:
+        """
+        MetadataType.validate(definition)  # type: ignore
+        return MetadataType(definition,
+                            dataset_search_fields=Index.get_dataset_fields(definition))
+
+
+def index_driver_init():
+    return NullIndexDriver()

--- a/datacube/index/postgres/_metadata_types.py
+++ b/datacube/index/postgres/_metadata_types.py
@@ -4,24 +4,15 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 import warnings
-from pathlib import Path
 
 from cachetools.func import lru_cache
 
 from datacube.index.abstract import AbstractMetadataTypeResource
 from datacube.model import MetadataType
-from datacube.utils import jsonify_document, changes, _readable_offset, read_documents
+from datacube.utils import jsonify_document, changes, _readable_offset
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes
 
 _LOG = logging.getLogger(__name__)
-
-_DEFAULT_METADATA_TYPES_PATH = Path(__file__).parent.parent.joinpath('default-metadata-types.yaml')
-
-
-def default_metadata_type_docs():
-    """A list of the bare dictionary format of default :class:`datacube.model.MetadataType`"""
-    return [doc for (path, doc) in read_documents(_DEFAULT_METADATA_TYPES_PATH)]
-
 
 class MetadataTypeResource(AbstractMetadataTypeResource):
     def __init__(self, db):

--- a/datacube/index/postgres/_products.py
+++ b/datacube/index/postgres/_products.py
@@ -46,35 +46,6 @@ class ProductResource(AbstractProductResource):
         """
         self.__init__(*state)
 
-    def from_doc(self, definition):
-        """
-        Create a Product from its definitions
-
-        :param dict definition: product definition document
-        :rtype: DatasetType
-        """
-        # This column duplication is getting out of hand:
-        DatasetType.validate(definition)
-        # Validate extra dimension metadata
-        DatasetType.validate_extra_dims(definition)
-
-        metadata_type = definition['metadata_type']
-
-        # They either specified the name of a metadata type, or specified a metadata type.
-        # Is it a name?
-        if isinstance(metadata_type, str):
-            metadata_type = self.metadata_type_resource.get_by_name(metadata_type)
-        else:
-            # Otherwise they embedded a document, add it if needed:
-            metadata_type = self.metadata_type_resource.from_doc(metadata_type)
-            definition = definition.copy()
-            definition['metadata_type'] = metadata_type.name
-
-        if not metadata_type:
-            raise InvalidDocException('Unknown metadata type: %r' % definition['metadata_type'])
-
-        return DatasetType(metadata_type, definition)
-
     def add(self, product, allow_table_lock=False):
         """
         Add a Product.

--- a/datacube/index/postgres/_products.py
+++ b/datacube/index/postgres/_products.py
@@ -246,16 +246,6 @@ class ProductResource(AbstractProductResource):
             allow_table_lock=allow_table_lock,
         )
 
-    def add_document(self, definition):
-        """
-        Add a Product using its definition
-
-        :param dict definition: product definition document
-        :rtype: DatasetType
-        """
-        type_ = self.from_doc(definition)
-        return self.add(type_)
-
     # This is memoized in the constructor
     # pylint: disable=method-hidden
     def get_unsafe(self, id_):  # type: ignore

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -6,10 +6,10 @@ import logging
 
 from datacube.drivers.postgres import PostgresDb
 from datacube.index.postgres._datasets import DatasetResource  # type: ignore
-from datacube.index.postgres._metadata_types import MetadataTypeResource, default_metadata_type_docs
+from datacube.index.postgres._metadata_types import MetadataTypeResource
 from datacube.index.postgres._products import ProductResource
 from datacube.index.postgres._users import UserResource
-from datacube.index.abstract import AbstractIndex, AbstractIndexDriver
+from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, default_metadata_type_docs
 from datacube.model import MetadataType
 
 _LOG = logging.getLogger(__name__)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,9 @@ What's New
 v1.8.next
 =========
 
+- Implement a minimal "null" index driver that provides an always-empty index. Mainly intended
+  to validate the recent abstraction work around the index driver layer, but may be useful
+  for some testing scenarios, and ODC use cases that do not require an index. (:pull:`1236')
 - Regularise some minor API inconsistencies and restore redis-server to Docker image. (:pull:`1234`)
 - Move (default) postgres driver-specific files from `datacube.index` to `datacube.index.postgres`.
   `datacube.index.Index` is now an alias for the abstract base class index interface definition

--- a/docs/installation/database/setup.rst
+++ b/docs/installation/database/setup.rst
@@ -36,6 +36,14 @@ Create Configuration File
 Datacube looks for a configuration file in ~/.datacube.conf or in the location specified by the ``DATACUBE_CONFIG_PATH`` environment variable. The file has this format::
 
     [datacube]
+    # One config file may contain multiple named sections providing multiple configuration environments.
+    # The section named "datacube" (or "default") is used if no environment is specified.
+
+    # index_driver is optional and defaults to "default" (the default Postgres index driver)
+    index_driver: default
+
+    # The remaining configuration entries are for the default Postgres index driver and
+    # may not apply to other index drivers.
     db_database: datacube
 
     # A blank host will use a local socket. Specify a hostname (such as localhost) to use TCP.
@@ -46,6 +54,15 @@ Datacube looks for a configuration file in ~/.datacube.conf or in the location s
     # db_username:
     # db_password:
 
+   [test]
+   # A "test" environment that accesses a separate test database.
+   index_driver: default
+   db_database: datacube_test
+
+   [null]
+   # A "null" environment for working with no index.
+   index_driver: null
+
 Uncomment and fill in lines as required.
 
 Alternately, you can configure the ODC connection to Postgres using environment variables:
@@ -55,7 +72,11 @@ Alternately, you can configure the ODC connection to Postgres using environment 
   DB_PASSWORD
   DB_DATABASE
 
-See also :ref:`runtime-config-doc`
+The desired environment can be specified:
+
+1. in code, with the ``env`` argument to the ``datacube.Datacube`` constructor;
+2. with the ``-E`` option to the command line ui;
+3. with the ``$DATACUBE_ENVIRONMENT`` environment variable.
 
 Initialise the Database Schema
 ==============================

--- a/docs/installation/extending-odc.rst
+++ b/docs/installation/extending-odc.rst
@@ -215,18 +215,10 @@ to connect to an ``Index``. This PR extends this with an
 to use. If this parameter is missing, it falls back to using the default
 PostgreSQL Index.
 
-Example code to implement an index driver
------------------------------------------
-
-.. code:: python
-
-    def index_driver_init():
-        return AbstractIndexDriver()
-
-    class AbstractIndexDriver(object):
-        @staticmethod
-        def connect_to_index(config, application_name=None, validate_connection=True):
-            return Index.from_config(config, application_name, validate_connection)
+A set of abstract base classes are defined in ``datacube.index.abstract``. An index plugin
+is expected to supply implementations of all these abstract base classes. If any abstract
+methods is not relevant to or implementable by a particular Index Driver, that method should
+defined to raise a ``NotImplementedError``.
 
 Default Implementation
 ----------------------
@@ -234,6 +226,18 @@ Default Implementation
 The default ``Index`` uses a PostgreSQL database for all storage and
 retrieval.
 
+Null Implementation
+-------------------
+
+`datacube-core` includes a minimal "null" index driver, that implements an index that is always
+empty. The code for this driver is located at ``datacube.index.null`` and can be used by setting
+the ``index_driver`` to ``null`` in the configuration file.
+
+The null index driver may be useful:
+
+1. for ODC use cases where no database access is required;
+2. for testing scenarios where no database access is required; or
+3. as an example/template for developing other index drivers.
 
 Drivers Plugin Management Module
 ================================
@@ -248,7 +252,8 @@ Drivers are registered in ``setup.py -> entry_points``::
             'netcdf = datacube.drivers.netcdf.driver:writer_driver_init',
         ],
         'datacube.plugins.index': [
-            'default = datacube.index.index:index_driver_init',
+            'default = datacube.index.postgres.index:index_driver_init',
+            'null = datacube.index.null.index:index_driver_init',
             *extra_plugins['index'],
         ],
     }

--- a/integration_tests/agdcintegration.conf
+++ b/integration_tests/agdcintegration.conf
@@ -5,3 +5,6 @@ index_driver: default
 
 [no_such_driver_env]
 index_driver: no_such_driver
+
+[null_driver]
+index_driver: null

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -84,6 +84,17 @@ def local_config(datacube_env_name):
 
 
 @pytest.fixture
+def null_config():
+    """Provides a :class:`LocalConfig` configured with suitable config file paths.
+
+    .. seealso::
+
+        The :func:`integration_config_paths` fixture sets up the config files.
+    """
+    return LocalConfig.find(CONFIG_FILE_PATHS, env="null_driver")
+
+
+@pytest.fixture
 def ingest_configs(datacube_env_name):
     """ Provides dictionary product_name => config file name
     """

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -22,7 +22,7 @@ import datacube.scripts.cli_app
 import datacube.utils
 from datacube.drivers.postgres import _core
 from datacube.index import index_connect
-from datacube.index.postgres._metadata_types import default_metadata_type_docs
+from datacube.index.abstract import default_metadata_type_docs
 from integration_tests.utils import _make_geotiffs, _make_ls5_scene_datasets, load_yaml_file, \
     GEOTIFF, load_test_products
 

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -12,7 +12,7 @@ import yaml
 
 from datacube.drivers.postgres._fields import NumericRangeDocField, PgField
 from datacube.index import Index
-from datacube.index.postgres._metadata_types import default_metadata_type_docs
+from datacube.index.abstract import default_metadata_type_docs
 from datacube.model import MetadataType, DatasetType
 from datacube.model import Range, Dataset
 from datacube.utils import changes

--- a/integration_tests/index/test_null_index.py
+++ b/integration_tests/index/test_null_index.py
@@ -1,0 +1,17 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2022 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from datacube import Datacube
+from datacube.config import LocalConfig
+
+
+def test_init_null(null_config):
+    from datacube.drivers.indexes import index_cache
+    idxs = index_cache()
+    assert "default" in idxs._drivers
+    assert "null" in idxs._drivers
+    with Datacube(config=null_config, validate_connection=True) as dc:
+        assert(dc.index.url) == "null"

--- a/integration_tests/index/test_null_index.py
+++ b/integration_tests/index/test_null_index.py
@@ -3,9 +3,13 @@
 # Copyright (c) 2015-2022 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import pytest
+from unittest.mock import MagicMock
+from uuid import UUID
 
 from datacube import Datacube
-from datacube.config import LocalConfig
+
+
+test_uuid = UUID('4ec8fe97-e8b9-11e4-87ff-1040f381a756')
 
 
 def test_init_null(null_config):
@@ -15,3 +19,106 @@ def test_init_null(null_config):
     assert "null" in idxs._drivers
     with Datacube(config=null_config, validate_connection=True) as dc:
         assert(dc.index.url) == "null"
+
+
+def test_null_user_resource(null_config):
+    with Datacube(config=null_config, validate_connection=True) as dc:
+        assert dc.index.users.list_users() == []
+        with pytest.raises(NotImplementedError) as e:
+            dc.index.users.create_user("user1", "password2", "role1")
+        with pytest.raises(NotImplementedError) as e:
+            dc.index.users.delete_user("user1", "user2")
+        with pytest.raises(NotImplementedError) as e:
+            dc.index.users.grant_role("role1", "user1", "user2")
+
+
+def test_null_user_resource(null_config):
+    with Datacube(config=null_config, validate_connection=True) as dc:
+        assert dc.index.metadata_types.get_all() == []
+        with pytest.raises(NotImplementedError) as e:
+            dc.index.metadata_types.from_doc({})
+        with pytest.raises(NotImplementedError) as e:
+            dc.index.metadata_types.add(MagicMock())
+        with pytest.raises(NotImplementedError) as e:
+            dc.index.metadata_types.can_update(MagicMock())
+        with pytest.raises(NotImplementedError) as e:
+            dc.index.metadata_types.update(MagicMock())
+        with pytest.raises(NotImplementedError) as e:
+            dc.index.metadata_types.update_document({})
+        with pytest.raises(KeyError) as e:
+            dc.index.metadata_types.get_unsafe(1)
+        with pytest.raises(KeyError) as e:
+            dc.index.metadata_types.get_by_name_unsafe("eo")
+        with pytest.raises(NotImplementedError) as e:
+            dc.index.metadata_types.check_field_indexes()
+
+
+def test_null_product_resource(null_config):
+    with Datacube(config=null_config, validate_connection=True) as dc:
+        assert dc.index.products.get_all() == []
+        assert dc.index.products.search_robust(foo="bar", baz=12) == []
+        assert dc.index.products.get_with_fields(["foo", "bar"]) == []
+        with pytest.raises(KeyError) as e:
+            dc.index.products.get_unsafe(1)
+        with pytest.raises(KeyError) as e:
+            dc.index.products.get_by_name_unsafe("product1")
+        with pytest.raises(NotImplementedError) as e:
+            dc.index.products.add(MagicMock())
+        with pytest.raises(NotImplementedError) as e:
+            dc.index.products.can_update(MagicMock())
+        with pytest.raises(NotImplementedError) as e:
+            dc.index.products.update(MagicMock())
+        with pytest.raises(NotImplementedError) as e:
+            dc.index.products.update_document({})
+
+
+def test_null_dataset_resource(null_config):
+    with Datacube(config=null_config, validate_connection=True) as dc:
+        assert dc.index.datasets.get(test_uuid) is None
+        assert dc.index.datasets.bulk_get([test_uuid, "foo"]) == []
+        assert dc.index.datasets.get_derived(test_uuid) == []
+        assert not dc.index.datasets.has(test_uuid)
+        assert dc.index.datasets.bulk_has([test_uuid, "foo"]) == [False, False]
+        with pytest.raises(NotImplementedError) as e:
+            dc.index.datasets.add(MagicMock())
+        with pytest.raises(NotImplementedError) as e:
+            dc.index.datasets.can_update(MagicMock())
+        with pytest.raises(NotImplementedError) as e:
+            dc.index.datasets.update(MagicMock())
+        with pytest.raises(NotImplementedError) as e:
+            dc.index.datasets.archive([test_uuid, "foo"])
+        with pytest.raises(NotImplementedError) as e:
+            dc.index.datasets.restore([test_uuid, "foo"])
+        with pytest.raises(NotImplementedError) as e:
+            dc.index.datasets.purge([test_uuid, "foo"])
+
+        assert dc.index.datasets.get_all_dataset_ids(True) == []
+        assert dc.index.datasets.get_field_names() == []
+        assert dc.index.datasets.get_locations(test_uuid) == []
+        assert dc.index.datasets.get_archived_locations(test_uuid) == []
+        assert dc.index.datasets.get_archived_location_times(test_uuid) == []
+        assert dc.index.datasets.get_datasets_for_location("http://a.uri/test") == []
+
+        with pytest.raises(NotImplementedError) as e:
+            dc.index.datasets.add_location(test_uuid, "http://a.uri/test")
+        with pytest.raises(NotImplementedError) as e:
+            dc.index.datasets.remove_location(test_uuid, "http://a.uri/test")
+        with pytest.raises(NotImplementedError) as e:
+            dc.index.datasets.archive_location(test_uuid, "http://a.uri/test")
+        with pytest.raises(NotImplementedError) as e:
+            dc.index.datasets.restore_location(test_uuid, "http://a.uri/test")
+        with pytest.raises(NotImplementedError) as e:
+            dc.index.datasets.get_product_time_bounds("product1")
+
+        assert dc.index.datasets.search_product_duplicates(MagicMock()) == []
+        assert dc.index.datasets.search_by_metadata({}) == []
+        assert dc.index.datasets.search(foo="bar", baz=12) == []
+        assert dc.index.datasets.search_by_product(foo="bar", baz=12) == []
+        assert dc.index.datasets.search_returning(["foo", "bar"], foo="bar", baz=12) == []
+        assert dc.index.datasets.count(foo="bar", baz=12) == 0
+        assert dc.index.datasets.count_by_product(foo="bar", baz=12) == []
+        assert dc.index.datasets.count_by_product_through_time("1 month", foo="bar", baz=12) == []
+        assert dc.index.datasets.count_product_through_time("1 month", foo="bar", baz=12) == []
+        assert dc.index.datasets.search_summaries(foo="bar", baz=12) == []
+        assert dc.index.datasets.search_eager(foo="bar", baz=12) == []
+        assert dc.index.datasets.search_returning_datasets_light(("foo", "baz"), foo="bar", baz=12) == []

--- a/setup.py
+++ b/setup.py
@@ -125,6 +125,7 @@ setup(
         ],
         'datacube.plugins.index': [
             'default = datacube.index.postgres.index:index_driver_init',
+            'null = datacube.index.null.index:index_driver_init',
             *extra_plugins['index'],
         ],
     },

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -48,6 +48,7 @@ def test_writer_drivers():
 def test_index_drivers():
     available_drivers = index_drivers()
     assert 'default' in available_drivers
+    assert 'null' in available_drivers
 
 
 def test_default_injection():
@@ -98,7 +99,9 @@ dataset:
         assert isinstance(metadata, MetadataType)
         assert metadata.id is None
         assert metadata.name == 'minimal'
-        assert 'some_custom_field' in metadata.dataset_fields
+        if name != "null":
+            # Null driver currently doesn't process dataset search fields
+            assert 'some_custom_field' in metadata.dataset_fields
 
 
 def test_reader_cache_throws_on_missing_fallback():


### PR DESCRIPTION
### Proposed changes

Implement a "null" index driver - an always empty index

### Reason for this pull request

Mostly this a validation that alternate index drivers can be defined and tested, and a template for implementing future index drivers.  It may also be convenient for ODC use cases that do not require an index.


 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes
