### PR TITLE
Deprecate celery

### DIFF
--- a/datacube/_celery_runner.py
+++ b/datacube/_celery_runner.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2015-2020 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import cloudpickle
+import logging
 from celery import Celery
 from time import sleep
 import redis
@@ -10,6 +11,7 @@ import os
 import kombu.serialization
 
 from celery.backends import base as celery_base
+_LOG = logging.getLogger(__name__)
 
 # This can be changed via environment variable `REDIS`
 REDIS_URL = 'redis://localhost:6379/0'
@@ -124,6 +126,7 @@ class CeleryExecutor(object):
         return 'CeleryRunner'
 
     def submit(self, func, *args, **kwargs):
+        _LOG.warning("WARNING: Celery executor is deprecated and will be removed in a future release.")
         return run_function.delay(func, *args, **kwargs)
 
     def map(self, func, iterable):

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,8 @@ What's New
 v1.8.next
 =========
 
+- Deprecate use of the celery executor. Update numpy pin in rtd-requirements.txt to suppress
+  Dependabot warnings. (:pull:`1239`)
 - Implement a minimal "null" index driver that provides an always-empty index. Mainly intended
   to validate the recent abstraction work around the index driver layer, but may be useful
   for some testing scenarios, and ODC use cases that do not require an index. (:pull:`1236')

--- a/docs/rtd-requirements.txt
+++ b/docs/rtd-requirements.txt
@@ -32,7 +32,7 @@ lark-parser==0.8.5
 MarkupSafe==1.1.1
 msgpack==1.0.0
 netCDF4==1.5.3
-numpy==1.18.2
+numpy==1.22.2
 packaging==20.3
 pandas==1.0.3
 paramiko==2.7.1


### PR DESCRIPTION
### Reason for this pull request

The ODC includes some old celery integration, that depends on an ancient version of celery with known security issues; and has not been used by for many years. (See #1238)

Also we are getting Dependabot warnings from an old version of numpy pinned in `rtd-requirements.txt`.

### Proposed changes

- Add a "deprecated ... will be removed in a future release" warning message on use of the celery runner.
- Update numpy pin in `rtd-requirements.txt`

