### PR TITLE
Update docs adding dataset, product and metadata in the right section

### DIFF
--- a/docs/installation/dataset-documents.rst
+++ b/docs/installation/dataset-documents.rst
@@ -344,17 +344,3 @@ Reasons for deprecation
 #. Format does not capture per band resolution/image size
 
 .. _metadata-type-definition:
-
-Metadata Type Definition
-========================
-A Metadata Type defines which fields should be searchable in your product or dataset metadata.
-
-A metadata type is added by default called ``eo`` with *platform/instrument/lat/lon/time* fields.
-
-You would create a new metadata type if you want custom fields to be searchable for your products, or
-if you want to structure your metadata documents differently.
-
-You can see the default metadata type in the repository at ``datacube/index/default-metadata-types.yaml``.
-
-Or more elaborate examples (with fewer comments) in GA's configuration
-repository: https://github.com/GeoscienceAustralia/datacube-ingestion

--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -31,6 +31,9 @@ This section contains information on setting up and managing the Open Data Cube.
     :caption: Configuring the ODC Database
 
     database/setup
+    metadata-types
+    product-definitions
+    dataset-documents
 
 
 .. toctree::

--- a/docs/installation/metadata-types.rst
+++ b/docs/installation/metadata-types.rst
@@ -1,0 +1,15 @@
+Metadata Types
+**************
+
+A Metadata Type defines which fields should be searchable in your product or dataset metadata.
+
+Two metadata types are added by default called ``eo`` and ``eo3``.
+
+You would create a new metadata type if you want custom fields to be searchable for your products, or
+if you want to structure your metadata documents differently.
+
+You can see the default metadata type in the repository at ``datacube/index/default-metadata-types.yaml``.
+
+To add or alter metadata types, you can use commands like: ``datacube metadata add <path-to-file>``
+and to update: ``datacube metadata update <path-to-file>``. Using ``--allow-unsafe`` will allow
+you to update metadata types where the changes may have unexpected consequences.

--- a/docs/installation/product-definitions.rst
+++ b/docs/installation/product-definitions.rst
@@ -1,0 +1,61 @@
+Product Definitions
+*******************
+
+A product definition defines what a dataset must look like and provides
+load hints to Datacube, as well as basic metadata about a product.
+
+The ``metadata`` section of a product definition is used to automatically match
+the product to a dataset. The simplest product definition is included below.
+This example uses only one measurement (equivalent to an ``asset`` in STAC)
+and some very basic information about the product
+
+.. code-block::yaml
+   ---
+   name: dem_srtm
+   metadata_type: eo3
+
+   metadata:
+     product:
+       name: dem_srtm
+
+   measurements:
+     - name: elevation
+       dtype: int16
+       nodata: -32768.0
+       units: "metre"
+
+A slightly more complex product definition is shown below. This example uses
+the ``storage`` section to provide load hints, so that default parameters are
+known when loading data.
+
+.. code-block::yaml
+
+  ---
+   name: dem_srtm
+   description: 1 second elevation model
+   metadata_type: eo3
+
+   license: CC-BY-4.0
+
+   metadata:
+     product:
+       name: dem_srtm
+
+   storage:
+     crs: EPSG:4326
+     resolution:
+       longitude: 0.000277777777780
+       latitude: -0.000277777777780
+
+   measurements:
+     - name: elevation
+       dtype: int16
+       nodata: -32768.0
+       units: "metre"
+
+
+You can add product definitions using the command line as follows: ``datacube product add <path-to-file>``
+and you can update them using ``datacube product update <path-to-file>``.
+
+A tool exists that can help you keep products in sync between a CSV list of products and the ODC
+dataset. See the `datacube-product-sync <https://github.com/opendatacube/odc-tools/blob/develop/apps/dc_tools/README.md#dc-sync-products>`_ tool.


### PR DESCRIPTION
### Reason for this pull request

The dataset-documents page was not included in the index. Now it is and I added a couple of other pages too.

### Proposed changes

- Move dataset-documents page to expected location
- Add product-definitions and metadata-docs pages

 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
