### PR TITLE
Backport fixes from odc-geo

### DIFF
--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -996,7 +996,6 @@ class GeoBox:
     """
 
     def __init__(self, width: int, height: int, affine: Affine, crs: MaybeCRS):
-        assert is_affine_st(affine), "Only axis-aligned geoboxes are currently supported"
         self.width = width
         self.height = height
         self.affine = affine
@@ -1119,6 +1118,7 @@ class GeoBox:
         """
         dict of coordinate labels
         """
+        assert is_affine_st(self.affine), "Only axis-aligned geoboxes are currently supported"
         yres, xres = self.resolution
         yoff, xoff = self.affine.yoff, self.affine.xoff
 

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -43,12 +43,12 @@ from datacube.utils.geometry._base import (
     bounding_box_in_pixel_domain,
     geobox_intersection_conservative,
     geobox_union_conservative,
-    _guess_crs_str,
     force_2d,
     _align_pix,
     _round_to_res,
     _norm_crs,
     _norm_crs_or_error,
+    _make_crs_key,
 )
 from datacube.testutils.geom import (
     epsg4326,
@@ -1475,9 +1475,9 @@ def test_crs_hash():
 
 
 def test_base_internals():
-    assert _guess_crs_str(CRS("epsg:3577")) == epsg3577.to_wkt()
+    assert _make_crs_key("epsg:3577") == "EPSG:3577"
     no_epsg_crs = CRS(SAMPLE_WKT_WITHOUT_AUTHORITY)
-    assert _guess_crs_str(no_epsg_crs) == no_epsg_crs.to_wkt()
+    assert _make_crs_key(no_epsg_crs.proj) == no_epsg_crs.proj.to_wkt()
 
     gjson_bad = {'type': 'a', 'coordinates': [1, [2, 3, 4]]}
     assert force_2d(gjson_bad) == {'type': 'a', 'coordinates': [1, [2, 3]]}


### PR DESCRIPTION
### Reason for this pull request

performance and correctness fixes back ported from `odc-geo`.

### Proposed changes

- changes constructor and hashing of the CRS class (related: #1222 #1230), note that I could not just fix hashing without also ensuring that string representation is consistent across equivalent CRS objects which constructor changes achieve.
- removes overly strict assert in GeoBox, axis-aligned constraint only applies for coordinate computation code

 - [x] Closes #1230 
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
