### PR TITLE
Better error message for missing local metadata file

### DIFF
--- a/datacube/ui/common.py
+++ b/datacube/ui/common.py
@@ -45,7 +45,7 @@ def get_metadata_path(possible_path: Union[str, Path]) -> str:
     if is_supported_document_type(dataset_path):
         raise ValueError(f'No such file {dataset_path}')
     else:
-        raise ValueError('No metadata found for input {dataset_path}')
+        raise ValueError(f'No supported metadata docs found for dataset {dataset_path}')
 
 
 def _find_any_metadata_suffix(path: Path) -> Optional[Path]:

--- a/datacube/ui/common.py
+++ b/datacube/ui/common.py
@@ -42,7 +42,10 @@ def get_metadata_path(possible_path: Union[str, Path]) -> str:
         if found:
             return str(found)
 
-    raise ValueError('No metadata found for input %r' % dataset_path)
+    if is_supported_document_type(dataset_path):
+        raise ValueError(f'No such file {dataset_path}')
+    else:
+        raise ValueError('No metadata found for input {dataset_path}')
 
 
 def _find_any_metadata_suffix(path: Path) -> Optional[Path]:
@@ -88,7 +91,7 @@ def ui_path_doc_stream(paths, logger=None, uri=True, raw=False):
 
     def on_error1(p, e):
         if logger is not None:
-            logger.error('No supported metadata docs found for dataset %s', str(p))
+            logger.error(str(e))
 
     def on_error2(p, e):
         if logger is not None:

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,7 @@ What's New
 v1.8.next
 =========
 
+- Clearer error message when local metadata file does not exist. (:pull:`1252`)
 - Address upstream security alerts and update upstream library versions. (:pull:`1250`)
 - Clone ``postgres`` index driver as ``postgis``, and flag as experimental. (:pull:`1248`)
 - Implement a local non-persistent in-memory index driver, with maximal backwards-compatibility
@@ -31,7 +32,6 @@ v1.8.next
 - Prefer WKT over EPSG when guessing CRS strings. (:pull:`1223`)
 - Updates to documentation. (:pull:`1208`, :pull:`1212`, :pull:`1215`, :pull:`1218`, :pull:`1240`, :pull:`1244`)
 - Tweak to segmented in geometry to suppress Shapely warning. (:pull:`1207`)
-- Improve documentation for Product Discovery, Data Searching and Data Loading docs
 
 v1.8.6 (30 September 2021)
 ==========================


### PR DESCRIPTION
### Reason for this pull request

Fixes #1088



### Proposed changes

Clearer error message when local metadata file does not exist.


 - [*] Closes #1088
 - [*] Tests added / passed
 - [*] Fully documented, including `docs/about/whats_new.rst` for all changes


