### PR TITLE
Deal with Shapely deprecation warning.

### DIFF
--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -705,7 +705,7 @@ class Geometry:
             yield Geometry(g, self.crs)
 
     def __iter__(self) -> Iterator['Geometry']:
-        for geom in self.geom:
+        for geom in self.geom.geoms:
             yield Geometry(geom, self.crs)
 
     def __nonzero__(self) -> bool:

--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -705,7 +705,8 @@ class Geometry:
             yield Geometry(g, self.crs)
 
     def __iter__(self) -> Iterator['Geometry']:
-        for geom in self.geom.geoms:
+        sub_geoms = getattr(self.geom, "geoms", [])
+        for geom in sub_geoms:
             yield Geometry(geom, self.crs)
 
     def __nonzero__(self) -> bool:

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,7 @@ What's New
 v1.8.next
 =========
 
+- Prevent Shapely deprecation warning. (:pull:`1253`)
 - Clearer error message when local metadata file does not exist. (:pull:`1252`)
 - Address upstream security alerts and update upstream library versions. (:pull:`1250`)
 - Clone ``postgres`` index driver as ``postgis``, and flag as experimental. (:pull:`1248`)


### PR DESCRIPTION
### Reason for this pull request

Prevent warning message: "ShapelyDeprecationWarning: Iteration over multi-part geometries is deprecated and will be removed in Shapely 2.0. Use the `geoms` property to access the constituent parts of a multi-part geometry."

Same patch has already been applied to `odc-geo`.

### Proposed changes

Loop over `geoms` property, as advised.



 - [*] Closes #1224
 - [*] Tests added / passed
 - [*] Fully documented, including `docs/about/whats_new.rst` for all changes

