### PR TITLE
Cleaner separation of postgis and postgres drivers.

### DIFF
--- a/datacube/drivers/postgis/_connections.py
+++ b/datacube/drivers/postgis/_connections.py
@@ -30,7 +30,7 @@ from datacube.utils import jsonify_document
 from . import _api
 from . import _core
 
-_LIB_ID = 'agdc-' + str(datacube.__version__)
+_LIB_ID = 'odc-' + str(datacube.__version__)
 
 _LOG = logging.getLogger(__name__)
 
@@ -60,6 +60,8 @@ class PostGisDb(object):
     processes. You can call close() before forking if you know no other threads currently hold connections,
     or else use a separate instance of this class in each process.
     """
+
+    driver_name = 'postgis'  # Mostly to support parametised tests
 
     def __init__(self, engine):
         # We don't recommend using this constructor directly as it may change.
@@ -169,13 +171,13 @@ class PostGisDb(object):
     def _expand_app_name(cls, application_name):
         """
         >>> PostGisDb._expand_app_name(None) #doctest: +ELLIPSIS
-        'agdc-...'
+        'odc-...'
         >>> PostGisDb._expand_app_name('') #doctest: +ELLIPSIS
-        'agdc-...'
+        'odc-...'
         >>> PostGisDb._expand_app_name('cli') #doctest: +ELLIPSIS
-        'cli agdc-...'
+        'cli odc-...'
         >>> PostGisDb._expand_app_name('a b.c/d')
-        'a-b-c-d agdc-...'
+        'a-b-c-d odc-...'
         >>> PostGisDb._expand_app_name(5)
         Traceback (most recent call last):
         ...

--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -8,7 +8,7 @@ Core SQL schema settings.
 
 import logging
 
-from datacube.drivers.postgres.sql import (INSTALL_TRIGGER_SQL_TEMPLATE,
+from datacube.drivers.postgis.sql import (INSTALL_TRIGGER_SQL_TEMPLATE,
                                            SCHEMA_NAME, TYPES_INIT_SQL,
                                            UPDATE_COLUMN_MIGRATE_SQL_TEMPLATE,
                                            ADDED_COLUMN_MIGRATE_SQL_TEMPLATE,
@@ -62,7 +62,7 @@ def install_added_column(connection):
 def schema_qualified(name):
     """
     >>> schema_qualified('dataset')
-    'agdc.dataset'
+    'odc.dataset'
     """
     return '{}.{}'.format(SCHEMA_NAME, name)
 

--- a/datacube/drivers/postgis/_fields.py
+++ b/datacube/drivers/postgis/_fields.py
@@ -264,7 +264,7 @@ class DateDocField(SimpleDocField):
             return _default_utc(value)
         # SQLAlchemy expression or string are parsed in pg as dates.
         elif isinstance(value, (ColumnElement, str)):
-            return func.agdc.common_timestamp(value)
+            return func.odc.common_timestamp(value)
         else:
             raise ValueError("Value not readable as date: %r" % (value,))
 
@@ -384,7 +384,7 @@ class DoubleRangeDocField(RangeDocField):
 
     def value_to_alchemy(self, value):
         low, high = value
-        return func.agdc.float8range(
+        return func.odc.float8range(
             low, high,
             # Inclusive on both sides.
             '[]',

--- a/datacube/drivers/postgis/samples/range-tests-explicit.sql
+++ b/datacube/drivers/postgis/samples/range-tests-explicit.sql
@@ -1,7 +1,7 @@
 -- Index each dimension using postgres range types
 -- (Also: numeric, not float, which may be slower?)
 
-create index ix_dataset_metadata_lat_range on agdc.dataset using gist (
+create index ix_dataset_metadata_lat_range on odc.dataset using gist (
     numrange(
             least(
                     CAST(metadata #>> '{extent, coord, ul, lat}' as numeric),
@@ -15,7 +15,7 @@ create index ix_dataset_metadata_lat_range on agdc.dataset using gist (
     )
 );
 
-create index ix_dataset_metadata_lon_range on agdc.dataset using gist (
+create index ix_dataset_metadata_lon_range on odc.dataset using gist (
     numrange(
             least(
                     CAST(metadata #>> '{extent, coord, ll, lon}' as numeric),
@@ -29,11 +29,11 @@ create index ix_dataset_metadata_lon_range on agdc.dataset using gist (
     )
 );
 
-create index id_dataset_metadata on agdc.dataset (metadata);
+create index id_dataset_metadata on odc.dataset (metadata);
 
 
 select *
-from agdc.dataset
+from odc.dataset
 where numrange(
               least(
                       cast(metadata #>> '{extent, coord, ul, lat}' as numeric),
@@ -61,7 +61,7 @@ where numrange(
 
 
 explain analyse select *
-                from agdc.dataset
+                from odc.dataset
                 where numrange(
                               least(
                                       cast(metadata #>> '{extent, coord, ul, lat}' as numeric),
@@ -93,5 +93,5 @@ select
     CAST(metadata #>> '{extent, coord, ll, lat}' as numeric),
     CAST(metadata #>> '{extent, coord, ur, lat}' as numeric),
     cast(metadata #>> '{extent, coord, lr, lat}' as numeric)
-from agdc.dataset
+from odc.dataset
 limit 3;

--- a/datacube/drivers/postgis/samples/range-tests-scalar.sql
+++ b/datacube/drivers/postgis/samples/range-tests-scalar.sql
@@ -1,36 +1,36 @@
 -- Index each dimension min/max value separately as traditional btree-indexed scalars.
 
-create index ix_dataset_metadata_lat_min on agdc.dataset (
+create index ix_dataset_metadata_lat_min on odc.dataset (
     least(
             CAST(metadata #>> '{extent, coord, ul, lat}' as float),
             CAST(metadata #>> '{extent, coord, ll, lat}' as float)
     )
 );
-create index ix_dataset_metadata_lat_max on agdc.dataset (
+create index ix_dataset_metadata_lat_max on odc.dataset (
     greatest(
             CAST(metadata #>> '{extent, coord, ur, lat}' as float),
             CAST(metadata #>> '{extent, coord, lr, lat}' as float)
     )
 );
 
-create index ix_dataset_metadata_lon_min on agdc.dataset (
+create index ix_dataset_metadata_lon_min on odc.dataset (
     least(
             CAST(metadata #>> '{extent, coord, ll, lon}' as float),
             CAST(metadata #>> '{extent, coord, lr, lon}' as float)
     )
 );
-create index ix_dataset_metadata_lon_max on agdc.dataset (
+create index ix_dataset_metadata_lon_max on odc.dataset (
     greatest(
             CAST(metadata #>> '{extent, coord, ul, lon}' as float),
             CAST(metadata #>> '{extent, coord, ur, lon}' as float)
     )
 );
 
-create index id_dataset_metadata on agdc.dataset (metadata);
+create index id_dataset_metadata on odc.dataset (metadata);
 
 
 explain analyse select *
-                from agdc.dataset
+                from odc.dataset
                 where
                     -30 :: float between
                     least(

--- a/datacube/drivers/postgis/samples/range-tests-view.sql
+++ b/datacube/drivers/postgis/samples/range-tests-view.sql
@@ -1,6 +1,6 @@
 -- Index using Postgres range types, using a view for convenient access.
 
-create index ix_dataset_metadata_lat_range on agdc.dataset using gist (
+create index ix_dataset_metadata_lat_range on odc.dataset using gist (
     numrange(
             least(
                     CAST(metadata #>> '{extent, coord, ul, lat}' as numeric),
@@ -14,7 +14,7 @@ create index ix_dataset_metadata_lat_range on agdc.dataset using gist (
     )
 );
 
-create index ix_dataset_metadata_lon_range on agdc.dataset using gist (
+create index ix_dataset_metadata_lon_range on odc.dataset using gist (
     numrange(
             least(
                     CAST(metadata #>> '{extent, coord, ll, lon}' as numeric),
@@ -29,10 +29,10 @@ create index ix_dataset_metadata_lon_range on agdc.dataset using gist (
 );
 
 
-create index id_dataset_metadata on agdc.dataset (metadata);
+create index id_dataset_metadata on odc.dataset (metadata);
 
 drop index ix_dataset_md_sat;
-create index ix_dataset_md_sat on agdc.dataset (upper(metadata #>> '{platform, code}'));
+create index ix_dataset_md_sat on odc.dataset (upper(metadata #>> '{platform, code}'));
 
 drop view eo_dataset;
 create view eo_dataset as
@@ -64,7 +64,7 @@ create view eo_dataset as
         )                                      as lon,
         metadata,
         metadata_path
-    from agdc.dataset;
+    from odc.dataset;
 
 
 select *

--- a/datacube/drivers/postgis/sql.py
+++ b/datacube/drivers/postgis/sql.py
@@ -13,10 +13,11 @@ from sqlalchemy.sql import sqltypes
 from sqlalchemy.sql.expression import Executable, ClauseElement
 from sqlalchemy.sql.functions import GenericFunction
 
-SCHEMA_NAME = 'agdc'
+SCHEMA_NAME = 'odc'
 
 
 class CreateView(Executable, ClauseElement):
+    inherit_cache = True
     def __init__(self, name, select):
         self.name = name
         self.select = select
@@ -85,8 +86,9 @@ def visit_float8range(element, compiler, **kw):
 # pylint: disable=too-many-ancestors
 class CommonTimestamp(GenericFunction):
     type = TIMESTAMP(timezone=True)
-    package = 'agdc'
+    package = 'odc'
     identifier = 'common_timestamp'
+    inherit_cache = False
 
     name = 'common_timestamp'
 
@@ -98,8 +100,9 @@ class CommonTimestamp(GenericFunction):
 # pylint: disable=too-many-ancestors
 class Float8Range(GenericFunction):
     type = FLOAT8RANGE
-    package = 'agdc'
+    package = 'odc'
     identifier = 'float8range'
+    inherit_cache = False
 
     name = 'float8range'
 

--- a/datacube/drivers/postgres/_connections.py
+++ b/datacube/drivers/postgres/_connections.py
@@ -61,6 +61,8 @@ class PostgresDb(object):
     or else use a separate instance of this class in each process.
     """
 
+    driver_name = 'postgres'   # Mostly to support parametised tests
+
     def __init__(self, engine):
         # We don't recommend using this constructor directly as it may change.
         # Use static methods PostgresDb.create() or PostgresDb.from_config()

--- a/datacube/drivers/postgres/sql.py
+++ b/datacube/drivers/postgres/sql.py
@@ -17,6 +17,7 @@ SCHEMA_NAME = 'agdc'
 
 
 class CreateView(Executable, ClauseElement):
+    inherit_cache = True
     def __init__(self, name, select):
         self.name = name
         self.select = select
@@ -87,6 +88,7 @@ class CommonTimestamp(GenericFunction):
     type = TIMESTAMP(timezone=True)
     package = 'agdc'
     identifier = 'common_timestamp'
+    inherit_cache = False
 
     name = 'common_timestamp'
 
@@ -100,6 +102,7 @@ class Float8Range(GenericFunction):
     type = FLOAT8RANGE
     package = 'agdc'
     identifier = 'float8range'
+    inherit_cache = False
 
     name = 'float8range'
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,7 @@ What's New
 v1.8.next
 =========
 
+- Cleaner separation of postgis and postgres drivers, and suppress SQLAlchemy cache warnings. (:pull:`1254`)
 - Prevent Shapely deprecation warning. (:pull:`1253`)
 - Clearer error message when local metadata file does not exist. (:pull:`1252`)
 - Address upstream security alerts and update upstream library versions. (:pull:`1250`)

--- a/integration_tests/index/test_update_columns.py
+++ b/integration_tests/index/test_update_columns.py
@@ -6,6 +6,8 @@
 Test creation of added/updated columns during
 `datacube system init`
 """
+import pytest
+
 from datacube.drivers.postgres.sql import SCHEMA_NAME
 from datacube.drivers.postgres import _schema
 
@@ -50,6 +52,7 @@ def drop_column(conn, table: str, column: str):
         schema=SCHEMA_NAME, table=table, column=column))
 
 
+@pytest.mark.parametrize('datacube_env_name', ('datacube', ))
 def test_added_column(clirunner, uninitialised_postgres_db):
     # Run on an empty database.
     result = clirunner(["system", "init"])
@@ -72,6 +75,7 @@ def test_added_column(clirunner, uninitialised_postgres_db):
         assert not check_trigger(connection, _schema.DATASET_LOCATION.name)
 
 
+@pytest.mark.parametrize('datacube_env_name', ('datacube', ))
 def test_readd_column(clirunner, uninitialised_postgres_db):
     # Run on an empty database. drop columns and readd
     result = clirunner(["system", "init"])

--- a/integration_tests/test_config_tool.py
+++ b/integration_tests/test_config_tool.py
@@ -12,8 +12,6 @@ from pathlib import Path
 
 import pytest
 
-from datacube.drivers.postgres import _dynamic
-from datacube.drivers.postgres._core import drop_db, has_schema, SCHEMA_NAME
 
 EXAMPLE_DATASET_TYPE_DOCS = map(str, Path(__file__).parent.parent.
                                 joinpath('docs', 'config_samples', 'dataset_types').glob('**/*.yaml'))
@@ -152,13 +150,19 @@ def test_db_init_noop(clirunner, local_config, ls5_telem_type):
 
 
 def test_db_init_rebuild(clirunner, local_config, ls5_telem_type):
+    if local_config._env == "datacube":
+        from datacube.drivers.postgres import _dynamic
+        from datacube.drivers.postgres._core import SCHEMA_NAME
+    else:
+        from datacube.drivers.postgis import _dynamic
+        from datacube.drivers.postgis._core import SCHEMA_NAME
     # We set the field creation logging to debug, as we assert its logging output below.
     _dynamic._LOG.setLevel(logging.DEBUG)
 
     # Run on an existing database.
     result = clirunner(
         [
-            '-v', 'system', 'init', '--rebuild'
+            '-v', '-E', local_config._env, 'system', 'init', '--rebuild'
         ]
     )
     assert 'Updated.' in result.output
@@ -174,13 +178,22 @@ def test_db_init_rebuild(clirunner, local_config, ls5_telem_type):
 
 
 def test_db_init(clirunner, initialised_postgres_db):
+    if initialised_postgres_db.driver_name == "postgis":
+        from datacube.drivers.postgis._core import drop_db, has_schema
+    else:
+        from datacube.drivers.postgres._core import drop_db, has_schema
+
     with initialised_postgres_db.connect() as connection:
         drop_db(connection._connection)
 
         assert not has_schema(initialised_postgres_db._engine, connection._connection)
 
     # Run on an empty database.
-    result = clirunner(['system', 'init'])
+    if initialised_postgres_db.driver_name == "postgis":
+        result = clirunner(['-E', 'experimental', 'system', 'init'])
+    else:
+        result = clirunner(['system', 'init'])
+
     assert 'Created.' in result.output
 
     with initialised_postgres_db.connect() as connection:


### PR DESCRIPTION
Started out as a quick fix for #1221 but the work quickly turned up some lingering crosstalk between the postgres and postgis drivers and issues with parametised testing of both drivers. This PR turned out to be mostly about removing that crosstalk and ensuring a cleaner separation of the two drivers.

Note in particular that the postgis driver now uses the `odc` schema instead of the `agdc` schema used by the postgres driver.  SQLAlchemy uses schema name to distinguish between custom SQL constructs with the same name, so changing the schema name was essential.

 - [x] Closes #1221
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes


