### PR TITLE
Remove reference to `rasterio.path`.

### DIFF
--- a/datacube/storage/_rio.py
+++ b/datacube/storage/_rio.py
@@ -13,7 +13,6 @@ from threading import RLock
 import numpy as np
 from affine import Affine
 import rasterio
-import rasterio.path
 from urllib.parse import urlparse
 from typing import Optional, Iterator
 
@@ -165,8 +164,7 @@ class RasterioDataSource(DataSource):
 
         try:
             _LOG.debug("opening %s", self.filename)
-            with rasterio.DatasetReader(rasterio.path.parse_path(str(self.filename)),
-                                        sharing=False) as src:
+            with rasterio.open(str(self.filename)) as src:
                 override = False
 
                 transform = src.transform

--- a/datacube/storage/_rio.py
+++ b/datacube/storage/_rio.py
@@ -164,7 +164,7 @@ class RasterioDataSource(DataSource):
 
         try:
             _LOG.debug("opening %s", self.filename)
-            with rasterio.open(str(self.filename)) as src:
+            with rasterio.open(str(self.filename), sharing=False) as src:
                 override = False
 
                 transform = src.transform

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,7 @@ What's New
 v1.8.next
 =========
 
+- Remove reference to `rasterio.path`. (:pull:`1255`)
 - Cleaner separation of postgis and postgres drivers, and suppress SQLAlchemy cache warnings. (:pull:`1254`)
 - Prevent Shapely deprecation warning. (:pull:`1253`)
 - Clearer error message when local metadata file does not exist. (:pull:`1252`)


### PR DESCRIPTION
Rasterio have expressed regret at publishing `rasterio.path` in their public API and intend to deprecate it.  See #1246

@Kirill888 said this was trivial, and indeed it was.  I can't shake the feeling that I'm missing something, but the tests pass.


 - [x] Closes #1246
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

