### PR TITLE
Support query parameters in datacube_db_url

### DIFF
--- a/datacube/config.py
+++ b/datacube/config.py
@@ -9,7 +9,7 @@ User configuration.
 import os
 from pathlib import Path
 import configparser
-from urllib.parse import unquote_plus, urlparse
+from urllib.parse import unquote_plus, urlparse, parse_qsl
 from typing import Optional, Iterable, Union, Any, Tuple, Dict
 
 PathLike = Union[str, 'os.PathLike[Any]']
@@ -172,7 +172,7 @@ def parse_connect_url(url: str) -> Dict[str, str]:
         i = s.find(separator)
         return (s, '') if i < 0 else (s[:i], s[i+1:])
 
-    _, netloc, path, *_ = urlparse(url)
+    _, netloc, path, _, query, *_ = urlparse(url)
 
     db = path[1:] if path else ''
     if '@' in netloc:
@@ -189,6 +189,16 @@ def parse_connect_url(url: str) -> Dict[str, str]:
         oo['password'] = unquote_plus(password)
     if user:
         oo['username'] = user
+
+    supported_keys = {
+        'user': 'username',
+        'host': 'hostname',
+        'dbname': 'database',
+        'password': 'password',
+        'port': 'port',
+    }
+    oo.update({supported_keys[k]: v for k, v in parse_qsl(query) if k in supported_keys})
+
     return oo
 
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -11,6 +11,7 @@ v1.8.next
 - Remove reference to `rasterio.path`. (:pull:`1255`)
 - Cleaner separation of postgis and postgres drivers, and suppress SQLAlchemy cache warnings. (:pull:`1254`)
 - Prevent Shapely deprecation warning. (:pull:`1253`)
+- Fix `DATACUBE_DB_URL` parsing to understand syntax like: `postgresql:///datacube?host=/var/run/postgresql` (:pull:`1256`)
 - Clearer error message when local metadata file does not exist. (:pull:`1252`)
 - Address upstream security alerts and update upstream library versions. (:pull:`1250`)
 - Clone ``postgres`` index driver as ``postgis``, and flag as experimental. (:pull:`1248`)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -119,6 +119,19 @@ def test_parse_db_url():
         hostname='some.tld',
         port='3344')
 
+    assert parse_connect_url('postgresql:///db?host=/var/run/postgresql') == dict(
+        database='db',
+        hostname='/var/run/postgresql')
+
+    assert parse_connect_url(
+        'postgresql:///?user=user&password=pass%40&host=/var/run/postgresql&port=3344&dbname=db&sslmode=allow'
+    ) == dict(
+        password='pass@',
+        username='user',
+        database='db',
+        hostname='/var/run/postgresql',
+        port='3344')
+
 
 def _clear_cfg_env(monkeypatch):
     for e in ('DATACUBE_DB_URL',


### PR DESCRIPTION
### Reason for this pull request

The only way to specify unix socket path rather than address is via query parameter part of the url. This is handy when working with conda on Ubuntu as conda expects to find postgresql sockets in /tmp but they are in /var/run/postgresql on Ubuntu.

### Proposed changes

Parse and use `?{host,user,password,dname,port}=` parameters when they are supplied in a query string.

 - [ ] Closes #xxxx
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
