### PR TITLE
Add support for group-by financial years.

### DIFF
--- a/datacube/virtual/transformations.py
+++ b/datacube/virtual/transformations.py
@@ -359,13 +359,22 @@ def year(time):
 
 def fiscal_year(time):
     """"
-    This function will support group-by financial years
+    This function supports group-by financial years
     """
-    df = pd.Series(time.values)
-    years = df.apply(lambda x: np.datetime64(str(x.to_period('Q-JUN').qyear))).values
-    ds = xr.DataArray(years, name='time', attrs=time.attrs, coords=time.coords, dims=time.dims)
+    def convert_to_quarters(x):
+        df = pd.Series(x)
+        return df.apply(lambda x: numpy.datetime64(str(x.to_period('Q-JUN').qyear))).values
+
+    ds = xarray.apply_ufunc(convert_to_quarters,
+                       time,
+                       input_core_dims=[["time"]],
+                       output_core_dims=[["time"]],
+                       vectorize=True)
+
+    df = time['time'].to_series()
+    years = df.apply(lambda x: numpy.datetime64(str(x.to_period('Q-JUN').qyear))).values
     ds = ds.assign_coords({"time": years})
-    return ds
+    return(ds)
 
 
 def month(time):

--- a/datacube/virtual/transformations.py
+++ b/datacube/virtual/transformations.py
@@ -6,6 +6,7 @@ from typing import Optional, Collection
 
 import numpy
 import xarray
+import pandas as pd
 
 from datacube.utils.masking import make_mask as make_mask_prim
 from datacube.utils.masking import mask_invalid_data as mask_invalid_data_prim
@@ -355,6 +356,16 @@ class Expressions(Transformation):
 
 def year(time):
     return time.astype('datetime64[Y]')
+
+def fiscal_year(time):
+    """"
+    This function will support group-by financial years
+    """
+    df = pd.Series(time.values)
+    years = df.apply(lambda x: np.datetime64(str(x.to_period('Q-JUN').qyear))).values
+    ds = xr.DataArray(years, name='time', attrs=time.attrs, coords=time.coords, dims=time.dims)
+    ds = ds.assign_coords({"time": years})
+    return ds
 
 
 def month(time):

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -7,7 +7,7 @@ What's New
 
 v1.8.next
 =========
-
+- Added support for group-by financial years to virtual products. (:pull:`1257`)
 - Remove reference to `rasterio.path`. (:pull:`1255`)
 - Cleaner separation of postgis and postgres drivers, and suppress SQLAlchemy cache warnings. (:pull:`1254`)
 - Prevent Shapely deprecation warning. (:pull:`1253`)

--- a/tests/api/test_virtual.py
+++ b/tests/api/test_virtual.py
@@ -2,21 +2,24 @@
 #
 # Copyright (c) 2015-2020 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from collections import OrderedDict
-from datetime import datetime
-from copy import deepcopy
-import warnings
+# from collections import OrderedDict
+# from datetime import datetime
+# from copy import deepcopy
+# import warnings
 
 import pytest
 from unittest import mock
 import numpy
+import xarray as xr
 
 from datacube.model import DatasetType, MetadataType, Dataset, GridSpec
 from datacube.utils import geometry
 from datacube.virtual import construct_from_yaml, catalog_from_yaml, VirtualProductException
 from datacube.virtual import DEFAULT_RESOLVER, Transformation
 from datacube.virtual.impl import Datacube
+
 from datacube.virtual.expr import formula_parser, FormulaEvaluator, evaluate_data
+from datacube.virtual.transformations import fiscal_year
 
 
 ##########################################
@@ -535,3 +538,65 @@ def test_reproject(dc, query, catalog):
     assert data.geobox.crs == geometry.CRS('EPSG:32755')
     assert data.coords['x'].attrs['resolution'] == -30
     assert data.coords['y'].attrs['resolution'] == 30
+
+def test_fiscal_year():
+    """
+    Test fiscal year function
+    """
+    times = ['2015-07-02T11:59:59.999999000',
+             '2015-07-02T11:59:59.999999000',
+             '2016-07-01T23:59:59.999999000',
+             '2016-07-01T23:59:59.999999']
+
+    times = [numpy.datetime64(x) for x in times]
+    coords = ({'time': times})
+    attribs = {'units': 'seconds since 1970-01-01 00:00:00'}
+    dimension = ('time',)
+    da = xr.DataArray(times, name='time',
+                      attrs=attribs,
+                      coords=coords,
+                      dims=dimension)
+
+    fy = fiscal_year(da)
+
+    expected = ['2016-01-01', '2016-01-01', '2017-01-01', '2017-01-01']
+    expected = [numpy.datetime64(x) for x in expected]
+
+    assert (expected == fy.data).all()
+    assert (expected == fy.time).all()
+
+
+def test_fiscal_year_multi_time_dimensions():
+    """
+    Test the fiscal year is applied to every
+    input time dimension
+    """
+
+    times_mock_1 = ['2015-06-30T11:59:59.999999000',
+                    '2015-12-31T11:59:59.999999000',
+                    '2016-01-01T23:59:59.999999000',
+                    '2016-07-01T23:59:59.999999']
+
+    times_mock_2 = ['2019-06-30T11:59:59.999999000',
+                    '2019-12-31T11:59:59.999999000',
+                    '2020-01-01T23:59:59.999999000',
+                    '2020-05-31T23:59:59.999999']
+
+    times_mock_1 = [numpy.datetime64(x) for x in times_mock_1]
+    times_mock_2 = [numpy.datetime64(x) for x in times_mock_2]
+    data = numpy.array([times_mock_1, times_mock_2])
+    attribs = {'units': 'seconds since 1970-01-01 00:00:00'}
+    da = xr.DataArray(data, name='time',
+                      attrs=attribs,
+                      coords={'x': [1, 2], 'time': times_mock_1},
+                      dims=('x', 'time'))
+    fy = fiscal_year(da)
+
+    expected_times_mock_1 = ['2015-01-01', '2016-01-01', '2016-01-01', '2017-01-01']
+    expected_times_mock_2 = ['2019-01-01', '2020-01-01', '2020-01-01', '2020-01-01']
+    expected_times_mock_1 = [numpy.datetime64(x) for x in expected_times_mock_1]
+    expected_times_mock_2 = [numpy.datetime64(x) for x in expected_times_mock_2]
+    expected_data = numpy.array([expected_times_mock_1, expected_times_mock_2])
+
+    assert (expected_data == fy.data).all()
+    assert (expected_times_mock_1 == fy.time).all()

--- a/tests/api/test_virtual.py
+++ b/tests/api/test_virtual.py
@@ -539,6 +539,7 @@ def test_reproject(dc, query, catalog):
     assert data.coords['x'].attrs['resolution'] == -30
     assert data.coords['y'].attrs['resolution'] == 30
 
+
 def test_fiscal_year():
     """
     Test fiscal year function

--- a/tests/api/test_virtual.py
+++ b/tests/api/test_virtual.py
@@ -2,10 +2,10 @@
 #
 # Copyright (c) 2015-2020 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-# from collections import OrderedDict
-# from datetime import datetime
-# from copy import deepcopy
-# import warnings
+from collections import OrderedDict
+from datetime import datetime
+from copy import deepcopy
+import warnings
 
 import pytest
 from unittest import mock


### PR DESCRIPTION
### Reason for this pull request

Support virtual products to group-by financial years.


### Proposed changes

-  Added a new function to support this alongside the calendar year.
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
