### PR TITLE
fix skip_broken_datasets settings in virtual products

### DIFF
--- a/datacube/virtual/impl.py
+++ b/datacube/virtual/impl.py
@@ -245,7 +245,7 @@ class VirtualProduct(Mapping):
 
     _GEOBOX_KEYS = {'output_crs', 'resolution', 'align'}
     _GROUPING_KEYS = {'group_by'}
-    _LOAD_KEYS = {'measurements', 'fuse_func', 'resampling', 'dask_chunks', 'like'}
+    _LOAD_KEYS = {'measurements', 'fuse_func', 'resampling', 'dask_chunks', 'like', 'skip_broken_datasets'}
     _ADDITIONAL_SEARCH_KEYS = {'dataset_predicate', 'ensure_location'}
 
     _NON_QUERY_KEYS = _GEOBOX_KEYS | _GROUPING_KEYS | _LOAD_KEYS
@@ -421,6 +421,7 @@ class Product(VirtualProduct):
                                     geobox, list(measurement_dicts.values()),
                                     fuse_func=merged.get('fuse_func'),
                                     dask_chunks=merged.get('dask_chunks'),
+                                    skip_broken_datasets=merged.get('skip_broken_datasets', False),
                                     resampling=merged.get('resampling', 'nearest'))
 
         return result

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -36,6 +36,7 @@ v1.8.next
 - Prefer WKT over EPSG when guessing CRS strings. (:pull:`1223`)
 - Updates to documentation. (:pull:`1208`, :pull:`1212`, :pull:`1215`, :pull:`1218`, :pull:`1240`, :pull:`1244`)
 - Tweak to segmented in geometry to suppress Shapely warning. (:pull:`1207`)
+- Fix to ensure ``skip_broken_datasets`` is correctly propagated in virtual products (:pull:`1259`)
 
 v1.8.6 (30 September 2021)
 ==========================


### PR DESCRIPTION
### Reason for this pull request
Virtual product load does not propagate `skip_broken_datasets` to `Datacube.load_data`.


### Proposed changes
Fix that.