### PR TITLE
Clearly report when dataset add operations fail due to lineage issues.

### DIFF
--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -11,13 +11,9 @@ from types import SimpleNamespace
 
 from datacube.model import Dataset
 from datacube.utils import changes, InvalidDocException, SimpleDocNav, jsonify_document
-from datacube.model.utils import dedup_lineage, remap_lineage_doc, flatten_datasets
+from datacube.model.utils import BadMatch, dedup_lineage, remap_lineage_doc, flatten_datasets
 from datacube.utils.changes import get_doc_changes
 from .eo3 import prep_eo3, is_doc_eo3
-
-
-class BadMatch(Exception):
-    pass
 
 
 def load_rules_from_types(index, product_names=None, excluding=None):

--- a/datacube/model/utils.py
+++ b/datacube/model/utils.py
@@ -25,6 +25,10 @@ except ImportError:
     from yaml import SafeDumper  # type: ignore
 
 
+class BadMatch(Exception):
+    pass
+
+
 def machine_info():
     info = {
         'software_versions': {
@@ -346,7 +350,13 @@ def remap_lineage_doc(root, mk_node, **kwargs):
     if not isinstance(root, SimpleDocNav):
         root = SimpleDocNav(root)
 
-    return visit(root)
+    try:
+        return visit(root)
+    except BadMatch as e:
+        if root.id not in str(e):
+            raise BadMatch(f"Error loading lineage dataset: {e}")
+        else:
+            raise
 
 
 def dedup_lineage(root):

--- a/datacube/model/utils.py
+++ b/datacube/model/utils.py
@@ -354,7 +354,7 @@ def remap_lineage_doc(root, mk_node, **kwargs):
         return visit(root)
     except BadMatch as e:
         if root.id not in str(e):
-            raise BadMatch(f"Error loading lineage dataset: {e}")
+            raise BadMatch(f"Error loading lineage dataset: {e}") from None
         else:
             raise
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -7,6 +7,9 @@ What's New
 
 v1.8.next
 =========
+
+- When dataset add operations fail due to lineage issues, the produced error message now clearly indicates that
+  the problem was due to lineage issues. (:pull:`1260`)
 - Added support for group-by financial years to virtual products. (:pull:`1257`)
 - Remove reference to `rasterio.path`. (:pull:`1255`)
 - Cleaner separation of postgis and postgres drivers, and suppress SQLAlchemy cache warnings. (:pull:`1254`)

--- a/integration_tests/test_dataset_add.py
+++ b/integration_tests/test_dataset_add.py
@@ -41,13 +41,15 @@ def check_no_product_match(clirunner, index):
     r = clirunner(['dataset', 'add',
                    '--product', 'A',
                    str(prefix)])
-    assert 'ERROR Dataset metadata did not match product signature' in r.output
+    assert 'ERROR' in r.output
+    assert 'Dataset metadata did not match product signature' in r.output
 
     r = clirunner(['dataset', 'add',
                    '--product', 'A',
                    '--product', 'B',
                    str(prefix)])
-    assert 'ERROR No matching Product found for dataset' in r.output
+    assert 'ERROR' in r.output
+    assert 'No matching Product found for dataset' in r.output
 
     ds_ = index.datasets.get(ds.id, include_sources=True)
     assert ds_ is None
@@ -58,7 +60,8 @@ def check_no_product_match(clirunner, index):
                    '--confirm-ignore-lineage',
                    str(prefix)])
 
-    assert 'ERROR Dataset metadata did not match product signature' in r.output
+    assert 'ERROR' in r.output
+    assert 'Dataset metadata did not match product signature' in r.output
     assert index.datasets.has(ds.id) is False
 
 


### PR DESCRIPTION
### Reason for this pull request

When indexing a dataset with missing lineage, the error message did not clearly state that the issue was due to lineage datasets.  (See #1251)

### Proposed changes

When dataset add operations fail due to lineage issues, the produced error message now clearly says so.


 - [x] Closes #1251
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

