### PR TITLE
Fix CRS when WKT only

### DIFF
--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -172,7 +172,7 @@ class CRS:
             self._crs, self._str, self._epsg = _make_crs(_CRS.from_dict(crs_spec))
         else:
             _to_epsg = getattr(crs_spec, "to_epsg", None)
-            if _to_epsg is not None:
+            if (_to_epsg is not None) and (_to_epsg() is not None):
                 self._crs, self._str, self._epsg = _make_crs(f"EPSG:{_to_epsg()}")
                 return
             _to_wkt = getattr(crs_spec, "to_wkt", None)

--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -171,13 +171,19 @@ class CRS:
         elif isinstance(crs_spec, dict):
             self._crs, self._str, self._epsg = _make_crs(_CRS.from_dict(crs_spec))
         else:
-            _to_epsg = getattr(crs_spec, "to_epsg", None)
-            if (_to_epsg is not None) and (_to_epsg() is not None):
-                self._crs, self._str, self._epsg = _make_crs(f"EPSG:{_to_epsg()}")
+            try:
+                epsg = crs_spec.to_epsg()
+            except AttributeError:
+                epsg = None
+            if epsg is not None:
+                self._crs, self._str, self._epsg = _make_crs(f"EPSG:{epsg}")
                 return
-            _to_wkt = getattr(crs_spec, "to_wkt", None)
-            if _to_wkt is not None:
-                self._crs, self._str, self._epsg = _make_crs(_to_wkt())
+            try:
+                wkt = crs_spec.to_wkt()
+            except AttributeError:
+                wkt = None
+            if wkt is not None:
+                self._crs, self._str, self._epsg = _make_crs(wkt)
                 return
 
             raise CRSError(

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1515,6 +1515,20 @@ def test_crs_units_per_degree():
     assert crs_units_per_degree('EPSG:3857', -180, 0) == approx(111319.49, 0.5)
 
 
+def test_rio_crs__no_epsg():
+    import rasterio.crs
+    rio_crs = rasterio.crs.CRS.from_wkt(
+        'PROJCS["unnamed",GEOGCS["Unknown datum based upon the custom spheroid",'
+        'DATUM["Not specified (based on custom spheroid)",'
+        'SPHEROID["Custom spheroid",6371007.181,0]],'
+        'PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]],'
+        'PROJECTION["Sinusoidal"],PARAMETER["longitude_of_center",0],'
+        'PARAMETER["false_easting",0],PARAMETER["false_northing",0],'
+        'UNIT["Meter",1],AXIS["Easting",EAST],AXIS["Northing",NORTH]]'
+    )
+    assert CRS(rio_crs).epsg is None
+
+
 @pytest.mark.parametrize("left, right, off, res, expect", [
     (20, 30, 10, 0, (20, 1)),
     (20, 30.5, 10, 0, (20, 1)),


### PR DESCRIPTION
### Reason for this pull request

Prevents failing when WKT does not have an associated EPSG code.
For example, this can occur when reading a MODIS sinusoidal tile whose CRS is defined by WKT. On file reading, a rasterio.CRS.crs object is returned, which has a `to_epsg` attribute but whose value is `None`.

### Proposed changes

- Check that crs.to_epsg() is also not None

 - [ ] Closes #xxxx
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
