### PR TITLE
Typehint cleanup - mypy compliance

### DIFF
--- a/datacube/_celery_runner.py
+++ b/datacube/_celery_runner.py
@@ -2,6 +2,8 @@
 #
 # Copyright (c) 2015-2020 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+#
+# type: ignore
 import cloudpickle
 import logging
 from celery import Celery

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -5,7 +5,7 @@
 import uuid
 import collections.abc
 from itertools import groupby
-from typing import Union, Optional, Dict, Tuple
+from typing import Set, Union, Optional, Dict, Tuple, cast
 import datetime
 
 import numpy
@@ -927,13 +927,13 @@ def _calculate_chunk_sizes(sources: xarray.DataArray,
                            geobox: GeoBox,
                            dask_chunks: Dict[str, Union[str, int]],
                            extra_dims: Optional[ExtraDimensions] = None):
-    extra_dim_names = ()
-    extra_dim_shapes = ()
+    extra_dim_names: Tuple[str, ...] = ()
+    extra_dim_shapes: Tuple[int, ...] = ()
     if extra_dims is not None:
         extra_dim_names, extra_dim_shapes = extra_dims.chunk_size()
 
     valid_keys = sources.dims + extra_dim_names + geobox.dimensions
-    bad_keys = set(dask_chunks) - set(valid_keys)
+    bad_keys = cast(Set[str], set(dask_chunks)) - cast(Set[str], set(valid_keys))
     if bad_keys:
         raise KeyError('Unknown dask_chunk dimension {}. Valid dimensions are: {}'.format(bad_keys, valid_keys))
 

--- a/datacube/config.py
+++ b/datacube/config.py
@@ -272,7 +272,7 @@ def auto_config() -> str:
     option3:
        default config
     """
-    cfg_path = os.environ.get('DATACUBE_CONFIG_PATH', None)
+    cfg_path: Optional[PathLike] = os.environ.get('DATACUBE_CONFIG_PATH', None)
     cfg_path = Path(cfg_path) if cfg_path else Path.home()/'.datacube.conf'
 
     if cfg_path.exists():

--- a/datacube/drivers/indexes.py
+++ b/datacube/drivers/indexes.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 
 from ._tools import singleton_setup
 from .driver_cache import load_drivers
+from ..index.abstract import AbstractIndexDriver
 
 
 class IndexDriverCache(object):
@@ -21,7 +22,7 @@ class IndexDriverCache(object):
                 for alias in driver.aliases:
                     self._drivers[alias] = driver
 
-    def __call__(self, name: str) -> "datacube.index.abstract.AbstractIndexDriver":
+    def __call__(self, name: str) -> AbstractIndexDriver:
         """
         :returns: None if driver with a given name is not found
 
@@ -50,7 +51,7 @@ def index_drivers() -> List[str]:
     return index_cache().drivers()
 
 
-def index_driver_by_name(name: str) -> Optional["datacube.index.AbstractIndexDriver"]:
+def index_driver_by_name(name: str) -> Optional[AbstractIndexDriver]:
     """ Lookup writer driver by name
 
     :returns: Initialised writer driver instance

--- a/datacube/drivers/netcdf/_safestrings.py
+++ b/datacube/drivers/netcdf/_safestrings.py
@@ -10,7 +10,7 @@ written as UTF-8 encoded bytes.
 
 For more information see https://github.com/Unidata/netcdf4-python/issues/448
 """
-import netCDF4
+import netCDF4   # type: ignore[import]
 
 
 class _VariableProxy(object):

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -308,7 +308,7 @@ class PostgisDbAPI(object):
 
     def all_dataset_ids(self, archived: bool):
         query = select(
-            DATASET.c.id
+            DATASET.c.id  # type: ignore[arg-type]
         ).select_from(
             DATASET
         )

--- a/datacube/drivers/postgis/_schema.py
+++ b/datacube/drivers/postgis/_schema.py
@@ -49,7 +49,8 @@ PRODUCT = Table(
     Column('metadata', postgres.JSONB, nullable=False),
 
     # The metadata format expected (eg. what fields to search by)
-    Column('metadata_type_ref', None, ForeignKey(METADATA_TYPE.c.id), nullable=False),
+    #   Typing note: sqlalchemy-stubs doesn't handle this legitimate calling pattern.
+    Column('metadata_type_ref', None, ForeignKey(METADATA_TYPE.c.id), nullable=False),  # type: ignore[call-overload]
 
     Column('definition', postgres.JSONB, nullable=False),
 
@@ -68,8 +69,10 @@ DATASET = Table(
     'dataset', _core.METADATA,
     Column('id', postgres.UUID(as_uuid=True), primary_key=True),
 
-    Column('metadata_type_ref', None, ForeignKey(METADATA_TYPE.c.id), nullable=False),
-    Column('dataset_type_ref', None, ForeignKey(PRODUCT.c.id), index=True, nullable=False),
+    #   Typing note: sqlalchemy-stubs doesn't handle this legitimate calling pattern.
+    Column('metadata_type_ref', None, ForeignKey(METADATA_TYPE.c.id), nullable=False),  # type: ignore[call-overload]
+    #   Typing note: sqlalchemy-stubs doesn't handle this legitimate calling pattern.
+    Column('dataset_type_ref', None, ForeignKey(PRODUCT.c.id), index=True, nullable=False),  # type: ignore[call-overload]
 
     Column('metadata', postgres.JSONB, index=False, nullable=False),
 
@@ -87,7 +90,8 @@ DATASET = Table(
 DATASET_LOCATION = Table(
     'dataset_location', _core.METADATA,
     Column('id', Integer, primary_key=True, autoincrement=True),
-    Column('dataset_ref', None, ForeignKey(DATASET.c.id), index=True, nullable=False),
+    #   Typing note: sqlalchemy-stubs doesn't handle this legitimate calling pattern.
+    Column('dataset_ref', None, ForeignKey(DATASET.c.id), index=True, nullable=False),  # type: ignore[call-overload]
 
     # The base URI to find the dataset.
     #
@@ -115,13 +119,15 @@ DATASET_LOCATION = Table(
 # Link datasets to their source datasets.
 DATASET_SOURCE = Table(
     'dataset_source', _core.METADATA,
-    Column('dataset_ref', None, ForeignKey(DATASET.c.id), nullable=False),
+    #   Typing note: sqlalchemy-stubs doesn't handle this legitimate calling pattern.
+    Column('dataset_ref', None, ForeignKey(DATASET.c.id), nullable=False),  # type: ignore[call-overload]
 
     # An identifier for this source dataset.
     #    -> Usually it's the dataset type ('ortho', 'nbar'...), as there's typically only one source
     #       of each type.
     Column('classifier', String, nullable=False),
-    Column('source_dataset_ref', None, ForeignKey(DATASET.c.id), nullable=False),
+    #   Typing note: sqlalchemy-stubs doesn't handle this legitimate calling pattern.
+    Column('source_dataset_ref', None, ForeignKey(DATASET.c.id), nullable=False),  # type: ignore[call-overload]
 
     PrimaryKeyConstraint('dataset_ref', 'classifier'),
     UniqueConstraint('source_dataset_ref', 'dataset_ref'),

--- a/datacube/drivers/postgis/sql.py
+++ b/datacube/drivers/postgis/sql.py
@@ -99,7 +99,7 @@ class CommonTimestamp(GenericFunction):
 
 # pylint: disable=too-many-ancestors
 class Float8Range(GenericFunction):
-    type = FLOAT8RANGE
+    type = FLOAT8RANGE  # type: ignore[assignment]
     package = 'odc'
     identifier = 'float8range'
     inherit_cache = False

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -308,7 +308,7 @@ class PostgresDbAPI(object):
 
     def all_dataset_ids(self, archived: bool):
         query = select(
-            DATASET.c.id
+            DATASET.c.id  # type: ignore[arg-type]
         ).select_from(
             DATASET
         )

--- a/datacube/drivers/postgres/_schema.py
+++ b/datacube/drivers/postgres/_schema.py
@@ -49,7 +49,8 @@ PRODUCT = Table(
     Column('metadata', postgres.JSONB, nullable=False),
 
     # The metadata format expected (eg. what fields to search by)
-    Column('metadata_type_ref', None, ForeignKey(METADATA_TYPE.c.id), nullable=False),
+    #   Typing note: sqlalchemy-stubs doesn't handle this legitimate calling pattern.
+    Column('metadata_type_ref', None, ForeignKey(METADATA_TYPE.c.id), nullable=False),  # type: ignore[call-overload]
 
     Column('definition', postgres.JSONB, nullable=False),
 
@@ -68,8 +69,10 @@ DATASET = Table(
     'dataset', _core.METADATA,
     Column('id', postgres.UUID(as_uuid=True), primary_key=True),
 
-    Column('metadata_type_ref', None, ForeignKey(METADATA_TYPE.c.id), nullable=False),
-    Column('dataset_type_ref', None, ForeignKey(PRODUCT.c.id), index=True, nullable=False),
+    #   Typing note: sqlalchemy-stubs doesn't handle this legitimate calling pattern.
+    Column('metadata_type_ref', None, ForeignKey(METADATA_TYPE.c.id), nullable=False),  # type: ignore[call-overload]
+    #   Typing note: sqlalchemy-stubs doesn't handle this legitimate calling pattern.
+    Column('dataset_type_ref', None, ForeignKey(PRODUCT.c.id), index=True, nullable=False),  # type: ignore[call-overload]
 
     Column('metadata', postgres.JSONB, index=False, nullable=False),
 
@@ -87,7 +90,8 @@ DATASET = Table(
 DATASET_LOCATION = Table(
     'dataset_location', _core.METADATA,
     Column('id', Integer, primary_key=True, autoincrement=True),
-    Column('dataset_ref', None, ForeignKey(DATASET.c.id), index=True, nullable=False),
+    #   Typing note: sqlalchemy-stubs doesn't handle this legitimate calling pattern.
+    Column('dataset_ref', None, ForeignKey(DATASET.c.id), index=True, nullable=False),  # type: ignore[call-overload]
 
     # The base URI to find the dataset.
     #
@@ -115,13 +119,15 @@ DATASET_LOCATION = Table(
 # Link datasets to their source datasets.
 DATASET_SOURCE = Table(
     'dataset_source', _core.METADATA,
-    Column('dataset_ref', None, ForeignKey(DATASET.c.id), nullable=False),
+    #   Typing note: sqlalchemy-stubs doesn't handle this legitimate calling pattern.
+    Column('dataset_ref', None, ForeignKey(DATASET.c.id), nullable=False),  # type: ignore[call-overload]
 
     # An identifier for this source dataset.
     #    -> Usually it's the dataset type ('ortho', 'nbar'...), as there's typically only one source
     #       of each type.
     Column('classifier', String, nullable=False),
-    Column('source_dataset_ref', None, ForeignKey(DATASET.c.id), nullable=False),
+    #   Typing note: sqlalchemy-stubs doesn't handle this legitimate calling pattern.
+    Column('source_dataset_ref', None, ForeignKey(DATASET.c.id), nullable=False),  # type: ignore[call-overload]
 
     PrimaryKeyConstraint('dataset_ref', 'classifier'),
     UniqueConstraint('source_dataset_ref', 'dataset_ref'),

--- a/datacube/drivers/postgres/sql.py
+++ b/datacube/drivers/postgres/sql.py
@@ -99,7 +99,7 @@ class CommonTimestamp(GenericFunction):
 
 # pylint: disable=too-many-ancestors
 class Float8Range(GenericFunction):
-    type = FLOAT8RANGE
+    type = FLOAT8RANGE  # type: ignore[assignment]
     package = 'agdc'
     identifier = 'float8range'
     inherit_cache = False

--- a/datacube/drivers/rio/_reader.py
+++ b/datacube/drivers/rio/_reader.py
@@ -11,9 +11,9 @@ from typing import (
 import numpy as np
 from affine import Affine
 from concurrent.futures import ThreadPoolExecutor
-import rasterio
-from rasterio.io import DatasetReader
-import rasterio.crs
+import rasterio                         # type: ignore[import]
+from rasterio.io import DatasetReader   # type: ignore[import]
+import rasterio.crs                     # type: ignore[import]
 
 from datacube.storage import BandInfo
 from datacube.utils.geometry import CRS

--- a/datacube/executor.py
+++ b/datacube/executor.py
@@ -2,6 +2,8 @@
 #
 # Copyright (c) 2015-2020 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+#
+# type: ignore
 import sys
 
 _REMOTE_LOG_FORMAT_STRING = '%(asctime)s {} %(process)d %(name)s %(levelname)s %(message)s'

--- a/datacube/helpers.py
+++ b/datacube/helpers.py
@@ -9,7 +9,7 @@ Not used internally, those should go in `utils.py`
 """
 
 import numpy as np
-import rasterio
+import rasterio  # type: ignore[import]
 import warnings
 
 DEFAULT_PROFILE = {

--- a/datacube/index/_api.py
+++ b/datacube/index/_api.py
@@ -9,7 +9,6 @@ Access methods for indexing datasets & products.
 import logging
 
 from datacube.config import LocalConfig
-from datacube.drivers import index_driver_by_name, index_drivers
 from datacube.index.abstract import AbstractIndex
 
 _LOG = logging.getLogger(__name__)
@@ -29,6 +28,8 @@ def index_connect(local_config: LocalConfig = None,
     :param validate_connection: Validate database connection and schema immediately
     :raises datacube.index.Exceptions.IndexSetupError:
     """
+    from datacube.drivers import index_driver_by_name, index_drivers
+
     if local_config is None:
         local_config = LocalConfig.find()
 

--- a/datacube/index/eo3.py
+++ b/datacube/index/eo3.py
@@ -2,11 +2,14 @@
 #
 # Copyright (c) 2015-2020 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+#
+# type: ignore
+# TODO: typehints need attention
 """ Tools for working with EO3 metadata
 """
 from types import SimpleNamespace
 from affine import Affine
-import toolz
+import toolz  # type: ignore[import]
 from typing import Dict, Any, Optional
 
 from datacube.utils.geometry import (

--- a/datacube/index/fields.py
+++ b/datacube/index/fields.py
@@ -11,7 +11,7 @@ from dateutil.tz import tz
 from typing import List
 
 from datacube.model import Range
-from datacube.model.fields import Expression, Field, SimpleEqualsExpression
+from datacube.model.fields import Expression, Field
 
 __all__ = ['Field',
            'Expression',

--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -13,7 +13,7 @@ from datacube.model import Dataset
 from datacube.utils import changes, InvalidDocException, SimpleDocNav, jsonify_document
 from datacube.model.utils import BadMatch, dedup_lineage, remap_lineage_doc, flatten_datasets
 from datacube.utils.changes import get_doc_changes
-from .eo3 import prep_eo3, is_doc_eo3
+from .eo3 import prep_eo3, is_doc_eo3  # type: ignore[attr-defined]
 
 
 def load_rules_from_types(index, product_names=None, excluding=None):

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -432,9 +432,9 @@ class DatasetResource(AbstractDatasetResource):
                         break
                 if not query_matches:
                     continue
-                if source_product and ds.sources:
+                if source_product:
                     matching_source = None
-                    for sds in ds.sources.values():
+                    for sds in cast(Mapping[str, Dataset], ds.sources).values():
                         if sds.type != source_product:
                             continue
                         source_matches = True

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -144,7 +144,7 @@ class DatasetResource(AbstractDatasetResource):
         def values(ds: Dataset) -> GroupedVals:
             vals = []
             for field in fields:
-                vals.append(field.extract(ds.metadata_doc))
+                vals.append(field.extract(ds.metadata_doc))  # type: ignore[attr-defined]
             return GroupedVals(*vals)
 
         dups: Dict[Tuple, List[UUID]] = {}
@@ -503,7 +503,7 @@ class DatasetResource(AbstractDatasetResource):
         for ds in self.search(limit=limit, **query):  # type: ignore[arg-type]
             ds_fields = get_dataset_fields(ds.type.metadata_type.definition)
             result_vals = {
-                 fn: ds_fields[fn].extract(ds.metadata_doc)
+                 fn: ds_fields[fn].extract(ds.metadata_doc)  # type: ignore[attr-defined]
                  for fn in field_names
             }
             yield result_type(**result_vals)
@@ -638,7 +638,10 @@ class DatasetResource(AbstractDatasetResource):
     def search_summaries(self, **query: QueryField) -> Iterable[Mapping[str, Any]]:
         def make_summary(ds: Dataset) -> Mapping[str, Any]:
             fields = ds.metadata_type.dataset_fields
-            return {field_name: field.extract(ds.metadata_doc) for field_name, field in fields.items()}
+            return {
+                field_name: field.extract(ds.metadata_doc)   # type: ignore[attr-defined]
+                for field_name, field in fields.items()
+            }
         for ds in self.search(**query):  # type: ignore[arg-type]
             yield make_summary(ds)
 
@@ -651,7 +654,7 @@ class DatasetResource(AbstractDatasetResource):
         time_fld = prod.metadata_type.dataset_fields["time"]
         for dsid in self.by_product.get(product, []):
             ds = cast(Dataset, self.get(dsid))
-            dsmin, dsmax = time_fld.extract(ds.metadata_doc)
+            dsmin, dsmax = time_fld.extract(ds.metadata_doc)  # type: ignore[attr-defined]
             if dsmax is None and dsmin is None:
                 continue
             elif dsmin is None:
@@ -691,7 +694,7 @@ class DatasetResource(AbstractDatasetResource):
                 class DatasetLight(result_type):  # type: ignore[no-redef]
                     __slots__ = ()
             fld_vals = {
-                fname: field.extract(ds.metadata_doc)
+                fname: field.extract(ds.metadata_doc)  # type: ignore[attr-defined]
                 for fname, field in fields.items()
             }
             return DatasetLight(**fld_vals)

--- a/datacube/index/memory/_fields.py
+++ b/datacube/index/memory/_fields.py
@@ -1,9 +1,9 @@
-from typing import Any, Mapping
+from typing import Any, Mapping, MutableMapping
 from datacube.model.fields import SimpleField, Field, get_dataset_fields as generic_get_dataset_fields
 from datacube.index.abstract import Offset
 
 # TODO: SimpleFields cannot handle non-metadata fields because e.g. the extract API expects a doc, not a Dataset model
-def get_native_fields() -> Mapping[str, Field]:
+def get_native_fields() -> MutableMapping[str, Field]:
     return {
         "id": SimpleField(
             ["id"],

--- a/datacube/index/memory/_products.py
+++ b/datacube/index/memory/_products.py
@@ -3,27 +3,27 @@
 # Copyright (c) 2015-2022 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import logging
-from copy import deepcopy
 
 from datacube.index.fields import as_expression
 from datacube.index.abstract import AbstractProductResource, QueryField
+from datacube.index.memory._metadata_types import MetadataTypeResource
 from datacube.model import DatasetType as Product
 from datacube.utils import changes, jsonify_document, _readable_offset
-from datacube.utils.changes import Change, check_doc_unchanged, get_doc_changes, classify_changes
-from typing import Any, Iterable, Iterator, Mapping, Tuple
+from datacube.utils.changes import AllowPolicy, Change, Offset, check_doc_unchanged, get_doc_changes, classify_changes
+from typing import Iterable, Iterator, Mapping, Tuple, Union, cast
 
 _LOG = logging.getLogger(__name__)
 
 
 class ProductResource(AbstractProductResource):
     def __init__(self, metadata_type_resource):
-        self.metadata_type_resource = metadata_type_resource
+        self.metadata_type_resource: MetadataTypeResource = metadata_type_resource
         self.by_id = {}
         self.by_name = {}
         self.next_id = 1
 
     def add(self, product: Product, allow_table_lock: bool = False) -> Product:
-        Product.validate(product.definition)
+        Product.validate(product.definition)  # type: ignore[attr-defined]
         existing = self.get_by_name(product.name)
         if existing:
             check_doc_unchanged(
@@ -42,19 +42,19 @@ class ProductResource(AbstractProductResource):
             self.next_id += 1
             self.by_id[clone.id] = clone
             self.by_name[clone.name] = clone
-        return self.get_by_name(product.name)
+        return cast(Product, self.get_by_name(product.name))
 
     def can_update(self, product: Product,
                    allow_unsafe_updates: bool = False,
                    allow_table_lock: bool = False
                   ) -> Tuple[bool, Iterable[Change], Iterable[Change]]:
-        Product.validate(product.definition)
+        Product.validate(product.definition)  # type: ignore[attr-defined]
 
         existing = self.get_by_name(product.name)
         if not existing:
             raise ValueError(f"Unknown product {product.name}, cannot update - add first")
 
-        updates_allowed = {
+        updates_allowed: Mapping[Offset, AllowPolicy] = {
             ('description',): changes.allow_any,
             ('license',): changes.allow_any,
             ('metadata_type',): changes.allow_any,
@@ -91,13 +91,13 @@ class ProductResource(AbstractProductResource):
 
         if not safe_changes and not unsafe_changes:
             _LOG.info(f"No changes detected for product {product.name}")
-            return self.get_by_name(product.name)
+            return cast(Product, self.get_by_name(product.name))
 
         if not can_update:
             errs = ", ".join(_readable_offset(offset) for offset, _, _ in unsafe_changes)
             raise ValueError(f"Unsafe changes in {product.name}: {errs}")
 
-        existing = self.get_by_name(product.name)
+        existing = cast(Product, self.get_by_name(product.name))
         if product.metadata_type.name != existing.metadata_type.name:
             raise ValueError("Unsafe change: cannot (currently) switch metadata types for a product")
         _LOG.info(f"Updating product {product.name}")
@@ -105,7 +105,7 @@ class ProductResource(AbstractProductResource):
         persisted.id = existing.id
         self.by_id[persisted.id] = persisted
         self.by_name[persisted.name] = persisted
-        return self.get_by_name(product.name)
+        return cast(Product, self.get_by_name(product.name))
 
     def get_unsafe(self, id_: int) -> Product:
         return self.clone(self.by_id[id_])

--- a/datacube/index/memory/_products.py
+++ b/datacube/index/memory/_products.py
@@ -146,7 +146,7 @@ class ProductResource(AbstractProductResource):
                 if not hasattr(field, 'extract'):
                     # non-document/native field (??)
                     continue
-                if field.extract(prod.metadata_doc) is None:
+                if field.extract(prod.metadata_doc) is None:  # type: ignore[attr-defined]
                     # Product has the field, but not defined in the type doc, so unmatchable
                     continue
                 expr = as_expression(field, value)

--- a/datacube/index/memory/_users.py
+++ b/datacube/index/memory/_users.py
@@ -64,5 +64,5 @@ class UserResource(AbstractUserResource):
         for user in usernames:
             del self.users[user]
 
-    def list_users(self) -> Iterable[Tuple[str, str, str]]:
+    def list_users(self) -> Iterable[Tuple[str, str, Optional[str]]]:
         return [(u.default_role, u.username, u.description) for u in self.users.values()]

--- a/datacube/index/null/_datasets.py
+++ b/datacube/index/null/_datasets.py
@@ -3,9 +3,8 @@
 # Copyright (c) 2015-2020 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 from typing import Iterable, Union, Optional
-from uuid import UUID
 
-from datacube.index.abstract import AbstractDatasetResource
+from datacube.index.abstract import AbstractDatasetResource, DSID
 from datacube.model import Dataset, DatasetType
 
 
@@ -13,7 +12,7 @@ class DatasetResource(AbstractDatasetResource):
     def __init__(self, product_resource):
         self.types = product_resource
 
-    def get(self, id_: Union[str, UUID], include_sources=False):
+    def get(self, id_: DSID, include_sources=False):
         return None
 
     def bulk_get(self, ids):
@@ -26,7 +25,7 @@ class DatasetResource(AbstractDatasetResource):
         return False
 
     def bulk_has(self, ids_):
-        return [False for id in ids_]
+        return [False for id_ in ids_]
 
     def add(self, dataset: Dataset,
             with_lineage: Optional[bool] = None,
@@ -48,7 +47,7 @@ class DatasetResource(AbstractDatasetResource):
     def restore(self, ids):
         raise NotImplementedError()
 
-    def purge(self, ids: Iterable[UUID]):
+    def purge(self, ids: Iterable[DSID]):
         raise NotImplementedError()
 
     def get_all_dataset_ids(self, archived: bool):

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -16,7 +16,7 @@ from sqlalchemy import select, func
 
 from datacube.drivers.postgis._fields import SimpleDocField, DateDocField
 from datacube.drivers.postgis._schema import DATASET
-from datacube.index.abstract import AbstractDatasetResource
+from datacube.index.abstract import AbstractDatasetResource, DSID
 from datacube.model import Dataset, DatasetType
 from datacube.model.fields import Field
 from datacube.model.utils import flatten_datasets
@@ -356,7 +356,7 @@ class DatasetResource(AbstractDatasetResource):
             for id_ in ids:
                 transaction.restore_dataset(id_)
 
-    def purge(self, ids: Iterable[UUID]):
+    def purge(self, ids: Iterable[DSID]):
         """
         Delete archived datasets
 

--- a/datacube/index/postgis/_metadata_types.py
+++ b/datacube/index/postgis/_metadata_types.py
@@ -147,8 +147,8 @@ class MetadataTypeResource(AbstractMetadataTypeResource):
                 concurrently=not allow_table_lock
             )
 
-        self.get_by_name_unsafe.cache_clear()
-        self.get_unsafe.cache_clear()
+        self.get_by_name_unsafe.cache_clear()   # type: ignore[attr-defined]
+        self.get_unsafe.cache_clear()           # type: ignore[attr-defined]
         return self.get_by_name(metadata_type.name)
 
     def update_document(self, definition, allow_unsafe_updates=False):

--- a/datacube/index/postgis/_users.py
+++ b/datacube/index/postgis/_users.py
@@ -4,11 +4,12 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import Iterable, Optional, Tuple
 from datacube.index.abstract import AbstractUserResource
+from datacube.drivers.postgis import PostGisDb
 
 class UserResource(AbstractUserResource):
-    def __init__(self, db: "datacube.drivers.postgis.PostGisDb") -> None:
+    def __init__(self, db: PostGisDb) -> None:
         """
-        :type db: datacube.drivers.postgis._connections.PostGisDb
+        :type db: datacube.drivers.postgis.PostGisDb
         """
         self._db = db
 
@@ -34,7 +35,7 @@ class UserResource(AbstractUserResource):
         with self._db.connect() as connection:
             connection.drop_users(usernames)
 
-    def list_users(self) -> Iterable[Tuple[str, str, str]]:
+    def list_users(self) -> Iterable[Tuple[str, str, Optional[str]]]:
         """
         :return: list of (role, user, description)
         :rtype: list[(str, str, str)]

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -69,7 +69,7 @@ WARNING: Database schema and internal APIs may change significantly between rele
 
     @property
     def url(self) -> str:
-        return self._db.url
+        return str(self._db.url)
 
     @classmethod
     def from_config(cls, config, application_name=None, validate_connection=True):

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -16,7 +16,7 @@ from sqlalchemy import select, func
 
 from datacube.drivers.postgres._fields import SimpleDocField, DateDocField
 from datacube.drivers.postgres._schema import DATASET
-from datacube.index.abstract import AbstractDatasetResource, DatasetSpatialMixin
+from datacube.index.abstract import AbstractDatasetResource, DatasetSpatialMixin, DSID
 from datacube.model import Dataset, DatasetType
 from datacube.model.fields import Field
 from datacube.model.utils import flatten_datasets
@@ -333,7 +333,7 @@ class DatasetResource(AbstractDatasetResource):
             for id_ in ids:
                 transaction.restore_dataset(id_)
 
-    def purge(self, ids: Iterable[UUID]):
+    def purge(self, ids: Iterable[DSID]):
         """
         Delete archived datasets
 

--- a/datacube/index/postgres/_metadata_types.py
+++ b/datacube/index/postgres/_metadata_types.py
@@ -147,8 +147,8 @@ class MetadataTypeResource(AbstractMetadataTypeResource):
                 concurrently=not allow_table_lock
             )
 
-        self.get_by_name_unsafe.cache_clear()
-        self.get_unsafe.cache_clear()
+        self.get_by_name_unsafe.cache_clear()   # type: ignore[attr-defined]
+        self.get_unsafe.cache_clear()           # type: ignore[attr-defined]
         return self.get_by_name(metadata_type.name)
 
     def update_document(self, definition, allow_unsafe_updates=False):

--- a/datacube/index/postgres/_products.py
+++ b/datacube/index/postgres/_products.py
@@ -8,11 +8,11 @@ from cachetools.func import lru_cache
 
 from datacube.index import fields
 from datacube.index.abstract import AbstractProductResource
-from datacube.model import DatasetType
+from datacube.model import DatasetType, MetadataType
 from datacube.utils import jsonify_document, changes, _readable_offset
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes
 
-from typing import Iterable
+from typing import Iterable, cast
 
 _LOG = logging.getLogger(__name__)
 
@@ -161,7 +161,7 @@ class ProductResource(AbstractProductResource):
 
         _LOG.info("Updating product %s", product.name)
 
-        existing = self.get_by_name(product.name)
+        existing = cast(DatasetType, self.get_by_name(product.name))
         changing_metadata_type = product.metadata_type.name != existing.metadata_type.name
         if changing_metadata_type:
             raise ValueError("Unsafe change: cannot (currently) switch metadata types for a product")
@@ -182,7 +182,7 @@ class ProductResource(AbstractProductResource):
             #                 name, field.sql_expression, new_field.sql_expression
             #             )
             #         )
-        metadata_type = self.metadata_type_resource.get_by_name(product.metadata_type.name)
+        metadata_type = cast(MetadataType, self.metadata_type_resource.get_by_name(product.metadata_type.name))
         #     Given we cannot change metadata type because of the check above, and this is an
         #     update method, the metadata type is guaranteed to already exist.
         with self._db.connect() as conn:
@@ -196,8 +196,8 @@ class ProductResource(AbstractProductResource):
                 concurrently=not allow_table_lock
             )
 
-        self.get_by_name_unsafe.cache_clear()
-        self.get_unsafe.cache_clear()
+        self.get_by_name_unsafe.cache_clear()  # type: ignore[attr-defined]
+        self.get_unsafe.cache_clear()          # type: ignore[attr-defined]
         return self.get_by_name(product.name)
 
     def update_document(self, definition, allow_unsafe_updates=False, allow_table_lock=False):
@@ -313,6 +313,6 @@ class ProductResource(AbstractProductResource):
     def _make(self, query_row) -> DatasetType:
         return DatasetType(
             definition=query_row['definition'],
-            metadata_type=self.metadata_type_resource.get(query_row['metadata_type_ref']),
+            metadata_type=cast(MetadataType, self.metadata_type_resource.get(query_row['metadata_type_ref'])),
             id_=query_row['id'],
         )

--- a/datacube/index/postgres/_users.py
+++ b/datacube/index/postgres/_users.py
@@ -4,9 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import Iterable, Optional, Tuple
 from datacube.index.abstract import AbstractUserResource
+from datacube.drivers.postgres import PostgresDb
 
 class UserResource(AbstractUserResource):
-    def __init__(self, db: "datacube.drivers.postgres.PostgresDb") -> None:
+    def __init__(self, db: PostgresDb) -> None:
         """
         :type db: datacube.drivers.postgres._connections.PostgresDb
         """
@@ -34,7 +35,7 @@ class UserResource(AbstractUserResource):
         with self._db.connect() as connection:
             connection.drop_users(usernames)
 
-    def list_users(self) -> Iterable[Tuple[str, str, str]]:
+    def list_users(self) -> Iterable[Tuple[str, str, Optional[str]]]:
         """
         :return: list of (role, user, description)
         :rtype: list[(str, str, str)]

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -65,7 +65,7 @@ class Index(AbstractIndex):
 
     @property
     def url(self) -> str:
-        return self._db.url
+        return str(self._db.url)
 
     @classmethod
     def from_config(cls, config, application_name=None, validate_connection=True):

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -530,7 +530,7 @@ class DatasetType:
         return GridSpec(crs=crs, **gs_params)
 
     @staticmethod
-    def validate_extra_dims(definition: dict):
+    def validate_extra_dims(definition: Mapping[str, Any]):
         """Validate 3D metadata in the product definition.
 
         Perform some basic checks for validity of the 3D dataset product definition:

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -2,9 +2,13 @@
 #
 # Copyright (c) 2015-2020 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+
+# TODO: Multi-dimension code is has incomplete type hints and significant type issues that will require attention
+# type: ignore
 """
 Core classes used across modules.
 """
+
 import logging
 import math
 import warnings
@@ -21,9 +25,6 @@ from datacube.utils import geometry, without_lineage_sources, parse_time, cached
     schema_validated, DocReader
 from .fields import Field, get_dataset_fields
 from ._base import Range, ranges_overlap
-
-# TODO: Multi-dimension code is has incomplete type hints and significant type issues that will require attention
-# type: ignore
 
 _LOG = logging.getLogger(__name__)
 

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -2,9 +2,6 @@
 #
 # Copyright (c) 2015-2020 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-
-# TODO: Multi-dimension code is has incomplete type hints and significant type issues that will require attention
-# type: ignore
 """
 Core classes used across modules.
 """
@@ -32,6 +29,8 @@ DEFAULT_SPATIAL_DIMS = ('y', 'x')  # Used when product lacks grid_spec
 
 SCHEMA_PATH = Path(__file__).parent / 'schema'
 
+
+# TODO: Multi-dimension code is has incomplete type hints and significant type issues that will require attention
 
 class Dataset:
     """
@@ -991,24 +990,24 @@ class ExtraDimensions:
         for dim_name, dim_slice in dim_slices.items():
             # Adjust slices relative to original.
             if dim_name in ed._dim_slice:
-                ed._dim_slice[dim_name] = (
-                    ed._dim_slice[dim_name][0] + dim_slice[0],
-                    ed._dim_slice[dim_name][0] + dim_slice[1],
+                ed._dim_slice[dim_name] = (    # type: ignore[assignment]
+                    ed._dim_slice[dim_name][0] + dim_slice[0],  # type: ignore[index]
+                    ed._dim_slice[dim_name][0] + dim_slice[1],  # type: ignore[index]
                 )
 
             # Subset dimension values.
             if dim_name in ed._dims:
-                ed._dims[dim_name]['values'] = ed._dims[dim_name]['values'][slice(*dim_slice)]
+                ed._dims[dim_name]['values'] = ed._dims[dim_name]['values'][slice(*dim_slice)]  # type: ignore[misc]
 
             # Subset dimension coordinates.
             if dim_name in ed._coords:
-                slice_dict = {k: slice(*v) for k, v in dim_slices.items()}
+                slice_dict = {k: slice(*v) for k, v in dim_slices.items()}  # type: ignore[misc]
                 ed._coords[dim_name] = ed._coords[dim_name].isel(slice_dict)
 
         return ed
 
     @property
-    def dims(self) -> Dict[str, dict]:
+    def dims(self) -> Mapping[str, dict]:
         """Returns stored dimension information
 
         :return: A dict of information about each dimension
@@ -1016,7 +1015,7 @@ class ExtraDimensions:
         return self._dims
 
     @property
-    def dim_slice(self) -> Dict[str, Tuple[int, int]]:
+    def dim_slice(self) -> Mapping[str, Tuple[int, int]]:
         """Returns dimension slice for this ExtraDimensions object
 
         :return: A dict of dimension slices that results in this ExtraDimensions object
@@ -1090,8 +1089,8 @@ class ExtraDimensions:
         if self.dims is not None:
             for dim in self.dims.values():
                 name = dim.get('name')
-                names += (name,)
-                shapes += (len(self.measurements_values(name)),)
+                names += (name,)   # type: ignore[assignment]
+                shapes += (len(self.measurements_values(name)),)   # type: ignore[assignment,arg-type]
         return names, shapes
 
     def __str__(self) -> str:

--- a/datacube/model/fields.py
+++ b/datacube/model/fields.py
@@ -7,7 +7,7 @@
 This allows extraction of fields of interest from dataset metadata document.
 """
 from typing import Mapping, Dict, Any
-import toolz
+import toolz  # type: ignore[import]
 import decimal
 from datacube.utils import parse_time
 from ._base import Range

--- a/datacube/model/fields.py
+++ b/datacube/model/fields.py
@@ -97,7 +97,7 @@ class SimpleField(Field):
         self.type_name = type_name
         super().__init__(name, description)
 
-    def __eq__(self, value) -> Expression:
+    def __eq__(self, value) -> Expression:  # type: ignore[override]
         return SimpleEqualsExpression(self, value)
 
     def extract(self, doc):

--- a/datacube/model/fields.py
+++ b/datacube/model/fields.py
@@ -40,6 +40,9 @@ class Expression:
             return False
         return self.__dict__ == other.__dict__
 
+    def evaluate(self, ctx):
+        raise NotImplementedError()
+
 
 class SimpleEqualsExpression(Expression):
     def __init__(self, field, value):
@@ -84,6 +87,9 @@ class Field:
         """
         raise NotImplementedError('between expression')
 
+    def extract(self, doc):
+        raise NotImplementedError('extract method')
+
 
 class SimpleField(Field):
     def __init__(self,
@@ -107,7 +113,7 @@ class SimpleField(Field):
         return self._converter(v)
 
 
-class RangeField:
+class RangeField(Field):
     def __init__(self,
                  min_offset,
                  max_offset,
@@ -116,11 +122,10 @@ class RangeField:
                  name='',
                  description=''):
         self.type_name = type_name
-        self.description = description
-        self.name = name
         self._converter = base_converter
         self._min_offset = min_offset
         self._max_offset = max_offset
+        super().__init__(name, description)
 
     def extract(self, doc):
         def extract_raw(paths):

--- a/datacube/model/fields.py
+++ b/datacube/model/fields.py
@@ -87,9 +87,6 @@ class Field:
         """
         raise NotImplementedError('between expression')
 
-    def extract(self, doc):
-        raise NotImplementedError('extract method')
-
 
 class SimpleField(Field):
     def __init__(self,

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -18,7 +18,7 @@ from click import echo
 
 from datacube.index.exceptions import MissingRecordError
 from datacube.index.hl import Doc2Dataset, check_dataset_consistent
-from datacube.index.eo3 import prep_eo3
+from datacube.index.eo3 import prep_eo3  # type: ignore[attr-defined]
 from datacube.index import Index
 from datacube.model import Dataset
 from datacube.ui import click as ui

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -8,7 +8,7 @@ import logging
 import sys
 from collections import OrderedDict
 from textwrap import dedent
-from typing import Iterable, Mapping, MutableMapping, Any, List, Set
+from typing import cast, Iterable, Mapping, MutableMapping, Any, List, Set
 from uuid import UUID
 
 import click
@@ -458,7 +458,7 @@ def _get_derived_set(index: Index, id_: UUID) -> Set[Dataset]:
     Get a single flat set of all derived datasets.
     (children, grandchildren, great-grandchildren...)
     """
-    derived_set = {index.datasets.get(id_)}
+    derived_set = {cast(Dataset, index.datasets.get(id_))}
     to_process = {id_}
     while to_process:
         derived = index.datasets.get_derived(to_process.pop())
@@ -498,11 +498,11 @@ def uri_search_cmd(index: Index, paths: List[str], search_mode):
 @click.argument('ids', nargs=-1)
 @ui.pass_index()
 def archive_cmd(index: Index, archive_derived: bool, dry_run: bool, all_ds: bool, ids: List[str]):
-    derived_datasets = []
+    derived_dataset_ids: List[UUID] = []
     if all_ds:
         datasets_for_archive = {dsid: True for dsid in index.datasets.get_all_dataset_ids(archived=False)}
     else:
-        datasets_for_archive = {dataset_id: exists for dataset_id, exists in zip(ids, index.datasets.bulk_has(ids))}
+        datasets_for_archive = {UUID(dataset_id): exists for dataset_id, exists in zip(ids, index.datasets.bulk_has(ids))}
 
         if False in datasets_for_archive.values():
             for dataset_id, exists in datasets_for_archive.items():
@@ -513,9 +513,9 @@ def archive_cmd(index: Index, archive_derived: bool, dry_run: bool, all_ds: bool
         if archive_derived:
             derived_datasets = [_get_derived_set(index, dataset) for dataset in datasets_for_archive]
             # Get the UUID of our found derived datasets
-            derived_datasets = [derived.id for derived_dataset in derived_datasets for derived in derived_dataset]
+            derived_dataset_ids = [derived.id for derived_dataset in derived_datasets for derived in derived_dataset]
 
-    all_datasets = derived_datasets + [uuid for uuid in datasets_for_archive.keys()]
+    all_datasets = derived_dataset_ids + [uuid for uuid in datasets_for_archive.keys()]
 
     for dataset in all_datasets:
         click.echo(f'Archiving dataset: {dataset}')
@@ -541,7 +541,7 @@ def archive_cmd(index: Index, archive_derived: bool, dry_run: bool, all_ds: bool
 def restore_cmd(index: Index, restore_derived: bool, derived_tolerance_seconds: int, dry_run: bool, all_ds: bool, ids: List[str]):
     tolerance = datetime.timedelta(seconds=derived_tolerance_seconds)
     if all_ds:
-        ids = index.datasets.get_all_dataset_ids(archived=True)
+        ids = index.datasets.get_all_dataset_ids(archived=True)  # type: ignore[assignment]
 
     for id_ in ids:
         target_dataset = index.datasets.get(id_)
@@ -549,7 +549,7 @@ def restore_cmd(index: Index, restore_derived: bool, derived_tolerance_seconds: 
             echo(f'No dataset found with id {id_}')
             sys.exit(-1)
 
-        to_process = _get_derived_set(index, id_) if restore_derived else {target_dataset}
+        to_process = _get_derived_set(index, UUID(id_)) if restore_derived else {target_dataset}
         _LOG.debug("%s selected", len(to_process))
 
         # Only the already-archived ones.
@@ -584,7 +584,7 @@ def purge_cmd(index: Index, dry_run: bool, all_ds: bool, ids: List[str]):
     if all_ds:
         datasets_for_archive = {dsid: True for dsid in index.datasets.get_all_dataset_ids(archived=True)}
     else:
-        datasets_for_archive = {dataset_id: exists for dataset_id, exists in zip(ids, index.datasets.bulk_has(ids))}
+        datasets_for_archive = {UUID(dataset_id): exists for dataset_id, exists in zip(ids, index.datasets.bulk_has(ids))}
 
         # Check for non-existent datasets
         if False in datasets_for_archive.values():

--- a/datacube/scripts/metadata.py
+++ b/datacube/scripts/metadata.py
@@ -89,12 +89,12 @@ def update_metadata_types(index: Index, allow_unsafe: bool, allow_exclusive_lock
             )
             if can_update:
                 echo('Can update "%s": %s unsafe changes, %s safe changes' % (type_.name,
-                                                                              len(unsafe_changes),
-                                                                              len(safe_changes)))
+                                                                              len(list(unsafe_changes)),
+                                                                              len(list(safe_changes))))
             else:
                 echo('Cannot update "%s": %s unsafe changes, %s safe changes' % (type_.name,
-                                                                                 len(unsafe_changes),
-                                                                                 len(safe_changes)))
+                                                                                 len(list(unsafe_changes)),
+                                                                                 len(list(safe_changes))))
 
 
 @this_group.command('show')

--- a/datacube/scripts/product.py
+++ b/datacube/scripts/product.py
@@ -110,12 +110,12 @@ def update_products(index: Index, allow_unsafe: bool, allow_exclusive_lock: bool
 
             if can_update:
                 echo('Can update "%s": %s unsafe changes, %s safe changes' % (type_.name,
-                                                                              len(unsafe_changes),
-                                                                              len(safe_changes)))
+                                                                              len(list(unsafe_changes)),
+                                                                              len(list(safe_changes))))
             else:
                 echo('Cannot update "%s": %s unsafe changes, %s safe changes' % (type_.name,
-                                                                                 len(unsafe_changes),
-                                                                                 len(safe_changes)))
+                                                                                 len(list(unsafe_changes)),
+                                                                                 len(list(safe_changes))))
     sys.exit(failures)
 
 

--- a/datacube/storage/_load.py
+++ b/datacube/storage/_load.py
@@ -132,7 +132,7 @@ def xr_load(sources: XrDataArray,
 
     out = _allocate_storage(sources.coords, geobox, measurements)
 
-    def all_groups() -> Iterator[Tuple[Measurement, int, List[BandInfo]]]:
+    def all_groups() -> Iterator[Tuple[Measurement, Tuple[int, ...], List[BandInfo]]]:
         for idx, dss in np.ndenumerate(sources.values):
             for m in measurements:
                 bbi = [BandInfo(ds, m.name) for ds in dss]

--- a/datacube/storage/_read.py
+++ b/datacube/storage/_read.py
@@ -196,7 +196,7 @@ def read_time_slice(rdr,
 def read_time_slice_v2(rdr,
                        dst_gbox: GeoBox,
                        resampling: Resampling,
-                       dst_nodata: Nodata) -> Tuple[np.ndarray,
+                       dst_nodata: Nodata) -> Tuple[Optional[np.ndarray],
                                                     Tuple[slice, slice]]:
     """ From opened reader object read into `dst`
 

--- a/datacube/storage/_rio.py
+++ b/datacube/storage/_rio.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 from threading import RLock
 import numpy as np
 from affine import Affine
-import rasterio
+import rasterio  # type: ignore[import]
 from urllib.parse import urlparse
 from typing import Optional, Iterator
 
@@ -249,7 +249,10 @@ class RasterDatasetDataSource(RasterioDataSource):
         raise DeprecationWarning("Stacked netcdf without explicit time index is not supported anymore")
 
     def get_transform(self, shape: RasterShape) -> Affine:
-        return self._band_info.transform * Affine.scale(1 / shape[1], 1 / shape[0])
+        return self._band_info.transform * Affine.scale(   # type: ignore[type-var, return-value]
+            1 / shape[1],
+            1 / shape[0]
+        )
 
     def get_crs(self):
         return self._band_info.crs

--- a/datacube/testutils/io.py
+++ b/datacube/testutils/io.py
@@ -12,7 +12,7 @@ from ..utils.geometry._warp import resampling_s2rio
 from ..storage._read import rdr_geobox
 from ..utils.geometry import GeoBox
 from ..utils.geometry import gbox as gbx
-from ..index.eo3 import is_doc_eo3, _norm_grid
+from ..index.eo3 import is_doc_eo3, _norm_grid  # type: ignore[attr-defined]
 from types import SimpleNamespace
 
 

--- a/datacube/ui/click.py
+++ b/datacube/ui/click.py
@@ -16,7 +16,7 @@ import click
 from datacube import config, __version__
 from datacube.api.core import Datacube
 
-from datacube.executor import get_executor, mk_celery_executor
+from datacube.executor import get_executor, mk_celery_executor  # type: ignore[attr-defined]
 from datacube.index import index_connect
 
 from datacube.ui.expression import parse_expressions

--- a/datacube/ui/common.py
+++ b/datacube/ui/common.py
@@ -8,7 +8,7 @@ Common methods for UI code.
 from pathlib import Path
 from typing import Union, Optional
 
-from toolz.functoolz import identity
+from toolz.functoolz import identity  # type: ignore[import]
 
 from datacube.utils import read_documents, InvalidDocException, SimpleDocNav, is_supported_document_type, is_url
 

--- a/datacube/utils/aws/__init__.py
+++ b/datacube/utils/aws/__init__.py
@@ -333,7 +333,7 @@ def s3_open(url: str,
 
     s3 = s3 or s3_client()
     bucket, key = s3_url_parse(url)
-    oo = s3.get_object(Bucket=bucket, Key=key, **kwargs)
+    oo = s3.get_object(Bucket=bucket, Key=key, **kwargs)  # type: ignore[attr-defined]
     return oo['Body']
 
 
@@ -353,7 +353,7 @@ def s3_head_object(url: str,
     bucket, key = s3_url_parse(url)
 
     try:
-        oo = s3.head_object(Bucket=bucket, Key=key, **kwargs)
+        oo = s3.head_object(Bucket=bucket, Key=key, **kwargs)  # type: ignore[attr-defined]
     except ClientError:
         return None
 
@@ -397,7 +397,7 @@ def s3_dump(data: Union[bytes, str, IO],
     s3 = s3 or s3_client()
     bucket, key = s3_url_parse(url)
 
-    r = s3.put_object(Bucket=bucket,
+    r = s3.put_object(Bucket=bucket,  # type: ignore[attr-defined]
                       Key=key,
                       Body=data,
                       **kwargs)
@@ -408,7 +408,7 @@ def s3_dump(data: Union[bytes, str, IO],
 def get_aws_settings(profile: Optional[str] = None,
                      region_name: str = "auto",
                      aws_unsigned: bool = False,
-                     requester_pays: bool = False) -> Tuple[Dict[str, Any], Credentials]:
+                     requester_pays: bool = False) -> Tuple[Dict[str, Any], Optional[Credentials]]:
     """
     Compute ``aws=`` parameter for ``set_default_rio_config``.
 

--- a/datacube/utils/cog.py
+++ b/datacube/utils/cog.py
@@ -3,9 +3,9 @@
 # Copyright (c) 2015-2020 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import warnings
-import toolz
-import rasterio
-from rasterio.shutil import copy as rio_copy
+import toolz                                  # type: ignore[import]
+import rasterio                               # type: ignore[import]
+from rasterio.shutil import copy as rio_copy  # type: ignore[import]
 import numpy as np
 import xarray as xr
 import dask

--- a/datacube/utils/dask.py
+++ b/datacube/utils/dask.py
@@ -7,7 +7,7 @@
 """
 from typing import Any, Iterable, Optional, Union, Tuple
 from random import randint
-import toolz
+import toolz  # type: ignore[import]
 import queue
 from dask.distributed import Client
 import dask

--- a/datacube/utils/dates.py
+++ b/datacube/utils/dates.py
@@ -8,7 +8,6 @@ Date and time utility functions
 Includes sequence generation functions to be used by statistics apps
 
 """
-import datetime
 from typing import Union, Callable
 from datetime import datetime, tzinfo
 

--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -20,7 +20,7 @@ from typing import Dict, Any, Mapping
 from copy import deepcopy
 
 import numpy
-import toolz
+import toolz  # type: ignore[import]
 import yaml
 
 try:
@@ -171,7 +171,7 @@ def netcdf_extract_string(chars):
     """
     Convert netcdf S|U chars to Unicode string.
     """
-    import netCDF4
+    import netCDF4  # type: ignore[import]
 
     if isinstance(chars, str):
         return chars

--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -28,7 +28,7 @@ from .tools import roi_normalise, roi_shape, is_affine_st
 from ..math import is_almost_int
 
 Coordinate = namedtuple('Coordinate', ('values', 'units', 'resolution'))
-_BoundingBox = namedtuple('BoundingBox', ('left', 'bottom', 'right', 'top'))
+_BoundingBox = namedtuple('BoundingBox', ('left', 'bottom', 'right', 'top'))  # type: ignore[name-match]
 SomeCRS = Union[str, 'CRS', _CRS, Dict[str, Any]]
 MaybeCRS = Optional[SomeCRS]
 CoordList = List[Tuple[float, float]]
@@ -125,7 +125,7 @@ def _make_crs_key(crs_spec: Union[str, _CRS]) -> str:
     return crs_spec.to_wkt()
 
 
-@cachetools.cached({}, key=_make_crs_key)
+@cachetools.cached({}, key=_make_crs_key)  # type: ignore[misc]
 def _make_crs(crs: Union[str, _CRS]) -> Tuple[_CRS, str, Optional[int]]:
     if isinstance(crs, str):
         crs = _CRS.from_user_input(crs)
@@ -207,7 +207,7 @@ class CRS:
 
     @property
     def wkt(self) -> str:
-        return self.to_wkt(version="WKT1_GDAL")
+        return self.to_wkt(version=WktVersion.WKT1_GDAL)
 
     def to_epsg(self) -> Optional[int]:
         """
@@ -277,7 +277,7 @@ class CRS:
     def __repr__(self) -> str:
         return "CRS('%s')" % self._str
 
-    def __eq__(self, other: SomeCRS) -> bool:
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, CRS):
             try:
                 other = CRS(other)

--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -16,9 +16,9 @@ import cachetools
 import numpy
 import xarray as xr
 from affine import Affine
-import rasterio
-from shapely import geometry, ops
-from shapely.geometry import base
+import rasterio                    # type: ignore[import]
+from shapely import geometry, ops  # type: ignore[import]
+from shapely.geometry import base  # type: ignore[import]
 from pyproj import CRS as _CRS
 from pyproj.enums import WktVersion
 from pyproj.transformer import Transformer
@@ -917,7 +917,7 @@ def polygon_from_transform(width: float, height: float, transform: Affine, crs: 
     :param crs: CRS
     """
     points = [(0, 0), (0, height), (width, height), (width, 0), (0, 0)]
-    transform.itransform(points)
+    transform.itransform(points)  # type: ignore[arg-type]
     return polygon(points, crs=crs)
 
 
@@ -936,13 +936,13 @@ def multigeom(geoms: Iterable[Geometry]) -> Geometry:
     """ Construct Multi{Polygon|LineString|Point}
     """
     geoms = [g for g in geoms]  # force into list
-    src_type = {g.type for g in geoms}
-    if len(src_type) > 1:
+    src_types = {g.type for g in geoms}
+    if len(src_types) > 1:
         raise ValueError("All Geometries must be of the same type")
 
     crs = common_crs(geoms)  # will raise if some differ
     raw_geoms = [g.geom for g in geoms]
-    src_type = src_type.pop()
+    src_type = src_types.pop()
     if src_type == 'Polygon':
         return Geometry(geometry.MultiPolygon(raw_geoms), crs)
     elif src_type == 'Point':
@@ -1158,13 +1158,12 @@ class GeoBox:
             with_crs = True
 
         attrs = {}
-        coords = self.coordinates
         crs = self.crs
         if crs is not None:
             attrs['crs'] = str(crs)
 
         coords = dict((n, _coord_to_xr(n, c, **attrs))
-                      for n, c in coords.items())  # type: Dict[Hashable, xr.DataArray]
+                      for n, c in self.coordinates.items())  # type: Dict[Hashable, xr.DataArray]
 
         if with_crs and crs is not None:
             coords[spatial_ref] = _mk_crs_coord(crs, spatial_ref)
@@ -1215,13 +1214,13 @@ def bounding_box_in_pixel_domain(geobox: GeoBox, reference: GeoBox) -> BoundingB
     if reference.crs != geobox.crs:
         raise ValueError("Cannot combine geoboxes in different CRSs")
 
-    a, b, c, d, e, f, *_ = ~reference.affine * geobox.affine
+    a, b, c, d, e, f, *_ = ~reference.affine * geobox.affine  # type: ignore[misc]
 
-    if not (numpy.isclose(a, 1) and numpy.isclose(b, 0) and is_almost_int(c, tol)
-            and numpy.isclose(d, 0) and numpy.isclose(e, 1) and is_almost_int(f, tol)):
+    if not (numpy.isclose(a, 1) and numpy.isclose(b, 0) and is_almost_int(c, tol)        # type: ignore[has-type]
+            and numpy.isclose(d, 0) and numpy.isclose(e, 1) and is_almost_int(f, tol)):  # type: ignore[has-type]
         raise ValueError("Incompatible grids")
 
-    tx, ty = round(c), round(f)
+    tx, ty = round(c), round(f)   # type: ignore[has-type]
     return BoundingBox(tx, ty, tx + geobox.width, ty + geobox.height)
 
 

--- a/datacube/utils/geometry/_warp.py
+++ b/datacube/utils/geometry/_warp.py
@@ -3,8 +3,8 @@
 # Copyright (c) 2015-2020 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 from typing import Union, Optional
-import rasterio.warp
-import rasterio.crs
+import rasterio.warp  # type: ignore[import]
+import rasterio.crs   # type: ignore[import]
 import numpy as np
 from affine import Affine
 from . import GeoBox

--- a/datacube/utils/geometry/gbox.py
+++ b/datacube/utils/geometry/gbox.py
@@ -229,7 +229,7 @@ class GeoboxTiles():
         """ Return tile indexes overlapping with a given geometry.
         """
         if self._gbox.crs is None:
-            poly = Polygon
+            poly = polygon
         else:
             poly = polygon.to_crs(self._gbox.crs)
         yy, xx = self.range_from_bbox(poly.boundingbox)

--- a/datacube/utils/geometry/gbox.py
+++ b/datacube/utils/geometry/gbox.py
@@ -228,7 +228,10 @@ class GeoboxTiles():
     def tiles(self, polygon: Geometry) -> Iterable[Tuple[int, int]]:
         """ Return tile indexes overlapping with a given geometry.
         """
-        poly = polygon.to_crs(self._gbox.crs)
+        if self._gbox.crs is None:
+            poly = Polygon
+        else:
+            poly = polygon.to_crs(self._gbox.crs)
         yy, xx = self.range_from_bbox(poly.boundingbox)
         for idx in itertools.product(yy, xx):
             gbox = self[idx]

--- a/datacube/utils/geometry/tools.py
+++ b/datacube/utils/geometry/tools.py
@@ -190,9 +190,9 @@ def apply_affine(A: Affine, x: np.ndarray, y: np.ndarray) -> Tuple[np.ndarray, n
 
     shape = x.shape
 
-    A = np.asarray(A).reshape(3, 3)
-    t = A[:2, -1].reshape((2, 1))
-    A = A[:2, :2]
+    A = np.asarray(A).reshape(3, 3)  # type: ignore[assignment]
+    t = A[:2, -1].reshape((2, 1))    # type: ignore[index]
+    A = A[:2, :2]                    # type: ignore[index]
 
     x, y = A @ np.vstack([x.ravel(), y.ravel()]) + t
     x, y = (a.reshape(shape) for a in (x, y))

--- a/datacube/utils/math.py
+++ b/datacube/utils/math.py
@@ -64,7 +64,8 @@ def spatial_dims(xx: Union[xr.DataArray, xr.Dataset],
             return guess
 
     if relaxed and len(xx.dims) >= 2:
-        return cast(Tuple[str, str], xx.dims[-2:])
+        # This operation is pushing mypy's type-inference engine.
+        return cast(Tuple[str, str], cast(Tuple[str, ...], xx.dims)[-2:])
 
     return None
 

--- a/datacube/utils/py.py
+++ b/datacube/utils/py.py
@@ -6,7 +6,7 @@ import importlib
 import logging
 from contextlib import contextmanager
 
-import toolz
+import toolz  # type: ignore[import]
 
 _LOG = logging.getLogger(__name__)
 

--- a/datacube/utils/rio/_rio.py
+++ b/datacube/utils/rio/_rio.py
@@ -6,9 +6,9 @@
 """
 import threading
 from types import SimpleNamespace
-import rasterio
-from rasterio.session import AWSSession, DummySession
-import rasterio.env
+import rasterio                                         # type: ignore[import]
+from rasterio.session import AWSSession, DummySession   # type: ignore[import]
+import rasterio.env                                     # type: ignore[import]
 from datacube.utils.generic import thread_local_cache
 
 _CFG_LOCK = threading.Lock()

--- a/datacube/utils/serialise.py
+++ b/datacube/utils/serialise.py
@@ -23,15 +23,15 @@ class SafeDatacubeDumper(yaml.SafeDumper):  # pylint: disable=too-many-ancestors
     pass
 
 
-def _dict_representer(dumper, data):
+def _dict_representer(dumper: SafeDatacubeDumper, data: OrderedDict) -> yaml.Node:
     return dumper.represent_mapping(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, data.items())
 
 
-def _reduced_accuracy_decimal_representer(dumper: yaml.Dumper, data: Decimal) -> yaml.Node:
+def _reduced_accuracy_decimal_representer(dumper: SafeDatacubeDumper, data: Decimal) -> yaml.Node:
     return dumper.represent_float(float(data))
 
 
-def _range_representer(dumper: yaml.Dumper, data: Range) -> yaml.Node:
+def _range_representer(dumper: SafeDatacubeDumper, data: Range) -> yaml.Node:
     begin, end = data
 
     # pyyaml doesn't output timestamps in flow style as timestamps(?)

--- a/datacube/virtual/__init__.py
+++ b/datacube/virtual/__init__.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2015-2020 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from typing import Mapping, Any
+from typing import Mapping, Any, cast
 import copy
 
 from .impl import VirtualProduct, Transformation, VirtualProductException
@@ -65,7 +65,7 @@ class NameResolver:
 
         if kind == 'transform':
             cls_name = recipe['transform']
-            input_product = get('input')
+            input_product = cast(Mapping, get('input'))
 
             self._assert(input_product is not None, "no input for transformation in {}".format(recipe))
 
@@ -87,7 +87,7 @@ class NameResolver:
 
         if kind == 'aggregate':
             cls_name = recipe['aggregate']
-            input_product = get('input')
+            input_product = cast(Mapping, get('input'))
             group_by = get('group_by')
 
             self._assert(input_product is not None, "no input for aggregate in {}".format(recipe))
@@ -99,7 +99,7 @@ class NameResolver:
                                               **reject_keys(recipe, ['aggregate', 'input', 'group_by'])))
 
         if kind == 'reproject':
-            input_product = get('input')
+            input_product = cast(Mapping, get('input'))
             output_crs = recipe['reproject'].get('output_crs')
             resolution = recipe['reproject'].get('resolution')
             align = recipe['reproject'].get('align')

--- a/datacube/virtual/expr.py
+++ b/datacube/virtual/expr.py
@@ -67,9 +67,11 @@ def formula_parser():
 
 @lark.v_args(inline=True)
 class FormulaEvaluator(lark.Transformer):
-    from operator import not_, or_, and_, xor
-    from operator import eq, ne, le, ge, lt, gt
-    from operator import add, sub, mul, truediv, floordiv, neg, pos, inv, mod, pow, lshift, rshift
+    from operator import not_, or_, and_, xor             # type: ignore[misc]
+    from operator import eq, ne, le, ge, lt, gt           # type: ignore[misc]
+    from operator import add, sub, mul, truediv, floordiv # type: ignore[misc]
+    from operator import neg, pos, inv                    # type: ignore[misc]
+    from operator import mod, pow, lshift, rshift         # type: ignore[misc]
 
     float_literal = float
     int_literal = int
@@ -78,7 +80,7 @@ class FormulaEvaluator(lark.Transformer):
 @lark.v_args(inline=True)
 class MaskEvaluator(lark.Transformer):
     # the result of an expression is nodata whenever any of its subexpressions is nodata
-    from operator import or_
+    from operator import or_     # type: ignore[misc]
 
     # pylint: disable=invalid-name
     and_ = _xor = or_

--- a/datacube/virtual/impl.py
+++ b/datacube/virtual/impl.py
@@ -11,7 +11,8 @@ products implementing the same interface.
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from functools import reduce
-from typing import Any, Dict, List, cast
+from typing import Any, Dict, List, Optional, cast
+from typing import Mapping as TypeMapping
 
 import uuid
 import numpy
@@ -321,8 +322,8 @@ class Product(VirtualProduct):
         return {key: value if key not in ['fuse_func', 'dataset_predicate'] else qualified_name(value)
                 for key, value in self.items()}
 
-    def output_measurements(self, product_definitions: Dict[str, DatasetType],  # type: ignore[override]
-                            measurements: List[str] = None) -> Mapping[str, Measurement]:
+    def output_measurements(self, product_definitions: TypeMapping[str, DatasetType],  # type: ignore[override]
+                            measurements: Optional[List[str]] = None) -> TypeMapping[str, Measurement]:
         self._assert(self._product in product_definitions,
                      "product {} not found in definitions".format(self._product))
 

--- a/datacube/virtual/impl.py
+++ b/datacube/virtual/impl.py
@@ -321,8 +321,8 @@ class Product(VirtualProduct):
         return {key: value if key not in ['fuse_func', 'dataset_predicate'] else qualified_name(value)
                 for key, value in self.items()}
 
-    def output_measurements(self, product_definitions: Dict[str, DatasetType],
-                            measurements: List[str] = None) -> Dict[str, Measurement]:
+    def output_measurements(self, product_definitions: Dict[str, DatasetType],  # type: ignore[override]
+                            measurements: List[str] = None) -> Mapping[str, Measurement]:
         self._assert(self._product in product_definitions,
                      "product {} not found in definitions".format(self._product))
 
@@ -392,7 +392,7 @@ class Product(VirtualProduct):
                              '{} not found in {}'.format(measurement, self._product))
 
         measurement_dicts = self.output_measurements(grouped.product_definitions,
-                                                     load_settings.get('measurements'))
+                                                     cast(List[str], load_settings.get('measurements')))
 
         if grouped.load_natively:
             canonical_names = [product.canonical_measurement(measurement) for measurement in measurement_dicts]

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -37,7 +37,7 @@ v1.8.next
   rather than postgres driver-specific implementation of that interface. (:pull:`1227`)
 - Migrate test docker image from `datacube/geobase` to `osgeo/gdal`. (:pull:`1233`)
 - Separate index driver interface definition from default index driver implementation. (:pull:`1226`)
-- Prefer WKT over EPSG when guessing CRS strings. (:pull:`1223`)
+- Prefer WKT over EPSG when guessing CRS strings. (:pull:`1223`, :pull:`1262`)
 - Updates to documentation. (:pull:`1208`, :pull:`1212`, :pull:`1215`, :pull:`1218`, :pull:`1240`, :pull:`1244`)
 - Tweak to segmented in geometry to suppress Shapely warning. (:pull:`1207`)
 - Fix to ensure ``skip_broken_datasets`` is correctly propagated in virtual products (:pull:`1259`)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,7 +8,7 @@ What's New
 v1.8.next
 =========
 
-- Cleanup mypy typechecking compliance. (:pull:`???`)
+- Cleanup mypy typechecking compliance. (:pull:`1266`)
 - When dataset add operations fail due to lineage issues, the produced error message now clearly indicates that
   the problem was due to lineage issues. (:pull:`1260`)
 - Added support for group-by financial years to virtual products. (:pull:`1257`, :pull:`1261`)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,9 +8,10 @@ What's New
 v1.8.next
 =========
 
+- Cleanup mypy typechecking compliance. (:pull:`???`)
 - When dataset add operations fail due to lineage issues, the produced error message now clearly indicates that
   the problem was due to lineage issues. (:pull:`1260`)
-- Added support for group-by financial years to virtual products. (:pull:`1257`)
+- Added support for group-by financial years to virtual products. (:pull:`1257`, :pull:`1261`)
 - Remove reference to `rasterio.path`. (:pull:`1255`)
 - Cleaner separation of postgis and postgres drivers, and suppress SQLAlchemy cache warnings. (:pull:`1254`)
 - Prevent Shapely deprecation warning. (:pull:`1253`)


### PR DESCRIPTION
### Reason for this pull request

Large chunks of the core codebase use typehints (which is good) but some of the typehints are either obviously or subtly  wrong (which is  bad). Static type-checking is not being performed as part of the CI code checks.

### Proposed changes

Correct typehints, add judicious `# type: ignore` comments, type-casts, and perform minor cosmetic refactors to ensure code passes mypy checks.  A couple of slightly more significant refactors/bug-fixes in the in-memory index driver code.

(Note that `typing.cast` is only used for static type-checking, it incurs no costs at run-time.)

To reproduce the static checks I used preparing this PR:

 1. Install mypy:  `pip install mypy`
 2. Install type-stubs for 3rd party libraries where available:
 ```
   pip install types-affine types-cachetools types-jsonschema types-psutil \
         types-python-dateutil types-PyYAML types-redis types-setuptools \
         boto3-stubs botocore-stubs pandas-stubs sqlalchemy-stubs
 ```
3. Run mypy over the source code: `mypy datacube`

Some code is particularly problematic and will need further attention in future PRs.  (marked with TODOs):

1. `datacube/index/eo3.py`  Typehints throughout are of dubious quality/accuracy.  Entire source  file skipped for now.
2. `datacube/model/__init__.py`  Typehints in multi-dimension code are incomplete and problematic where supplied.

If this PR is merged, I will add Mypy checking to the CI checks in a future PR.

 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

