### PR TITLE
Add release number and release date to whats_new.rst

### DIFF
--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,9 @@ What's New
 v1.8.next
 =========
 
+v1.8.7 (7 June 2022)
+====================
+
 - Cleanup mypy typechecking compliance. (:pull:`1266`)
 - When dataset add operations fail due to lineage issues, the produced error message now clearly indicates that
   the problem was due to lineage issues. (:pull:`1260`)
@@ -41,7 +44,7 @@ v1.8.next
 - Updates to documentation. (:pull:`1208`, :pull:`1212`, :pull:`1215`, :pull:`1218`, :pull:`1240`, :pull:`1244`)
 - Tweak to segmented in geometry to suppress Shapely warning. (:pull:`1207`)
 - Fix to ensure ``skip_broken_datasets`` is correctly propagated in virtual products (:pull:`1259`)
-- Deprecate `Rename`, `Select` and `ToFloat` built-in transforms in virtual products (:pull:`1263`) 
+- Deprecate `Rename`, `Select` and `ToFloat` built-in transforms in virtual products (:pull:`1263`)
 
 v1.8.6 (30 September 2021)
 ==========================


### PR DESCRIPTION
### Reason for this pull request

Last PR before 1.8.7 release.


### Proposed changes

Add release number and date to whats_new.rst

 - [ x] Fully documented, including `docs/about/whats_new.rst` for all changes

