### PR TITLE
Fix broken paths in api docs.

### DIFF
--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -9,6 +9,7 @@ v1.8.next
 =========
 
 - Remove several features that had been deprecated in previous releases. (:pull:`1275`)
+- Fix broken paths in api docs. (:pull:`???`)
 - Fix readthedocs build. (:pull:`1269`)
 
 v1.8.7 (7 June 2022)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -9,7 +9,7 @@ v1.8.next
 =========
 
 - Remove several features that had been deprecated in previous releases. (:pull:`1275`)
-- Fix broken paths in api docs. (:pull:`???`)
+- Fix broken paths in api docs. (:pull:`1277`)
 - Fix readthedocs build. (:pull:`1269`)
 
 v1.8.7 (7 June 2022)

--- a/docs/api/indexed-data/dataset-querying.rst
+++ b/docs/api/indexed-data/dataset-querying.rst
@@ -10,7 +10,7 @@ When connected to an ODC Database, these methods are available for searching and
 
 
 
-.. currentmodule:: datacube.index._datasets.DatasetResource
+.. currentmodule:: datacube.index.abstract.AbstractDatasetResource
 
 .. autosummary::
    :toctree: generate/

--- a/docs/api/indexed-data/dataset-writing.rst
+++ b/docs/api/indexed-data/dataset-writing.rst
@@ -10,7 +10,7 @@ When connected to an ODC Database, these methods are available for adding, updat
 
 
 
-.. currentmodule:: datacube.index._datasets.DatasetResource
+.. currentmodule:: datacube.index.abstract.AbstractDatasetResource
 
 .. autosummary::
    :toctree: generate/

--- a/docs/api/indexed-data/product-querying.rst
+++ b/docs/api/indexed-data/product-querying.rst
@@ -10,7 +10,7 @@ When connected to an ODC Database, these methods are available for discovering i
 
 
 
-.. currentmodule:: datacube.index._products.ProductResource
+.. currentmodule:: datacube.index.abstract.AbstractProductResource
 
 .. autosummary::
    :nosignatures:

--- a/docs/api/indexed-data/product-writing.rst
+++ b/docs/api/indexed-data/product-writing.rst
@@ -11,7 +11,7 @@ When connected to an ODC Database, these methods are available for altering info
 
 
 
-.. currentmodule:: datacube.index._products.ProductResource
+.. currentmodule:: datacube.index.abstract.AbstractProductResource
 
 .. autosummary::
    :nosignatures:


### PR DESCRIPTION
### Reason for this pull request

Autogenerated API documentation uses paths that are no longer valid (post multiple index drivers) (e.g. `datacube.index._datasets.DatasetResource` should be `datacube.index.abstract.AbstractDatasetResource`, etc.)


 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

