### PR TITLE
Build Documentation Pages written as Jupyter Notebooks

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -29,7 +29,7 @@ jobs:
                   -v $(pwd):/code \
                   -e SKIP_DB=yes \
                   ${DKR} bash -
-        sudo apt-get update && sudo apt-get install -y plantuml make
+        sudo apt-get update && sudo apt-get install -y plantuml make pandoc
         cd docs
         pip install -r requirements.txt
         make html

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -39,4 +39,4 @@ livehtml:
 
 clean:
 	rm -rf _build/
-	rm -rf dev/api/generate/*
+	rm -rf dev/api/generate data-access-analysis/apis/generate api/indexed-data/generate api/geometry/generate

--- a/docs/click_utils.py
+++ b/docs/click_utils.py
@@ -77,3 +77,8 @@ def setup(app):
     app.add_config_value('click_utils_commands', {}, 'html')
 
     app.add_domain(DatacubeDomain)
+    return {
+        'parallel_read_safe': False,
+        'parallel_write_safe': False,
+    }
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,7 @@ extensions = [
     'sphinx_click.ext',
     'click_utils',
     'autodocsumm',
+    'nbsphinx',
     'sphinx.ext.napoleon'
 ]
 
@@ -68,7 +69,7 @@ release = version
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['README.rst']
+exclude_patterns = ['README.rst', '.condaenv', '.direnv']
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 add_function_parentheses = True

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,7 @@
-paramiko>=2.10.1
 Sphinx==4.1.2
 sphinx-autodoc-typehints==1.12.0
 autodocsumm==0.2.6
 sphinx-click==3.0.1
-sphinx-rtd-theme==0.4.3
 pydata-sphinx-theme==0.6.3
-sshtunnel==0.1.5
 beautifulsoup4==4.9.3
+nbsphinx==0.8.9

--- a/docs/rtd-requirements.txt
+++ b/docs/rtd-requirements.txt
@@ -31,14 +31,14 @@ jsonschema==4.5.1
 lark-parser==0.12.0
 MarkupSafe==2.1.1
 msgpack==1.0.3
+nbsphinx==0.8.9
 netCDF4==1.5.8
 numpy==1.22.3
 packaging==21.3
 pandas==1.4.2
-paramiko>=2.10.1
 pbr==5.4.5
 psutil==5.9.0
-psycopg2==2.9.3
+psycopg2-binary==2.9.3
 pydata-sphinx-theme==0.8.1
 pycparser==2.21
 Pygments==2.12.0
@@ -62,7 +62,6 @@ sortedcontainers==2.4.0
 Sphinx==4.5.0
 sphinx-autodoc-typehints==1.18.1
 sphinx-click==4.0.3
-sphinx-rtd-theme==1.0.0
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.0
@@ -70,7 +69,6 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 SQLAlchemy==1.4.36
-sshtunnel==0.1.5
 tblib==1.6.0
 toml==0.10.2
 toolz==0.11.2


### PR DESCRIPTION
@robbitbt added some lovely documentation on using some of the ODC APIs, but they aren't being rendered to the documentation site. This is because Sphinx by default doesn't include a builder for rendering Jupyter notebooks. 

This PR installs the [Jupyter Notebook Tools for Sphinx — nbsphinx version 0.8.9](https://nbsphinx.readthedocs.io/en/0.8.9/) package to the documentation build, to fix them up.

## Before
![image](https://user-images.githubusercontent.com/108979/174951598-11b3bb18-b9e3-4d39-8fd3-323cf64b43fe.png)

## After:
![image](https://user-images.githubusercontent.com/108979/174951630-234b7f16-8a42-486a-b94c-46c28e6cfdf0.png)


Fixes #1278

