### PR TITLE
add flake8 and pylint to lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -47,3 +47,15 @@ jobs:
           pip install --upgrade -e '.[test]'
           pip install pylint
           pylint -j 2 --reports no datacube
+
+
+  pycodestyle:
+    name: pycodestyle
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: pycodestyle
+      uses: ankitvgupta/pycodestyle-action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PRECOMMAND_MESSAGE: You have style errors. See them below.

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,7 +25,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - run: python -m pip install flake8
       - name: flake8
         uses: liskin/gh-problem-matcher-wrap@v1
         with:
@@ -53,9 +52,16 @@ jobs:
     name: pycodestyle
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: pycodestyle
-      uses: ankitvgupta/pycodestyle-action@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        PRECOMMAND_MESSAGE: You have style errors. See them below.
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - run: python -m pip install pycodestyle
+      - name: pycodestyle
+        uses: liskin/gh-problem-matcher-wrap@v1
+        with:
+          linters: pycodestyle
+          run: |
+            pycodestyle tests integration_tests examples --max-line-length 120

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -54,14 +54,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - run: python -m pip install pycodestyle
-      - name: pycodestyle
-        uses: liskin/gh-problem-matcher-wrap@v1
-        with:
-          linters: pycodestyle
-          run: |
-            pycodestyle tests integration_tests examples --max-line-length 120
+      - name: Run pycodestyle
+        run: |
+          pip install --upgrade -e '.[test]'
+          pip install pycodestyle
+          pycodestyle tests integration_tests examples --max-line-length 120

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-name: build
+name: lint
 
 on:
   pull_request:
@@ -26,7 +26,7 @@ jobs:
         with:
           python-version: 3.9
       - name: flake8
-        uses: liskin/gh-problem-matcher-wrap@v1
+        uses: liskin/gh-problem-matcher-wrap@v1.0.1
         with:
           linters: flake8
           run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           linters: flake8
           run: |
-            flake8 . --exclude Dockerfile --ignore=E711,E226,W503,W504 --ignore-names=W,H,A,S,R,T,WS,X,Y,Z,XX,YY,XY,B,M,N,L,NX,NY
+            flake8 . --exclude Dockerfile --ignore=E711,E226,W503,W504,E124,F841,W605 --ignore-names=W,H,A,S,R,T,WS,X,Y,Z,XX,YY,XY,B,M,N,L,NX,NY
 
   pylint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
+      - run: python -m pip install flake8
       # ignore list as per setup.cfg
       - name: flake8
         uses: liskin/gh-problem-matcher-wrap@v1.0.1

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,14 +25,14 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - run: python -m pip install flake8
-      # ignore list as per setup.cfg
+      - run: python -m pip install flake8 pep8-naming
+      # ignore and ignore-names list as per setup.cfg
       - name: flake8
         uses: liskin/gh-problem-matcher-wrap@v1.0.1
         with:
           linters: flake8
           run: |
-            flake8 . --exclude Dockerfile --ignore=E711,E226,W503,W504
+            flake8 . --exclude Dockerfile --ignore=E711,E226,W503,W504 --ignore-names=W,H,A,S,R,T,WS,X,Y,Z,XX,YY,XY,B,M,N,L,NX,NY
 
   pylint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,12 +25,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
+      # ignore list as per setup.cfg
       - name: flake8
         uses: liskin/gh-problem-matcher-wrap@v1.0.1
         with:
           linters: flake8
           run: |
-            # ignore list as per setup.cfg
             flake8 . --exclude Dockerfile --ignore=E711,E226,W503,W504
 
   pylint:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,14 +81,6 @@ jobs:
         fi
         EOF
 
-    - name: Check Code Style
-      run: |
-        docker run --rm  \
-          -v $(pwd):/code \
-          -e SKIP_DB=yes \
-          ${{ matrix.docker_image }} \
-          pycodestyle tests integration_tests examples --max-line-length 120
-
     - name: Run Tests
       run: |
         cat <<EOF | docker run --rm -i -v $(pwd):/code ${{ matrix.docker_image }} bash -

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,14 +89,6 @@ jobs:
           ${{ matrix.docker_image }} \
           pycodestyle tests integration_tests examples --max-line-length 120
 
-    - name: Lint Code
-      run: |
-        docker run --rm  \
-          -v $(pwd):/code \
-          -e SKIP_DB=yes \
-          ${{ matrix.docker_image }} \
-          pylint -j 2 --reports no datacube
-
     - name: Run Tests
       run: |
         cat <<EOF | docker run --rm -i -v $(pwd):/code ${{ matrix.docker_image }} bash -

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -27,7 +27,7 @@ from ..index import index_connect
 from ..drivers import new_datasource
 
 
-class TerminateCurrentLoad(Exception):
+class TerminateCurrentLoad(Exception):  # noqa: N818
     """ This exception is raised by user code from `progress_cbk`
         to terminate currently running `.load`
     """
@@ -126,16 +126,16 @@ class Datacube(object):
 
         # Optionally compute dataset count for each product and add to row/cols
         # Product lists are sorted by product name to ensure 1:1 match
-        if dataset_count:            
-           
+        if dataset_count:
+
             # Load counts
             counts = [(p.name, c) for p, c in self.index.datasets.count_by_product()]
-            
+
             # Sort both rows and counts by product name
             from operator import itemgetter
             rows = sorted(rows, key=itemgetter(0))
             counts = sorted(counts, key=itemgetter(0))
-            
+
             # Add sorted count to each existing row
             rows = [row + [count[1]] for row, count in zip(rows, counts)]
             cols = cols + ['dataset_count']
@@ -181,10 +181,11 @@ class Datacube(object):
 
     #: pylint: disable=too-many-arguments, too-many-locals
     def load(self, product=None, measurements=None, output_crs=None, resolution=None, resampling=None,
-         skip_broken_datasets=False, dask_chunks=None, like=None, fuse_func=None, align=None,
-         datasets=None, dataset_predicate=None, progress_cbk=None, **query):
+             skip_broken_datasets=False, dask_chunks=None, like=None, fuse_func=None, align=None,
+             datasets=None, dataset_predicate=None, progress_cbk=None, **query):
         """
-        Load data as an ``xarray.Dataset`` object.  Each measurement will be a data variable in the :class:`xarray.Dataset`.
+        Load data as an ``xarray.Dataset`` object.
+        Each measurement will be a data variable in the :class:`xarray.Dataset`.
 
         See the `xarray documentation <http://xarray.pydata.org/en/stable/data-structures.html>`_ for usage of the
         :class:`xarray.Dataset` and :class:`xarray.DataArray` objects.
@@ -279,7 +280,8 @@ class Datacube(object):
 
         :param list(str) measurements:
             Measurements name or list of names to be included, as listed in :meth:`list_measurements`.
-            These will be loaded as individual ``xr.DataArray`` variables in the output ``xarray.Dataset`` object.
+            These will be loaded as individual ``xr.DataArray`` variables in
+            the output ``xarray.Dataset`` object.
 
             If a list is specified, the measurements will be returned in the order requested.
             By default all available measurements are included.
@@ -289,8 +291,8 @@ class Datacube(object):
             For example: ``'x', 'y', 'time', 'crs'``.
 
         :param str output_crs:
-            The CRS of the returned data, for example ``EPSG:3577``. If no CRS is supplied, the CRS of the stored data is used
-            if available.
+            The CRS of the returned data, for example ``EPSG:3577``.
+            If no CRS is supplied, the CRS of the stored data is used if available.
 
             This differs from the ``crs`` parameter desribed above, which is used to define the CRS
             of the coordinates in the query itself.
@@ -358,7 +360,8 @@ class Datacube(object):
 
         :param function dataset_predicate:
             Optional. A function that can be passed to restrict loaded datasets. A predicate function should
-            take a :class:`datacube.model.Dataset` object (e.g. as returned from :meth:`find_datasets`) and return a boolean.
+            take a :class:`datacube.model.Dataset` object (e.g. as returned from :meth:`find_datasets`) and
+            return a boolean.
             For example, loaded data could be filtered to January observations only by passing the following
             predicate function that returns True for datasets acquired in January::
 

--- a/datacube/api/grid_workflow.py
+++ b/datacube/api/grid_workflow.py
@@ -3,9 +3,7 @@
 # Copyright (c) 2015-2020 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import logging
-import numpy
 import xarray
-from itertools import groupby
 from collections import OrderedDict
 import pandas as pd
 

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -46,7 +46,7 @@ class GroupBy:
         self.sort_key = sort_key
 
         if group_key is None:
-            group_key = lambda datasets: group_by_func(datasets[0])
+            group_key = lambda datasets: group_by_func(datasets[0])  # noqa: E731
         self.group_key = group_key
 
 

--- a/datacube/config.py
+++ b/datacube/config.py
@@ -10,7 +10,7 @@ import os
 from pathlib import Path
 import configparser
 from urllib.parse import unquote_plus, urlparse, parse_qsl
-from typing import Any, Dict, Iterable, MutableMapping, Optional, Tuple, Union, cast
+from typing import Any, Dict, Iterable, MutableMapping, Optional, Tuple, Union
 
 PathLike = Union[str, 'os.PathLike[Any]']
 

--- a/datacube/drivers/netcdf/_safestrings.py
+++ b/datacube/drivers/netcdf/_safestrings.py
@@ -75,7 +75,7 @@ class _NC4DatasetProxy(object):
         return _VariableProxy(var)
 
     #: pylint: disable=invalid-name
-    def createVariable(self, *args, **kwargs):
+    def createVariable(self, *args, **kwargs):  # noqa: N802
         new_var = super(_NC4DatasetProxy, self).createVariable(*args, **kwargs)
         return _VariableProxy(new_var)
 

--- a/datacube/drivers/netcdf/writer.py
+++ b/datacube/drivers/netcdf/writer.py
@@ -192,7 +192,7 @@ def _write_lcc2_params(crs_var, crs):
 
     # e.g. http://spatialreference.org/ref/sr-org/mexico-inegi-lambert-conformal-conic/
     crs_var.grid_mapping_name = cf['grid_mapping_name']
-    crs_var.standard_parallel =  cf['standard_parallel']
+    crs_var.standard_parallel = cf['standard_parallel']
     crs_var.latitude_of_projection_origin = cf['latitude_of_projection_origin']
     crs_var.longitude_of_central_meridian = cf['longitude_of_central_meridian']
     crs_var.false_easting = cf['false_easting']

--- a/datacube/drivers/postgis/_connections.py
+++ b/datacube/drivers/postgis/_connections.py
@@ -21,7 +21,7 @@ from typing import Callable, Optional, Union
 
 from sqlalchemy import event, create_engine, text
 from sqlalchemy.engine import Engine
-from sqlalchemy.engine.url import URL as EngineUrl
+from sqlalchemy.engine.url import URL as EngineUrl  # noqa: N811
 
 import datacube
 from datacube.index.exceptions import IndexSetupError

--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -9,12 +9,12 @@ Core SQL schema settings.
 import logging
 
 from datacube.drivers.postgis.sql import (INSTALL_TRIGGER_SQL_TEMPLATE,
-                                           SCHEMA_NAME, TYPES_INIT_SQL,
-                                           UPDATE_COLUMN_MIGRATE_SQL_TEMPLATE,
-                                           ADDED_COLUMN_MIGRATE_SQL_TEMPLATE,
-                                           UPDATE_TIMESTAMP_SQL,
-                                           escape_pg_identifier,
-                                           pg_column_exists, pg_exists)
+                                          SCHEMA_NAME, TYPES_INIT_SQL,
+                                          UPDATE_COLUMN_MIGRATE_SQL_TEMPLATE,
+                                          ADDED_COLUMN_MIGRATE_SQL_TEMPLATE,
+                                          UPDATE_TIMESTAMP_SQL,
+                                          escape_pg_identifier,
+                                          pg_column_exists)
 from sqlalchemy import MetaData
 from sqlalchemy.engine import Engine
 from sqlalchemy.schema import CreateSchema
@@ -40,7 +40,7 @@ _LOG = logging.getLogger(__name__)
 
 def install_timestamp_trigger(connection):
     from . import _schema
-    TABLE_NAMES = [
+    TABLE_NAMES = [  # noqa: N806
         _schema.METADATA_TYPE.name,
         _schema.PRODUCT.name,
         _schema.DATASET.name,
@@ -53,9 +53,10 @@ def install_timestamp_trigger(connection):
         connection.execute(UPDATE_COLUMN_MIGRATE_SQL_TEMPLATE.format(schema=SCHEMA_NAME, table=name))
         connection.execute(INSTALL_TRIGGER_SQL_TEMPLATE.format(schema=SCHEMA_NAME, table=name))
 
+
 def install_added_column(connection):
     from . import _schema
-    TABLE_NAME = _schema.DATASET_LOCATION.name
+    TABLE_NAME = _schema.DATASET_LOCATION.name  # noqa: N806
     connection.execute(ADDED_COLUMN_MIGRATE_SQL_TEMPLATE.format(schema=SCHEMA_NAME, table=TABLE_NAME))
 
 
@@ -113,7 +114,7 @@ def ensure_db(engine, with_permissions=True):
             _LOG.info("Creating added column.")
             install_added_column(c)
             c.execute('commit')
-        except:
+        except:  # noqa: E722
             c.execute('rollback')
             raise
         finally:

--- a/datacube/drivers/postgis/_schema.py
+++ b/datacube/drivers/postgis/_schema.py
@@ -72,7 +72,7 @@ DATASET = Table(
     #   Typing note: sqlalchemy-stubs doesn't handle this legitimate calling pattern.
     Column('metadata_type_ref', None, ForeignKey(METADATA_TYPE.c.id), nullable=False),  # type: ignore[call-overload]
     #   Typing note: sqlalchemy-stubs doesn't handle this legitimate calling pattern.
-    Column('dataset_type_ref', None, ForeignKey(PRODUCT.c.id), index=True, nullable=False),  # type: ignore[call-overload]
+    Column('dataset_type_ref', None, ForeignKey(PRODUCT.c.id), index=True, nullable=False),  # type: ignore[call-overload]  # noqa: E501
 
     Column('metadata', postgres.JSONB, index=False, nullable=False),
 

--- a/datacube/drivers/postgis/sql.py
+++ b/datacube/drivers/postgis/sql.py
@@ -18,6 +18,7 @@ SCHEMA_NAME = 'odc'
 
 class CreateView(Executable, ClauseElement):
     inherit_cache = True
+
     def __init__(self, name, select):
         self.name = name
         self.select = select

--- a/datacube/drivers/postgres/_connections.py
+++ b/datacube/drivers/postgres/_connections.py
@@ -21,7 +21,7 @@ from typing import Callable, Optional, Union
 
 from sqlalchemy import event, create_engine, text
 from sqlalchemy.engine import Engine
-from sqlalchemy.engine.url import URL as EngineUrl
+from sqlalchemy.engine.url import URL as EngineUrl  # noqa: N811
 
 import datacube
 from datacube.index.exceptions import IndexSetupError

--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -14,7 +14,7 @@ from datacube.drivers.postgres.sql import (INSTALL_TRIGGER_SQL_TEMPLATE,
                                            ADDED_COLUMN_MIGRATE_SQL_TEMPLATE,
                                            UPDATE_TIMESTAMP_SQL,
                                            escape_pg_identifier,
-                                           pg_column_exists, pg_exists)
+                                           pg_column_exists)
 from sqlalchemy import MetaData
 from sqlalchemy.engine import Engine
 from sqlalchemy.schema import CreateSchema
@@ -40,7 +40,7 @@ _LOG = logging.getLogger(__name__)
 
 def install_timestamp_trigger(connection):
     from . import _schema
-    TABLE_NAMES = [
+    TABLE_NAMES = [  # noqa: N806
         _schema.METADATA_TYPE.name,
         _schema.PRODUCT.name,
         _schema.DATASET.name,
@@ -53,9 +53,10 @@ def install_timestamp_trigger(connection):
         connection.execute(UPDATE_COLUMN_MIGRATE_SQL_TEMPLATE.format(schema=SCHEMA_NAME, table=name))
         connection.execute(INSTALL_TRIGGER_SQL_TEMPLATE.format(schema=SCHEMA_NAME, table=name))
 
+
 def install_added_column(connection):
     from . import _schema
-    TABLE_NAME = _schema.DATASET_LOCATION.name
+    TABLE_NAME = _schema.DATASET_LOCATION.name  # noqa: N806
     connection.execute(ADDED_COLUMN_MIGRATE_SQL_TEMPLATE.format(schema=SCHEMA_NAME, table=TABLE_NAME))
 
 
@@ -113,7 +114,7 @@ def ensure_db(engine, with_permissions=True):
             _LOG.info("Creating added column.")
             install_added_column(c)
             c.execute('commit')
-        except:
+        except:  # noqa: E722
             c.execute('rollback')
             raise
         finally:

--- a/datacube/drivers/postgres/_schema.py
+++ b/datacube/drivers/postgres/_schema.py
@@ -72,7 +72,7 @@ DATASET = Table(
     #   Typing note: sqlalchemy-stubs doesn't handle this legitimate calling pattern.
     Column('metadata_type_ref', None, ForeignKey(METADATA_TYPE.c.id), nullable=False),  # type: ignore[call-overload]
     #   Typing note: sqlalchemy-stubs doesn't handle this legitimate calling pattern.
-    Column('dataset_type_ref', None, ForeignKey(PRODUCT.c.id), index=True, nullable=False),  # type: ignore[call-overload]
+    Column('dataset_type_ref', None, ForeignKey(PRODUCT.c.id), index=True, nullable=False),  # type: ignore[call-overload] # noqa: E501
 
     Column('metadata', postgres.JSONB, index=False, nullable=False),
 

--- a/datacube/drivers/postgres/sql.py
+++ b/datacube/drivers/postgres/sql.py
@@ -18,6 +18,7 @@ SCHEMA_NAME = 'agdc'
 
 class CreateView(Executable, ClauseElement):
     inherit_cache = True
+
     def __init__(self, name, select):
         self.name = name
         self.select = select

--- a/datacube/helpers.py
+++ b/datacube/helpers.py
@@ -9,8 +9,6 @@ Not used internally, those should go in `utils.py`
 """
 
 import numpy as np
-import rasterio  # type: ignore[import]
-import warnings
 
 DEFAULT_PROFILE = {
     'blockxsize': 256,

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -238,8 +238,10 @@ class AbstractMetadataTypeResource(ABC):
         :returns: All available MetadataType models
         """
 
+
 QueryField = Union[str, float, int, Range, datetime.datetime]
 QueryDict = Mapping[str, QueryField]
+
 
 class AbstractProductResource(ABC):
     """
@@ -909,23 +911,28 @@ class AbstractIndex(ABC):
 
     @property
     @abstractmethod
-    def url(self) -> str: pass
+    def url(self) -> str:
+        pass
 
     @property
     @abstractmethod
-    def users(self) -> AbstractUserResource: pass
+    def users(self) -> AbstractUserResource:
+        pass
 
     @property
     @abstractmethod
-    def metadata_types(self) -> AbstractMetadataTypeResource: pass
+    def metadata_types(self) -> AbstractMetadataTypeResource:
+        pass
 
     @property
     @abstractmethod
-    def products(self) -> AbstractProductResource: pass
+    def products(self) -> AbstractProductResource:
+        pass
 
     @property
     @abstractmethod
-    def datasets(self) -> AbstractDatasetResource: pass
+    def datasets(self) -> AbstractDatasetResource:
+        pass
 
     @classmethod
     @abstractmethod
@@ -946,10 +953,12 @@ class AbstractIndex(ABC):
     @abstractmethod
     def init_db(self,
                 with_default_types: bool = True,
-                with_permissions: bool = True) -> bool: pass
+                with_permissions: bool = True) -> bool:
+        pass
 
     @abstractmethod
-    def close(self) -> None: pass
+    def close(self) -> None:
+        pass
 
     def __enter__(self):
         return self
@@ -973,8 +982,7 @@ class AbstractIndexDriver(ABC):
 
     @staticmethod
     @abstractmethod
-    def metadata_type_from_doc(
-                               definition: dict
+    def metadata_type_from_doc(definition: dict
                               ) -> MetadataType:
         pass
 

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -329,9 +329,9 @@ class DatasetResource(AbstractDatasetResource):
             raise ValueError(f"Unsupported query mode: {mode}")
         ids: Set[DSID] = set()
         if mode == "exact":
-            test: Callable[[str], bool] = lambda l: l == uri
+            test: Callable[[str], bool] = lambda l: l == uri  # noqa: E741
         else:
-            test = lambda l: l.startswith(uri)
+            test = lambda l: l.startswith(uri)  # noqa: E731
         for id_, locs in self.locations.items():
             for loc in locs:
                 if test(loc):
@@ -400,9 +400,10 @@ class DatasetResource(AbstractDatasetResource):
             if not product_queries:
                 raise ValueError(f"No products match source filter: {source_filter}")
             if len(product_queries) > 1:
-                raise RuntimeError(f"Multiproduct source_filters are not supported. Try adding 'product' field.")
+                raise RuntimeError("Multiproduct source_filters are not supported. Try adding 'product' field.")
             source_queries, source_product = product_queries[0]
-            source_exprs = tuple(fields.to_expressions(source_product.metadata_type.dataset_fields.get, **source_queries))
+            source_exprs = tuple(fields.to_expressions(source_product.metadata_type.dataset_fields.get,
+                                                       **source_queries))
         else:
             source_product = None
             source_exprs = ()
@@ -461,10 +462,10 @@ class DatasetResource(AbstractDatasetResource):
             **query: QueryField
     ) -> Iterable[Dataset]:
         return cast(Iterable[Dataset], self._search(
-                return_format=self.RET_FORMAT_DATASETS,
-                limit=limit,
-                source_filter=source_filter,
-                **query)
+                    return_format=self.RET_FORMAT_DATASETS,
+                    limit=limit,
+                    source_filter=source_filter,
+                    **query)
         )
 
     def _search_grouped(
@@ -474,10 +475,10 @@ class DatasetResource(AbstractDatasetResource):
             **query: QueryField
     ) -> Iterable[Tuple[Iterable[Dataset], Product]]:
         return cast(Iterable[Tuple[Iterable[Dataset], Product]], self._search(
-                return_format=self.RET_FORMAT_PRODUCT_GROUPED,
-                limit=limit,
-                source_filter=source_filter,
-                **query)
+                    return_format=self.RET_FORMAT_PRODUCT_GROUPED,
+                    limit=limit,
+                    source_filter=source_filter,
+                    **query)
         )
 
     def _get_prod_queries(self, **query: QueryField) -> Iterable[Tuple[Mapping[str, QueryField], Product]]:
@@ -502,8 +503,8 @@ class DatasetResource(AbstractDatasetResource):
         for ds in self.search(limit=limit, **query):  # type: ignore[arg-type]
             ds_fields = get_dataset_fields(ds.type.metadata_type.definition)
             result_vals = {
-                 fn: ds_fields[fn].extract(ds.metadata_doc)  # type: ignore[attr-defined]
-                 for fn in field_names
+                fn: ds_fields[fn].extract(ds.metadata_doc)  # type: ignore[attr-defined]
+                for fn in field_names
             }
             yield result_type(**result_vals)
 
@@ -515,8 +516,8 @@ class DatasetResource(AbstractDatasetResource):
             yield (prod, len(list(datasets)))
 
     def count_by_product_through_time(self,
-            period: str,
-            **query: QueryField
+                                      period: str,
+                                      **query: QueryField
     ) -> Iterable[
         Tuple[
             Product,
@@ -542,6 +543,7 @@ class DatasetResource(AbstractDatasetResource):
         if precision <= 0:
             raise ValueError('Invalid period string. Must specify a natural number of days, weeks, months or years')
         unit = match.group("unit")
+
         def next_period(prev: datetime.datetime) -> datetime.datetime:
             if unit == 'day':
                 return prev + datetime.timedelta(days=precision)
@@ -597,19 +599,19 @@ class DatasetResource(AbstractDatasetResource):
             ],
         ]
     ]:
-        YieldType = Tuple[Product, Iterable[Tuple[Range, int]]]
+        yieldtype = Tuple[Product, Iterable[Tuple[Range, int]]]
         query = dict(query)
         try:
             start, end = cast(Range, query.pop('time'))
         except KeyError:
             raise ValueError('Must specify "time" range in period-counting query')
         periods = self._expand_period(period, start, end)
-        last_product: Optional[YieldType] = None
+        last_product: Optional[yieldtype] = None
         for dss, product in self._search_grouped(**query):  # type: ignore[arg-type]
             if last_product and single_product_only:
                 raise ValueError(f"Multiple products match single query search: {repr(query)}")
             if last_product:
-                yield cast(YieldType, last_product)
+                yield cast(yieldtype, last_product)
             period_counts = []
             for p in periods:
                 count = 0
@@ -664,7 +666,7 @@ class DatasetResource(AbstractDatasetResource):
                 min_time = dsmin
             if max_time is None or dsmax > max_time:
                 max_time = dsmax
-        return (cast(datetime.datetime, min_time), cast(datetime.datetime,max_time))
+        return (cast(datetime.datetime, min_time), cast(datetime.datetime, max_time))
 
     # pylint: disable=redefined-outer-name
     def search_returning_datasets_light(
@@ -678,6 +680,7 @@ class DatasetResource(AbstractDatasetResource):
             custom_fields = build_custom_fields(custom_offsets)
         else:
             custom_fields = {}
+
         def make_ds_light(ds: Dataset) -> Tuple:
             fields = {
                 fname: ds.metadata_type.dataset_fields[fname]

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -599,19 +599,19 @@ class DatasetResource(AbstractDatasetResource):
             ],
         ]
     ]:
-        yieldtype = Tuple[Product, Iterable[Tuple[Range, int]]]
+        YieldType = Tuple[Product, Iterable[Tuple[Range, int]]]
         query = dict(query)
         try:
             start, end = cast(Range, query.pop('time'))
         except KeyError:
             raise ValueError('Must specify "time" range in period-counting query')
         periods = self._expand_period(period, start, end)
-        last_product: Optional[yieldtype] = None
+        last_product: Optional[YieldType] = None
         for dss, product in self._search_grouped(**query):  # type: ignore[arg-type]
             if last_product and single_product_only:
                 raise ValueError(f"Multiple products match single query search: {repr(query)}")
             if last_product:
-                yield cast(yieldtype, last_product)
+                yield cast(YieldType, last_product)
             period_counts = []
             for p in periods:
                 count = 0

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -599,7 +599,7 @@ class DatasetResource(AbstractDatasetResource):
             ],
         ]
     ]:
-        YieldType = Tuple[Product, Iterable[Tuple[Range, int]]]
+        YieldType = Tuple[Product, Iterable[Tuple[Range, int]]]  # noqa: N806
         query = dict(query)
         try:
             start, end = cast(Range, query.pop('time'))

--- a/datacube/index/memory/_fields.py
+++ b/datacube/index/memory/_fields.py
@@ -2,6 +2,7 @@ from typing import Any, Mapping, MutableMapping
 from datacube.model.fields import SimpleField, Field, get_dataset_fields as generic_get_dataset_fields
 from datacube.index.abstract import Offset
 
+
 # TODO: SimpleFields cannot handle non-metadata fields because e.g. the extract API expects a doc, not a Dataset model
 def get_native_fields() -> MutableMapping[str, Field]:
     return {
@@ -37,10 +38,12 @@ def get_native_fields() -> MutableMapping[str, Field]:
         ),
     }
 
+
 def get_dataset_fields(metadata_definition: Mapping[str, Any]) -> Mapping[str, Field]:
     fields = get_native_fields()
     fields.update(generic_get_dataset_fields(metadata_definition))
     return fields
+
 
 def build_custom_fields(custom_offsets: Mapping[str, Offset]):
     return {

--- a/datacube/index/memory/_products.py
+++ b/datacube/index/memory/_products.py
@@ -10,7 +10,7 @@ from datacube.index.memory._metadata_types import MetadataTypeResource
 from datacube.model import DatasetType as Product
 from datacube.utils import changes, jsonify_document, _readable_offset
 from datacube.utils.changes import AllowPolicy, Change, Offset, check_doc_unchanged, get_doc_changes, classify_changes
-from typing import Iterable, Iterator, Mapping, Tuple, Union, cast
+from typing import Iterable, Iterator, Mapping, Tuple, cast
 
 _LOG = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ class ProductResource(AbstractProductResource):
             if mdt is None:
                 _LOG.warning(f'Adding metadata_type "{product.metadata_type.name}" as it doesn\'t exist')
                 product.metadata_type = self.metadata_type_resource.add(product.metadata_type,
-                                                      allow_table_lock=allow_table_lock)
+                                                                        allow_table_lock=allow_table_lock)
             clone = self.clone(product)
             clone.id = self.next_id
             self.next_id += 1

--- a/datacube/index/memory/_users.py
+++ b/datacube/index/memory/_users.py
@@ -5,6 +5,7 @@
 from typing import Iterable, Optional, Tuple
 from datacube.index.abstract import AbstractUserResource
 
+
 class User:
     def __init__(self, username: str, password: str, role: str,
                  description: Optional[str] = None):
@@ -29,7 +30,7 @@ class UserResource(AbstractUserResource):
             "agdc_ingest",
             "agdc_manage",
             "agdc_admin",
-            
+
             # For forwards compatibility with future driver(s)
             "odc_user",
             "odc_ingest",

--- a/datacube/index/null/_datasets.py
+++ b/datacube/index/null/_datasets.py
@@ -2,10 +2,10 @@
 #
 # Copyright (c) 2015-2020 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from typing import Iterable, Union, Optional
 
 from datacube.index.abstract import AbstractDatasetResource, DSID
 from datacube.model import Dataset, DatasetType
+from collections import Iterable
 
 
 class DatasetResource(AbstractDatasetResource):

--- a/datacube/index/null/_datasets.py
+++ b/datacube/index/null/_datasets.py
@@ -5,7 +5,7 @@
 
 from datacube.index.abstract import AbstractDatasetResource, DSID
 from datacube.model import Dataset, DatasetType
-from collections import Iterable
+from typing import Iterable
 
 
 class DatasetResource(AbstractDatasetResource):

--- a/datacube/index/null/_users.py
+++ b/datacube/index/null/_users.py
@@ -5,6 +5,7 @@
 from typing import Iterable, Optional, Tuple
 from datacube.index.abstract import AbstractUserResource
 
+
 class UserResource(AbstractUserResource):
     def __init__(self) -> None:
         pass

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -9,7 +9,7 @@ import json
 import logging
 import warnings
 from collections import namedtuple
-from typing import Iterable, Tuple, Union, List, Optional
+from typing import Iterable, Union, List
 from uuid import UUID
 
 from sqlalchemy import select, func

--- a/datacube/index/postgis/_metadata_types.py
+++ b/datacube/index/postgis/_metadata_types.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2015-2020 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import logging
-import warnings
 
 from cachetools.func import lru_cache
 
@@ -13,6 +12,7 @@ from datacube.utils import jsonify_document, changes, _readable_offset
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes
 
 _LOG = logging.getLogger(__name__)
+
 
 class MetadataTypeResource(AbstractMetadataTypeResource):
     def __init__(self, db):

--- a/datacube/index/postgis/_users.py
+++ b/datacube/index/postgis/_users.py
@@ -6,6 +6,7 @@ from typing import Iterable, Optional, Tuple
 from datacube.index.abstract import AbstractUserResource
 from datacube.drivers.postgis import PostGisDb
 
+
 class UserResource(AbstractUserResource):
     def __init__(self, db: PostGisDb) -> None:
         """

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -42,7 +42,7 @@ class Index(AbstractIndex):
     def __init__(self, db: PostGisDb) -> None:
         # POSTGIS driver is not stable with respect to database schema or internal APIs.
         _LOG.warning("""WARNING: The POSTGIS index driver implementation is considered EXPERIMENTAL.
-WARNING:        
+WARNING:
 WARNING: Database schema and internal APIs may change significantly between releases. Use at your own risk.""")
         self._db = db
 
@@ -74,7 +74,7 @@ WARNING: Database schema and internal APIs may change significantly between rele
     @classmethod
     def from_config(cls, config, application_name=None, validate_connection=True):
         db = PostGisDb.from_config(config, application_name=application_name,
-                                    validate_connection=validate_connection)
+                                   validate_connection=validate_connection)
         return cls(db)
 
     @classmethod

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -9,7 +9,7 @@ import json
 import logging
 import warnings
 from collections import namedtuple
-from typing import Iterable, Tuple, Union, List, Optional
+from typing import Iterable, Union, List
 from uuid import UUID
 
 from sqlalchemy import select, func
@@ -29,8 +29,6 @@ _LOG = logging.getLogger(__name__)
 
 # It's a public api, so we can't reorganise old methods.
 # pylint: disable=too-many-public-methods, too-many-lines
-
-
 class DatasetResource(AbstractDatasetResource):
     """
     :type _db: datacube.drivers.postgres._connections.PostgresDb
@@ -163,7 +161,6 @@ class DatasetResource(AbstractDatasetResource):
             # Finally update location for top-level dataset only
             if main_ds.uris is not None:
                 self._ensure_new_locations(main_ds, transaction=transaction)
-
 
         _LOG.info('Indexing %s', dataset.id)
 

--- a/datacube/index/postgres/_metadata_types.py
+++ b/datacube/index/postgres/_metadata_types.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2015-2020 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import logging
-import warnings
 
 from cachetools.func import lru_cache
 
@@ -13,6 +12,7 @@ from datacube.utils import jsonify_document, changes, _readable_offset
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes
 
 _LOG = logging.getLogger(__name__)
+
 
 class MetadataTypeResource(AbstractMetadataTypeResource):
     def __init__(self, db):

--- a/datacube/index/postgres/_users.py
+++ b/datacube/index/postgres/_users.py
@@ -6,6 +6,7 @@ from typing import Iterable, Optional, Tuple
 from datacube.index.abstract import AbstractUserResource
 from datacube.drivers.postgres import PostgresDb
 
+
 class UserResource(AbstractUserResource):
     def __init__(self, db: PostgresDb) -> None:
         """

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -8,7 +8,6 @@ Core classes used across modules.
 
 import logging
 import math
-import warnings
 from collections import OrderedDict
 from datetime import datetime
 from pathlib import Path
@@ -21,7 +20,7 @@ from urllib.parse import urlparse
 from datacube.utils import geometry, without_lineage_sources, parse_time, cached_property, uri_to_local_path, \
     schema_validated, DocReader
 from .fields import Field, get_dataset_fields
-from ._base import Range, ranges_overlap
+from ._base import Range
 
 _LOG = logging.getLogger(__name__)
 

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -20,7 +20,7 @@ from urllib.parse import urlparse
 from datacube.utils import geometry, without_lineage_sources, parse_time, cached_property, uri_to_local_path, \
     schema_validated, DocReader
 from .fields import Field, get_dataset_fields
-from ._base import Range
+from ._base import Range, ranges_overlap  # noqa: F401
 
 _LOG = logging.getLogger(__name__)
 

--- a/datacube/model/utils.py
+++ b/datacube/model/utils.py
@@ -25,7 +25,7 @@ except ImportError:
     from yaml import SafeDumper  # type: ignore
 
 
-class BadMatch(Exception):
+class BadMatch(Exception):  # noqa: N818
     pass
 
 

--- a/datacube/scripts/cli_app.py
+++ b/datacube/scripts/cli_app.py
@@ -10,12 +10,12 @@ Datacube command-line interface
 
 
 from datacube.ui.click import cli
-import datacube.scripts.dataset
-import datacube.scripts.ingest
-import datacube.scripts.product
-import datacube.scripts.metadata
-import datacube.scripts.system
-import datacube.scripts.user
+import datacube.scripts.dataset   # noqa: F401
+import datacube.scripts.ingest    # noqa: F401
+import datacube.scripts.product   # noqa: F401
+import datacube.scripts.metadata  # noqa: F401
+import datacube.scripts.system    # noqa: F401
+import datacube.scripts.user      # noqa: F401
 
 
 if __name__ == '__main__':

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -235,7 +235,7 @@ def parse_update_rules(keys_that_can_change):
               default='keep',
               help=dedent('''
               What to do with previously recorded dataset location(s)
-              
+
               \b
               - 'keep': keep as alternative location [default]
               - 'archive': mark as archived
@@ -487,7 +487,8 @@ def uri_search_cmd(index: Index, paths: List[str], search_mode):
 @click.option('--archive-derived', '-d', help='Also recursively archive derived datasets', is_flag=True, default=False)
 @click.option('--dry-run', help="Don't archive. Display datasets that would get archived",
               is_flag=True, default=False)
-@click.option('--all', "all_ds", help="Ignore id list - archive ALL non-archived datasets  (warning: may be slow on large databases)",
+@click.option('--all', "all_ds",
+              help="Ignore id list - archive ALL non-archived datasets  (warning: may be slow on large databases)",
               is_flag=True, default=False)
 @click.argument('ids', nargs=-1)
 @ui.pass_index()
@@ -496,7 +497,8 @@ def archive_cmd(index: Index, archive_derived: bool, dry_run: bool, all_ds: bool
     if all_ds:
         datasets_for_archive = {dsid: True for dsid in index.datasets.get_all_dataset_ids(archived=False)}
     else:
-        datasets_for_archive = {UUID(dataset_id): exists for dataset_id, exists in zip(ids, index.datasets.bulk_has(ids))}
+        datasets_for_archive = {UUID(dataset_id): exists
+                                for dataset_id, exists in zip(ids, index.datasets.bulk_has(ids))}
 
         if False in datasets_for_archive.values():
             for dataset_id, exists in datasets_for_archive.items():
@@ -528,11 +530,13 @@ def archive_cmd(index: Index, archive_derived: bool, dry_run: bool, all_ds: bool
               help="Only restore derived datasets that were archived "
                    "this recently to the original dataset",
               default=10 * 60)
-@click.option('--all', "all_ds", help="Ignore id list - restore ALL archived datasets  (warning: may be slow on large databases)",
+@click.option('--all', "all_ds",
+              help="Ignore id list - restore ALL archived datasets  (warning: may be slow on large databases)",
               is_flag=True, default=False)
 @click.argument('ids', nargs=-1)
 @ui.pass_index()
-def restore_cmd(index: Index, restore_derived: bool, derived_tolerance_seconds: int, dry_run: bool, all_ds: bool, ids: List[str]):
+def restore_cmd(index: Index, restore_derived: bool, derived_tolerance_seconds: int,
+                dry_run: bool, all_ds: bool, ids: List[str]):
     tolerance = datetime.timedelta(seconds=derived_tolerance_seconds)
     if all_ds:
         ids = index.datasets.get_all_dataset_ids(archived=True)  # type: ignore[assignment]
@@ -570,7 +574,8 @@ def restore_cmd(index: Index, restore_derived: bool, derived_tolerance_seconds: 
 @dataset_cmd.command('purge', help="Purge archived datasets")
 @click.option('--dry-run', help="Don't archive. Display datasets that would get archived",
               is_flag=True, default=False)
-@click.option('--all', "all_ds", help="Ignore id list - purge ALL archived datasets  (warning: may be slow on large databases)",
+@click.option('--all', "all_ds",
+              help="Ignore id list - purge ALL archived datasets  (warning: may be slow on large databases)",
               is_flag=True, default=False)
 @click.argument('ids', nargs=-1)
 @ui.pass_index()
@@ -578,7 +583,8 @@ def purge_cmd(index: Index, dry_run: bool, all_ds: bool, ids: List[str]):
     if all_ds:
         datasets_for_archive = {dsid: True for dsid in index.datasets.get_all_dataset_ids(archived=True)}
     else:
-        datasets_for_archive = {UUID(dataset_id): exists for dataset_id, exists in zip(ids, index.datasets.bulk_has(ids))}
+        datasets_for_archive = {UUID(dataset_id): exists
+                                for dataset_id, exists in zip(ids, index.datasets.bulk_has(ids))}
 
         # Check for non-existent datasets
         if False in datasets_for_archive.values():

--- a/datacube/scripts/product.py
+++ b/datacube/scripts/product.py
@@ -42,7 +42,7 @@ def add_products(index, allow_exclusive_lock, files):
     Add or update products in the generic index.
     """
     def on_ctrlc(sig, frame):
-        echo(f'''Can not abort `product add` without leaving database in bad state.
+        echo('''Can not abort `product add` without leaving database in bad state.
 
 This operation requires constructing a bunch of indexes and this takes time, the
 bigger your database the longer it will take. Just wait a bit.''')
@@ -151,15 +151,15 @@ def _write_tab(products):
         echo('No products discovered :(')
         return
 
-    output_columns=('id', 'name', 'description', 'ancillary_quality',
-                    'product_type', 'gqa_abs_iterative_mean_xy',
-                    'gqa_ref_source', 'sat_path',
-                    'gqa_iterative_stddev_xy', 'time', 'sat_row',
-                    'orbit', 'gqa', 'instrument', 'gqa_abs_xy', 'crs',
-                    'resolution', 'tile_size', 'spatial_dimensions')
+    output_columns = ('id', 'name', 'description', 'ancillary_quality',
+                      'product_type', 'gqa_abs_iterative_mean_xy',
+                      'gqa_ref_source', 'sat_path',
+                      'gqa_iterative_stddev_xy', 'time', 'sat_row',
+                      'orbit', 'gqa', 'instrument', 'gqa_abs_xy', 'crs',
+                      'resolution', 'tile_size', 'spatial_dimensions')
     # If the intersection of desired columns with available columns is empty, just use whatever IS in df
-    output_columns=tuple(col for col in output_columns if col in df.columns) or df.columns
-    echo(df.to_string(columns=output_columns,justify='left',index=False))
+    output_columns = tuple(col for col in output_columns if col in df.columns) or df.columns
+    echo(df.to_string(columns=output_columns, justify='left', index=False))
 
 
 def _default_lister(products):

--- a/datacube/storage/_rio.py
+++ b/datacube/storage/_rio.py
@@ -6,7 +6,6 @@
 Driver implementation for Rasterio based reader.
 """
 import logging
-import warnings
 import contextlib
 from contextlib import contextmanager
 from threading import RLock

--- a/datacube/storage/masking.py
+++ b/datacube/storage/masking.py
@@ -2,9 +2,9 @@
 #
 # Copyright (c) 2015-2020 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from datacube.utils.masking import *  # noqa: F401, F403
+
 import warnings
 
 warnings.warn("datacube.storage.masking has moved to datacube.utils.masking",
               category=DeprecationWarning)
-
-from datacube.utils.masking import *

--- a/datacube/testutils/__init__.py
+++ b/datacube/testutils/__init__.py
@@ -27,8 +27,6 @@ from datacube.ui.common import get_metadata_path
 from datacube.utils import read_documents, SimpleDocNav
 from datacube.utils.geometry import GeoBox, CRS
 
-from datacube.model.fields import parse_search_field
-
 _DEFAULT = object()
 
 

--- a/datacube/testutils/geom.py
+++ b/datacube/testutils/geom.py
@@ -41,7 +41,7 @@ SAMPLE_WKT_WITHOUT_AUTHORITY = '''PROJCS["unnamed",
 '''
 
 
-def mkA(rot=0, scale=(1, 1), shear=0, translation=(0, 0)):
+def mkA(rot=0, scale=(1, 1), shear=0, translation=(0, 0)):  # noqa: N802
     return Affine.translation(*translation)*Affine.rotation(rot)*Affine.shear(shear)*Affine.scale(*scale)
 
 
@@ -85,7 +85,7 @@ def xy_norm(x: np.ndarray, y: np.ndarray,
 
         return (s, -vmin*s)
 
-    A_rot = Affine.rotation(deg)
+    A_rot = Affine.rotation(deg)   # noqa: N806
     x, y = apply_affine(A_rot, x, y)
 
     sx, tx = norm_v(x)

--- a/datacube/ui/click.py
+++ b/datacube/ui/click.py
@@ -77,7 +77,7 @@ class ClickHandler(logging.Handler):
         try:
             msg = self.format(record)
             click.echo(msg, err=True)
-        except:  # noqa: E772  pylint: disable=bare-except
+        except:   # pylint: disable=bare-except  # noqa: E722
             self.handleError(record)
 
 

--- a/datacube/utils/_misc.py
+++ b/datacube/utils/_misc.py
@@ -8,7 +8,7 @@ Utility functions
 import os
 
 
-class DatacubeException(Exception):
+class DatacubeException(Exception):  # noqa: N818
     """Your Data Cube has malfunctioned"""
     pass
 

--- a/datacube/utils/dask.py
+++ b/datacube/utils/dask.py
@@ -257,12 +257,11 @@ def _save_blob_to_file(data: Union[bytes, str],
 def _save_blob_to_s3(data: Union[bytes, str],
                      url: str,
                      profile: Optional[str] = None,
-                     creds = None,
+                     creds=None,
                      region_name: Optional[str] = None,
                      with_deps=None,
                      **kw) -> Tuple[str, bool]:
     from botocore.errorfactory import ClientError
-    from botocore.credentials import ReadOnlyCredentials
     from botocore.exceptions import BotoCoreError
     from .aws import s3_dump, s3_client
 

--- a/datacube/utils/dates.py
+++ b/datacube/utils/dates.py
@@ -135,7 +135,7 @@ def mk_time_coord(dts, name='time', units=None):
 
 def _mk_parse_time() -> Callable[[Union[str, datetime]], datetime]:
     try:
-        import ciso8601             # pylint: disable=wrong-import-position
+        import ciso8601             # pylint: disable=wrong-import-position # noqa: F401
         return _parse_time_ciso8601
     except ImportError:             # pragma: no cover
         return _parse_time_generic  # pragma: no cover

--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -262,7 +262,7 @@ class NoDatesSafeLoader(SafeLoader):  # pylint: disable=too-many-ancestors
 NoDatesSafeLoader.remove_implicit_resolver('tag:yaml.org,2002:timestamp')
 
 
-class InvalidDocException(Exception):
+class InvalidDocException(Exception):  # noqa: N818
     pass
 
 

--- a/datacube/utils/geometry/tools.py
+++ b/datacube/utils/geometry/tools.py
@@ -380,7 +380,7 @@ def _same_crs_pix_transform(src, dst):
     return pt_tr
 
 
-def compute_axis_overlap(Ns: int, Nd: int, s: float, t: float) -> Tuple[slice, slice]:
+def compute_axis_overlap(Ns: int, Nd: int, s: float, t: float) -> Tuple[slice, slice]:  # noqa: N803
     """
     s, t define linear transform from destination coordinate space to source
     >>  x_s = s * x_d + t
@@ -435,7 +435,7 @@ def compute_axis_overlap(Ns: int, Nd: int, s: float, t: float) -> Tuple[slice, s
     return (src, dst)
 
 
-def box_overlap(src_shape, dst_shape, ST, tol):
+def box_overlap(src_shape, dst_shape, ST, tol):  # noqa: N803
     """
     Given two image planes whose coordinate systems are related via scale and
     translation only, find overlapping regions within both.

--- a/datacube/utils/py.py
+++ b/datacube/utils/py.py
@@ -43,7 +43,7 @@ def ignore_exceptions_if(ignore_errors, errors=None):
         yield
 
 
-class cached_property(object):  # pylint: disable=invalid-name
+class cached_property(object):  # pylint: disable=invalid-name  # noqa: N801
     """
     A property that is only computed once per instance and then replaces
     itself with an ordinary attribute. Deleting the attribute resets the

--- a/datacube/virtual/expr.py
+++ b/datacube/virtual/expr.py
@@ -67,11 +67,11 @@ def formula_parser():
 
 @lark.v_args(inline=True)
 class FormulaEvaluator(lark.Transformer):
-    from operator import not_, or_, and_, xor             # type: ignore[misc]
-    from operator import eq, ne, le, ge, lt, gt           # type: ignore[misc]
-    from operator import add, sub, mul, truediv, floordiv # type: ignore[misc]
-    from operator import neg, pos, inv                    # type: ignore[misc]
-    from operator import mod, pow, lshift, rshift         # type: ignore[misc]
+    from operator import not_, or_, and_, xor              # type: ignore[misc]
+    from operator import eq, ne, le, ge, lt, gt            # type: ignore[misc]
+    from operator import add, sub, mul, truediv, floordiv  # type: ignore[misc]
+    from operator import neg, pos, inv                     # type: ignore[misc]
+    from operator import mod, pow, lshift, rshift          # type: ignore[misc]
 
     float_literal = float
     int_literal = int
@@ -113,6 +113,7 @@ def evaluate_type(formula, env, parser, evaluator):
             return numpy.array([], dtype=env[key.value].dtype)
 
     return TypeEvaluator().transform(parser.parse(formula))
+
 
 def evaluate_data(formula, env, parser, evaluator):
     """

--- a/datacube/virtual/impl.py
+++ b/datacube/virtual/impl.py
@@ -10,7 +10,7 @@ products implementing the same interface.
 
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
-from functools import reduce
+
 from typing import Any, Dict, List, Optional, cast
 from typing import Mapping as TypeMapping
 
@@ -22,7 +22,7 @@ from dask.core import flatten
 import yaml
 
 from datacube import Datacube
-from datacube.api.core import select_datasets_inside_polygon, output_geobox
+from datacube.api.core import output_geobox
 from datacube.api.grid_workflow import _fast_slice
 from datacube.api.query import Query, query_group_by
 from datacube.model import Measurement, DatasetType
@@ -38,7 +38,7 @@ from .utils import qualified_name, merge_dicts
 from .utils import select_unique, select_keys, reject_keys, merge_search_terms
 
 
-class VirtualProductException(Exception):
+class VirtualProductException(Exception):  # noqa: N818
     """ Raised if the construction of the virtual product cannot be validated. """
 
 

--- a/datacube/virtual/transformations.py
+++ b/datacube/virtual/transformations.py
@@ -439,6 +439,7 @@ class Expressions(Transformation):
 def year(time):
     return time.astype('datetime64[Y]')
 
+
 def fiscal_year(time):
     """"
     This function supports group-by financial years
@@ -448,10 +449,10 @@ def fiscal_year(time):
         return df.apply(lambda x: numpy.datetime64(str(x.to_period('Q-JUN').qyear))).values
 
     ds = xarray.apply_ufunc(convert_to_quarters,
-                       time,
-                       input_core_dims=[["time"]],
-                       output_core_dims=[["time"]],
-                       vectorize=True)
+                            time,
+                            input_core_dims=[["time"]],
+                            output_core_dims=[["time"]],
+                            vectorize=True)
 
     df = time['time'].to_series()
     years = df.apply(lambda x: numpy.datetime64(str(x.to_period('Q-JUN').qyear))).values

--- a/datacube/virtual/utils.py
+++ b/datacube/virtual/utils.py
@@ -5,7 +5,6 @@
 """ Utilities to facilitate virtual product implementation. """
 
 import warnings
-import math
 
 
 def select_unique(things):

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -12,6 +12,7 @@ v1.8.next
 - Fix broken paths in api docs. (:pull:`1277`)
 - Fix readthedocs build. (:pull:`1269`)
 - Added doc change comparison for tuple and list types with identical values (:pull:`1281`)
+- Added flake8 to Github action workflow and correct code base per flake8 rules (:pull:`1285`)
 
 v1.8.7 (7 June 2022)
 ====================

--- a/docs/click_utils.py
+++ b/docs/click_utils.py
@@ -81,4 +81,3 @@ def setup(app):
         'parallel_read_safe': False,
         'parallel_write_safe': False,
     }
-

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,7 +5,7 @@
 import os
 import sys
 
-from bs4 import BeautifulSoup as bs
+from bs4 import BeautifulSoup as bs  # noqa: N813
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -171,6 +171,7 @@ latex_documents = [
 
 numfig = True
 
+
 def custom_page_funcs(app, pagename, templatename, context, doctree):
 
     def get_autosummary_toc():
@@ -230,11 +231,11 @@ def custom_page_funcs(app, pagename, templatename, context, doctree):
                 'title': '',
                 'menu_items': []
             }
-            out_section['title'] = section.find_previous_sibling('p').text.replace(':','')
+            out_section['title'] = section.find_previous_sibling('p').text.replace(':', '')
             matches = section.find_all('tr')
             for match in matches:
                 link = match.find(class_="internal")
-                
+
                 if link != None:
                     title = link['title']
                     if title != None:
@@ -251,7 +252,6 @@ def custom_page_funcs(app, pagename, templatename, context, doctree):
 
     context['get_class_toc'] = get_class_toc
     context['get_autosummary_toc'] = get_autosummary_toc
-
 
 
 def setup(app):

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -433,7 +433,7 @@ def telemetry_metadata_type_doc():
 
 @pytest.fixture
 def ga_metadata_type_doc():
-    _FULL_EO_METADATA = Path(__file__).parent.joinpath('extensive-eo-metadata.yaml')
+    _FULL_EO_METADATA = Path(__file__).parent.joinpath('extensive-eo-metadata.yaml')  # noqa: N806
     [(path, eo_md_type)] = datacube.utils.read_documents(_FULL_EO_METADATA)
     return eo_md_type
 

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -474,8 +474,8 @@ def test_update_metadata_type(index, default_metadata_type):
     index.metadata_types.update_document(different_mt_doc, allow_unsafe_updates=True)
     updated_type = index.metadata_types.get_by_name(mt_doc['name'])
     assert (
-            isinstance(updated_type.dataset_fields['time'], PgrNumericRangeDocField)
-            or isinstance(updated_type.dataset_fields['time'], PgsNumericRangeDocField)
+        isinstance(updated_type.dataset_fields['time'], PgrNumericRangeDocField)
+        or isinstance(updated_type.dataset_fields['time'], PgsNumericRangeDocField)
     )
 
 

--- a/integration_tests/index/test_null_index.py
+++ b/integration_tests/index/test_null_index.py
@@ -32,7 +32,7 @@ def test_null_user_resource(null_config):
             dc.index.users.grant_role("role1", "user1", "user2")
 
 
-def test_null_user_resource(null_config):
+def test_null_metadata_types_resource(null_config):
     with Datacube(config=null_config, validate_connection=True) as dc:
         assert dc.index.metadata_types.get_all() == []
         with pytest.raises(NotImplementedError) as e:

--- a/integration_tests/index/test_search.py
+++ b/integration_tests/index/test_search.py
@@ -986,7 +986,7 @@ def test_cli_info(index: Index,
         '    sat_path: {begin: 116, end: 116}',
         '    sat_row: {begin: 74, end: 84}',
         "    time: {begin: '2014-07-26T23:48:00.343853', end: '2014-07-26T23:52:00.343853'}",
-        ]
+    ]
     assert expected_lines == output_lines
 
     # Check indexed time separately, as we don't care what timezone it's displayed in.

--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -11,7 +11,7 @@ import rasterio
 from datacube.api.query import query_group_by
 from datacube.api.core import Datacube
 
-from integration_tests.utils import assert_click_command, prepare_test_ingestion_configuration
+from integration_tests.utils import prepare_test_ingestion_configuration
 
 PROJECT_ROOT = Path(__file__).parents[1]
 CONFIG_SAMPLES = PROJECT_ROOT / 'docs/config_samples/'

--- a/integration_tests/test_model.py
+++ b/integration_tests/test_model.py
@@ -2,7 +2,6 @@
 #
 # Copyright (c) 2015-2020 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-import pytest
 from datacube.model import Dataset, DatasetType
 from typing import List
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,5 +15,11 @@ ignore =
     # W50{3,4}: line break before/after binary operator
     W503
     W504
+    # E124 closing bracket does not match visual indentation
+    E124
+    # F841 local variable 'e' is assigned to but never used
+    F841
+    # W605 invalid escape sequence '\*'
+    W605
 
 ignore-names = W,H,A,S,R,T,WS,X,Y,Z,XX,YY,XY,B,M,N,L,NX,NY

--- a/tests/drivers/test_rio_reader.py
+++ b/tests/drivers/test_rio_reader.py
@@ -53,7 +53,7 @@ def test_rio_rd_entry():
 
 
 def test_rd_internals_crs():
-    from rasterio.crs import CRS as RioCRS
+    from rasterio.crs import CRS as RioCRS  # noqa: N811
 
     assert _dc_crs(None) is None
     assert _dc_crs(RioCRS()) is None

--- a/tests/storage/test_base.py
+++ b/tests/storage/test_base.py
@@ -77,4 +77,4 @@ def test_band_info():
 
     ds = mk_sample_dataset(bands, uri='/not/a/uri')
     band = BandInfo(ds, 'a')
-    assert(band.uri_scheme is '')
+    assert(band.uri_scheme is '')  # noqa: F632

--- a/tests/storage/test_netcdfwriter.py
+++ b/tests/storage/test_netcdfwriter.py
@@ -238,35 +238,39 @@ def test_chunksizes(tmpnetcdf_filename):
 
 
 EXAMPLE_FLAGS_DEF = {
-        'band_1_saturated': {
-            'bits': 0,
-            'values': {
-                0: True,
-                1: False
-            },
-            'description': 'Band 1 is saturated'},
-        'band_2_saturated': {
-            'bits': 1,
-            'values': {
-                0: True,
-                1: False
-            },
-            'description': 'Band 2 is saturated'},
-        'band_3_saturated': {
-            'bits': 2,
-            'values': {
-                0: True,
-                1: False
-            },
-            'description': 'Band 3 is saturated'},
-        'land_sea': {
-            'bits': 9,
-            'values': {
-                0: 'sea',
-                1: 'land'
-            },
-            'description': 'Land/Sea observation'},
-    }
+    'band_1_saturated': {
+        'bits': 0,
+        'values': {
+            0: True,
+            1: False
+        },
+        'description': 'Band 1 is saturated'
+    },
+    'band_2_saturated': {
+        'bits': 1,
+        'values': {
+            0: True,
+            1: False
+        },
+        'description': 'Band 2 is saturated'
+    },
+    'band_3_saturated': {
+        'bits': 2,
+        'values': {
+            0: True,
+            1: False
+        },
+        'description': 'Band 3 is saturated'
+    },
+    'land_sea': {
+        'bits': 9,
+        'values': {
+            0: 'sea',
+            1: 'land'
+        },
+        'description': 'Land/Sea observation'
+    },
+}
 
 
 def test_measurements_model_netcdfflags():

--- a/tests/test_dynamic_db_passwd.py
+++ b/tests/test_dynamic_db_passwd.py
@@ -20,11 +20,9 @@ def next_token(base):
 
 
 def test_dynamic_password():
-    url = URL.create(
-                    'postgresql',
-                    host="fake_host", database="fake_database", port=6543,
-                    username="fake_username", password="fake_password"
-    )
+    url = URL.create('postgresql',
+                     host="fake_host", database="fake_database", port=6543,
+                     username="fake_username", password="fake_password")
     engine = PostgresDb._create_engine(url)
     counter[0] = 0
     last_base[0] = None

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -922,7 +922,7 @@ def test_3d_point_converted_to_2d_point():
 
 
 def test_crs():
-    CRS = geometry.CRS
+    CRS = geometry.CRS  # noqa: N806
     custom_crs = geometry.CRS("""PROJCS["unnamed",
                            GEOGCS["Unknown datum based upon the custom spheroid",
                            DATUM["Not specified (based on custom spheroid)", SPHEROID["Custom spheroid",6371007.181,0]],
@@ -1217,8 +1217,8 @@ def test_fit():
     def run_test(A, n, tol=1e-5):
         X = [(uniform(0, 1), uniform(0, 1))
              for _ in range(n)]
-        Y = [A*x for x in X]
-        A_ = affine_from_pts(X, Y)
+        Y = [A*x for x in X]  # noqa: N806
+        A_ = affine_from_pts(X, Y)  # noqa: N806
 
         assert get_diff(A, A_) < tol
 

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -922,7 +922,6 @@ def test_3d_point_converted_to_2d_point():
 
 
 def test_crs():
-    CRS = geometry.CRS  # noqa: N806
     custom_crs = geometry.CRS("""PROJCS["unnamed",
                            GEOGCS["Unknown datum based upon the custom spheroid",
                            DATUM["Not specified (based on custom spheroid)", SPHEROID["Custom spheroid",6371007.181,0]],
@@ -947,7 +946,7 @@ def test_crs():
     assert crs.dimensions == ('latitude', 'longitude')
     assert crs.epsg == 4326
 
-    crs2 = CRS(crs)
+    crs2 = geometry.CRS(crs)
     assert crs2 == crs
     assert crs.proj == crs2.proj
 

--- a/tests/test_testutils.py
+++ b/tests/test_testutils.py
@@ -3,9 +3,8 @@
 # Copyright (c) 2015-2020 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import pytest
-from datacube.model import Dataset
 from datacube.testutils.threads import FakeThreadPoolExecutor
-from datacube.testutils import mk_sample_xr_dataset, mk_sample_product, mk_sample_dataset
+from datacube.testutils import mk_sample_xr_dataset, mk_sample_dataset
 from datacube.testutils.io import native_geobox
 
 

--- a/tests/test_utils_docs.py
+++ b/tests/test_utils_docs.py
@@ -324,7 +324,7 @@ def test_simple_doc_nav():
     def node(name, **kwargs):
         return dict(id=name, lineage=dict(source_datasets=kwargs))
 
-    A, _, C, _, _ = make_graph_abcde(node)
+    A, _, C, _, _ = make_graph_abcde(node)  # noqa: N806
     rdr = SimpleDocNav(A)
 
     assert rdr.doc == A

--- a/tests/test_utils_other.py
+++ b/tests/test_utils_other.py
@@ -14,7 +14,6 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-import rasterio
 import xarray as xr
 from dateutil.parser import parse
 from hypothesis import given
@@ -44,7 +43,7 @@ from datacube.utils.uris import (uri_to_local_path, mk_part_uri, get_part_from_u
                                  pick_uri, uri_resolve, is_vsipath,
                                  normalise_path, default_base_dir)
 from datacube.utils.io import check_write_path
-from datacube.testutils import mk_sample_product, remove_crs
+from datacube.testutils import mk_sample_product
 
 
 def test_stats_dates():


### PR DESCRIPTION
### Reason for this pull request
When commits are checked by pre-commit and flake8 code lint was corrected, it applies to lines that were committed without flake8 causing extra lines of changes shown in a pull request increasing difficulty in reviewing.

Adding flake8 to code lint as part of GitHub action ensures commits with or without pre-commit checks are all passing flake8 code lint.

### Proposed changes

- create `lint.yaml` for code lint run as part of PR action 
- add flake8 for code lint as per `pre-commit` hook
- streamline github action, move `pycodestyle` and `pylint` out of build and into lint
- apply flake8 lint correction to all effected lines
- add more ignore to `setup.cfg`

 - [x] Closes #1284 
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
