### PR TITLE
[DOC ONLY] add instruction for running single test with docker to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,9 +66,9 @@ Developer setup
 
    (this script approximates what is run by Travis. You can
    alternatively run ``pytest`` yourself). Some test dependencies may need to be installed, attempt to install these using:
-   
+
    ``pip install --upgrade -e '.[test]'``
-   
+
    If install for these fails please lodge them as issues.
 
 6. **(or)** Run all tests, including integration tests.
@@ -91,6 +91,12 @@ to ``./check-code.sh`` script.
 ::
 
    ./check-code.sh --with-docker integration_tests
+
+
+To run individual test in docker container
+
+::
+    docker run -ti -v /home/ubuntu/datacube-core:/code opendatacube/datacube-tests:latest pytest integration_tests/test_filename.py::test_function_name
 
 
 Developer setup on Ubuntu

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -14,6 +14,7 @@ v1.8.next
 - Added doc change comparison for tuple and list types with identical values (:pull:`1281`)
 - Added flake8 to Github action workflow and correct code base per flake8 rules (:pull:`1285`)
 - Add `dataset id` check to dataset doc resolve to prevent `uuid` returning error when `id` used in `None`  (:pull:`1287`)
+- Add how to run targeted single test case in docker guide to README (:pull:`1288`)
 - Add `help message` for all `dataset`, `product` and `metadata` subcommands when required arg is not passed in (:pull:`1292`)
 
 v1.8.7 (7 June 2022)


### PR DESCRIPTION
### Reason for this pull request

Developed an integration test case as per pr: #1287 , using `./check-code.sh --with-docker` was slowing down the development, `pytest` for single test function is import for development speed.

### Proposed changes

- Doc change only, add instruction for targeted pytesting function using docker

 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
