### PR TITLE
add help messages to subcommands returning no message

### DIFF
--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -22,7 +22,7 @@ from datacube.index.eo3 import prep_eo3  # type: ignore[attr-defined]
 from datacube.index import Index
 from datacube.model import Dataset
 from datacube.ui import click as ui
-from datacube.ui.click import cli
+from datacube.ui.click import cli, print_help_msg
 from datacube.ui.common import ui_path_doc_stream
 from datacube.utils import changes, SimpleDocNav
 from datacube.utils.serialise import SafeDatacubeDumper
@@ -168,6 +168,11 @@ def index_cmd(index, product_names,
               ignore_lineage,
               confirm_ignore_lineage,
               dataset_paths):
+
+    if not dataset_paths:
+        print_help_msg(index_cmd)
+        sys.exit(0)
+
     if confirm_ignore_lineage is False and ignore_lineage is True:
         if sys.stdin.isatty():
             confirmed = click.confirm("Requested to skip lineage information, Are you sure?", default=False)
@@ -243,6 +248,10 @@ def parse_update_rules(keys_that_can_change):
 @click.argument('dataset-paths', nargs=-1)
 @ui.pass_index()
 def update_cmd(index, keys_that_can_change, dry_run, location_policy, dataset_paths):
+    if not dataset_paths:
+        print_help_msg(update_cmd)
+        sys.exit(0)
+
     def loc_action(action, new_ds, existing_ds, action_name):
         if len(existing_ds.uris) == 0:
             return None
@@ -406,6 +415,10 @@ def info_cmd(index: Index, show_sources: bool, show_derived: bool,
              f: str,
              max_depth: int,
              ids: Iterable[str]) -> None:
+    if not ids:
+        print_help_msg(info_cmd)
+        sys.exit(0)
+
     # Using an array wrapper to get around the lack of "nonlocal" in py2
     missing_datasets = [0]
 
@@ -472,6 +485,10 @@ def uri_search_cmd(index: Index, paths: List[str], search_mode):
 
     PATHS may be either file paths or URIs
     """
+    if not paths:
+        print_help_msg(uri_search_cmd)
+        sys.exit(0)
+
     if search_mode == 'guess':
         # This is what the API expects. I think it should be changed.
         search_mode = None
@@ -493,6 +510,10 @@ def uri_search_cmd(index: Index, paths: List[str], search_mode):
 @click.argument('ids', nargs=-1)
 @ui.pass_index()
 def archive_cmd(index: Index, archive_derived: bool, dry_run: bool, all_ds: bool, ids: List[str]):
+    if not ids and not all_ds:
+        print_help_msg(archive_cmd)
+        sys.exit(0)
+
     derived_dataset_ids: List[UUID] = []
     if all_ds:
         datasets_for_archive = {dsid: True for dsid in index.datasets.get_all_dataset_ids(archived=False)}
@@ -537,6 +558,10 @@ def archive_cmd(index: Index, archive_derived: bool, dry_run: bool, all_ds: bool
 @ui.pass_index()
 def restore_cmd(index: Index, restore_derived: bool, derived_tolerance_seconds: int,
                 dry_run: bool, all_ds: bool, ids: List[str]):
+    if not ids and not all_ds:
+        print_help_msg(restore_cmd)
+        sys.exit(0)
+
     tolerance = datetime.timedelta(seconds=derived_tolerance_seconds)
     if all_ds:
         ids = index.datasets.get_all_dataset_ids(archived=True)  # type: ignore[assignment]
@@ -580,6 +605,10 @@ def restore_cmd(index: Index, restore_derived: bool, derived_tolerance_seconds: 
 @click.argument('ids', nargs=-1)
 @ui.pass_index()
 def purge_cmd(index: Index, dry_run: bool, all_ds: bool, ids: List[str]):
+    if not ids and not all_ds:
+        print_help_msg(purge_cmd)
+        sys.exit(0)
+
     if all_ds:
         datasets_for_archive = {dsid: True for dsid in index.datasets.get_all_dataset_ids(archived=True)}
     else:

--- a/datacube/scripts/metadata.py
+++ b/datacube/scripts/metadata.py
@@ -14,7 +14,7 @@ from click import echo, style
 
 from datacube.index import Index
 from datacube.ui import click as ui
-from datacube.ui.click import cli
+from datacube.ui.click import cli, print_help_msg
 from datacube.utils import read_documents, InvalidDocException
 from datacube.utils.serialise import SafeDatacubeDumper
 
@@ -38,6 +38,10 @@ def add_metadata_types(index, allow_exclusive_lock, files):
     """
     Add or update metadata types in the index
     """
+    if not files:
+        print_help_msg(add_metadata_types)
+        sys.exit(0)
+
     for descriptor_path, parsed_doc in read_documents(*files):
         try:
             type_ = index.metadata_types.from_doc(parsed_doc)
@@ -68,6 +72,10 @@ def update_metadata_types(index: Index, allow_unsafe: bool, allow_exclusive_lock
     (An unsafe change is anything that may potentially make the metadata type
     incompatible with existing types of the same name)
     """
+    if not files:
+        print_help_msg(update_metadata_types)
+        sys.exit(0)
+
     for descriptor_path, parsed_doc in read_documents(*files):
         try:
             type_ = index.metadata_types.from_doc(parsed_doc)

--- a/datacube/scripts/product.py
+++ b/datacube/scripts/product.py
@@ -17,7 +17,7 @@ from click import echo, style
 
 from datacube.index import Index
 from datacube.ui import click as ui
-from datacube.ui.click import cli
+from datacube.ui.click import cli, print_help_msg
 from datacube.utils import read_documents, InvalidDocException
 from datacube.utils.serialise import SafeDatacubeDumper
 
@@ -41,6 +41,9 @@ def add_products(index, allow_exclusive_lock, files):
     """
     Add or update products in the generic index.
     """
+    if not files:
+        print_help_msg(add_products)
+
     def on_ctrlc(sig, frame):
         echo('''Can not abort `product add` without leaving database in bad state.
 
@@ -81,6 +84,10 @@ def update_products(index: Index, allow_unsafe: bool, allow_exclusive_lock: bool
     (An unsafe change is anything that may potentially make the product
     incompatible with existing datasets of that type)
     """
+    if not files:
+        print_help_msg(update_products)
+        sys.exit(0)
+
     failures = 0
     for descriptor_path, parsed_doc in read_documents(*files):
         try:

--- a/datacube/ui/click.py
+++ b/datacube/ui/click.py
@@ -360,3 +360,8 @@ def parsed_search_expressions(f):
 
     f = click.argument('expressions', callback=my_parse, nargs=-1)(f)
     return f
+
+
+def print_help_msg(command):
+    with click.Context(command) as ctx:
+        click.echo(command.get_help(ctx))

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -14,6 +14,7 @@ v1.8.next
 - Added doc change comparison for tuple and list types with identical values (:pull:`1281`)
 - Added flake8 to Github action workflow and correct code base per flake8 rules (:pull:`1285`)
 - Add `dataset id` check to dataset doc resolve to prevent `uuid` returning error when `id` used in `None`  (:pull:`1287`)
+- Add `help message` for all `dataset`, `product` and `metadata` subcommands when required arg is not passed in (:pull:`1292`)
 
 v1.8.7 (7 June 2022)
 ====================

--- a/integration_tests/data/dataset_add/products.yml
+++ b/integration_tests/data/dataset_add/products.yml
@@ -6,7 +6,7 @@
 ##  metadata:
 ##  product_type: {{name}}
 ##  {% endfor %}''').render(products='ABCDE')
-##  
+##
 ---
 name: A
 description: test product A

--- a/integration_tests/test_cli_output.py
+++ b/integration_tests/test_cli_output.py
@@ -1,0 +1,81 @@
+def test_cli_product_subcommand(index_empty, clirunner):
+    runner = clirunner(['product', 'update'], verbose_flag=False)
+    assert "Usage:  [OPTIONS] [FILES]" in runner.output
+    assert "Update existing products." in runner.output
+
+    runner = clirunner(['product', 'add'], verbose_flag=False)
+    assert "Usage:  [OPTIONS] [FILES]" in runner.output
+    assert "Add or update products in" in runner.output
+
+
+def test_cli_metadata_subcommand(index_empty, clirunner):
+    runner = clirunner(['metadata', 'update'], verbose_flag=False)
+    assert "Usage:  [OPTIONS] [FILES]" in runner.output
+    assert "Update existing metadata types." in runner.output
+
+    runner = clirunner(['metadata', 'add'], verbose_flag=False)
+    assert "Usage:  [OPTIONS] [FILES]" in runner.output
+    assert "Add or update metadata types in" in runner.output
+
+
+def test_cli_dataset_subcommand(index_empty, clirunner, dataset_add_configs):
+    clirunner(['metadata', 'add', dataset_add_configs.metadata])
+    clirunner(['product', 'add', dataset_add_configs.products])
+
+    runner = clirunner(['dataset', 'add'], verbose_flag=False)
+    assert "Indexing datasets  [####################################]  100%" not in runner.output
+    assert "Usage:  [OPTIONS] [DATASET_PATHS]" in runner.output
+    assert "Add datasets" in runner.output
+    assert runner.exit_code == 0
+
+    runner = clirunner(['dataset', 'update'], verbose_flag=False)
+    assert "0 successful, 0 failed" not in runner.output
+    assert "Usage:  [OPTIONS] [DATASET_PATHS]" in runner.output
+    assert "Update datasets" in runner.output
+    assert runner.exit_code == 0
+
+    runner = clirunner(['dataset', 'info'], verbose_flag=False)
+    assert "Usage:  [OPTIONS] [IDS]" in runner.output
+    assert "Display dataset information" in runner.output
+    assert runner.exit_code == 0
+
+    runner = clirunner(['dataset', 'uri-search'], verbose_flag=False)
+    assert "Usage:  [OPTIONS] [PATHS]" in runner.output
+    assert "Search by dataset locations" in runner.output
+    assert runner.exit_code == 0
+
+    clirunner(['dataset', 'add', dataset_add_configs.datasets])
+
+    runner = clirunner(['dataset', 'archive'], verbose_flag=False)
+    assert "Completed dataset archival." not in runner.output
+    assert "Usage:  [OPTIONS] [IDS]" in runner.output
+    assert "Archive datasets" in runner.output
+    assert runner.exit_code == 0
+
+    runner = clirunner(['dataset', 'archive', "--all"], verbose_flag=False)
+    assert "Completed dataset archival." in runner.output
+    assert "Usage:  [OPTIONS] [IDS]" not in runner.output
+    assert "Archive datasets" not in runner.output
+    assert runner.exit_code == 0
+
+    runner = clirunner(['dataset', 'restore'], verbose_flag=False)
+    assert "Usage:  [OPTIONS] [IDS]" in runner.output
+    assert "Restore datasets" in runner.output
+    assert runner.exit_code == 0
+
+    runner = clirunner(['dataset', 'restore', "--all"], verbose_flag=False)
+    assert "restoring" in runner.output
+    assert "Usage:  [OPTIONS] [IDS]" not in runner.output
+    assert "Restore datasets" not in runner.output
+    assert runner.exit_code == 0
+
+    runner = clirunner(['dataset', 'purge'], verbose_flag=False)
+    assert "Completed dataset purge." not in runner.output
+    assert "Usage:  [OPTIONS] [IDS]" in runner.output
+    assert "Purge archived datasets" in runner.output
+    assert runner.exit_code == 0
+
+    runner = clirunner(['dataset', 'purge', "--all"], verbose_flag=False)
+    assert "Completed dataset purge." in runner.output
+    assert "Usage:  [OPTIONS] [IDS]" not in runner.output
+    assert runner.exit_code == 0

--- a/integration_tests/test_config_tool.py
+++ b/integration_tests/test_config_tool.py
@@ -201,7 +201,7 @@ def test_db_init(clirunner, initialised_postgres_db):
 
 
 def test_add_no_such_product(clirunner, initialised_postgres_db):
-    result = clirunner(['dataset', 'add', '--dtype', 'no_such_product'], expect_success=False)
+    result = clirunner(['dataset', 'add', '--dtype', 'no_such_product', '/tmp'], expect_success=False)
     assert result.exit_code != 0
     assert "DEPRECATED option detected" in result.output
     assert "ERROR Supplied product name" in result.output


### PR DESCRIPTION
### Reason for this pull request
many existing subcommand provides the user with no message when the required args are not passed to the command. This pr adds a help message for the subcommand if args are not provided for the command to proceed meaningfully

### Proposed changes
- add `print_help_message` to all subcommands that are currently returning no console output
- add test cases for all subcommands in (datasets, metadata and products) that are either returning no output or misleading output


 - [x] Closes #1291 
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes
