### PR TITLE
add error code 1 to all incomplete subcommands

### DIFF
--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -171,7 +171,7 @@ def index_cmd(index, product_names,
 
     if not dataset_paths:
         print_help_msg(index_cmd)
-        sys.exit(0)
+        sys.exit(1)
 
     if confirm_ignore_lineage is False and ignore_lineage is True:
         if sys.stdin.isatty():
@@ -250,7 +250,7 @@ def parse_update_rules(keys_that_can_change):
 def update_cmd(index, keys_that_can_change, dry_run, location_policy, dataset_paths):
     if not dataset_paths:
         print_help_msg(update_cmd)
-        sys.exit(0)
+        sys.exit(1)
 
     def loc_action(action, new_ds, existing_ds, action_name):
         if len(existing_ds.uris) == 0:
@@ -417,7 +417,7 @@ def info_cmd(index: Index, show_sources: bool, show_derived: bool,
              ids: Iterable[str]) -> None:
     if not ids:
         print_help_msg(info_cmd)
-        sys.exit(0)
+        sys.exit(1)
 
     # Using an array wrapper to get around the lack of "nonlocal" in py2
     missing_datasets = [0]
@@ -487,7 +487,7 @@ def uri_search_cmd(index: Index, paths: List[str], search_mode):
     """
     if not paths:
         print_help_msg(uri_search_cmd)
-        sys.exit(0)
+        sys.exit(1)
 
     if search_mode == 'guess':
         # This is what the API expects. I think it should be changed.
@@ -512,7 +512,7 @@ def uri_search_cmd(index: Index, paths: List[str], search_mode):
 def archive_cmd(index: Index, archive_derived: bool, dry_run: bool, all_ds: bool, ids: List[str]):
     if not ids and not all_ds:
         print_help_msg(archive_cmd)
-        sys.exit(0)
+        sys.exit(1)
 
     derived_dataset_ids: List[UUID] = []
     if all_ds:
@@ -560,7 +560,7 @@ def restore_cmd(index: Index, restore_derived: bool, derived_tolerance_seconds: 
                 dry_run: bool, all_ds: bool, ids: List[str]):
     if not ids and not all_ds:
         print_help_msg(restore_cmd)
-        sys.exit(0)
+        sys.exit(1)
 
     tolerance = datetime.timedelta(seconds=derived_tolerance_seconds)
     if all_ds:
@@ -607,7 +607,7 @@ def restore_cmd(index: Index, restore_derived: bool, derived_tolerance_seconds: 
 def purge_cmd(index: Index, dry_run: bool, all_ds: bool, ids: List[str]):
     if not ids and not all_ds:
         print_help_msg(purge_cmd)
-        sys.exit(0)
+        sys.exit(1)
 
     if all_ds:
         datasets_for_archive = {dsid: True for dsid in index.datasets.get_all_dataset_ids(archived=True)}

--- a/datacube/scripts/metadata.py
+++ b/datacube/scripts/metadata.py
@@ -40,7 +40,7 @@ def add_metadata_types(index, allow_exclusive_lock, files):
     """
     if not files:
         print_help_msg(add_metadata_types)
-        sys.exit(0)
+        sys.exit(1)
 
     for descriptor_path, parsed_doc in read_documents(*files):
         try:
@@ -74,7 +74,7 @@ def update_metadata_types(index: Index, allow_unsafe: bool, allow_exclusive_lock
     """
     if not files:
         print_help_msg(update_metadata_types)
-        sys.exit(0)
+        sys.exit(1)
 
     for descriptor_path, parsed_doc in read_documents(*files):
         try:

--- a/datacube/scripts/product.py
+++ b/datacube/scripts/product.py
@@ -43,6 +43,7 @@ def add_products(index, allow_exclusive_lock, files):
     """
     if not files:
         print_help_msg(add_products)
+        sys.exit(1)
 
     def on_ctrlc(sig, frame):
         echo('''Can not abort `product add` without leaving database in bad state.
@@ -86,7 +87,7 @@ def update_products(index: Index, allow_unsafe: bool, allow_exclusive_lock: bool
     """
     if not files:
         print_help_msg(update_products)
-        sys.exit(0)
+        sys.exit(1)
 
     failures = 0
     for descriptor_path, parsed_doc in read_documents(*files):

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -16,6 +16,7 @@ v1.8.next
 - Add `dataset id` check to dataset doc resolve to prevent `uuid` returning error when `id` used in `None`  (:pull:`1287`)
 - Add how to run targeted single test case in docker guide to README (:pull:`1288`)
 - Add `help message` for all `dataset`, `product` and `metadata` subcommands when required arg is not passed in (:pull:`1292`)
+- Add `error code 1` to all incomplete `dataset`, `product` and `metadata` subcommands (:pull:`1293`)
 
 v1.8.7 (7 June 2022)
 ====================

--- a/integration_tests/test_cli_output.py
+++ b/integration_tests/test_cli_output.py
@@ -1,56 +1,60 @@
 def test_cli_product_subcommand(index_empty, clirunner):
-    runner = clirunner(['product', 'update'], verbose_flag=False)
+    runner = clirunner(['product', 'update'], verbose_flag=False, expect_success=False)
     assert "Usage:  [OPTIONS] [FILES]" in runner.output
     assert "Update existing products." in runner.output
+    assert runner.exit_code == 1
 
-    runner = clirunner(['product', 'add'], verbose_flag=False)
+    runner = clirunner(['product', 'add'], verbose_flag=False, expect_success=False)
     assert "Usage:  [OPTIONS] [FILES]" in runner.output
     assert "Add or update products in" in runner.output
+    assert runner.exit_code == 1
 
 
 def test_cli_metadata_subcommand(index_empty, clirunner):
-    runner = clirunner(['metadata', 'update'], verbose_flag=False)
+    runner = clirunner(['metadata', 'update'], verbose_flag=False, expect_success=False)
     assert "Usage:  [OPTIONS] [FILES]" in runner.output
     assert "Update existing metadata types." in runner.output
+    assert runner.exit_code == 1
 
-    runner = clirunner(['metadata', 'add'], verbose_flag=False)
+    runner = clirunner(['metadata', 'add'], verbose_flag=False, expect_success=False)
     assert "Usage:  [OPTIONS] [FILES]" in runner.output
     assert "Add or update metadata types in" in runner.output
+    assert runner.exit_code == 1
 
 
 def test_cli_dataset_subcommand(index_empty, clirunner, dataset_add_configs):
     clirunner(['metadata', 'add', dataset_add_configs.metadata])
     clirunner(['product', 'add', dataset_add_configs.products])
 
-    runner = clirunner(['dataset', 'add'], verbose_flag=False)
+    runner = clirunner(['dataset', 'add'], verbose_flag=False, expect_success=False)
     assert "Indexing datasets  [####################################]  100%" not in runner.output
     assert "Usage:  [OPTIONS] [DATASET_PATHS]" in runner.output
     assert "Add datasets" in runner.output
-    assert runner.exit_code == 0
+    assert runner.exit_code == 1
 
-    runner = clirunner(['dataset', 'update'], verbose_flag=False)
+    runner = clirunner(['dataset', 'update'], verbose_flag=False, expect_success=False)
     assert "0 successful, 0 failed" not in runner.output
     assert "Usage:  [OPTIONS] [DATASET_PATHS]" in runner.output
     assert "Update datasets" in runner.output
-    assert runner.exit_code == 0
+    assert runner.exit_code == 1
 
-    runner = clirunner(['dataset', 'info'], verbose_flag=False)
+    runner = clirunner(['dataset', 'info'], verbose_flag=False, expect_success=False)
     assert "Usage:  [OPTIONS] [IDS]" in runner.output
     assert "Display dataset information" in runner.output
-    assert runner.exit_code == 0
+    assert runner.exit_code == 1
 
-    runner = clirunner(['dataset', 'uri-search'], verbose_flag=False)
+    runner = clirunner(['dataset', 'uri-search'], verbose_flag=False, expect_success=False)
     assert "Usage:  [OPTIONS] [PATHS]" in runner.output
     assert "Search by dataset locations" in runner.output
-    assert runner.exit_code == 0
+    assert runner.exit_code == 1
 
     clirunner(['dataset', 'add', dataset_add_configs.datasets])
 
-    runner = clirunner(['dataset', 'archive'], verbose_flag=False)
+    runner = clirunner(['dataset', 'archive'], verbose_flag=False, expect_success=False)
     assert "Completed dataset archival." not in runner.output
     assert "Usage:  [OPTIONS] [IDS]" in runner.output
     assert "Archive datasets" in runner.output
-    assert runner.exit_code == 0
+    assert runner.exit_code == 1
 
     runner = clirunner(['dataset', 'archive', "--all"], verbose_flag=False)
     assert "Completed dataset archival." in runner.output
@@ -58,10 +62,10 @@ def test_cli_dataset_subcommand(index_empty, clirunner, dataset_add_configs):
     assert "Archive datasets" not in runner.output
     assert runner.exit_code == 0
 
-    runner = clirunner(['dataset', 'restore'], verbose_flag=False)
+    runner = clirunner(['dataset', 'restore'], verbose_flag=False, expect_success=False)
     assert "Usage:  [OPTIONS] [IDS]" in runner.output
     assert "Restore datasets" in runner.output
-    assert runner.exit_code == 0
+    assert runner.exit_code == 1
 
     runner = clirunner(['dataset', 'restore', "--all"], verbose_flag=False)
     assert "restoring" in runner.output
@@ -69,11 +73,11 @@ def test_cli_dataset_subcommand(index_empty, clirunner, dataset_add_configs):
     assert "Restore datasets" not in runner.output
     assert runner.exit_code == 0
 
-    runner = clirunner(['dataset', 'purge'], verbose_flag=False)
+    runner = clirunner(['dataset', 'purge'], verbose_flag=False, expect_success=False)
     assert "Completed dataset purge." not in runner.output
     assert "Usage:  [OPTIONS] [IDS]" in runner.output
     assert "Purge archived datasets" in runner.output
-    assert runner.exit_code == 0
+    assert runner.exit_code == 1
 
     runner = clirunner(['dataset', 'purge', "--all"], verbose_flag=False)
     assert "Completed dataset purge." in runner.output


### PR DESCRIPTION
### Reason for this pull request

Incomplete cli subcommand by standard should return error instead of success.

### Proposed changes

- change `sys.exit` code from `0` to `1` for incomplete `dataset`, `product` and `metadata` subcommands

 - [x] Extends #1292 
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

