### PR TITLE
add exist_on_empty_files to subcommands

### DIFF
--- a/datacube/scripts/metadata.py
+++ b/datacube/scripts/metadata.py
@@ -14,7 +14,7 @@ from click import echo, style
 
 from datacube.index import Index
 from datacube.ui import click as ui
-from datacube.ui.click import cli, print_help_msg
+from datacube.ui.click import cli, print_help_msg, exit_on_empty_file
 from datacube.utils import read_documents, InvalidDocException
 from datacube.utils.serialise import SafeDatacubeDumper
 
@@ -41,6 +41,8 @@ def add_metadata_types(index, allow_exclusive_lock, files):
     if not files:
         print_help_msg(add_metadata_types)
         sys.exit(1)
+
+    exit_on_empty_file(list(read_documents(*files)))
 
     for descriptor_path, parsed_doc in read_documents(*files):
         try:
@@ -75,6 +77,8 @@ def update_metadata_types(index: Index, allow_unsafe: bool, allow_exclusive_lock
     if not files:
         print_help_msg(update_metadata_types)
         sys.exit(1)
+
+    exit_on_empty_file(list(read_documents(*files)))
 
     for descriptor_path, parsed_doc in read_documents(*files):
         try:

--- a/datacube/scripts/product.py
+++ b/datacube/scripts/product.py
@@ -17,7 +17,7 @@ from click import echo, style
 
 from datacube.index import Index
 from datacube.ui import click as ui
-from datacube.ui.click import cli, print_help_msg
+from datacube.ui.click import cli, print_help_msg, exit_on_empty_file
 from datacube.utils import read_documents, InvalidDocException
 from datacube.utils.serialise import SafeDatacubeDumper
 
@@ -52,6 +52,8 @@ This operation requires constructing a bunch of indexes and this takes time, the
 bigger your database the longer it will take. Just wait a bit.''')
 
     signal.signal(signal.SIGINT, on_ctrlc)
+
+    exit_on_empty_file(list(read_documents(*files)))
 
     for descriptor_path, parsed_doc in read_documents(*files):
         try:
@@ -88,6 +90,8 @@ def update_products(index: Index, allow_unsafe: bool, allow_exclusive_lock: bool
     if not files:
         print_help_msg(update_products)
         sys.exit(1)
+
+    exit_on_empty_file(list(read_documents(*files)))
 
     failures = 0
     for descriptor_path, parsed_doc in read_documents(*files):

--- a/datacube/ui/click.py
+++ b/datacube/ui/click.py
@@ -365,3 +365,9 @@ def parsed_search_expressions(f):
 def print_help_msg(command):
     with click.Context(command) as ctx:
         click.echo(command.get_help(ctx))
+
+
+def exit_on_empty_file(read_files_list):
+    if len(read_files_list) == 0:
+        click.echo("All files are empty, exit")
+        sys.exit(1)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -11,12 +11,13 @@ v1.8.next
 - Remove several features that had been deprecated in previous releases. (:pull:`1275`)
 - Fix broken paths in api docs. (:pull:`1277`)
 - Fix readthedocs build. (:pull:`1269`)
-- Added doc change comparison for tuple and list types with identical values (:pull:`1281`)
-- Added flake8 to Github action workflow and correct code base per flake8 rules (:pull:`1285`)
+- Add doc change comparison for tuple and list types with identical values (:pull:`1281`)
+- Add flake8 to Github action workflow and correct code base per flake8 rules (:pull:`1285`)
 - Add `dataset id` check to dataset doc resolve to prevent `uuid` returning error when `id` used in `None`  (:pull:`1287`)
 - Add how to run targeted single test case in docker guide to README (:pull:`1288`)
 - Add `help message` for all `dataset`, `product` and `metadata` subcommands when required arg is not passed in (:pull:`1292`)
 - Add `error code 1` to all incomplete `dataset`, `product` and `metadata` subcommands (:pull:`1293`)
+- Add `exit_on_empty_file` message to `product` and `dataset` subcommands instead of returning no output when file is empty (:pull:`1294`)
 
 v1.8.7 (7 June 2022)
 ====================

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -539,4 +539,5 @@ def dataset_add_configs():
                            datasets_bad1=str(B / 'datasets_bad1.yml'),
                            datasets_no_id=str(B / 'datasets_no_id.yml'),
                            datasets_eo3=str(B / 'datasets_eo3.yml'),
-                           datasets=str(B / 'datasets.yml'))
+                           datasets=str(B / 'datasets.yml'),
+                           empty_file=str(B / 'empty_file.yml'))

--- a/integration_tests/test_cli_output.py
+++ b/integration_tests/test_cli_output.py
@@ -1,7 +1,11 @@
-def test_cli_product_subcommand(index_empty, clirunner):
+def test_cli_product_subcommand(index_empty, clirunner, dataset_add_configs):
     runner = clirunner(['product', 'update'], verbose_flag=False, expect_success=False)
     assert "Usage:  [OPTIONS] [FILES]" in runner.output
     assert "Update existing products." in runner.output
+    assert runner.exit_code == 1
+
+    runner = clirunner(['product', 'update', dataset_add_configs.empty_file], verbose_flag=False, expect_success=False)
+    assert "All files are empty, exit" in runner.output
     assert runner.exit_code == 1
 
     runner = clirunner(['product', 'add'], verbose_flag=False, expect_success=False)
@@ -9,16 +13,28 @@ def test_cli_product_subcommand(index_empty, clirunner):
     assert "Add or update products in" in runner.output
     assert runner.exit_code == 1
 
+    runner = clirunner(['product', 'add', dataset_add_configs.empty_file], verbose_flag=False, expect_success=False)
+    assert "All files are empty, exit" in runner.output
+    assert runner.exit_code == 1
 
-def test_cli_metadata_subcommand(index_empty, clirunner):
+
+def test_cli_metadata_subcommand(index_empty, clirunner, dataset_add_configs):
     runner = clirunner(['metadata', 'update'], verbose_flag=False, expect_success=False)
     assert "Usage:  [OPTIONS] [FILES]" in runner.output
     assert "Update existing metadata types." in runner.output
     assert runner.exit_code == 1
 
+    runner = clirunner(['metadata', 'update', dataset_add_configs.empty_file], verbose_flag=False, expect_success=False)
+    assert "All files are empty, exit" in runner.output
+    assert runner.exit_code == 1
+
     runner = clirunner(['metadata', 'add'], verbose_flag=False, expect_success=False)
     assert "Usage:  [OPTIONS] [FILES]" in runner.output
     assert "Add or update metadata types in" in runner.output
+    assert runner.exit_code == 1
+
+    runner = clirunner(['metadata', 'add', dataset_add_configs.empty_file], verbose_flag=False, expect_success=False)
+    assert "All files are empty, exit" in runner.output
     assert runner.exit_code == 1
 
 


### PR DESCRIPTION
### Reason for this pull request

All commands should return some kind of output, returning no output is not helping the user. Currently, when the file is empty, the command will still try to process the file but no indexing is done and the user won't know what happened.


### Proposed changes

- before processing the file, check if the file is empty, if empty, exit early with `error code 1`

 - [x] Closes #1289 
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

