### PR TITLE
Regularise terminology in postgis driver

### DIFF
--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -132,7 +132,6 @@ def ensure_db(engine, with_permissions=True):
                         {schema}.dataset_location,
                         {schema}.dataset_source to odc_ingest;
         grant usage, select on all sequences in schema {schema} to odc_ingest;
-        
 
         -- (We're only granting deletion of types that have nothing written yet: they can't delete the data itself)
         grant insert, delete on {schema}.product,

--- a/datacube/drivers/postgis/_schema.py
+++ b/datacube/drivers/postgis/_schema.py
@@ -38,7 +38,7 @@ METADATA_TYPE = Table(
 )
 
 PRODUCT = Table(
-    'dataset_type', _core.METADATA,
+    'product', _core.METADATA,
     Column('id', SmallInteger, primary_key=True, autoincrement=True),
 
     # A name/label for this type (eg. 'ls7_nbar'). Specified by users.
@@ -72,7 +72,7 @@ DATASET = Table(
     #   Typing note: sqlalchemy-stubs doesn't handle this legitimate calling pattern.
     Column('metadata_type_ref', None, ForeignKey(METADATA_TYPE.c.id), nullable=False),  # type: ignore[call-overload]
     #   Typing note: sqlalchemy-stubs doesn't handle this legitimate calling pattern.
-    Column('dataset_type_ref', None, ForeignKey(PRODUCT.c.id), index=True, nullable=False),  # type: ignore[call-overload]  # noqa: E501
+    Column('product_ref', None, ForeignKey(PRODUCT.c.id), index=True, nullable=False),  # type: ignore[call-overload]  # noqa: E501
 
     Column('metadata', postgres.JSONB, index=False, nullable=False),
 
@@ -98,8 +98,8 @@ DATASET_LOCATION = Table(
     # All paths in the dataset metadata can be computed relative to this.
     # (it is often the path of the source metadata file)
     #
-    # eg 'file:///g/data/datasets/LS8_NBAR/agdc-metadata.yaml' or 'ftp://eo.something.com/dataset'
-    # 'file' is a scheme, '///g/data/datasets/LS8_NBAR/agdc-metadata.yaml' is a body.
+    # eg 'file:///g/data/datasets/LS8_NBAR/odc-metadata.yaml' or 'ftp://eo.something.com/dataset'
+    # 'file' is a scheme, '///g/data/datasets/LS8_NBAR/odc-metadata.yaml' is a body.
     Column('uri_scheme', String, nullable=False),
     Column('uri_body', String, nullable=False),
 

--- a/datacube/index/postgis/_products.py
+++ b/datacube/index/postgis/_products.py
@@ -8,7 +8,7 @@ from cachetools.func import lru_cache
 
 from datacube.index import fields
 from datacube.index.abstract import AbstractProductResource
-from datacube.model import DatasetType, MetadataType
+from datacube.model import Product, MetadataType
 from datacube.utils import jsonify_document, changes, _readable_offset
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes
 
@@ -55,10 +55,10 @@ class ProductResource(AbstractProductResource):
             This will halt other user's requests until completed.
 
             If false, creation will be slightly slower and cannot be done in a transaction.
-        :param DatasetType product: Product to add
-        :rtype: DatasetType
+        :param Product product: Product to add
+        :rtype: Product
         """
-        DatasetType.validate(product.definition)
+        Product.validate(product.definition)
 
         existing = self.get_by_name(product.name)
         if existing:
@@ -91,11 +91,11 @@ class ProductResource(AbstractProductResource):
         (An unsafe change is anything that may potentially make the product
         incompatible with existing datasets of that type)
 
-        :param DatasetType product: Product to update
+        :param Product product: Product to update
         :param bool allow_unsafe_updates: Allow unsafe changes. Use with caution.
         :rtype: bool,list[change],list[change]
         """
-        DatasetType.validate(product.definition)
+        Product.validate(product.definition)
 
         existing = self.get_by_name(product.name)
         if not existing:
@@ -128,21 +128,21 @@ class ProductResource(AbstractProductResource):
 
         return allow_unsafe_updates or not bad_changes, good_changes, bad_changes
 
-    def update(self, product: DatasetType, allow_unsafe_updates=False, allow_table_lock=False):
+    def update(self, product: Product, allow_unsafe_updates=False, allow_table_lock=False):
         """
         Update a product. Unsafe changes will throw a ValueError by default.
 
         (An unsafe change is anything that may potentially make the product
         incompatible with existing datasets of that type)
 
-        :param DatasetType product: Product to update
+        :param Product product: Product to update
         :param bool allow_unsafe_updates: Allow unsafe changes. Use with caution.
         :param allow_table_lock:
             Allow an exclusive lock to be taken on the table while creating the indexes.
             This will halt other user's requests until completed.
 
             If false, creation will be slower and cannot be done in a transaction.
-        :rtype: DatasetType
+        :rtype: Product
         """
 
         can_update, safe_changes, unsafe_changes = self.can_update(product, allow_unsafe_updates)
@@ -161,7 +161,7 @@ class ProductResource(AbstractProductResource):
 
         _LOG.info("Updating product %s", product.name)
 
-        existing = cast(DatasetType, self.get_by_name(product.name))
+        existing = cast(Product, self.get_by_name(product.name))
         changing_metadata_type = product.metadata_type.name != existing.metadata_type.name
         if changing_metadata_type:
             raise ValueError("Unsafe change: cannot (currently) switch metadata types for a product")
@@ -208,7 +208,7 @@ class ProductResource(AbstractProductResource):
             This will halt other user's requests until completed.
 
             If false, creation will be slower and cannot be done in a transaction.
-        :rtype: DatasetType
+        :rtype: Product
         """
         type_ = self.from_doc(definition)
         return self.update(
@@ -240,7 +240,7 @@ class ProductResource(AbstractProductResource):
         Return dataset types that have all the given fields.
 
         :param tuple[str] field_names:
-        :rtype: __generator[DatasetType]
+        :rtype: __generator[Product]
         """
         for type_ in self.get_all():
             for name in field_names:
@@ -254,7 +254,7 @@ class ProductResource(AbstractProductResource):
         Return dataset types that match match-able fields and dict of remaining un-matchable fields.
 
         :param dict query:
-        :rtype: __generator[(DatasetType, dict)]
+        :rtype: __generator[(Product, dict)]
         """
 
         def _listify(v):
@@ -297,7 +297,7 @@ class ProductResource(AbstractProductResource):
             else:
                 yield type_, remaining_matchable
 
-    def get_all(self) -> Iterable[DatasetType]:
+    def get_all(self) -> Iterable[Product]:
         """
         Retrieve all Products
         """
@@ -307,8 +307,8 @@ class ProductResource(AbstractProductResource):
     def _make_many(self, query_rows):
         return (self._make(c) for c in query_rows)
 
-    def _make(self, query_row) -> DatasetType:
-        return DatasetType(
+    def _make(self, query_row) -> Product:
+        return Product(
             definition=query_row['definition'],
             metadata_type=cast(MetadataType, self.metadata_type_resource.get(query_row['metadata_type_ref'])),
             id_=query_row['id'],

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -27,8 +27,8 @@ class Index(AbstractIndex):
     other connections are active. Or else use a separate instance of this class in each process.
 
     :ivar datacube.index._datasets.DatasetResource datasets: store and retrieve :class:`datacube.model.Dataset`
-    :ivar datacube.index._products.ProductResource products: store and retrieve :class:`datacube.model.DatasetType`\
-    (should really be called Product)
+    :ivar datacube.index._products.ProductResource products: store and retrieve :class:`datacube.model.Product`\
+    (formerly called DatasetType)
     :ivar datacube.index._metadata_types.MetadataTypeResource metadata_types: store and retrieve \
     :class:`datacube.model.MetadataType`
     :ivar UserResource users: user management

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -42,14 +42,14 @@ class Dataset:
     """
 
     def __init__(self,
-                 type_: 'DatasetType',
+                 type_: 'Product',
                  metadata_doc: Dict[str, Any],
                  uris: Optional[List[str]] = None,
                  sources: Optional[Mapping[str, 'Dataset']] = None,
                  indexed_by: Optional[str] = None,
                  indexed_time: Optional[datetime] = None,
                  archived_time: Optional[datetime] = None):
-        assert isinstance(type_, DatasetType)
+        assert isinstance(type_, Product)
 
         self.type = type_
 
@@ -369,7 +369,7 @@ class MetadataType:
 
 
 @schema_validated(SCHEMA_PATH / 'dataset-type-schema.yaml')
-class DatasetType:
+class Product:
     """
     Product definition
 
@@ -673,7 +673,7 @@ class DatasetType:
         return row
 
     def __str__(self) -> str:
-        return "DatasetType(name={name!r}, id_={id!r})".format(id=self.id, name=self.name)
+        return "Product(name={name!r}, id_={id!r})".format(id=self.id, name=self.name)
 
     def __repr__(self) -> str:
         return self.__str__()
@@ -691,6 +691,10 @@ class DatasetType:
 
     def __hash__(self):
         return hash(self.name)
+
+
+# Type alias for backwards compatibility
+DatasetType = Product
 
 
 @schema_validated(SCHEMA_PATH / 'ingestor-config-type-schema.yaml')

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update -y \
     && DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-change-held-packages --fix-missing --no-install-recommends \
         libpq-dev libudunits2-dev \
+        git \
         python3-dev python3-distutils python3-pip \
         build-essential \
         postgresql \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get update -y \
     && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
     && DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-change-held-packages --fix-missing --no-install-recommends \
-        git \
         libpq-dev libudunits2-dev \
         python3-dev python3-distutils python3-pip \
         build-essential \

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -20,6 +20,7 @@ v1.8.next
 - Add `exit_on_empty_file` message to `product` and `dataset` subcommands instead of returning no output when file is empty (:pull:`1294`)
 - Add flags to index drivers advertising what format datasets they support (eo/eo3/non-geo (e.g. telemetry only))
   and validate in the high-level API. General refactor and cleanup of eo3.py and hl.py. (:pull: `1296`)
+- Replace references to 'agdc' and 'dataset_type' in postgis driver with 'odc' and 'product'. (:pull: `1298`)
 
 v1.8.7 (7 June 2022)
 ====================

--- a/integration_tests/index/test_search.py
+++ b/integration_tests/index/test_search.py
@@ -1188,12 +1188,12 @@ def test_csv_search_via_cli(clirunner: Any,
 
 # Headers are currently in alphabetical order.
 _EXPECTED_OUTPUT_HEADER_LEGACY = 'creation_time,dataset_type_id,format,gsi,id,indexed_by,indexed_time,' \
-        'instrument,label,lat,lon,metadata_doc,metadata_type,metadata_type_id,' \
-        'orbit,platform,product,product_type,sat_path,sat_row,time,uri'
+    'instrument,label,lat,lon,metadata_doc,metadata_type,metadata_type_id,' \
+    'orbit,platform,product,product_type,sat_path,sat_row,time,uri'
 
 _EXPECTED_OUTPUT_HEADER = 'creation_time,format,gsi,id,indexed_by,indexed_time,instrument,label,' \
-        'lat,lon,metadata_doc,metadata_type,metadata_type_id,orbit,platform,' \
-        'product,product_id,product_type,sat_path,sat_row,time,uri'
+    'lat,lon,metadata_doc,metadata_type,metadata_type_id,orbit,platform,' \
+    'product,product_id,product_type,sat_path,sat_row,time,uri'
 
 
 def test_csv_structure(clirunner, pseudo_ls8_type, ls5_telem_type,

--- a/integration_tests/index/test_search.py
+++ b/integration_tests/index/test_search.py
@@ -1188,12 +1188,12 @@ def test_csv_search_via_cli(clirunner: Any,
 
 # Headers are currently in alphabetical order.
 _EXPECTED_OUTPUT_HEADER_LEGACY = 'creation_time,dataset_type_id,format,gsi,id,indexed_by,indexed_time,' \
-                          'instrument,label,lat,lon,metadata_doc,metadata_type,metadata_type_id,' \
-                          'orbit,platform,product,product_type,sat_path,sat_row,time,uri'
+        'instrument,label,lat,lon,metadata_doc,metadata_type,metadata_type_id,' \
+        'orbit,platform,product,product_type,sat_path,sat_row,time,uri'
 
 _EXPECTED_OUTPUT_HEADER = 'creation_time,format,gsi,id,indexed_by,indexed_time,instrument,label,' \
-                          'lat,lon,metadata_doc,metadata_type,metadata_type_id,orbit,platform,' \
-                          'product,product_id,product_type,sat_path,sat_row,time,uri'
+        'lat,lon,metadata_doc,metadata_type,metadata_type_id,orbit,platform,' \
+        'product,product_id,product_type,sat_path,sat_row,time,uri'
 
 
 def test_csv_structure(clirunner, pseudo_ls8_type, ls5_telem_type,

--- a/integration_tests/index/test_search.py
+++ b/integration_tests/index/test_search.py
@@ -1187,9 +1187,13 @@ def test_csv_search_via_cli(clirunner: Any,
 
 
 # Headers are currently in alphabetical order.
-_EXPECTED_OUTPUT_HEADER = 'creation_time,dataset_type_id,format,gsi,id,indexed_by,indexed_time,' \
+_EXPECTED_OUTPUT_HEADER_LEGACY = 'creation_time,dataset_type_id,format,gsi,id,indexed_by,indexed_time,' \
                           'instrument,label,lat,lon,metadata_doc,metadata_type,metadata_type_id,' \
                           'orbit,platform,product,product_type,sat_path,sat_row,time,uri'
+
+_EXPECTED_OUTPUT_HEADER = 'creation_time,format,gsi,id,indexed_by,indexed_time,instrument,label,' \
+                          'lat,lon,metadata_doc,metadata_type,metadata_type_id,orbit,platform,' \
+                          'product,product_id,product_type,sat_path,sat_row,time,uri'
 
 
 def test_csv_structure(clirunner, pseudo_ls8_type, ls5_telem_type,
@@ -1198,8 +1202,8 @@ def test_csv_structure(clirunner, pseudo_ls8_type, ls5_telem_type,
     lines = [line.strip() for line in output.split('\n') if line]
     # A header and two dataset rows
     assert len(lines) == 3
-
-    assert lines[0] == _EXPECTED_OUTPUT_HEADER
+    header_line = lines[0]
+    assert header_line in (_EXPECTED_OUTPUT_HEADER, _EXPECTED_OUTPUT_HEADER_LEGACY)
 
 
 # Current formulation of this test relies on non-EO3 test data


### PR DESCRIPTION
### Reason for this pull request

The legacy postgres driver contains some out-dated terminology for backwards compatibility reasons, in particular the use of "agdc" for some database entities, and the term "dataset_type" for what is usually referred to as "product".

There is no need to perpetuate these anachronisms in the new postgis driver.

### Proposed changes

- Replace all occurences of 'agdc' with 'odc' in postgis driver.
- Replace all occurences of 'dataset_type' and 'DatasetType' with '[Pp]roduct' in postgis driver.
- Add 'Product' to `datacube.model` as a synonym for DatasetType.


 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes
