### PR TITLE
Ensure SimpleDocNav.id is of type UUID, to improve lineage resolution

### DIFF
--- a/datacube/index/eo3.py
+++ b/datacube/index/eo3.py
@@ -9,7 +9,8 @@
 """
 from affine import Affine
 from functools import reduce
-from typing import Dict, Any, Iterable, Optional, Tuple
+from typing import Dict, Any, Iterable, Optional, Tuple, Union
+from uuid import UUID
 
 from datacube.utils.geometry import (
     SomeCRS,
@@ -217,6 +218,11 @@ def prep_eo3(doc: Dict[str, Any],
         if not is_doc_eo3(doc):
             return doc
 
+    def stringify(u: Optional[Union[str, UUID]]) -> Optional[str]:
+        return u if isinstance(u, str) else str(u) if u else None
+
+    doc['id'] = stringify(doc.get('id', None))
+
     doc = add_eo3_parts(doc, resolution=resolution)
     lineage = doc.pop('lineage', {})
 
@@ -228,11 +234,11 @@ def prep_eo3(doc: Dict[str, Any],
         if isinstance(uuids, dict) or isinstance(uuids[0], dict):
             raise ValueError("Embedded lineage not supported for eo3 metadata types")
         if len(uuids) == 1:
-            return {name: {'id': uuids[0]}}
+            return {name: {'id': stringify(uuids[0])}}
 
         out = {}
         for idx, uuid in enumerate(uuids, start=1):
-            out[name+str(idx)] = {'id': uuid}
+            out[name+str(idx)] = {'id': stringify(uuid)}
         return out
 
     sources = {}

--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -171,13 +171,14 @@ def dataset_resolver(index: AbstractIndex,
 
         ds_by_uuid = toolz.valmap(toolz.first, flatten_datasets(main_ds))
         all_uuid = list(ds_by_uuid)
-        db_dss = {str(ds.id): ds for ds in index.datasets.bulk_get(all_uuid)}
+        db_dss = {ds.id: ds for ds in index.datasets.bulk_get(all_uuid)}
 
         lineage_uuids = set(filter(lambda x: x != main_uuid, all_uuid))
         missing_lineage = lineage_uuids - set(db_dss)
 
         if missing_lineage and fail_on_missing_lineage:
-            return None, "Following lineage datasets are missing from DB: %s" % (','.join(missing_lineage))
+            return None, "Following lineage datasets are missing from DB: %s" % (
+                ','.join(str(m) for m in missing_lineage))
 
         if not is_doc_eo3(main_ds.doc):
             if is_doc_geo(main_ds.doc, check_eo3=False):
@@ -206,7 +207,7 @@ def dataset_resolver(index: AbstractIndex,
             return v
 
         def resolve_ds(ds: SimpleDocNav,
-                       sources: Optional[Mapping[str, Dataset]],
+                       sources: Optional[Mapping[UUID, Dataset]],
                        cache: MutableMapping[UUID, Dataset]) -> Dataset:
             cached = cache.get(ds.id)
             if cached is not None:

--- a/datacube/model/utils.py
+++ b/datacube/model/utils.py
@@ -353,7 +353,7 @@ def remap_lineage_doc(root, mk_node, **kwargs):
     try:
         return visit(root)
     except BadMatch as e:
-        if root.id not in str(e):
+        if str(root.id) not in str(e):
             raise BadMatch(f"Error loading lineage dataset: {e}") from None
         else:
             raise

--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -18,6 +18,7 @@ from urllib.parse import urlparse
 from urllib.request import urlopen
 from typing import Dict, Any, Mapping
 from copy import deepcopy
+from uuid import UUID
 
 import numpy
 import toolz  # type: ignore[import]
@@ -372,6 +373,7 @@ class SimpleDocNav(object):
         self._doc_without = None
         self._sources_path = ('lineage', 'source_datasets')
         self._sources = None
+        self._doc_uuid = None
 
     @property
     def doc(self):
@@ -386,7 +388,11 @@ class SimpleDocNav(object):
 
     @property
     def id(self):
-        return self._doc.get('id', None)
+        if not self._doc_uuid:
+            doc_id = self._doc.get('id', None)
+            if doc_id:
+                self._doc_uuid = doc_id if isinstance(doc_id, UUID) else UUID(doc_id)
+        return self._doc_uuid
 
     @property
     def sources(self):

--- a/integration_tests/index/test_memory_index.py
+++ b/integration_tests/index/test_memory_index.py
@@ -5,7 +5,6 @@
 import datetime
 
 import pytest
-from uuid import UUID
 from datacube.testutils import gen_dataset_test_dag
 
 from datacube.utils import InvalidDocException, read_documents, SimpleDocNav
@@ -549,7 +548,7 @@ def test_memory_dataset_add(dataset_add_configs, mem_index_fresh):
     for id_ in ds_ids:
         assert id_ in loc_ids
     ds_ = SimpleDocNav(gen_dataset_test_dag(1, force_tree=True))
-    assert UUID(ds_.id) in ds_ids
+    assert ds_.id in ds_ids
     ds_from_idx = idx.datasets.get(ds_.id, include_sources=True)
-    assert str(ds_from_idx.sources['ab'].id) == ds_.sources['ab'].id
-    assert str(ds_from_idx.sources['ac'].sources["cd"].id) == ds_.sources['ac'].sources['cd'].id
+    assert ds_from_idx.sources['ab'].id == ds_.sources['ab'].id
+    assert ds_from_idx.sources['ac'].sources["cd"].id == ds_.sources['ac'].sources['cd'].id

--- a/integration_tests/test_dataset_add.py
+++ b/integration_tests/test_dataset_add.py
@@ -25,7 +25,7 @@ def check_skip_lineage_test(clirunner, index):
 
     ds_ = index.datasets.get(ds.id, include_sources=True)
     assert ds_ is not None
-    assert str(ds_.id) == ds.id
+    assert ds_.id == ds.id
     assert ds_.sources == {}
 
     assert index.datasets.get(ds.sources['ab'].id) is None
@@ -234,31 +234,31 @@ def test_dataset_add(dataset_add_configs, index_empty, clirunner):
     doc2ds = Doc2Dataset(index)
     _ds, _err = doc2ds(ds.doc, 'file:///something')
     assert _err is None
-    assert str(_ds.id) == ds.id
+    assert _ds.id == ds.id
     assert _ds.metadata_doc == ds.doc
 
     # Check dataset search
     r = clirunner(['dataset', 'search'], expect_success=True)
-    assert ds.id in r.output
-    assert ds_bad1.id not in r.output
-    assert ds.sources['ab'].id in r.output
-    assert ds.sources['ac'].sources['cd'].id in r.output
+    assert str(ds.id) in r.output
+    assert str(ds_bad1.id) not in r.output
+    assert str(ds.sources['ab'].id) in r.output
+    assert str(ds.sources['ac'].sources['cd'].id) in r.output
 
-    r = clirunner(['dataset', 'info', '-f', 'csv', ds.id])
-    assert ds.id in r.output
+    r = clirunner(['dataset', 'info', '-f', 'csv', str(ds.id)])
+    assert str(ds.id) in r.output
 
-    r = clirunner(['dataset', 'info', '-f', 'yaml', '--show-sources', ds.id])
-    assert ds.sources['ae'].id in r.output
+    r = clirunner(['dataset', 'info', '-f', 'yaml', '--show-sources', str(ds.id)])
+    assert str(ds.sources['ae'].id) in r.output
 
-    r = clirunner(['dataset', 'info', '-f', 'yaml', '--show-derived', ds.sources['ae'].id])
-    assert ds.id in r.output
+    r = clirunner(['dataset', 'info', '-f', 'yaml', '--show-derived', str(ds.sources['ae'].id)])
+    assert str(ds.id) in r.output
 
     ds_ = SimpleDocNav(gen_dataset_test_dag(1, force_tree=True))
     assert ds_.id == ds.id
 
     x = index.datasets.get(ds.id, include_sources=True)
-    assert str(x.sources['ab'].id) == ds.sources['ab'].id
-    assert str(x.sources['ac'].sources['cd'].id) == ds.sources['ac'].sources['cd'].id
+    assert x.sources['ab'].id == ds.sources['ab'].id
+    assert x.sources['ac'].sources['cd'].id == ds.sources['ac'].sources['cd'].id
 
     check_skip_lineage_test(clirunner, index)
     check_no_product_match(clirunner, index)
@@ -453,11 +453,11 @@ measurements:
     print(r.output)
 
     r = clirunner(['dataset', 'search', '-f', 'csv'])
-    assert ds1.id not in r.output
-    assert ds2.id not in r.output
-    assert ds3.id not in r.output
-    assert ds4.id in r.output
-    assert ds5.id in r.output
+    assert str(ds1.id) not in r.output
+    assert str(ds2.id) not in r.output
+    assert str(ds3.id) not in r.output
+    assert str(ds4.id) in r.output
+    assert str(ds5.id) in r.output
 
 
 def dataset_archive_prep(dataset_add_configs, index_empty, clirunner):
@@ -483,8 +483,8 @@ def test_dataset_archive_dry_run(dataset_add_configs, index_empty, clirunner):
     non_existent_uuid = '00000000-1036-5607-a62f-fde5e3fec985'
 
     # Single valid UUID is detected and not archived
-    single_valid_uuid = clirunner(['dataset', 'archive', '--dry-run', ds.id])
-    assert ds.id in single_valid_uuid.output
+    single_valid_uuid = clirunner(['dataset', 'archive', '--dry-run', str(ds.id)])
+    assert str(ds.id) in single_valid_uuid.output
     assert index.datasets.has(ds.id) is True
 
     # Single invalid UUID is detected
@@ -498,7 +498,7 @@ def test_dataset_archive_dry_run(dataset_add_configs, index_empty, clirunner):
     valid_and_invalid_uuid = clirunner(['dataset',
                                         'archive',
                                         '--dry-run',
-                                        ds.id,
+                                        str(ds.id),
                                         non_existent_uuid],
                                        expect_success=False)
     assert non_existent_uuid in valid_and_invalid_uuid.output
@@ -509,7 +509,7 @@ def test_dataset_archive_dry_run(dataset_add_configs, index_empty, clirunner):
                                         'archive',
                                         '--dry-run',
                                         '--archive-derived',
-                                        ds.id,
+                                        str(ds.id),
                                         non_existent_uuid
                                         ],
                                        expect_success=False)
@@ -519,9 +519,11 @@ def test_dataset_archive_dry_run(dataset_add_configs, index_empty, clirunner):
 
     # Multiple Valid UUIDs
     # Not archived in the database and are shown in output
-    multiple_valid_uuid = clirunner(['dataset', 'archive', '--dry-run', ds.sources['ae'].id, ds.sources['ab'].id])
-    assert ds.sources['ae'].id in multiple_valid_uuid.output
-    assert ds.sources['ab'].id in multiple_valid_uuid.output
+    multiple_valid_uuid = clirunner([
+        'dataset', 'archive', '--dry-run',
+        str(ds.sources['ae'].id), str(ds.sources['ab'].id)])
+    assert str(ds.sources['ae'].id) in multiple_valid_uuid.output
+    assert str(ds.sources['ab'].id) in multiple_valid_uuid.output
     assert index.datasets.has(ds.sources['ae'].id) is True
     assert index.datasets.has(ds.sources['ab'].id) is True
 
@@ -529,11 +531,11 @@ def test_dataset_archive_dry_run(dataset_add_configs, index_empty, clirunner):
                                  'archive',
                                  '--dry-run',
                                  '--archive-derived',
-                                 ds.sources['ae'].id,
-                                 ds.sources['ab'].id
+                                 str(ds.sources['ae'].id),
+                                 str(ds.sources['ab'].id)
                                  ])
-    assert ds.id in archive_derived.output
-    assert ds.sources['ae'].id in archive_derived.output
+    assert str(ds.id) in archive_derived.output
+    assert str(ds.sources['ae'].id) in archive_derived.output
     assert index.datasets.has(ds.id) is True
 
 
@@ -545,15 +547,15 @@ def test_dataset_archive_restore_invalid(dataset_add_configs, index_empty, cliru
     non_existent_uuid = '00000000-1036-5607-a62f-fde5e3fec985'
 
     # With non-existent uuid, operations should halt.
-    r = clirunner(['dataset', 'archive', ds.id, non_existent_uuid], expect_success=False)
-    r = clirunner(['dataset', 'info', ds.id])
+    r = clirunner(['dataset', 'archive', str(ds.id), non_existent_uuid], expect_success=False)
+    r = clirunner(['dataset', 'info', str(ds.id)])
     assert 'status: archived' not in r.output
     assert index.datasets.has(ds.id) is True
 
     # With non-existent uuid, operations should halt.
     d_id = ds.sources['ac'].sources['cd'].id
-    r = clirunner(['dataset', 'archive', '--archive-derived', d_id, non_existent_uuid], expect_success=False)
-    r = clirunner(['dataset', 'info', ds.id, ds.sources['ab'].id, ds.sources['ac'].id])
+    r = clirunner(['dataset', 'archive', '--archive-derived', str(d_id), non_existent_uuid], expect_success=False)
+    r = clirunner(['dataset', 'info', str(ds.id), str(ds.sources['ab'].id), str(ds.sources['ac'].id)])
     assert 'status: active' in r.output
     assert 'status: archived' not in r.output
     assert index.datasets.has(ds.id) is True
@@ -565,30 +567,30 @@ def test_dataset_archive_restore(dataset_add_configs, index_empty, clirunner):
     p, index, ds = dataset_archive_prep(dataset_add_configs, index_empty, clirunner)
 
     # Run for real
-    r = clirunner(['dataset', 'archive', ds.id])
-    r = clirunner(['dataset', 'info', ds.id])
+    r = clirunner(['dataset', 'archive', str(ds.id)])
+    r = clirunner(['dataset', 'info', str(ds.id)])
     assert 'status: archived' in r.output
 
     # restore dry run
-    r = clirunner(['dataset', 'restore', '--dry-run', ds.id])
-    r = clirunner(['dataset', 'info', ds.id])
+    r = clirunner(['dataset', 'restore', '--dry-run', str(ds.id)])
+    r = clirunner(['dataset', 'info', str(ds.id)])
     assert 'status: archived' in r.output
 
     # restore for real
-    r = clirunner(['dataset', 'restore', ds.id])
-    r = clirunner(['dataset', 'info', ds.id])
+    r = clirunner(['dataset', 'restore', str(ds.id)])
+    r = clirunner(['dataset', 'info', str(ds.id)])
     assert 'status: active' in r.output
 
     # archive derived
     d_id = ds.sources['ac'].sources['cd'].id
-    r = clirunner(['dataset', 'archive', '--archive-derived', d_id])
-    r = clirunner(['dataset', 'info', ds.id, ds.sources['ab'].id, ds.sources['ac'].id])
+    r = clirunner(['dataset', 'archive', '--archive-derived', str(d_id)])
+    r = clirunner(['dataset', 'info', str(ds.id), str(ds.sources['ab'].id), str(ds.sources['ac'].id)])
     assert 'status: active' not in r.output
     assert 'status: archived' in r.output
 
     # restore derived
-    r = clirunner(['dataset', 'restore', '--restore-derived', d_id])
-    r = clirunner(['dataset', 'info', ds.id, ds.sources['ab'].id, ds.sources['ac'].id])
+    r = clirunner(['dataset', 'restore', '--restore-derived', str(d_id)])
+    r = clirunner(['dataset', 'info', str(ds.id), str(ds.sources['ab'].id), str(ds.sources['ac'].id)])
     assert 'status: active' in r.output
     assert 'status: archived' not in r.output
 


### PR DESCRIPTION
### Reason for this pull request

Fix issue #1300 [Doc2Dataset fails if lineage sources are specified as UUIDs rather than strings](https://github.com/opendatacube/datacube-core/issues/1300#)

### Proposed changes

- Let SimpleDocNav.id property return a UUID (instead of a string)

 - [X] Closes #1300
 - [X] Tests passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

