### PR TITLE
Populate spatial indexes

### DIFF
--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -285,7 +285,7 @@ class PostgisDbAPI(object):
         extent = self._sanitise_extent(extent, crs)
         if extent is None:
             return False
-        SpatialIndex = self._db.spatial_index(crs) # noqa: N806
+        SpatialIndex = self._db.spatial_index(crs)  # noqa: N806
         geom_alch = geom_alchemy(extent)
         r = self._connection.execute(
             insert(
@@ -402,7 +402,7 @@ class PostgisDbAPI(object):
             )
         )
         for crs in self._db.spatial_indexes():
-            SpatialIndex = self._db.spatial_index(crs) # noqa: N806
+            SpatialIndex = self._db.spatial_index(crs)  # noqa: N806
             self._connection.execute(
                 delete(
                     SpatialIndex

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -285,7 +285,7 @@ class PostgisDbAPI(object):
         extent = self._sanitise_extent(extent, crs)
         if extent is None:
             return False
-        SpatialIndex = self._db.spatial_index(crs)
+        SpatialIndex = self._db.spatial_index(crs) # noqa: N806
         geom_alch = geom_alchemy(extent)
         r = self._connection.execute(
             insert(
@@ -402,7 +402,7 @@ class PostgisDbAPI(object):
             )
         )
         for crs in self._db.spatial_indexes():
-            SpatialIndex = self._db.spatial_index(crs)
+            SpatialIndex = self._db.spatial_index(crs) # noqa: N806
             self._connection.execute(
                 delete(
                     SpatialIndex

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -20,12 +20,13 @@ from sqlalchemy import delete, update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy import select, text, and_, or_, func
 from sqlalchemy.dialects.postgresql import INTERVAL
-from typing import Iterable, Tuple
+from typing import Iterable, Tuple, Optional, Sequence
 
 from sqlalchemy.engine import Connection
 
 from datacube.index.fields import OrExpression
 from datacube.model import Range
+from utils.geometry import CRS
 from . import _core
 from . import _dynamic as dynamic
 from ._fields import parse_fields, Expression, PgField, PgExpression  # noqa: F401
@@ -598,6 +599,21 @@ class PostgisDbAPI(object):
         )
 
         return select((time_ranges.c.time_period, count_query.label('dataset_count')))
+
+    def update_spindex(self, crs: Optional[CRS] = None,
+                       product_names: Sequence[str]=[],
+                       dsids: Sequence[str] = []) -> int:
+        """
+        Update a spatial index
+        :param crs: CRS for Spatial Index to update, or None for all Spatial Indexes
+        :param product_names: Product names to update
+        :param dsids: Dataset IDs to update
+
+        if neither product_names nor dataset ids are supplied, update for all datasets.
+
+        :return:  Number of spatial index entries updated or verified as unindexed.
+        """
+        # TODO
 
     @staticmethod
     def _join_tables(source_table, expressions=None, fields=None):

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -22,8 +22,6 @@ from sqlalchemy import select, text, and_, or_, func
 from sqlalchemy.dialects.postgresql import INTERVAL
 from typing import Iterable, Tuple, Sequence
 
-from sqlalchemy.engine import Connection
-
 from datacube.index.fields import OrExpression
 from datacube.model import Range
 from datacube.utils import geometry

--- a/datacube/drivers/postgis/_connections.py
+++ b/datacube/drivers/postgis/_connections.py
@@ -236,10 +236,10 @@ class PostGisDb(object):
             self.spindexes[crs] = spidx
         return spidx
 
-    def spatial_index(self, crs: "datacube.utils.geometry.CRS") -> Optional[Type[SpatialIndex]]:
-        return self.spindexes.get(CRS)
+    def spatial_index(self, crs: CRS) -> Optional[Type[SpatialIndex]]:
+        return self.spindexes.get(crs)
 
-    def spatial_indexes(self, refresh=False) -> Iterable[Any]:
+    def spatial_indexes(self, refresh=False) -> Iterable[CRS]:
         if refresh:
             self._refresh_spindexes()
         return list(self.spindexes.keys())
@@ -260,7 +260,7 @@ class PostGisDb(object):
         connection from being reused while borrowed.
         """
         with self._engine.connect() as connection:
-            yield _api.PostgisDbAPI(connection)
+            yield _api.PostgisDbAPI(self, connection)
             connection.close()
 
     @contextmanager
@@ -282,7 +282,7 @@ class PostGisDb(object):
         with self._engine.connect() as connection:
             connection.execute(text('BEGIN'))
             try:
-                yield _api.PostgisDbAPI(connection)
+                yield _api.PostgisDbAPI(self, connection)
                 connection.execute(text('COMMIT'))
             except Exception:  # pylint: disable=broad-except
                 connection.execute(text('ROLLBACK'))

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from abc import ABC, abstractmethod
 from typing import (Any, Iterable, Iterator,
                     List, Mapping, Optional,
-                    Tuple, Union)
+                    Tuple, Union, Sequence)
 from uuid import UUID
 
 from datacube.config import LocalConfig
@@ -991,6 +991,27 @@ class AbstractIndex(ABC):
         :return:
         """
         return []
+
+    def update_spatial_index(self,
+                             crses: Sequence[CRS] = [],
+                             product_names: Sequence[str] = [],
+                             dataset_ids: Sequence[DSID] = []
+                             ) -> int:
+        """
+        Update a spatial index
+        :param crs: CRSs for Spatial Indexes to update. Default=all indexes
+        :param product_names: Product names to update
+        :param dsids: Dataset IDs to update
+
+        If neither product_names nor dataset ids are supplied, update for all datasets.
+
+        If both are supplied, both the named products and identified datasets are updated.
+
+        If spatial indexes are not supported by the index driver, always return zero.
+
+        :return:  Number of spatial index entries updated or verified as unindexed.
+        """
+        return 0
 
     def __enter__(self):
         return self

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -23,6 +23,7 @@ from datacube.utils.geometry import CRS
 
 _LOG = logging.getLogger(__name__)
 
+
 class AbstractUserResource(ABC):
     """
     Abstract base class for the User portion of an index api.

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2015-2022 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import datetime
+import logging
 from pathlib import Path
 
 from abc import ABC, abstractmethod
@@ -19,6 +20,8 @@ from datacube.utils import cached_property, read_documents, InvalidDocException
 from datacube.utils.changes import AllowPolicy, Change, Offset
 from datacube.utils.geometry import CRS
 
+
+_LOG = logging.getLogger(__name__)
 
 class AbstractUserResource(ABC):
     """
@@ -990,6 +993,7 @@ class AbstractIndex(ABC):
                         indexes recently created in another datacube session.
         :return:
         """
+        _LOG.warning("Spatial index API is unstable and may change between releases.")
         return []
 
     def update_spatial_index(self,
@@ -1011,6 +1015,7 @@ class AbstractIndex(ABC):
 
         :return:  Number of spatial index entries updated or verified as unindexed.
         """
+        _LOG.warning("Spatial index API is unstable and may change between releases.")
         return 0
 
     def __enter__(self):

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -3,10 +3,10 @@
 # Copyright (c) 2015-2020 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import logging
-from typing import Iterable
+from typing import Iterable, Sequence
 
 from datacube.drivers.postgis import PostGisDb
-from datacube.index.postgis._datasets import DatasetResource  # type: ignore
+from datacube.index.postgis._datasets import DatasetResource, DSID  # type: ignore
 from datacube.index.postgis._metadata_types import MetadataTypeResource
 from datacube.index.postgis._products import ProductResource
 from datacube.index.postgis._users import UserResource
@@ -118,6 +118,14 @@ WARNING: Database schema and internal APIs may change significantly between rele
 
     def spatial_indexes(self, refresh=False) -> Iterable[CRS]:
         return self._db.spatial_indexes(refresh)
+
+    def update_spatial_index(self,
+                             crses: Sequence[CRS] = [],
+                             product_names: Sequence[str] = [],
+                             dataset_ids: Sequence[DSID] = []
+                             ) -> int:
+        with self._db.connect() as conn:
+            return conn.update_spindex(crses, product_names, dataset_ids)
 
     def __repr__(self):
         return "Index<db={!r}>".format(self._db)

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -19,6 +19,7 @@ from typing import Optional, List, Mapping, Any, Dict, Tuple, Iterator, Iterable
 from urllib.parse import urlparse
 from datacube.utils import geometry, without_lineage_sources, parse_time, cached_property, uri_to_local_path, \
     schema_validated, DocReader
+from datacube.index.eo3 import is_doc_eo3
 from .fields import Field, get_dataset_fields
 from ._base import Range, ranges_overlap  # noqa: F401
 
@@ -71,6 +72,10 @@ class Dataset:
         self.indexed_time = indexed_time
         # When the dataset was archived. Null it not archived.
         self.archived_time = archived_time
+
+    @property
+    def is_eo3(self) -> bool:
+        return is_doc_eo3(self.metadata_doc)
 
     @property
     def metadata_type(self) -> 'MetadataType':

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,8 +8,10 @@ What's New
 v1.8.next
 =========
 
+
 - Migrate main test docker build to Ubuntu 22.04 and Python 3.10. (:pull:`1283`)
 - Dynamically create tables to serve as spatial indexes in postgis driver. (:pull:`1312`)
+- Populate spatial index tables, automatically and manually. (:pull:`1314`)
 - EO3 data fixtures and tests. Fix SQLAlchemy bugs in postgis driver. (:pull:`1309`)
 - Dependency updates. (:pull:`1308`, :pull:`1313`)
 - Remove several features that had been deprecated in previous releases. (:pull:`1275`)

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -120,6 +120,15 @@ def eo3_wo_dataset_doc():
 
 
 @pytest.fixture
+def eo3_africa_dataset_doc():
+    return (
+        get_eo3_test_data_doc("s2_africa_dataset.yaml"),
+        's3://deafrica-sentinel-2/sentinel-s2-l2a-cogs/37/M/CQ/'
+        '2022/8/S2A_37MCQ_20220808_0_L2A/S2A_37MCQ_20220808_0_L2A.json'
+    )
+
+
+@pytest.fixture
 def datasets_with_unembedded_lineage_doc():
     return [
         (
@@ -150,6 +159,11 @@ def base_eo3_product_doc():
     return get_eo3_test_data_doc("ga_ls_wo_3.odc-product.yaml")
 
 
+@pytest.fixture
+def africa_s2_product_doc():
+    return get_eo3_test_data_doc("s2_africa_product.yaml")
+
+
 def doc_to_ds(index, product_name, ds_doc, ds_path):
     from datacube.index.hl import Doc2Dataset
     resolver = Doc2Dataset(index, products=[product_name], verify_lineage=False)
@@ -174,6 +188,11 @@ def ls8_eo3_product(index, extended_eo3_metadata_type, extended_eo3_product_doc)
 @pytest.fixture
 def wo_eo3_product(index, base_eo3_product_doc):
     return index.products.add_document(base_eo3_product_doc)
+
+
+@pytest.fixture
+def africa_s2_eo3_product(index, africa_s2_product_doc):
+    return index.products.add_document(africa_s2_product_doc)
 
 
 @pytest.fixture
@@ -209,6 +228,13 @@ def wo_eo3_dataset(index, wo_eo3_product, eo3_wo_dataset_doc, ls8_eo3_dataset):
     return doc_to_ds(index,
                      wo_eo3_product.name,
                      *eo3_wo_dataset_doc)
+
+
+@pytest.fixture
+def africa_eo3_dataset(index, africa_s2_eo3_product, eo3_africa_dataset_doc):
+    return doc_to_ds(index,
+                     africa_s2_eo3_product.name,
+                     *eo3_africa_dataset_doc)
 
 
 @pytest.fixture

--- a/integration_tests/data/eo3/s2_africa_dataset.yaml
+++ b/integration_tests/data/eo3/s2_africa_dataset.yaml
@@ -1,0 +1,114 @@
+---
+# Dataset
+# url: https://explorer.digitalearth.africa/dataset/324fd220-388a-5501-bf2d-de00e78c93e6.odc-metadata.yaml
+$schema: https://schemas.opendatacube.org/dataset
+id: 324fd220-388a-5501-bf2d-de00e78c93e6
+
+label: S2A_MSIL2A_20220808T072631_N0400_R049_T37MCQ_20220808T111058
+product:
+  name: s2_l2a
+
+location: s3://deafrica-sentinel-2/sentinel-s2-l2a-cogs/37/M/CQ/2022/8/S2A_37MCQ_20220808_0_L2A/S2A_37MCQ_20220808_0_L2A.json
+
+crs: epsg:32737
+geometry:
+  type: Polygon
+  coordinates: [[[4.09799e+05, 9.390221e+06], [3.29704e+05, 9.390221e+06], [3.53943e+05,
+        9.500019e+06], [4.09799e+05, 9.500019e+06], [4.09799e+05, 9.390221e+06]]]
+grids:
+  g20m:
+    shape: [5490, 5490]
+    transform: [2.e+01, 0.e+00, 3.e+05, 0.e+00, -2.e+01, 9.50002e+06, 0.e+00, 0.e+00,
+      1.e+00]
+  g60m:
+    shape: [1830, 1830]
+    transform: [6.e+01, 0.e+00, 3.e+05, 0.e+00, -6.e+01, 9.50002e+06, 0.e+00, 0.e+00,
+      1.e+00]
+  g320m:
+    shape: [343, 343]
+    transform: [3.2e+02, 0.e+00, 3.e+05, 0.e+00, -3.2e+02, 9.50002e+06, 0.e+00, 0.e+00,
+      1.e+00]
+  default:
+    shape: [10980, 10980]
+    transform: [1.e+01, 0.e+00, 3.e+05, 0.e+00, -1.e+01, 9.50002e+06, 0.e+00, 0.e+00,
+      1.e+00]
+
+properties:
+  datetime: '2022-08-08T07:51:36Z'
+  eo:cloud_cover: 5.028e+01
+  eo:constellation: sentinel-2
+  eo:gsd: 10  # Ground sample distance (m)
+  eo:instrument: MSI
+  eo:off_nadir: 0
+  eo:platform: sentinel-2a
+  odc:file_format: GeoTIFF
+  odc:processing_datetime: '2022-08-08T07:51:36Z'
+  odc:region_code: 37MCQ
+  proj:epsg: 32737
+  sentinel:boa_offset_applied: true
+  sentinel:data_coverage: 6.191e+01
+  sentinel:grid_square: CQ
+  sentinel:latitude_band: M
+  sentinel:processing_baseline: '04.00'
+  sentinel:product_id: S2A_MSIL2A_20220808T072631_N0400_R049_T37MCQ_20220808T111058
+  sentinel:sequence: '0'
+  sentinel:utm_zone: 37
+  sentinel:valid_cloud_cover: true
+
+measurements:
+  AOT:
+    grid: g60m
+    path: AOT.tif
+  B01:
+    grid: g60m
+    path: B01.tif
+  B02:
+    path: B02.tif
+  B03:
+    path: B03.tif
+  B04:
+    path: B04.tif
+  B05:
+    grid: g20m
+    path: B05.tif
+  B06:
+    grid: g20m
+    path: B06.tif
+  B07:
+    grid: g20m
+    path: B07.tif
+  B08:
+    path: B08.tif
+  B09:
+    grid: g60m
+    path: B09.tif
+  B11:
+    grid: g20m
+    path: B11.tif
+  B12:
+    grid: g20m
+    path: B12.tif
+  B8A:
+    grid: g20m
+    path: B8A.tif
+  SCL:
+    grid: g20m
+    path: SCL.tif
+  WVP:
+    path: WVP.tif
+  visual:
+    path: TCI.tif
+  overview:
+    grid: g320m
+    path: L2A_PVI.tif
+
+accessories:
+  info:
+    path: https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/37/M/CQ/2022/8/8/0/tileInfo.json
+  metadata:
+    path: https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/37/M/CQ/2022/8/8/0/metadata.xml
+  thumbnail:
+    path: https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles/37/M/CQ/2022/8/8/0/preview.jpg
+
+lineage: {}
+...

--- a/integration_tests/data/eo3/s2_africa_product.yaml
+++ b/integration_tests/data/eo3/s2_africa_product.yaml
@@ -1,0 +1,144 @@
+---
+# Product
+# url: https://explorer.digitalearth.africa/products/s2_l2a.odc-product.yaml
+name: s2_l2a
+metadata_type: eo3
+description: Sentinel-2a and Sentinel-2b imagery, processed to Level 2A (Surface Reflectance)
+  and converted to Cloud Optimized GeoTIFFs
+metadata:
+  product:
+    name: s2_l2a
+measurements:
+- name: B01
+  dtype: uint16
+  units: '1'
+  nodata: 0
+  aliases:
+  - band_01
+  - coastal_aerosol
+- name: B02
+  dtype: uint16
+  units: '1'
+  nodata: 0
+  aliases:
+  - band_02
+  - blue
+- name: B03
+  dtype: uint16
+  units: '1'
+  nodata: 0
+  aliases:
+  - band_03
+  - green
+- name: B04
+  dtype: uint16
+  units: '1'
+  nodata: 0
+  aliases:
+  - band_04
+  - red
+- name: B05
+  dtype: uint16
+  units: '1'
+  nodata: 0
+  aliases:
+  - band_05
+  - red_edge_1
+- name: B06
+  dtype: uint16
+  units: '1'
+  nodata: 0
+  aliases:
+  - band_06
+  - red_edge_2
+- name: B07
+  dtype: uint16
+  units: '1'
+  nodata: 0
+  aliases:
+  - band_07
+  - red_edge_3
+- name: B08
+  dtype: uint16
+  units: '1'
+  nodata: 0
+  aliases:
+  - band_08
+  - nir
+  - nir_1
+- name: B8A
+  dtype: uint16
+  units: '1'
+  nodata: 0
+  aliases:
+  - band_8a
+  - nir_narrow
+  - nir_2
+- name: B09
+  dtype: uint16
+  units: '1'
+  nodata: 0
+  aliases:
+  - band_09
+  - water_vapour
+- name: B11
+  dtype: uint16
+  units: '1'
+  nodata: 0
+  aliases:
+  - band_11
+  - swir_1
+  - swir_16
+- name: B12
+  dtype: uint16
+  units: '1'
+  nodata: 0
+  aliases:
+  - band_12
+  - swir_2
+  - swir_22
+- name: SCL
+  dtype: uint8
+  units: '1'
+  nodata: 0
+  aliases:
+  - mask
+  - qa
+  flags_definition:
+    qa:
+      bits:
+      - 0
+      - 1
+      - 2
+      - 3
+      - 4
+      - 5
+      - 6
+      - 7
+      values:
+        '0': no data
+        '1': saturated or defective
+        '2': dark area pixels
+        '3': cloud shadows
+        '4': vegetation
+        '5': bare soils
+        '6': water
+        '7': unclassified
+        '8': cloud medium probability
+        '9': cloud high probability
+        '10': thin cirrus
+        '11': snow or ice
+      description: Sen2Cor Scene Classification
+- name: AOT
+  dtype: uint16
+  units: '1'
+  nodata: 0
+  aliases:
+  - aerosol_optical_thickness
+- name: WVP
+  dtype: uint16
+  units: '1'
+  nodata: 0
+  aliases:
+  - scene_average_water_vapour
+...

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -345,6 +345,7 @@ def test_index_dataset_with_sources(index, default_metadata_type):
     index.datasets.add(child, with_lineage=False)
 
 
+@pytest.mark.parametrize('datacube_env_name', ('datacube', ))
 def test_index_dataset_with_location(index: Index, default_metadata_type: MetadataType):
     first_file = Path('/tmp/first/something.yaml').absolute()
     second_file = Path('/tmp/second/something.yaml').absolute()

--- a/integration_tests/index/test_postgis_index.py
+++ b/integration_tests/index/test_postgis_index.py
@@ -9,7 +9,7 @@ from datacube.utils.geometry import CRS
 
 
 @pytest.mark.parametrize('datacube_env_name', ('experimental',))
-def test_spatial_index(index: Index):
+def test_create_spatial_index(index: Index):
     assert list(index.spatial_indexes()) == []
     # WKT CRS which cannot be mapped to an EPSG number.
     assert not index.create_spatial_index(CRS(
@@ -24,7 +24,7 @@ def test_spatial_index(index: Index):
 
 
 @pytest.mark.parametrize('datacube_env_name', ('experimental',))
-def test_spatial_index_populate(index: Index, ls8_eo3_product, eo3_ls8_dataset_doc):
+def test_spatial_index_maintain(index: Index, ls8_eo3_product, eo3_ls8_dataset_doc):
     index.create_spatial_index(CRS("EPSG:4326"))
     index.create_spatial_index(CRS("EPSG:3577"))
     assert set(index.spatial_indexes(refresh=True)) == {CRS("EPSG:3577"), CRS("EPSG:4326")}
@@ -36,4 +36,21 @@ def test_spatial_index_populate(index: Index, ls8_eo3_product, eo3_ls8_dataset_d
     assert ds
     index.datasets.archive([ds.id])
     index.datasets.purge([ds.id])
-    # Can't really read yet, but seems to write
+    # Can't really read yet, but seems to write at least
+
+
+@pytest.mark.parametrize('datacube_env_name', ('experimental',))
+def test_spatial_index_populate(index: Index, 
+                                ls8_eo3_product,
+                                wo_eo3_product,
+                                ls8_eo3_dataset, ls8_eo3_dataset2, 
+                                ls8_eo3_dataset3, ls8_eo3_dataset4,
+                                wo_eo3_dataset):
+    index.create_spatial_index(CRS("EPSG:4326"))
+    index.create_spatial_index(CRS("EPSG:3577"))
+    assert set(index.spatial_indexes(refresh=True)) == {CRS("EPSG:3577"), CRS("EPSG:4326")}
+    assert index.update_spatial_index(crses=[CRS("EPSG:4326")], dataset_ids=[ls8_eo3_dataset.id, ls8_eo3_dataset2.id]) == 2
+    assert index.update_spatial_index(product_names=[ls8_eo3_product.name]) == 8
+    assert index.update_spatial_index() == 10
+    assert index.update_spatial_index(crses=[CRS("EPSG:4326")], product_names=[wo_eo3_product.name], dataset_ids=[ls8_eo3_dataset.id]) == 2
+    assert index.update_spatial_index(product_names=[ls8_eo3_product.name], dataset_ids=[ls8_eo3_dataset.id]) == 8

--- a/integration_tests/index/test_postgis_index.py
+++ b/integration_tests/index/test_postgis_index.py
@@ -40,17 +40,59 @@ def test_spatial_index_maintain(index: Index, ls8_eo3_product, eo3_ls8_dataset_d
 
 
 @pytest.mark.parametrize('datacube_env_name', ('experimental',))
-def test_spatial_index_populate(index: Index, 
+def test_spatial_index_populate(index: Index,
                                 ls8_eo3_product,
                                 wo_eo3_product,
-                                ls8_eo3_dataset, ls8_eo3_dataset2, 
+                                ls8_eo3_dataset, ls8_eo3_dataset2,
                                 ls8_eo3_dataset3, ls8_eo3_dataset4,
                                 wo_eo3_dataset):
     index.create_spatial_index(CRS("EPSG:4326"))
     index.create_spatial_index(CRS("EPSG:3577"))
     assert set(index.spatial_indexes(refresh=True)) == {CRS("EPSG:3577"), CRS("EPSG:4326")}
-    assert index.update_spatial_index(crses=[CRS("EPSG:4326")], dataset_ids=[ls8_eo3_dataset.id, ls8_eo3_dataset2.id]) == 2
+    assert index.update_spatial_index(
+        crses=[CRS("EPSG:4326")],
+        dataset_ids=[ls8_eo3_dataset.id, ls8_eo3_dataset2.id]
+    ) == 2
     assert index.update_spatial_index(product_names=[ls8_eo3_product.name]) == 8
     assert index.update_spatial_index() == 10
-    assert index.update_spatial_index(crses=[CRS("EPSG:4326")], product_names=[wo_eo3_product.name], dataset_ids=[ls8_eo3_dataset.id]) == 2
+    assert index.update_spatial_index(
+        crses=[CRS("EPSG:4326")],
+        product_names=[wo_eo3_product.name],
+        dataset_ids=[ls8_eo3_dataset.id]
+    ) == 2
     assert index.update_spatial_index(product_names=[ls8_eo3_product.name], dataset_ids=[ls8_eo3_dataset.id]) == 8
+
+
+@pytest.mark.parametrize('datacube_env_name', ('experimental',))
+def test_spatial_index_crs_validity(index: Index,
+                                    ls8_eo3_product, ls8_eo3_dataset,
+                                    africa_s2_eo3_product, africa_eo3_dataset):
+    epsg4326 = CRS("EPSG:4326")
+    epsg3577 = CRS("EPSG:3577")
+    index.create_spatial_index(epsg4326)
+    index.create_spatial_index(epsg3577)
+    assert set(index.spatial_indexes(refresh=True)) == {epsg4326, epsg3577}
+    assert index.update_spatial_index(crses=[epsg4326]) == 2
+    assert index.update_spatial_index(crses=[epsg3577]) == 2
+
+
+def test_spatial_index_crs_santise():
+    epsg4326 = CRS("EPSG:4326")
+    epsg3577 = CRS("EPSG:3577")
+    from datacube.drivers.postgis._api import PostgisDbAPI
+    from datacube.utils.geometry import polygon
+    from math import isclose
+    # EPSG:4326 polygons to be converted in EPSG:3577
+    # Equal to entire valid region
+    entire = polygon(((112.85, -43.7), (112.85, -9.86), (153.69, -9.86), (153.69, -43.7), (112.85, -43.7)), crs=epsg4326)
+    # inside valid region
+    valid = polygon(((130.15, -25.7), (130.15, -19.86), (135.22, -19.86), (135.22, -25.7), (130.15, -25.7)), crs=epsg4326)
+    # completely outside valid region
+    invalid = polygon(((-10.15, 25.7), (-10.15, 33.86), (5.22, 33.86), (5.22, 25.7), (-10.15, 25.7)), crs=epsg4326)
+    # intersects valid region
+    partial = polygon(((103.15, -25.7), (103.15, -19.86), (135.22, -19.86), (135.22, -25.7), (103.15, -25.7)), crs=epsg4326)
+
+    assert PostgisDbAPI._sanitise_extent(entire, epsg3577) == entire.to_crs("EPSG:3577")
+    assert PostgisDbAPI._sanitise_extent(valid, epsg3577) == valid.to_crs("EPSG:3577")
+    assert PostgisDbAPI._sanitise_extent(partial, epsg3577).area < partial.to_crs("EPSG:3577").area
+    assert PostgisDbAPI._sanitise_extent(invalid, epsg3577) is None

--- a/integration_tests/index/test_postgis_index.py
+++ b/integration_tests/index/test_postgis_index.py
@@ -84,15 +84,35 @@ def test_spatial_index_crs_santise():
     from math import isclose
     # EPSG:4326 polygons to be converted in EPSG:3577
     # Equal to entire valid region
-    entire = polygon(((112.85, -43.7), (112.85, -9.86), (153.69, -9.86), (153.69, -43.7), (112.85, -43.7)), crs=epsg4326)
+    entire = polygon((
+        (112.85, -43.7),
+        (112.85, -9.86),
+        (153.69, -9.86),
+        (153.69, -43.7),
+        (112.85, -43.7)), crs=epsg4326)
     # inside valid region
-    valid = polygon(((130.15, -25.7), (130.15, -19.86), (135.22, -19.86), (135.22, -25.7), (130.15, -25.7)), crs=epsg4326)
+    valid = polygon((
+        (130.15, -25.7),
+        (130.15, -19.86),
+        (135.22, -19.86),
+        (135.22, -25.7),
+        (130.15, -25.7)), crs=epsg4326)
     # completely outside valid region
-    invalid = polygon(((-10.15, 25.7), (-10.15, 33.86), (5.22, 33.86), (5.22, 25.7), (-10.15, 25.7)), crs=epsg4326)
+    invalid = polygon((
+        (-10.15, 25.7),
+        (-10.15, 33.86),
+        (5.22, 33.86),
+        (5.22, 25.7),
+        (-10.15, 25.7)), crs=epsg4326)
     # intersects valid region
-    partial = polygon(((103.15, -25.7), (103.15, -19.86), (135.22, -19.86), (135.22, -25.7), (103.15, -25.7)), crs=epsg4326)
+    partial = polygon((
+        (103.15, -25.7),
+        (103.15, -19.86),
+        (135.22, -19.86),
+        (135.22, -25.7),
+        (103.15, -25.7)), crs=epsg4326)
 
     assert PostgisDbAPI._sanitise_extent(entire, epsg3577) == entire.to_crs("EPSG:3577")
     assert PostgisDbAPI._sanitise_extent(valid, epsg3577) == valid.to_crs("EPSG:3577")
-    assert PostgisDbAPI._sanitise_extent(partial, epsg3577).area < partial.to_crs("EPSG:3577").area
     assert PostgisDbAPI._sanitise_extent(invalid, epsg3577) is None
+    assert PostgisDbAPI._sanitise_extent(partial, epsg3577).area < partial.to_crs("EPSG:3577").area

--- a/integration_tests/index/test_postgis_index.py
+++ b/integration_tests/index/test_postgis_index.py
@@ -21,3 +21,19 @@ def test_spatial_index(index: Index):
     assert index.create_spatial_index(CRS("EPSG:3577"))
     assert index.create_spatial_index(CRS("WGS-84"))
     assert set(index.spatial_indexes(refresh=True)) == {CRS("EPSG:3577"), CRS("EPSG:4326")}
+
+
+@pytest.mark.parametrize('datacube_env_name', ('experimental',))
+def test_spatial_index_populate(index: Index, ls8_eo3_product, eo3_ls8_dataset_doc):
+    index.create_spatial_index(CRS("EPSG:4326"))
+    index.create_spatial_index(CRS("EPSG:3577"))
+    assert set(index.spatial_indexes(refresh=True)) == {CRS("EPSG:3577"), CRS("EPSG:4326")}
+    from datacube.index.hl import Doc2Dataset
+    resolver = Doc2Dataset(index, products=[ls8_eo3_product.name], verify_lineage=False)
+    ds, err = resolver(*eo3_ls8_dataset_doc)
+    assert err is None and ds is not None
+    ds = index.datasets.add(ds)
+    assert ds
+    index.datasets.archive([ds.id])
+    index.datasets.purge([ds.id])
+    # Can't really read yet, but seems to write

--- a/integration_tests/index/test_postgis_index.py
+++ b/integration_tests/index/test_postgis_index.py
@@ -81,7 +81,6 @@ def test_spatial_index_crs_santise():
     epsg3577 = CRS("EPSG:3577")
     from datacube.drivers.postgis._api import PostgisDbAPI
     from datacube.utils.geometry import polygon
-    from math import isclose
     # EPSG:4326 polygons to be converted in EPSG:3577
     # Equal to entire valid region
     entire = polygon((


### PR DESCRIPTION
### Reason for this pull request

A recent PR gave the postgis driver the ability to create spatial index tables.  This PR adds support for populating these index tables.

Ideally spatial indexes are created before any datasets are added to the index - this is invisible

### Proposed changes

- Spatial indexes can be populated auutomatically and incrementally - all standard dataset add/update/purge operations will automatically update all relevant spatial index tables.
- If a spatial index is created after the dataset table is already populated an update_spatial_index method is supplied to populate spatial index tables in bulk. (new api method)
- CRS valid regions are checked and indexed extents are sanitised.  i.e. if there is a spatial index for CRS C and the extent of dataset D is outside of C's valid region, then dataset D will not be included in the spatial index.  If dataset D's extent overlaps C's valid region, then the indexed extent will be cropped to the valid region.

### To be addressed in future PRs:

- actually querying spatial indexes for search queries.
- API needs further refinement
- spatial Index for EPSG:4326 created by default as part of database initialisation.
- CLI for managing spatial indexes.

 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes


