### PR TITLE
Url signing callback

### DIFF
--- a/.github/workflows/docker-test-runner.yml
+++ b/.github/workflows/docker-test-runner.yml
@@ -58,7 +58,7 @@ jobs:
         outputs: type=docker
         build-args: |
           V_BASE=3.3.0
-          V_PG=12
+          V_PG=14
         cache-from: |
           type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -44,6 +44,7 @@ jobs:
           fetch-depth: 0
       - name: Install dependencies and run pylint
         run: |
+          sudo apt-get remove python3-openssl
           pip install --upgrade -e '.[test]'
           pip install pylint
           pylint -j 2 --reports no datacube
@@ -57,6 +58,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Run pycodestyle
         run: |
+          sudo apt-get remove python3-openssl
           pip install --upgrade -e '.[test]'
           pip install pycodestyle
           pycodestyle tests integration_tests examples --max-line-length 120

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -662,7 +662,8 @@ class Datacube(object):
     @staticmethod
     def _xr_load(sources, geobox, measurements,
                  skip_broken_datasets=False,
-                 progress_cbk=None, extra_dims=None):
+                 progress_cbk=None, extra_dims=None,
+                 patch_url=None):
 
         def mk_cbk(cbk):
             if cbk is None:

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -773,7 +773,6 @@ class Datacube(object):
         """
         measurements = per_band_load_data_settings(measurements, resampling=resampling, fuse_func=fuse_func)
 
-
         if dask_chunks is not None:
             # TODO: url mangler for Dask?
             return Datacube._dask_load(sources, geobox, measurements, dask_chunks,

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -774,7 +774,9 @@ class Datacube(object):
         measurements = per_band_load_data_settings(measurements, resampling=resampling, fuse_func=fuse_func)
 
         if dask_chunks is not None:
-            # TODO: url mangler for Dask?
+            if patch_url is not None:
+                # TODO: url mangler for Dask?
+                raise ValueError("The patch_url arguments is not currently supported for Dask loading.")
             return Datacube._dask_load(sources, geobox, measurements, dask_chunks,
                                        skip_broken_datasets=skip_broken_datasets,
                                        extra_dims=extra_dims)

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -377,7 +377,8 @@ class Datacube(object):
             only applicable to non-lazy loads, ignored when using dask.
 
         :param Callable[[str], str], patch_url:
-            if supplied, will be used to patch/sign the url(s), as required to access some commercial archives.
+            if supplied, will be used to patch/sign the url(s), as required to access some commercial archives
+            (e.g. Microsoft Planetary Computer).
 
         :return:
             Requested data in a :class:`xarray.Dataset`

--- a/datacube/testutils/__init__.py
+++ b/datacube/testutils/__init__.py
@@ -383,6 +383,7 @@ def gen_tiff_dataset(bands,
                      base_folder,
                      prefix='',
                      timestamp='2018-07-19',
+                     base_folder_of_record=None,
                      **kwargs):
     """
        each band:
@@ -394,6 +395,9 @@ def gen_tiff_dataset(bands,
     """
     from .io import write_gtiff
     from pathlib import Path
+
+    if base_folder_of_record is None:
+        base_folder_of_record = base_folder
 
     if not isinstance(bands, Sequence):
         bands = (bands,)
@@ -416,7 +420,7 @@ def gen_tiff_dataset(bands,
                        layer=1,
                        dtype=meta.dtype))
 
-    uri = Path(base_folder/'metadata.yaml').absolute().as_uri()
+    uri = Path(base_folder_of_record/'metadata.yaml').absolute().as_uri()
     ds = mk_sample_dataset(mm,
                            uri=uri,
                            timestamp=timestamp,

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -35,7 +35,7 @@ v1.8.next
   stable. (:pull: `1305`)
 - Implement `patch_url` argument to `dc.load()` and `dc.load_data()` to provide a way to sign dataset URIs, as
   is required to access some commercial archives (e.g. Microsoft Planetary Computer).  API is based on the `odc-stac`
-  implementation. Only works for direct loading.  More work required for deferred (i.e. Dask) loading. (:pull: `xxxx`)
+  implementation. Only works for direct loading.  More work required for deferred (i.e. Dask) loading. (:pull: `1317`)
 
 
 v1.8.7 (7 June 2022)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -33,6 +33,10 @@ v1.8.next
   Portions of API dealing with lineage handling, locations, and dynamic indexes are currently broken in the postgis
   driver. As per the warning message, the postgis driver is currently flagged as "experimental" and is not considered
   stable. (:pull: `1305`)
+- Implement `patch_url` argument to `dc.load()` and `dc.load_data()` to provide a way to sign dataset URIs, as
+  is required to access some commercial archives (e.g. Microsoft Planetary Computer).  API is based on the `odc-stac`
+  implementation. Only works for direct loading.  More work required for deferred (i.e. Dask) loading. (:pull: `xxxx`)
+
 
 v1.8.7 (7 June 2022)
 ====================

--- a/tests/storage/test_base.py
+++ b/tests/storage/test_base.py
@@ -78,3 +78,23 @@ def test_band_info():
     ds = mk_sample_dataset(bands, uri='/not/a/uri')
     band = BandInfo(ds, 'a')
     assert band.uri_scheme is ''  # noqa: F632
+
+
+def test_band_info_with_url_mangling():
+    def url_mangler(raw):
+        return raw.replace("tmp", "tmp/mangled")
+
+    bands = [dict(name=n,
+                  dtype='uint8',
+                  units='K',
+                  nodata=33,
+                  path=n+'.tiff')
+             for n in 'a b c'.split(' ')]
+
+    ds = mk_sample_dataset(bands,
+                           uri='file:///tmp/datataset.yml',
+                           format='GeoTIFF')
+
+    binfo = BandInfo(ds, 'b', patch_url=url_mangler)
+    assert binfo.name == 'b'
+    assert binfo.uri == 'file:///tmp/mangled/b.tiff'

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -78,6 +78,7 @@ def test_load_data(tmpdir):
 def test_load_data_with_url_mangling(tmpdir):
     actual_tmpdir = Path(str(tmpdir))
     recorded_tmpdir = Path(str(tmpdir / "not" / "actual" / "location"))
+
     def url_mangler(raw):
         actual_uri_root = actual_tmpdir.absolute().as_uri()
         recorded_uri_root = recorded_tmpdir.absolute().as_uri()

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -75,6 +75,69 @@ def test_load_data(tmpdir):
     assert progress_call_data == [(1, 2), (2, 2)]
 
 
+def test_load_data_with_url_mangling(tmpdir):
+    actual_tmpdir = Path(str(tmpdir))
+    recorded_tmpdir = Path(str(tmpdir / "not" / "actual" / "location"))
+    def url_mangler(raw):
+        actual_uri_root = actual_tmpdir.absolute().as_uri()
+        recorded_uri_root = recorded_tmpdir.absolute().as_uri()
+        return raw.replace(recorded_uri_root, actual_uri_root)
+
+    group_by = query_group_by('time')
+    spatial = dict(resolution=(15, -15),
+                   offset=(11230, 1381110),)
+
+    nodata = -999
+    aa = mk_test_image(96, 64, 'int16', nodata=nodata)
+
+    ds, gbox = gen_tiff_dataset([SimpleNamespace(name='aa', values=aa, nodata=nodata)],
+                                tmpdir,
+                                prefix='ds1-',
+                                timestamp='2018-07-19',
+                                base_folder_of_record=recorded_tmpdir,
+                                **spatial)
+    assert ds.time is not None
+
+    ds2, _ = gen_tiff_dataset([SimpleNamespace(name='aa', values=aa, nodata=nodata)],
+                              tmpdir,
+                              prefix='ds2-',
+                              timestamp='2018-07-19',
+                              base_folder_of_record=recorded_tmpdir,
+                              **spatial)
+    assert ds.time is not None
+    assert ds.time == ds2.time
+
+    sources = Datacube.group_datasets([ds], 'time')
+    sources2 = Datacube.group_datasets([ds, ds2], group_by)
+
+    mm = ['aa']
+    mm = [ds.type.measurements[k] for k in mm]
+
+    ds_data = Datacube.load_data(sources, gbox, mm, patch_url=url_mangler)
+    assert ds_data.aa.nodata == nodata
+    np.testing.assert_array_equal(aa, ds_data.aa.values[0])
+
+    custom_fuser_call_count = 0
+
+    def custom_fuser(dest, delta):
+        nonlocal custom_fuser_call_count
+        custom_fuser_call_count += 1
+        dest[:] += delta
+
+    progress_call_data = []
+
+    def progress_cbk(n, nt):
+        progress_call_data.append((n, nt))
+
+    ds_data = Datacube.load_data(sources2, gbox, mm, fuse_func=custom_fuser,
+                                 progress_cbk=progress_cbk, patch_url=url_mangler)
+    assert ds_data.aa.nodata == nodata
+    assert custom_fuser_call_count > 0
+    np.testing.assert_array_equal(nodata + aa + aa, ds_data.aa.values[0])
+
+    assert progress_call_data == [(1, 2), (2, 2)]
+
+
 def test_load_data_cbk(tmpdir):
     from datacube.api import TerminateCurrentLoad
 


### PR DESCRIPTION
### Reason for this pull request

Some commercial providers (e.g. Microsoft Planetary Computer) require signing of urls at load time.  An API for this functionality is already available in `odc-stac` but no equivalent functionality is available in `datacube-core`.

### Proposed changes

- Implemented `odc-stac` style `patch_url` argument to `dc.load()` and `dc.load_data()` (and lower level APIs as required).
- Only implemented for direct load path.  Deferred (i.e dask) load will require some further work.

API is:
```
def patch_func(raw_url):
     # Function takes str (unsigned url as stored in odc database) and returns str (signed url, as required by provider)
     return sign_url(raw_url, my_key)

dc.load(..., patch_url=patch_func)
```

 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
