### PR TITLE
Database Transaction API - as per EP07.

### DIFF
--- a/datacube/drivers/postgis/__init__.py
+++ b/datacube/drivers/postgis/__init__.py
@@ -9,5 +9,6 @@ This package tries to contain any SQLAlchemy and database-specific code.
 """
 
 from ._connections import PostGisDb
+from ._api import PostgisDbAPI
 
-__all__ = ['PostGisDb']
+__all__ = ['PostGisDb', 'PostgisDbAPI']

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -182,6 +182,9 @@ class PostgisDbAPI(object):
     def in_transaction(self):
         return self._connection.in_transaction()
 
+    def commit(self):
+        self._connection.execute(text('COMMIT'))
+
     def rollback(self):
         self._connection.execute(text('ROLLBACK'))
 

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -182,6 +182,9 @@ class PostgisDbAPI(object):
     def in_transaction(self):
         return self._connection.in_transaction()
 
+    def begin(self):
+        self._connection.execute(text('BEGIN'))
+
     def commit(self):
         self._connection.execute(text('COMMIT'))
 

--- a/datacube/drivers/postgis/_connections.py
+++ b/datacube/drivers/postgis/_connections.py
@@ -245,7 +245,7 @@ class PostGisDb(object):
         return list(self.spindexes.keys())
 
     @contextmanager
-    def connect(self):
+    def _connect(self):
         """
         Borrow a connection from the pool.
 
@@ -258,35 +258,12 @@ class PostGisDb(object):
         The connection can raise errors if not following this advice ("server closed the connection unexpectedly"),
         as some servers will aggressively close idle connections (eg. DEA's NCI servers). It also prevents the
         connection from being reused while borrowed.
+
+        Low level context manager, user self._db_connection instead
         """
         with self._engine.connect() as connection:
-            yield _api.PostgisDbAPI(self, connection)
-            connection.close()
-
-    @contextmanager
-    def begin(self):
-        """
-        Start a transaction.
-
-        Returns an instance that will maintain a single connection in a transaction.
-
-        Call commit() or rollback() to complete the transaction or use a context manager:
-
-            with db.begin() as trans:
-                trans.insert_dataset(...)
-
-        (Don't share an instance between threads)
-
-        :rtype: PostgresDBAPI
-        """
-        with self._engine.connect() as connection:
-            connection.execute(text('BEGIN'))
             try:
                 yield _api.PostgisDbAPI(self, connection)
-                connection.execute(text('COMMIT'))
-            except Exception:  # pylint: disable=broad-except
-                connection.execute(text('ROLLBACK'))
-                raise
             finally:
                 connection.close()
 

--- a/datacube/drivers/postgis/_connections.py
+++ b/datacube/drivers/postgis/_connections.py
@@ -259,7 +259,7 @@ class PostGisDb(object):
         as some servers will aggressively close idle connections (eg. DEA's NCI servers). It also prevents the
         connection from being reused while borrowed.
 
-        Low level context manager, user self._db_connection instead
+        Low level context manager, use <index_resource>._db_connection instead
         """
         with self._engine.connect() as connection:
             try:

--- a/datacube/drivers/postgis/_connections.py
+++ b/datacube/drivers/postgis/_connections.py
@@ -19,7 +19,7 @@ import re
 from contextlib import contextmanager
 from typing import Any, Callable, Iterable, Mapping, Optional, Union, Type
 
-from sqlalchemy import event, create_engine, text
+from sqlalchemy import event, create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.engine.url import URL as EngineUrl  # noqa: N811
 

--- a/datacube/drivers/postgres/__init__.py
+++ b/datacube/drivers/postgres/__init__.py
@@ -9,5 +9,6 @@ This package tries to contain any SQLAlchemy and database-specific code.
 """
 
 from ._connections import PostgresDb
+from ._api import PostgresDbAPI
 
-__all__ = ['PostgresDb']
+__all__ = ['PostgresDb', 'PostgresDbAPI']

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -185,6 +185,9 @@ class PostgresDbAPI(object):
     def rollback(self):
         self._connection.execute(text('ROLLBACK'))
 
+    def commit(self):
+        self._connection.execute(text('COMMIT'))
+
     def execute(self, command):
         return self._connection.execute(command)
 

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -182,6 +182,9 @@ class PostgresDbAPI(object):
     def in_transaction(self):
         return self._connection.in_transaction()
 
+    def begin(self):
+        self._connection.execute(text('BEGIN'))
+
     def rollback(self):
         self._connection.execute(text('ROLLBACK'))
 

--- a/datacube/drivers/postgres/_connections.py
+++ b/datacube/drivers/postgres/_connections.py
@@ -19,7 +19,7 @@ import re
 from contextlib import contextmanager
 from typing import Callable, Optional, Union
 
-from sqlalchemy import event, create_engine, text
+from sqlalchemy import event, create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.engine.url import URL as EngineUrl  # noqa: N811
 

--- a/datacube/drivers/postgres/_connections.py
+++ b/datacube/drivers/postgres/_connections.py
@@ -207,7 +207,7 @@ class PostgresDb(object):
         return is_new
 
     @contextmanager
-    def connect(self):
+    def _connect(self):
         """
         Borrow a connection from the pool.
 
@@ -220,35 +220,12 @@ class PostgresDb(object):
         The connection can raise errors if not following this advice ("server closed the connection unexpectedly"),
         as some servers will aggressively close idle connections (eg. DEA's NCI servers). It also prevents the
         connection from being reused while borrowed.
+
+        Low level context manager, user self._db_connection instead
         """
         with self._engine.connect() as connection:
-            yield _api.PostgresDbAPI(connection)
-            connection.close()
-
-    @contextmanager
-    def begin(self):
-        """
-        Start a transaction.
-
-        Returns an instance that will maintain a single connection in a transaction.
-
-        Call commit() or rollback() to complete the transaction or use a context manager:
-
-            with db.begin() as trans:
-                trans.insert_dataset(...)
-
-        (Don't share an instance between threads)
-
-        :rtype: PostgresDBAPI
-        """
-        with self._engine.connect() as connection:
-            connection.execute(text('BEGIN'))
             try:
                 yield _api.PostgresDbAPI(connection)
-                connection.execute(text('COMMIT'))
-            except Exception:  # pylint: disable=broad-except
-                connection.execute(text('ROLLBACK'))
-                raise
             finally:
                 connection.close()
 

--- a/datacube/drivers/postgres/_connections.py
+++ b/datacube/drivers/postgres/_connections.py
@@ -221,7 +221,7 @@ class PostgresDb(object):
         as some servers will aggressively close idle connections (eg. DEA's NCI servers). It also prevents the
         connection from being reused while borrowed.
 
-        Low level context manager, user self._db_connection instead
+        Low level context manager, use <index_resource>._db_connection instead
         """
         with self._engine.connect() as connection:
             try:

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -1025,8 +1025,8 @@ class AbstractTransaction(ABC):
 
         Calls implementation-specific _commit() method, and manages thread local storage and locks.
         """
-        with self.lock:
-            if self._connection is not None:
+        with self.obj_lock:
+            if self._connection is None:
                 raise ValueError("Cannot commit inactive transaction")
             self._commit()
             self._release_connection()
@@ -1041,8 +1041,8 @@ class AbstractTransaction(ABC):
 
         Calls implementation-specific _rollback() method, and manages thread local storage and locks.
         """
-        with self.lock:
-            if self._connection is not None:
+        with self.obj_lock:
+            if self._connection is None:
                 raise ValueError("Cannot rollback inactive transaction")
             self._rollback()
             self._release_connection()
@@ -1066,7 +1066,8 @@ class AbstractTransaction(ABC):
         if stored_val is not None:
             raise ValueError("Cannot start a new transaction as one is already active for this thread")
         self._connection = self._new_connection()
-        thread_local_cache(self.tls_id, self, purge=True)
+        thread_local_cache(self.tls_id, purge=True)
+        thread_local_cache(self.tls_id, self)
 
     def _tls_purge(self) -> None:
         thread_local_cache(self.tls_id, purge=True)

--- a/datacube/index/exceptions.py
+++ b/datacube/index/exceptions.py
@@ -16,7 +16,7 @@ class IndexSetupError(Exception):
     pass
 
 
-class TransactionException(Exception):
+class TransactionException(Exception):  # noqa: N818
     def __init__(self, *args, commit=False, **kwargs):
         super().__init__(*args, **kwargs)
         self.commit = commit

--- a/datacube/index/exceptions.py
+++ b/datacube/index/exceptions.py
@@ -14,3 +14,9 @@ class MissingRecordError(Exception):
 
 class IndexSetupError(Exception):
     pass
+
+
+class TransactionException(Exception):
+    def __init__(self, *args, commit=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.commit = commit

--- a/datacube/index/memory/index.py
+++ b/datacube/index/memory/index.py
@@ -56,8 +56,12 @@ class Index(AbstractIndex):
     def url(self) -> str:
         return "memory"
 
+    @property
+    def index_id(self) -> str:
+        return self._index_id
+
     def transaction(self) -> UnhandledTransaction:
-        return UnhandledTransaction(self._index_id)
+        return UnhandledTransaction(self.index_id)
 
     @classmethod
     def from_config(cls, config, application_name=None, validate_connection=True):

--- a/datacube/index/memory/index.py
+++ b/datacube/index/memory/index.py
@@ -3,17 +3,22 @@
 # Copyright (c) 2015-2022 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import logging
+from threading import Lock
 
 from datacube.index.memory._datasets import DatasetResource  # type: ignore
 from datacube.index.memory._fields import get_dataset_fields
 from datacube.index.memory._metadata_types import MetadataTypeResource
 from datacube.index.memory._products import ProductResource
 from datacube.index.memory._users import UserResource
-from datacube.index.abstract import AbstractIndex, AbstractIndexDriver
+from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, UnhandledTransaction
 from datacube.model import MetadataType
 from datacube.utils.geometry import CRS
 
 _LOG = logging.getLogger(__name__)
+
+
+counter = 0
+counter_lock = Lock()
 
 
 class Index(AbstractIndex):
@@ -26,6 +31,10 @@ class Index(AbstractIndex):
         self._metadata_types = MetadataTypeResource()
         self._products = ProductResource(self.metadata_types)
         self._datasets = DatasetResource(self.products)
+        global counter
+        with counter_lock:
+            counter = counter + 1
+            self._index_id = f"memory={counter}"
 
     @property
     def users(self) -> UserResource:
@@ -46,6 +55,9 @@ class Index(AbstractIndex):
     @property
     def url(self) -> str:
         return "memory"
+
+    def transaction(self) -> UnhandledTransaction:
+        return UnhandledTransaction(self._index_id)
 
     @classmethod
     def from_config(cls, config, application_name=None, validate_connection=True):

--- a/datacube/index/null/index.py
+++ b/datacube/index/null/index.py
@@ -8,7 +8,7 @@ from datacube.index.null._datasets import DatasetResource  # type: ignore
 from datacube.index.null._metadata_types import MetadataTypeResource
 from datacube.index.null._products import ProductResource
 from datacube.index.null._users import UserResource
-from datacube.index.abstract import AbstractIndex, AbstractIndexDriver
+from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, UnhandledTransaction
 from datacube.model import MetadataType
 from datacube.model.fields import get_dataset_fields
 from datacube.utils.geometry import CRS
@@ -48,6 +48,9 @@ class Index(AbstractIndex):
     @property
     def url(self) -> str:
         return "null"
+
+    def transaction(self) -> UnhandledTransaction:
+        return UnhandledTransaction("null")
 
     @classmethod
     def from_config(cls, config, application_name=None, validate_connection=True):

--- a/datacube/index/null/index.py
+++ b/datacube/index/null/index.py
@@ -49,8 +49,12 @@ class Index(AbstractIndex):
     def url(self) -> str:
         return "null"
 
+    @property
+    def index_id(self) -> str:
+        return "null"
+
     def transaction(self) -> UnhandledTransaction:
-        return UnhandledTransaction("null")
+        return UnhandledTransaction(self.index_id)
 
     @classmethod
     def from_config(cls, config, application_name=None, validate_connection=True):

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -893,5 +893,5 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         return custom_exprs
 
     def spatial_extent(self, ids: Iterable[DSID], crs: CRS = CRS("EPSG:4326")) -> Optional[Geometry]:
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             return connection.spatial_extent(ids, crs)

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -38,14 +38,15 @@ class DatasetResource(AbstractDatasetResource):
     :type types: datacube.index._products.ProductResource
     """
 
-    def __init__(self, db, product_resource):
+    def __init__(self, db, index):
         """
         :type db: datacube.drivers.postgis._connections.PostgresDb
         :type product_resource: datacube.index._products.ProductResource
         """
         self._db = db
-        self.types = product_resource
-        self.products = product_resource
+        self._index = index
+        self.types = self._index.products   # types is a compatibility alias for products.
+        self.products = self._index.products
 
     def get(self, id_: Union[str, UUID], include_sources=False):
         """

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -17,6 +17,7 @@ from sqlalchemy import select, func
 from datacube.drivers.postgis._fields import SimpleDocField, DateDocField
 from datacube.drivers.postgis._schema import Dataset as SQLDataset
 from datacube.index.abstract import AbstractDatasetResource, DatasetSpatialMixin, DSID
+from datacube.index.postgis._transaction import IndexResourceAddIn
 from datacube.model import Dataset, Product
 from datacube.model.fields import Field
 from datacube.model.utils import flatten_datasets
@@ -32,7 +33,7 @@ _LOG = logging.getLogger(__name__)
 # pylint: disable=too-many-public-methods, too-many-lines
 
 
-class DatasetResource(AbstractDatasetResource):
+class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
     """
     :type _db: datacube.drivers.postgis._connections.PostgresDb
     :type types: datacube.index._products.ProductResource
@@ -59,7 +60,7 @@ class DatasetResource(AbstractDatasetResource):
         if isinstance(id_, str):
             id_ = UUID(id_)
 
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             if not include_sources:
                 dataset = connection.get_dataset(id_)
                 return self._make(dataset, full_info=True) if dataset else None
@@ -88,7 +89,7 @@ class DatasetResource(AbstractDatasetResource):
 
         ids = [to_uuid(i) for i in ids]
 
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             rows = connection.get_datasets(ids)
             return [self._make(r, full_info=True) for r in rows]
 
@@ -101,7 +102,7 @@ class DatasetResource(AbstractDatasetResource):
         """
         if not isinstance(id_, UUID):
             id_ = UUID(id_)
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             return [
                 self._make(result, full_info=True)
                 for result in connection.get_derived_datasets(id_)
@@ -114,7 +115,7 @@ class DatasetResource(AbstractDatasetResource):
         :param typing.Union[UUID, str] id_: dataset id
         :rtype: bool
         """
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             return connection.contains_dataset(id_)
 
     def bulk_has(self, ids_):
@@ -127,7 +128,7 @@ class DatasetResource(AbstractDatasetResource):
 
         :rtype: [bool]
         """
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             existing = set(connection.datasets_intersection(ids_))
 
         return [x in existing for x in
@@ -194,7 +195,7 @@ class DatasetResource(AbstractDatasetResource):
 
             dss = [dataset]
 
-        with self._db.begin() as transaction:
+        with self._db_connection(transaction=True) as transaction:
             process_bunch(dss, dataset, transaction)
 
         return dataset
@@ -219,7 +220,7 @@ class DatasetResource(AbstractDatasetResource):
 
         expressions = [product.metadata_type.dataset_fields.get('product') == product.name]
 
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             for record in connection.get_duplicates(group_fields, expressions):
                 dataset_ids = set(record[0])
                 grouped_fields = tuple(record[1:])
@@ -289,7 +290,7 @@ class DatasetResource(AbstractDatasetResource):
         _LOG.info("Updating dataset %s", dataset.id)
 
         product = self.types.get_by_name(dataset.type.name)
-        with self._db.begin() as transaction:
+        with self._db_connection(transaction=True) as transaction:
             if not transaction.update_dataset(dataset.metadata_doc_without_lineage(), dataset.id, product.id):
                 raise ValueError("Failed to update dataset %s..." % dataset.id)
 
@@ -308,7 +309,7 @@ class DatasetResource(AbstractDatasetResource):
         # front of a stack
         for uri in new_uris[::-1]:
             if transaction is None:
-                with self._db.begin() as tr:
+                with self._db_connection(transaction=True) as tr:
                     insert_one(uri, tr)
             else:
                 insert_one(uri, transaction)
@@ -319,7 +320,7 @@ class DatasetResource(AbstractDatasetResource):
 
         :param Iterable[UUID] ids: list of dataset ids to archive
         """
-        with self._db.begin() as transaction:
+        with self._db_connection(transaction=True) as transaction:
             for id_ in ids:
                 transaction.archive_dataset(id_)
 
@@ -329,7 +330,7 @@ class DatasetResource(AbstractDatasetResource):
 
         :param Iterable[UUID] ids: list of dataset ids to restore
         """
-        with self._db.begin() as transaction:
+        with self._db_connection(transaction=True) as transaction:
             for id_ in ids:
                 transaction.restore_dataset(id_)
 
@@ -339,7 +340,7 @@ class DatasetResource(AbstractDatasetResource):
 
         :param ids: iterable of dataset ids to purge
         """
-        with self._db.begin() as transaction:
+        with self._db_connection(transaction=True) as transaction:
             for id_ in ids:
                 transaction.delete_dataset(id_)
 
@@ -353,7 +354,7 @@ class DatasetResource(AbstractDatasetResource):
         :param archived:
         :rtype: list[UUID]
         """
-        with self._db.begin() as transaction:
+        with self._db_connection(transaction=True) as transaction:
             return [dsid[0] for dsid in transaction.all_dataset_ids(archived)]
 
     def get_field_names(self, product_name=None):
@@ -380,7 +381,7 @@ class DatasetResource(AbstractDatasetResource):
         :param typing.Union[UUID, str] id_: dataset id
         :rtype: list[str]
         """
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             return connection.get_locations(id_)
 
     def get_archived_locations(self, id_):
@@ -390,7 +391,7 @@ class DatasetResource(AbstractDatasetResource):
         :param typing.Union[UUID, str] id_: dataset id
         :rtype: list[str]
         """
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             return [uri for uri, archived_dt in connection.get_archived_locations(id_)]
 
     def get_archived_location_times(self, id_):
@@ -400,7 +401,7 @@ class DatasetResource(AbstractDatasetResource):
         :param typing.Union[UUID, str] id_: dataset id
         :rtype: List[Tuple[str, datetime.datetime]]
         """
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             return list(connection.get_archived_locations(id_))
 
     def add_location(self, id_, uri):
@@ -415,7 +416,7 @@ class DatasetResource(AbstractDatasetResource):
             warnings.warn("Cannot add empty uri. (dataset %s)" % id_)
             return False
 
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             return connection.insert_dataset_location(id_, uri)
 
     def get_datasets_for_location(self, uri, mode=None):
@@ -426,7 +427,7 @@ class DatasetResource(AbstractDatasetResource):
         :param str mode: 'exact', 'prefix' or None (to guess)
         :return:
         """
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             return (self._make(row) for row in connection.get_datasets_for_location(uri, mode=mode))
 
     def remove_location(self, id_, uri):
@@ -437,7 +438,7 @@ class DatasetResource(AbstractDatasetResource):
         :param str uri: fully qualified uri
         :returns bool: Was one removed?
         """
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             was_removed = connection.remove_location(id_, uri)
             return was_removed
 
@@ -449,7 +450,7 @@ class DatasetResource(AbstractDatasetResource):
         :param str uri: fully qualified uri
         :return bool: location was able to be archived
         """
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             was_archived = connection.archive_location(id_, uri)
             return was_archived
 
@@ -461,7 +462,7 @@ class DatasetResource(AbstractDatasetResource):
         :param str uri: fully qualified uri
         :return bool: location was able to be restored
         """
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             was_restored = connection.restore_location(id_, uri)
             return was_restored
 
@@ -502,7 +503,7 @@ class DatasetResource(AbstractDatasetResource):
         :param dict metadata:
         :rtype: list[Dataset]
         """
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             for dataset in self._make_many(connection.search_datasets_by_metadata(metadata)):
                 yield dataset
 
@@ -651,7 +652,7 @@ class DatasetResource(AbstractDatasetResource):
                 else:
                     select_fields = tuple(dataset_fields[field_name]
                                           for field_name in select_field_names)
-            with self._db.connect() as connection:
+            with self._db_connection() as connection:
                 yield (product,
                        connection.search_datasets(
                            query_exprs,
@@ -667,7 +668,7 @@ class DatasetResource(AbstractDatasetResource):
         for q, product in product_queries:
             dataset_fields = product.metadata_type.dataset_fields
             query_exprs = tuple(fields.to_expressions(dataset_fields.get, **q))
-            with self._db.connect() as connection:
+            with self._db_connection() as connection:
                 count = connection.count_datasets(query_exprs)
             if count > 0:
                 yield product, count
@@ -692,7 +693,7 @@ class DatasetResource(AbstractDatasetResource):
         for q, product in product_queries:
             dataset_fields = product.metadata_type.dataset_fields
             query_exprs = tuple(fields.to_expressions(dataset_fields.get, **q))
-            with self._db.connect() as connection:
+            with self._db_connection() as connection:
                 yield product, list(connection.count_datasets_through_time(
                     start,
                     end,
@@ -739,7 +740,7 @@ class DatasetResource(AbstractDatasetResource):
                                 offset=max_offset,
                                 selection='greatest')
 
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             result = connection.execute(
                 select(
                     [func.min(time_min.alchemy_expression), func.max(time_max.alchemy_expression)]
@@ -793,7 +794,7 @@ class DatasetResource(AbstractDatasetResource):
                 class DatasetLight(result_type):  # type: ignore
                     __slots__ = ()
 
-            with self._db.connect() as connection:
+            with self._db_connection() as connection:
                 results = connection.search_unique_datasets(
                     query_exprs,
                     select_fields=select_fields,

--- a/datacube/index/postgis/_metadata_types.py
+++ b/datacube/index/postgis/_metadata_types.py
@@ -7,6 +7,7 @@ import logging
 from cachetools.func import lru_cache
 
 from datacube.index.abstract import AbstractMetadataTypeResource
+from datacube.index.postgis._transaction import IndexResourceAddIn
 from datacube.model import MetadataType
 from datacube.utils import jsonify_document, changes, _readable_offset
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes
@@ -14,7 +15,7 @@ from datacube.utils.changes import check_doc_unchanged, get_doc_changes
 _LOG = logging.getLogger(__name__)
 
 
-class MetadataTypeResource(AbstractMetadataTypeResource):
+class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
     def __init__(self, db, index):
         """
         :type db: datacube.drivers.postgis._connections.PostgresDb
@@ -68,7 +69,7 @@ class MetadataTypeResource(AbstractMetadataTypeResource):
                 'Metadata Type {}'.format(metadata_type.name)
             )
         else:
-            with self._db.connect() as connection:
+            with self._db_connection() as connection:
                 connection.insert_metadata_type(
                     name=metadata_type.name,
                     definition=metadata_type.definition,
@@ -142,7 +143,7 @@ class MetadataTypeResource(AbstractMetadataTypeResource):
 
         _LOG.info("Updating metadata type %s", metadata_type.name)
 
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             connection.update_metadata_type(
                 name=metadata_type.name,
                 definition=metadata_type.definition,
@@ -168,7 +169,7 @@ class MetadataTypeResource(AbstractMetadataTypeResource):
     # This is memoized in the constructor
     # pylint: disable=method-hidden
     def get_unsafe(self, id_):  # type: ignore
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             record = connection.get_metadata_type(id_)
         if record is None:
             raise KeyError('%s is not a valid MetadataType id')
@@ -177,7 +178,7 @@ class MetadataTypeResource(AbstractMetadataTypeResource):
     # This is memoized in the constructor
     # pylint: disable=method-hidden
     def get_by_name_unsafe(self, name):  # type: ignore
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             record = connection.get_metadata_type_by_name(name)
         if not record:
             raise KeyError('%s is not a valid MetadataType name' % name)
@@ -193,7 +194,7 @@ class MetadataTypeResource(AbstractMetadataTypeResource):
 
             If false, creation will be slightly slower and cannot be done in a transaction.
         """
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             connection.check_dynamic_fields(
                 concurrently=not allow_table_lock,
                 rebuild_indexes=rebuild_indexes,
@@ -206,7 +207,7 @@ class MetadataTypeResource(AbstractMetadataTypeResource):
 
         :rtype: iter[datacube.model.MetadataType]
         """
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             return self._make_many(connection.get_all_metadata_types())
 
     def _make_many(self, query_rows):

--- a/datacube/index/postgis/_metadata_types.py
+++ b/datacube/index/postgis/_metadata_types.py
@@ -15,11 +15,12 @@ _LOG = logging.getLogger(__name__)
 
 
 class MetadataTypeResource(AbstractMetadataTypeResource):
-    def __init__(self, db):
+    def __init__(self, db, index):
         """
         :type db: datacube.drivers.postgis._connections.PostgresDb
         """
         self._db = db
+        self._index = index
 
         self.get_unsafe = lru_cache()(self.get_unsafe)
         self.get_by_name_unsafe = lru_cache()(self.get_by_name_unsafe)

--- a/datacube/index/postgis/_products.py
+++ b/datacube/index/postgis/_products.py
@@ -23,13 +23,14 @@ class ProductResource(AbstractProductResource):
     :type metadata_type_resource: datacube.index._metadata_types.MetadataTypeResource
     """
 
-    def __init__(self, db, metadata_type_resource):
+    def __init__(self, db, index):
         """
         :type db: datacube.drivers.postgis._connections.PostgresDb
         :type metadata_type_resource: datacube.index._metadata_types.MetadataTypeResource
         """
         self._db = db
-        self.metadata_type_resource = metadata_type_resource
+        self._index = index
+        self.metadata_type_resource = self._index.metadata_types
 
         self.get_unsafe = lru_cache()(self.get_unsafe)
         self.get_by_name_unsafe = lru_cache()(self.get_by_name_unsafe)

--- a/datacube/index/postgis/_products.py
+++ b/datacube/index/postgis/_products.py
@@ -8,6 +8,7 @@ from cachetools.func import lru_cache
 
 from datacube.index import fields
 from datacube.index.abstract import AbstractProductResource
+from datacube.index.postgis._transaction import IndexResourceAddIn
 from datacube.model import Product, MetadataType
 from datacube.utils import jsonify_document, changes, _readable_offset
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes
@@ -17,7 +18,7 @@ from typing import Iterable, cast
 _LOG = logging.getLogger(__name__)
 
 
-class ProductResource(AbstractProductResource):
+class ProductResource(AbstractProductResource, IndexResourceAddIn):
     """
     :type _db: datacube.drivers.postgis._connections.PostgresDb
     :type metadata_type_resource: datacube.index._metadata_types.MetadataTypeResource
@@ -75,7 +76,7 @@ class ProductResource(AbstractProductResource):
                 _LOG.warning('Adding metadata_type "%s" as it doesn\'t exist.', product.metadata_type.name)
                 metadata_type = self.metadata_type_resource.add(product.metadata_type,
                                                                 allow_table_lock=allow_table_lock)
-            with self._db.connect() as connection:
+            with self._db_connection() as connection:
                 connection.insert_product(
                     name=product.name,
                     metadata=product.metadata_doc,
@@ -184,7 +185,7 @@ class ProductResource(AbstractProductResource):
         metadata_type = self.metadata_type_resource.get_by_name(product.metadata_type.name)
         # TODO: should we add metadata type here?
         assert metadata_type, "TODO: should we add metadata type here?"
-        with self._db.connect() as conn:
+        with self._db_connection() as conn:
             conn.update_product(
                 name=product.name,
                 metadata=product.metadata_doc,
@@ -222,7 +223,7 @@ class ProductResource(AbstractProductResource):
     # This is memoized in the constructor
     # pylint: disable=method-hidden
     def get_unsafe(self, id_):  # type: ignore
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             result = connection.get_product(id_)
         if not result:
             raise KeyError('"%s" is not a valid Product id' % id_)
@@ -231,7 +232,7 @@ class ProductResource(AbstractProductResource):
     # This is memoized in the constructor
     # pylint: disable=method-hidden
     def get_by_name_unsafe(self, name):  # type: ignore
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             result = connection.get_product_by_name(name)
         if not result:
             raise KeyError('"%s" is not a valid Product name' % name)
@@ -306,7 +307,7 @@ class ProductResource(AbstractProductResource):
         """
         Retrieve all Products
         """
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             return (self._make(record) for record in connection.get_all_products())
 
     def _make_many(self, query_rows):

--- a/datacube/index/postgis/_transaction.py
+++ b/datacube/index/postgis/_transaction.py
@@ -3,8 +3,6 @@
 # Copyright (c) 2015-2022 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import logging
-
 from contextlib import contextmanager
 from sqlalchemy import text
 from typing import Any
@@ -13,7 +11,6 @@ from datacube.drivers.postgis import PostGisDb
 from datacube.drivers.postgis._api import PostgisDbAPI
 from datacube.index.abstract import AbstractTransaction
 
-_LOG = logging.getLogger(__name__)
 
 class PostgisTransaction(AbstractTransaction):
     def __init__(self, db: PostGisDb, idx_id: str) -> None:

--- a/datacube/index/postgis/_transaction.py
+++ b/datacube/index/postgis/_transaction.py
@@ -9,21 +9,21 @@ from contextlib import contextmanager
 from sqlalchemy import text
 from typing import Any
 
-from datacube.drivers.postgres import PostgresDb
-from datacube.drivers.postgres._api import PostgresDbAPI
+from datacube.drivers.postgis import PostGisDb
+from datacube.drivers.postgis._api import PostgisDbAPI
 from datacube.index.abstract import AbstractTransaction
 
 _LOG = logging.getLogger(__name__)
 
-class PostgresTransaction(AbstractTransaction):
-    def __init__(self, db: PostgresDb, idx_id: str) -> None:
+class PostgisTransaction(AbstractTransaction):
+    def __init__(self, db: PostGisDb, idx_id: str) -> None:
         super().__init__(idx_id)
         self._db = db
 
     def _new_connection(self) -> Any:
         dbconn = self._db.give_me_a_connection()
         dbconn.execute(text('BEGIN'))
-        conn = PostgresDbAPI(dbconn)
+        conn = PostgisDbAPI(self._db, dbconn)
         return conn
 
     def _commit(self) -> None:
@@ -39,7 +39,7 @@ class PostgresTransaction(AbstractTransaction):
 
 class IndexResourceAddIn:
     @contextmanager
-    def _db_connection(self, transaction: bool = False) -> PostgresDbAPI:
+    def _db_connection(self, transaction: bool = False) -> PostgisDbAPI:
         """
         Context manager representing a database connection.
 

--- a/datacube/index/postgis/_transaction.py
+++ b/datacube/index/postgis/_transaction.py
@@ -61,23 +61,5 @@ class IndexResourceAddIn:
         :param transaction: Use a transaction if one is not already active for the thread.
         :return: A PostgresDbAPI object, with the specified transaction semantics.
         """
-        trans = self._index.thread_transaction()
-        closing = False
-        if trans is not None:
-            # Use active transaction
-            yield trans._connection
-        elif transaction:
-            closing = True
-            with self._db._connect() as conn:
-                conn.begin()
-                try:
-                    yield conn
-                    conn.commit()
-                except Exception:  # pylint: disable=broad-except
-                    conn.rollback()
-                    raise
-        else:
-            closing = True
-            # Autocommit behaviour:
-            with self._db._connect() as conn:
-                yield conn
+        with self._index._active_connection(transaction=transaction) as conn:
+            yield conn

--- a/datacube/index/postgis/_transaction.py
+++ b/datacube/index/postgis/_transaction.py
@@ -68,10 +68,16 @@ class IndexResourceAddIn:
             yield trans._connection
         elif transaction:
             closing = True
-            with self._db.begin() as conn:
-                yield conn
+            with self._db._connect() as conn:
+                conn.begin()
+                try:
+                    yield conn
+                    conn.commit()
+                except Exception:  # pylint: disable=broad-except
+                    conn.rollback()
+                    raise
         else:
             closing = True
             # Autocommit behaviour:
-            with self._db.connect() as conn:
+            with self._db._connect() as conn:
                 yield conn

--- a/datacube/index/postgis/_users.py
+++ b/datacube/index/postgis/_users.py
@@ -4,10 +4,11 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import Iterable, Optional, Tuple
 from datacube.index.abstract import AbstractUserResource
+from datacube.index.postgis._transaction import IndexResourceAddIn
 from datacube.drivers.postgis import PostGisDb
 
 
-class UserResource(AbstractUserResource):
+class UserResource(AbstractUserResource, IndexResourceAddIn):
     def __init__(self, db: PostGisDb, index: "datacube.index.postgis.index.Index") -> None:
         """
         :type db: datacube.drivers.postgis.PostGisDb
@@ -19,7 +20,7 @@ class UserResource(AbstractUserResource):
         """
         Grant a role to users
         """
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             connection.grant_role(role, usernames)
 
     def create_user(self, username: str, password: str,
@@ -27,14 +28,14 @@ class UserResource(AbstractUserResource):
         """
         Create a new user.
         """
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             connection.create_user(username, password, role, description=description)
 
     def delete_user(self, *usernames: str) -> None:
         """
         Delete a user
         """
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             connection.drop_users(usernames)
 
     def list_users(self) -> Iterable[Tuple[str, str, Optional[str]]]:
@@ -42,6 +43,6 @@ class UserResource(AbstractUserResource):
         :return: list of (role, user, description)
         :rtype: list[(str, str, str)]
         """
-        with self._db.connect() as connection:
+        with self._db_connection() as connection:
             for role, user, description in connection.list_users():
                 yield role, user, description

--- a/datacube/index/postgis/_users.py
+++ b/datacube/index/postgis/_users.py
@@ -8,11 +8,12 @@ from datacube.drivers.postgis import PostGisDb
 
 
 class UserResource(AbstractUserResource):
-    def __init__(self, db: PostGisDb) -> None:
+    def __init__(self, db: PostGisDb, index: "datacube.index.postgis.index.Index") -> None:
         """
         :type db: datacube.drivers.postgis.PostGisDb
         """
         self._db = db
+        self._index = index
 
     def grant_role(self, role: str, *usernames: str) -> None:
         """

--- a/datacube/index/postgis/_users.py
+++ b/datacube/index/postgis/_users.py
@@ -9,7 +9,10 @@ from datacube.drivers.postgis import PostGisDb
 
 
 class UserResource(AbstractUserResource, IndexResourceAddIn):
-    def __init__(self, db: PostGisDb, index: "datacube.index.postgis.index.Index") -> None:
+    def __init__(self,
+                 db: PostGisDb,
+                 index: "datacube.index.postgis.index.Index"  # noqa: F821
+                ) -> None:
         """
         :type db: datacube.drivers.postgis.PostGisDb
         """

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -136,7 +136,7 @@ WARNING: Database schema and internal APIs may change significantly between rele
                              product_names: Sequence[str] = [],
                              dataset_ids: Sequence[DSID] = []
                              ) -> int:
-        with self._db.connect() as conn:
+        with self.datasets._db_connection(transaction=True) as conn:
             return conn.update_spindex(crses, product_names, dataset_ids)
 
     def __repr__(self):

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 from contextlib import contextmanager
-from typing import Any, Iterable, Sequence
+from typing import Iterable, Sequence
 
 from datacube.drivers.postgis import PostGisDb, PostgisDbAPI
 from datacube.index.postgis._transaction import PostgisTransaction

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -75,10 +75,10 @@ WARNING:
 WARNING: Database schema and internal APIs may change significantly between releases. Use at your own risk.""")
         self._db = db
 
-        self._users = UserResource(db)
-        self._metadata_types = MetadataTypeResource(db)
-        self._products = ProductResource(db, self.metadata_types)
-        self._datasets = DatasetResource(db, self.products)
+        self._users = UserResource(db, self)
+        self._metadata_types = MetadataTypeResource(db, self)
+        self._products = ProductResource(db, self)
+        self._datasets = DatasetResource(db, self)
 
     @property
     def users(self) -> UserResource:

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any, Iterable, Sequence
 
 from datacube.drivers.postgis import PostGisDb
+from datacube.index.postgis._transaction import PostgisTransaction
 from datacube.index.postgis._datasets import DatasetResource, DSID  # type: ignore
 from datacube.index.postgis._metadata_types import MetadataTypeResource
 from datacube.index.postgis._products import ProductResource
@@ -15,24 +16,6 @@ from datacube.model import MetadataType
 from datacube.utils.geometry import CRS
 
 _LOG = logging.getLogger(__name__)
-
-
-class PostgisTransaction(AbstractTransaction):
-    def __init__(self, db: PostGisDb, idx_id: str) -> None:
-        super().__init__(idx_id)
-        self._db = db
-
-    def _new_connection(self) -> Any:
-        return self._db.begin()
-
-    def _commit(self) -> None:
-        self._connection.commit()
-
-    def _rollback(self) -> None:
-        self._connection.rollback()
-
-    def _release_connection(self) -> None:
-        self._connection.close()
 
 
 class Index(AbstractIndex):

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -10,7 +10,7 @@ from datacube.index.postgis._datasets import DatasetResource, DSID  # type: igno
 from datacube.index.postgis._metadata_types import MetadataTypeResource
 from datacube.index.postgis._products import ProductResource
 from datacube.index.postgis._users import UserResource
-from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, default_metadata_type_docs
+from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, default_metadata_type_docs, AbstractTransaction
 from datacube.model import MetadataType
 from datacube.utils.geometry import CRS
 
@@ -48,6 +48,7 @@ class Index(AbstractIndex):
     # Hopefully can reinstate a simpler form of lineage support, but leave for now
     supports_lineage = False
     supports_source_filters = False
+    supports_transactions = True
 
     def __init__(self, db: PostGisDb) -> None:
         # POSTGIS driver is not stable with respect to database schema or internal APIs.
@@ -114,6 +115,10 @@ WARNING: Database schema and internal APIs may change significantly between rele
         (Connections are normally closed automatically when this object is deleted: ie. no references exist)
         """
         self._db.close()
+
+    def transaction(self) -> AbstractTransaction:
+        # TODO
+        return None
 
     def create_spatial_index(self, crs: CRS) -> bool:
         sp_idx = self._db.create_spatial_index(crs)

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -116,6 +116,10 @@ WARNING: Database schema and internal APIs may change significantly between rele
         """
         self._db.close()
 
+    @property
+    def index_id(self) -> str:
+        return self.url
+
     def transaction(self) -> AbstractTransaction:
         # TODO
         return None

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -1,6 +1,6 @@
 # This file is part of the Open Data Cube, see https://opendatacube.org for more information
 #
-# Copyright (c) 2015-2020 ODC Contributors
+# Copyright (c) 2015-2022 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 """
 API for dataset indexing, access and search.
@@ -17,6 +17,7 @@ from sqlalchemy import select, func
 from datacube.drivers.postgres._fields import SimpleDocField, DateDocField
 from datacube.drivers.postgres._schema import DATASET
 from datacube.index.abstract import AbstractDatasetResource, DatasetSpatialMixin, DSID
+from datacube.index.postgres._transaction import IndexResourceAddIn
 from datacube.model import Dataset, DatasetType
 from datacube.model.fields import Field
 from datacube.model.utils import flatten_datasets
@@ -29,7 +30,7 @@ _LOG = logging.getLogger(__name__)
 
 # It's a public api, so we can't reorganise old methods.
 # pylint: disable=too-many-public-methods, too-many-lines
-class DatasetResource(AbstractDatasetResource):
+class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
     """
     :type _db: datacube.drivers.postgres._connections.PostgresDb
     :type types: datacube.index._products.ProductResource
@@ -55,7 +56,7 @@ class DatasetResource(AbstractDatasetResource):
         if isinstance(id_, str):
             id_ = UUID(id_)
 
-        with self._db.connect() as connection:
+        with self.db_connection() as connection:
             if not include_sources:
                 dataset = connection.get_dataset(id_)
                 return self._make(dataset, full_info=True) if dataset else None
@@ -84,7 +85,7 @@ class DatasetResource(AbstractDatasetResource):
 
         ids = [to_uuid(i) for i in ids]
 
-        with self._db.connect() as connection:
+        with self.db_connection() as connection:
             rows = connection.get_datasets(ids)
             return [self._make(r, full_info=True) for r in rows]
 
@@ -97,7 +98,7 @@ class DatasetResource(AbstractDatasetResource):
         """
         if not isinstance(id_, UUID):
             id_ = UUID(id_)
-        with self._db.connect() as connection:
+        with self.db_connection() as connection:
             return [
                 self._make(result, full_info=True)
                 for result in connection.get_derived_datasets(id_)
@@ -110,7 +111,7 @@ class DatasetResource(AbstractDatasetResource):
         :param typing.Union[UUID, str] id_: dataset id
         :rtype: bool
         """
-        with self._db.connect() as connection:
+        with self.db_connection() as connection:
             return connection.contains_dataset(id_)
 
     def bulk_has(self, ids_):
@@ -123,7 +124,7 @@ class DatasetResource(AbstractDatasetResource):
 
         :rtype: [bool]
         """
-        with self._db.connect() as connection:
+        with self.db_connection() as connection:
             existing = set(connection.datasets_intersection(ids_))
 
         return [x in existing for x in
@@ -183,7 +184,7 @@ class DatasetResource(AbstractDatasetResource):
 
             dss = [dataset]
 
-        with self._db.begin() as transaction:
+        with self.db_connection(transaction=True) as transaction:
             process_bunch(dss, dataset, transaction)
 
         return dataset
@@ -208,7 +209,7 @@ class DatasetResource(AbstractDatasetResource):
 
         expressions = [product.metadata_type.dataset_fields.get('product') == product.name]
 
-        with self._db.connect() as connection:
+        with self.db_connection() as connection:
             for record in connection.get_duplicates(group_fields, expressions):
                 dataset_ids = set(record[0])
                 grouped_fields = tuple(record[1:])
@@ -276,7 +277,7 @@ class DatasetResource(AbstractDatasetResource):
         _LOG.info("Updating dataset %s", dataset.id)
 
         product = self.types.get_by_name(dataset.type.name)
-        with self._db.begin() as transaction:
+        with self.db_connection(transaction=True) as transaction:
             if not transaction.update_dataset(dataset.metadata_doc_without_lineage(), dataset.id, product.id):
                 raise ValueError("Failed to update dataset %s..." % dataset.id)
 
@@ -295,7 +296,7 @@ class DatasetResource(AbstractDatasetResource):
         # front of a stack
         for uri in new_uris[::-1]:
             if transaction is None:
-                with self._db.begin() as tr:
+                with self.db_connection(transaction=True) as tr:
                     insert_one(uri, tr)
             else:
                 insert_one(uri, transaction)
@@ -306,7 +307,7 @@ class DatasetResource(AbstractDatasetResource):
 
         :param Iterable[UUID] ids: list of dataset ids to archive
         """
-        with self._db.begin() as transaction:
+        with self.db_connection(transaction=True) as transaction:
             for id_ in ids:
                 transaction.archive_dataset(id_)
 
@@ -316,7 +317,7 @@ class DatasetResource(AbstractDatasetResource):
 
         :param Iterable[UUID] ids: list of dataset ids to restore
         """
-        with self._db.begin() as transaction:
+        with self.db_connection(transaction=True) as transaction:
             for id_ in ids:
                 transaction.restore_dataset(id_)
 
@@ -326,7 +327,7 @@ class DatasetResource(AbstractDatasetResource):
 
         :param ids: iterable of dataset ids to purge
         """
-        with self._db.begin() as transaction:
+        with self.db_connection(transaction=True) as transaction:
             for id_ in ids:
                 transaction.delete_dataset(id_)
 
@@ -340,7 +341,7 @@ class DatasetResource(AbstractDatasetResource):
         :param archived:
         :rtype: list[UUID]
         """
-        with self._db.begin() as transaction:
+        with self.db_connection(transaction=True) as transaction:
             return [dsid[0] for dsid in transaction.all_dataset_ids(archived)]
 
     def get_field_names(self, product_name=None):
@@ -367,7 +368,7 @@ class DatasetResource(AbstractDatasetResource):
         :param typing.Union[UUID, str] id_: dataset id
         :rtype: list[str]
         """
-        with self._db.connect() as connection:
+        with self.db_connection() as connection:
             return connection.get_locations(id_)
 
     def get_archived_locations(self, id_):
@@ -377,7 +378,7 @@ class DatasetResource(AbstractDatasetResource):
         :param typing.Union[UUID, str] id_: dataset id
         :rtype: list[str]
         """
-        with self._db.connect() as connection:
+        with self.db_connection() as connection:
             return [uri for uri, archived_dt in connection.get_archived_locations(id_)]
 
     def get_archived_location_times(self, id_):
@@ -387,7 +388,7 @@ class DatasetResource(AbstractDatasetResource):
         :param typing.Union[UUID, str] id_: dataset id
         :rtype: List[Tuple[str, datetime.datetime]]
         """
-        with self._db.connect() as connection:
+        with self.db_connection() as connection:
             return list(connection.get_archived_locations(id_))
 
     def add_location(self, id_, uri):
@@ -402,7 +403,7 @@ class DatasetResource(AbstractDatasetResource):
             warnings.warn("Cannot add empty uri. (dataset %s)" % id_)
             return False
 
-        with self._db.connect() as connection:
+        with self.db_connection() as connection:
             return connection.insert_dataset_location(id_, uri)
 
     def get_datasets_for_location(self, uri, mode=None):
@@ -413,7 +414,7 @@ class DatasetResource(AbstractDatasetResource):
         :param str mode: 'exact', 'prefix' or None (to guess)
         :return:
         """
-        with self._db.connect() as connection:
+        with self.db_connection() as connection:
             return (self._make(row) for row in connection.get_datasets_for_location(uri, mode=mode))
 
     def remove_location(self, id_, uri):
@@ -424,7 +425,7 @@ class DatasetResource(AbstractDatasetResource):
         :param str uri: fully qualified uri
         :returns bool: Was one removed?
         """
-        with self._db.connect() as connection:
+        with self.db_connection() as connection:
             was_removed = connection.remove_location(id_, uri)
             return was_removed
 
@@ -436,7 +437,7 @@ class DatasetResource(AbstractDatasetResource):
         :param str uri: fully qualified uri
         :return bool: location was able to be archived
         """
-        with self._db.connect() as connection:
+        with self.db_connection() as connection:
             was_archived = connection.archive_location(id_, uri)
             return was_archived
 
@@ -448,7 +449,7 @@ class DatasetResource(AbstractDatasetResource):
         :param str uri: fully qualified uri
         :return bool: location was able to be restored
         """
-        with self._db.connect() as connection:
+        with self.db_connection() as connection:
             was_restored = connection.restore_location(id_, uri)
             return was_restored
 
@@ -489,7 +490,7 @@ class DatasetResource(AbstractDatasetResource):
         :param dict metadata:
         :rtype: list[Dataset]
         """
-        with self._db.connect() as connection:
+        with self.db_connection() as connection:
             for dataset in self._make_many(connection.search_datasets_by_metadata(metadata)):
                 yield dataset
 
@@ -645,7 +646,7 @@ class DatasetResource(AbstractDatasetResource):
                 else:
                     select_fields = tuple(dataset_fields[field_name]
                                           for field_name in select_field_names)
-            with self._db.connect() as connection:
+            with self.db_connection() as connection:
                 yield (product,
                        connection.search_datasets(
                            query_exprs,
@@ -661,7 +662,7 @@ class DatasetResource(AbstractDatasetResource):
         for q, product in product_queries:
             dataset_fields = product.metadata_type.dataset_fields
             query_exprs = tuple(fields.to_expressions(dataset_fields.get, **q))
-            with self._db.connect() as connection:
+            with self.db_connection() as connection:
                 count = connection.count_datasets(query_exprs)
             if count > 0:
                 yield product, count
@@ -686,7 +687,7 @@ class DatasetResource(AbstractDatasetResource):
         for q, product in product_queries:
             dataset_fields = product.metadata_type.dataset_fields
             query_exprs = tuple(fields.to_expressions(dataset_fields.get, **q))
-            with self._db.connect() as connection:
+            with self.db_connection() as connection:
                 yield product, list(connection.count_datasets_through_time(
                     start,
                     end,
@@ -731,7 +732,7 @@ class DatasetResource(AbstractDatasetResource):
                                 offset=max_offset,
                                 selection='greatest')
 
-        with self._db.connect() as connection:
+        with self.db_connection() as connection:
             result = connection.execute(
                 select(
                     [func.min(time_min.alchemy_expression), func.max(time_max.alchemy_expression)]
@@ -785,7 +786,7 @@ class DatasetResource(AbstractDatasetResource):
                 class DatasetLight(result_type):  # type: ignore
                     __slots__ = ()
 
-            with self._db.connect() as connection:
+            with self.db_connection() as connection:
                 results = connection.search_unique_datasets(
                     query_exprs,
                     select_fields=select_fields,

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -35,13 +35,14 @@ class DatasetResource(AbstractDatasetResource):
     :type types: datacube.index._products.ProductResource
     """
 
-    def __init__(self, db, dataset_type_resource):
+    def __init__(self, db, index):
         """
         :type db: datacube.drivers.postgres._connections.PostgresDb
         :type dataset_type_resource: datacube.index._products.ProductResource
         """
         self._db = db
-        self.types = dataset_type_resource
+        self._index = index
+        self.types = self._index.products
 
     def get(self, id_: Union[str, UUID], include_sources=False):
         """

--- a/datacube/index/postgres/_metadata_types.py
+++ b/datacube/index/postgres/_metadata_types.py
@@ -15,11 +15,12 @@ _LOG = logging.getLogger(__name__)
 
 
 class MetadataTypeResource(AbstractMetadataTypeResource):
-    def __init__(self, db):
+    def __init__(self, db, index):
         """
         :type db: datacube.drivers.postgres._connections.PostgresDb
         """
         self._db = db
+        self._index = index
 
         self.get_unsafe = lru_cache()(self.get_unsafe)
         self.get_by_name_unsafe = lru_cache()(self.get_by_name_unsafe)

--- a/datacube/index/postgres/_metadata_types.py
+++ b/datacube/index/postgres/_metadata_types.py
@@ -70,7 +70,7 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
                 'Metadata Type {}'.format(metadata_type.name)
             )
         else:
-            with self.db_connection(transaction=allow_table_lock) as connection:
+            with self._db_connection(transaction=allow_table_lock) as connection:
                 connection.insert_metadata_type(
                     name=metadata_type.name,
                     definition=metadata_type.definition,
@@ -144,7 +144,7 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
 
         _LOG.info("Updating metadata type %s", metadata_type.name)
 
-        with self.db_connection(transaction=allow_table_lock) as connection:
+        with self._db_connection(transaction=allow_table_lock) as connection:
             connection.update_metadata_type(
                 name=metadata_type.name,
                 definition=metadata_type.definition,
@@ -170,7 +170,7 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
     # This is memoized in the constructor
     # pylint: disable=method-hidden
     def get_unsafe(self, id_):  # type: ignore
-        with self.db_connection() as connection:
+        with self._db_connection() as connection:
             record = connection.get_metadata_type(id_)
         if record is None:
             raise KeyError('%s is not a valid MetadataType id')
@@ -179,7 +179,7 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
     # This is memoized in the constructor
     # pylint: disable=method-hidden
     def get_by_name_unsafe(self, name):  # type: ignore
-        with self.db_connection() as connection:
+        with self._db_connection() as connection:
             record = connection.get_metadata_type_by_name(name)
         if not record:
             raise KeyError('%s is not a valid MetadataType name' % name)
@@ -195,7 +195,7 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
 
             If false, creation will be slightly slower and cannot be done in a transaction.
         """
-        with self.db_connection(transaction=allow_table_lock) as connection:
+        with self._db_connection(transaction=allow_table_lock) as connection:
             connection.check_dynamic_fields(
                 concurrently=not allow_table_lock,
                 rebuild_indexes=rebuild_indexes,
@@ -208,7 +208,7 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
 
         :rtype: iter[datacube.model.MetadataType]
         """
-        with self.db_connection() as connection:
+        with self._db_connection() as connection:
             return self._make_many(connection.get_all_metadata_types())
 
     def _make_many(self, query_rows):

--- a/datacube/index/postgres/_products.py
+++ b/datacube/index/postgres/_products.py
@@ -78,7 +78,7 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
                 _LOG.warning('Adding metadata_type "%s" as it doesn\'t exist.', product.metadata_type.name)
                 metadata_type = self.metadata_type_resource.add(product.metadata_type,
                                                                 allow_table_lock=allow_table_lock)
-            with self.db_connection(transaction=allow_table_lock) as connection:
+            with self._db_connection(transaction=allow_table_lock) as connection:
                 connection.insert_product(
                     name=product.name,
                     metadata=product.metadata_doc,
@@ -190,7 +190,7 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
         metadata_type = cast(MetadataType, self.metadata_type_resource.get_by_name(product.metadata_type.name))
         #     Given we cannot change metadata type because of the check above, and this is an
         #     update method, the metadata type is guaranteed to already exist.
-        with self.db_connection(transaction=allow_table_lock) as conn:
+        with self._db_connection(transaction=allow_table_lock) as conn:
             conn.update_product(
                 name=product.name,
                 metadata=product.metadata_doc,
@@ -228,7 +228,7 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
     # This is memoized in the constructor
     # pylint: disable=method-hidden
     def get_unsafe(self, id_):  # type: ignore
-        with self.db_connection() as connection:
+        with self._db_connection() as connection:
             result = connection.get_product(id_)
         if not result:
             raise KeyError('"%s" is not a valid Product id' % id_)
@@ -237,7 +237,7 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
     # This is memoized in the constructor
     # pylint: disable=method-hidden
     def get_by_name_unsafe(self, name):  # type: ignore
-        with self.db_connection() as connection:
+        with self._db_connection() as connection:
             result = connection.get_product_by_name(name)
         if not result:
             raise KeyError('"%s" is not a valid Product name' % name)
@@ -309,7 +309,7 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
         """
         Retrieve all Products
         """
-        with self.db_connection() as connection:
+        with self._db_connection() as connection:
             return (self._make(record) for record in connection.get_all_products())
 
     def _make_many(self, query_rows):

--- a/datacube/index/postgres/_products.py
+++ b/datacube/index/postgres/_products.py
@@ -23,13 +23,14 @@ class ProductResource(AbstractProductResource):
     :type metadata_type_resource: datacube.index._metadata_types.MetadataTypeResource
     """
 
-    def __init__(self, db, metadata_type_resource):
+    def __init__(self, db, index):
         """
         :type db: datacube.drivers.postgres._connections.PostgresDb
         :type metadata_type_resource: datacube.index._metadata_types.MetadataTypeResource
         """
         self._db = db
-        self.metadata_type_resource = metadata_type_resource
+        self._index = index
+        self.metadata_type_resource = self._index.metadata_types
 
         self.get_unsafe = lru_cache()(self.get_unsafe)
         self.get_by_name_unsafe = lru_cache()(self.get_by_name_unsafe)

--- a/datacube/index/postgres/_products.py
+++ b/datacube/index/postgres/_products.py
@@ -8,16 +8,18 @@ from cachetools.func import lru_cache
 
 from datacube.index import fields
 from datacube.index.abstract import AbstractProductResource
+from datacube.index.postgres._transaction import IndexResourceAddIn
 from datacube.model import DatasetType, MetadataType
 from datacube.utils import jsonify_document, changes, _readable_offset
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes
 
 from typing import Iterable, cast
 
+
 _LOG = logging.getLogger(__name__)
 
 
-class ProductResource(AbstractProductResource):
+class ProductResource(AbstractProductResource, IndexResourceAddIn):
     """
     :type _db: datacube.drivers.postgres._connections.PostgresDb
     :type metadata_type_resource: datacube.index._metadata_types.MetadataTypeResource
@@ -55,7 +57,8 @@ class ProductResource(AbstractProductResource):
             Allow an exclusive lock to be taken on the table while creating the indexes.
             This will halt other user's requests until completed.
 
-            If false, creation will be slightly slower and cannot be done in a transaction.
+            If false (and there is no already active transaction), creation will be slightly slower
+            and cannot be done in a transaction.
         :param DatasetType product: Product to add
         :rtype: DatasetType
         """
@@ -75,7 +78,7 @@ class ProductResource(AbstractProductResource):
                 _LOG.warning('Adding metadata_type "%s" as it doesn\'t exist.', product.metadata_type.name)
                 metadata_type = self.metadata_type_resource.add(product.metadata_type,
                                                                 allow_table_lock=allow_table_lock)
-            with self._db.connect() as connection:
+            with self.db_connection(transaction=allow_table_lock) as connection:
                 connection.insert_product(
                     name=product.name,
                     metadata=product.metadata_doc,
@@ -187,7 +190,7 @@ class ProductResource(AbstractProductResource):
         metadata_type = cast(MetadataType, self.metadata_type_resource.get_by_name(product.metadata_type.name))
         #     Given we cannot change metadata type because of the check above, and this is an
         #     update method, the metadata type is guaranteed to already exist.
-        with self._db.connect() as conn:
+        with self.db_connection(transaction=allow_table_lock) as conn:
             conn.update_product(
                 name=product.name,
                 metadata=product.metadata_doc,
@@ -225,7 +228,7 @@ class ProductResource(AbstractProductResource):
     # This is memoized in the constructor
     # pylint: disable=method-hidden
     def get_unsafe(self, id_):  # type: ignore
-        with self._db.connect() as connection:
+        with self.db_connection() as connection:
             result = connection.get_product(id_)
         if not result:
             raise KeyError('"%s" is not a valid Product id' % id_)
@@ -234,7 +237,7 @@ class ProductResource(AbstractProductResource):
     # This is memoized in the constructor
     # pylint: disable=method-hidden
     def get_by_name_unsafe(self, name):  # type: ignore
-        with self._db.connect() as connection:
+        with self.db_connection() as connection:
             result = connection.get_product_by_name(name)
         if not result:
             raise KeyError('"%s" is not a valid Product name' % name)
@@ -306,7 +309,7 @@ class ProductResource(AbstractProductResource):
         """
         Retrieve all Products
         """
-        with self._db.connect() as connection:
+        with self.db_connection() as connection:
             return (self._make(record) for record in connection.get_all_products())
 
     def _make_many(self, query_rows):

--- a/datacube/index/postgres/_transaction.py
+++ b/datacube/index/postgres/_transaction.py
@@ -1,0 +1,68 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2022 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+
+from contextlib import contextmanager
+from typing import Any
+
+from datacube.drivers.postgres import PostgresDb
+from datacube.drivers.postgres._api import PostgresDbAPI
+from datacube.index.abstract import AbstractTransaction
+
+
+class PostgresTransaction(AbstractTransaction):
+    def __init__(self, db: PostgresDb, idx_id: str) -> None:
+        super().__init__(idx_id)
+        self._db = db
+
+    def _new_connection(self) -> Any:
+        return self._db.begin()
+
+    def _commit(self) -> None:
+        self._connection.commit()
+
+    def _rollback(self) -> None:
+        self._connection.rollback()
+
+    def _release_connection(self) -> None:
+        self._connection.close()
+
+
+class IndexResourceAddIn:
+    @contextmanager
+    def db_connection(self, transaction=False) -> PostgresDbAPI:
+        """
+        Context manager representing a database connection.
+
+        If there is an active transaction for this index in the current thread, the connection object from that
+        transaction is returned, with the active transaction remaining in control of commit and rollback.
+
+        If there is no active transaction and the transaction argument is True, a new transactionised connection
+        is returned, with this context manager handling commit and rollback.
+
+        If there is no active transaction and the transaction argument is False (the default), a new connection
+        is returned with autocommit semantics.
+
+        Note that autocommit behaviour is NOT available if there is an active transaction for the index
+        and the active thread.
+
+        In Resource Manager code replace self._db.connect() with self.db_connection(), and replace
+        self._db.begin() with self.db_connection(transaction=True).
+
+        :param transaction: Use a transaction if one is not already active for the thread.
+        :return: A PostgresDbAPI object, with the specified transaction semantics.
+        """
+        trans = self._index.thread_transaction()
+        if trans is not None:
+            # Use active transaction
+            yield trans._connection
+        elif transaction:
+            with self._db.begin() as conn:
+                yield conn
+        else:
+            # Autocommit behaviour:
+            with self._db.connect() as conn:
+                yield conn
+

--- a/datacube/index/postgres/_transaction.py
+++ b/datacube/index/postgres/_transaction.py
@@ -61,23 +61,5 @@ class IndexResourceAddIn:
         :param transaction: Use a transaction if one is not already active for the thread.
         :return: A PostgresDbAPI object, with the specified transaction semantics.
         """
-        trans = self._index.thread_transaction()
-        closing = False
-        if trans is not None:
-            # Use active transaction
-            yield trans._connection
-        elif transaction:
-            closing = True
-            with self._db._connect() as conn:
-                conn.begin()
-                try:
-                    yield conn
-                    conn.commit()
-                except Exception:  # pylint: disable=broad-except
-                    conn.rollback()
-                    raise
-        else:
-            closing = True
-            # Autocommit behaviour:
-            with self._db._connect() as conn:
-                yield conn
+        with self._index._active_connection(transaction=transaction) as conn:
+            yield conn

--- a/datacube/index/postgres/_transaction.py
+++ b/datacube/index/postgres/_transaction.py
@@ -68,10 +68,16 @@ class IndexResourceAddIn:
             yield trans._connection
         elif transaction:
             closing = True
-            with self._db.begin() as conn:
-                yield conn
+            with self._db._connect() as conn:
+                conn.begin()
+                try:
+                    yield conn
+                    conn.commit()
+                except Exception:  # pylint: disable=broad-except
+                    conn.rollback()
+                    raise
         else:
             closing = True
             # Autocommit behaviour:
-            with self._db.connect() as conn:
+            with self._db._connect() as conn:
                 yield conn

--- a/datacube/index/postgres/_transaction.py
+++ b/datacube/index/postgres/_transaction.py
@@ -3,8 +3,6 @@
 # Copyright (c) 2015-2022 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import logging
-
 from contextlib import contextmanager
 from sqlalchemy import text
 from typing import Any
@@ -13,7 +11,6 @@ from datacube.drivers.postgres import PostgresDb
 from datacube.drivers.postgres._api import PostgresDbAPI
 from datacube.index.abstract import AbstractTransaction
 
-_LOG = logging.getLogger(__name__)
 
 class PostgresTransaction(AbstractTransaction):
     def __init__(self, db: PostgresDb, idx_id: str) -> None:

--- a/datacube/index/postgres/_users.py
+++ b/datacube/index/postgres/_users.py
@@ -8,11 +8,12 @@ from datacube.drivers.postgres import PostgresDb
 
 
 class UserResource(AbstractUserResource):
-    def __init__(self, db: PostgresDb) -> None:
+    def __init__(self, db: PostgresDb, index: "datacube.index.postgres.index.Index") -> None:
         """
         :type db: datacube.drivers.postgres._connections.PostgresDb
         """
         self._db = db
+        self._index = index
 
     def grant_role(self, role: str, *usernames: str) -> None:
         """

--- a/datacube/index/postgres/_users.py
+++ b/datacube/index/postgres/_users.py
@@ -9,7 +9,10 @@ from datacube.drivers.postgres import PostgresDb
 
 
 class UserResource(AbstractUserResource, IndexResourceAddIn):
-    def __init__(self, db: PostgresDb, index: "datacube.index.postgres.index.Index") -> None:
+    def __init__(self,
+                 db: PostgresDb,
+                 index: "datacube.index.postgres.index.Index"  # noqa: F821
+                ) -> None:
         """
         :type db: datacube.drivers.postgres._connections.PostgresDb
         """

--- a/datacube/index/postgres/_users.py
+++ b/datacube/index/postgres/_users.py
@@ -20,7 +20,7 @@ class UserResource(AbstractUserResource, IndexResourceAddIn):
         """
         Grant a role to users
         """
-        with self.db_connection() as connection:
+        with self._db_connection() as connection:
             connection.grant_role(role, usernames)
 
     def create_user(self, username: str, password: str,
@@ -28,14 +28,14 @@ class UserResource(AbstractUserResource, IndexResourceAddIn):
         """
         Create a new user.
         """
-        with self.db_connection() as connection:
+        with self._db_connection() as connection:
             connection.create_user(username, password, role, description=description)
 
     def delete_user(self, *usernames: str) -> None:
         """
         Delete a user
         """
-        with self.db_connection() as connection:
+        with self._db_connection() as connection:
             connection.drop_users(usernames)
 
     def list_users(self) -> Iterable[Tuple[str, str, Optional[str]]]:
@@ -43,6 +43,6 @@ class UserResource(AbstractUserResource, IndexResourceAddIn):
         :return: list of (role, user, description)
         :rtype: list[(str, str, str)]
         """
-        with self.db_connection() as connection:
+        with self._db_connection() as connection:
             for role, user, description in connection.list_users():
                 yield role, user, description

--- a/datacube/index/postgres/_users.py
+++ b/datacube/index/postgres/_users.py
@@ -1,13 +1,14 @@
 # This file is part of the Open Data Cube, see https://opendatacube.org for more information
 #
-# Copyright (c) 2015-2020 ODC Contributors
+# Copyright (c) 2015-2022 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 from typing import Iterable, Optional, Tuple
 from datacube.index.abstract import AbstractUserResource
+from datacube.index.postgres._transaction import IndexResourceAddIn
 from datacube.drivers.postgres import PostgresDb
 
 
-class UserResource(AbstractUserResource):
+class UserResource(AbstractUserResource, IndexResourceAddIn):
     def __init__(self, db: PostgresDb, index: "datacube.index.postgres.index.Index") -> None:
         """
         :type db: datacube.drivers.postgres._connections.PostgresDb
@@ -19,7 +20,7 @@ class UserResource(AbstractUserResource):
         """
         Grant a role to users
         """
-        with self._db.connect() as connection:
+        with self.db_connection() as connection:
             connection.grant_role(role, usernames)
 
     def create_user(self, username: str, password: str,
@@ -27,14 +28,14 @@ class UserResource(AbstractUserResource):
         """
         Create a new user.
         """
-        with self._db.connect() as connection:
+        with self.db_connection() as connection:
             connection.create_user(username, password, role, description=description)
 
     def delete_user(self, *usernames: str) -> None:
         """
         Delete a user
         """
-        with self._db.connect() as connection:
+        with self.db_connection() as connection:
             connection.drop_users(usernames)
 
     def list_users(self) -> Iterable[Tuple[str, str, Optional[str]]]:
@@ -42,6 +43,6 @@ class UserResource(AbstractUserResource):
         :return: list of (role, user, description)
         :rtype: list[(str, str, str)]
         """
-        with self._db.connect() as connection:
+        with self.db_connection() as connection:
             for role, user, description in connection.list_users():
                 yield role, user, description

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -64,10 +64,10 @@ class Index(AbstractIndex):
     def __init__(self, db: PostgresDb) -> None:
         self._db = db
 
-        self._users = UserResource(db)
-        self._metadata_types = MetadataTypeResource(db)
-        self._products = ProductResource(db, self.metadata_types)
-        self._datasets = DatasetResource(db, self.products)
+        self._users = UserResource(db, self)
+        self._metadata_types = MetadataTypeResource(db, self)
+        self._products = ProductResource(db, self)
+        self._datasets = DatasetResource(db, self)
 
     @property
     def users(self) -> UserResource:

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 from contextlib import contextmanager
-from typing import Any
 
 from datacube.drivers.postgres import PostgresDb, PostgresDbAPI
 from datacube.index.postgres._transaction import PostgresTransaction

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -101,6 +101,10 @@ class Index(AbstractIndex):
         """
         self._db.close()
 
+    @property
+    def index_id(self) -> str:
+        return f"legacy_{self.url}"
+
     def transaction(self) -> AbstractTransaction:
         # TODO
         return None

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -3,9 +3,11 @@
 # Copyright (c) 2015-2020 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import logging
+from contextlib import contextmanager
 from typing import Any
 
 from datacube.drivers.postgres import PostgresDb
+from datacube.index.postgres._transaction import PostgresTransaction
 from datacube.index.postgres._datasets import DatasetResource  # type: ignore
 from datacube.index.postgres._metadata_types import MetadataTypeResource
 from datacube.index.postgres._products import ProductResource
@@ -15,24 +17,6 @@ from datacube.model import MetadataType
 from datacube.utils.geometry import CRS
 
 _LOG = logging.getLogger(__name__)
-
-
-class PostgresTransaction(AbstractTransaction):
-    def __init__(self, db: PostgresDb, idx_id: str) -> None:
-        super().__init__(idx_id)
-        self._db = db
-
-    def _new_connection(self) -> Any:
-        return self._db.begin()
-
-    def _commit(self) -> None:
-        self._connection.commit()
-
-    def _rollback(self) -> None:
-        self._connection.rollback()
-
-    def _release_connection(self) -> None:
-        self._connection.close()
 
 
 class Index(AbstractIndex):

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -9,7 +9,7 @@ from datacube.index.postgres._datasets import DatasetResource  # type: ignore
 from datacube.index.postgres._metadata_types import MetadataTypeResource
 from datacube.index.postgres._products import ProductResource
 from datacube.index.postgres._users import UserResource
-from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, default_metadata_type_docs
+from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, default_metadata_type_docs, AbstractTransaction
 from datacube.model import MetadataType
 from datacube.utils.geometry import CRS
 
@@ -39,6 +39,8 @@ class Index(AbstractIndex):
     :type products: datacube.index._products.ProductResource
     :type metadata_types: datacube.index._metadata_types.MetadataTypeResource
     """
+
+    supports_transactions = True
 
     def __init__(self, db: PostgresDb) -> None:
         self._db = db
@@ -98,6 +100,10 @@ class Index(AbstractIndex):
         (Connections are normally closed automatically when this object is deleted: ie. no references exist)
         """
         self._db.close()
+
+    def transaction(self) -> AbstractTransaction:
+        # TODO
+        return None
 
     def create_spatial_index(self, crs: CRS) -> None:
         _LOG.warning("postgres driver does not support spatio-temporal indexes")

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -37,6 +37,8 @@ v1.8.next
 - Implement `patch_url` argument to `dc.load()` and `dc.load_data()` to provide a way to sign dataset URIs, as
   is required to access some commercial archives (e.g. Microsoft Planetary Computer).  API is based on the `odc-stac`
   implementation. Only works for direct loading.  More work required for deferred (i.e. Dask) loading. (:pull: `1317`)
+- Implement public-facing index-driver-independent API for managing database transactions, as per Enhancement Proposal
+  EP07 (:pull: `1318`)
 
 
 v1.8.7 (7 June 2022)

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -376,15 +376,6 @@ def index_empty(local_config, uninitialised_postgres_db: PostgresDb):
     del index
 
 
-@pytest.fixture
-def initialised_postgres_db(index):
-    """
-    Return a connection to an PostgreSQL (or Postgis) database, initialised with the default schema
-    and tables.
-    """
-    return index._db
-
-
 def remove_postgres_dynamic_indexes():
     """
     Clear any dynamically created postgresql indexes from the schema.

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -379,7 +379,7 @@ def index_empty(local_config, uninitialised_postgres_db: PostgresDb):
 @pytest.fixture
 def initialised_postgres_db(index):
     """
-    Return a connection to an PostgreSQL database, initialised with the default schema
+    Return a connection to an PostgreSQL (or Postgis) database, initialised with the default schema
     and tables.
     """
     return index._db

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -214,7 +214,7 @@ def _object_exists(db, index_name):
         schema_name = "odc"
     else:
         schema_name = "agdc"
-    with db.connect() as connection:
+    with db._connect() as connection:
         val = connection._connection.execute(f"SELECT to_regclass('{schema_name}.{index_name}')").scalar()
     return val in (index_name, f'{schema_name}.{index_name}')
 

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -16,7 +16,6 @@ from uuid import UUID
 import pytest
 from dateutil import tz
 
-from datacube.drivers.postgres import PostgresDb
 from datacube.index.exceptions import MissingRecordError
 from datacube.index import Index
 from datacube.model import Dataset, MetadataType
@@ -279,8 +278,6 @@ def test_transactions_api_ctx_mgr(index,
                                   eo3_ls8_dataset_doc,
                                   eo3_ls8_dataset2_doc):
     from datacube.index.hl import Doc2Dataset
-    import logging
-    _LOG = logging.getLogger(__name__)
     resolver = Doc2Dataset(index, products=[ls8_eo3_product.name], verify_lineage=False)
     ds1, err = resolver(*eo3_ls8_dataset_doc)
     ds2, err = resolver(*eo3_ls8_dataset2_doc)
@@ -311,8 +308,6 @@ def test_transactions_api_manual(index,
                                  eo3_ls8_dataset_doc,
                                  eo3_ls8_dataset2_doc):
     from datacube.index.hl import Doc2Dataset
-    import logging
-    _LOG = logging.getLogger(__name__)
     resolver = Doc2Dataset(index, products=[ls8_eo3_product.name], verify_lineage=False)
     ds1, err = resolver(*eo3_ls8_dataset_doc)
     ds2, err = resolver(*eo3_ls8_dataset2_doc)
@@ -339,8 +334,6 @@ def test_transactions_api_hybrid(index,
                                  eo3_ls8_dataset_doc,
                                  eo3_ls8_dataset2_doc):
     from datacube.index.hl import Doc2Dataset
-    import logging
-    _LOG = logging.getLogger(__name__)
     resolver = Doc2Dataset(index, products=[ls8_eo3_product.name], verify_lineage=False)
     ds1, err = resolver(*eo3_ls8_dataset_doc)
     ds2, err = resolver(*eo3_ls8_dataset2_doc)

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -358,10 +358,10 @@ def test_transactions_api_manual(index,
 
 
 def test_transactions_api_hybrid(index,
-                                  extended_eo3_metadata_type_doc,
-                                  ls8_eo3_product,
-                                  eo3_ls8_dataset_doc,
-                                  eo3_ls8_dataset2_doc):
+                                 extended_eo3_metadata_type_doc,
+                                 ls8_eo3_product,
+                                 eo3_ls8_dataset_doc,
+                                 eo3_ls8_dataset2_doc):
     from datacube.index.hl import Doc2Dataset
     import logging
     _LOG = logging.getLogger(__name__)

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -330,10 +330,10 @@ def test_transactions_api_ctx_mgr(index,
 
 
 def test_transactions_api_manual(index,
-                          extended_eo3_metadata_type_doc,
-                          ls8_eo3_product,
-                          eo3_ls8_dataset_doc,
-                          eo3_ls8_dataset2_doc):
+                                 extended_eo3_metadata_type_doc,
+                                 ls8_eo3_product,
+                                 eo3_ls8_dataset_doc,
+                                 eo3_ls8_dataset2_doc):
     from datacube.index.hl import Doc2Dataset
     import logging
     _LOG = logging.getLogger(__name__)

--- a/integration_tests/index/test_memory_index.py
+++ b/integration_tests/index/test_memory_index.py
@@ -552,3 +552,19 @@ def test_memory_dataset_add(dataset_add_configs, mem_index_fresh):
     ds_from_idx = idx.datasets.get(ds_.id, include_sources=True)
     assert ds_from_idx.sources['ab'].id == ds_.sources['ab'].id
     assert ds_from_idx.sources['ac'].sources["cd"].id == ds_.sources['ac'].sources['cd'].id
+
+
+def test_mem_transactions(mem_index_fresh):
+    trans = mem_index_fresh.index.transaction()
+    assert not trans.active
+    trans.begin()
+    assert trans.active
+    trans.commit()
+    assert not trans.active
+    trans.begin()
+    assert mem_index_fresh.index.thread_transaction() == trans
+    with pytest.raises(ValueError):
+        trans.begin()
+    trans.rollback()
+    assert not trans.active
+    assert mem_index_fresh.index.thread_transaction() is None

--- a/integration_tests/index/test_null_index.py
+++ b/integration_tests/index/test_null_index.py
@@ -120,3 +120,20 @@ def test_null_dataset_resource(null_config):
         assert dc.index.datasets.search_summaries(foo="bar", baz=12) == []
         assert dc.index.datasets.search_eager(foo="bar", baz=12) == []
         assert dc.index.datasets.search_returning_datasets_light(("foo", "baz"), foo="bar", baz=12) == []
+
+
+def test_null_transactions(null_config):
+    with Datacube(config=null_config, validate_connection=True) as dc:
+        trans = dc.index.transaction()
+        assert not trans.active
+        trans.begin()
+        assert trans.active
+        trans.commit()
+        assert not trans.active
+        trans.begin()
+        assert dc.index.thread_transaction() == trans
+        with pytest.raises(ValueError):
+            trans.begin()
+        trans.rollback()
+        assert not trans.active
+        assert dc.index.thread_transaction() is None

--- a/integration_tests/index/test_search_legacy.py
+++ b/integration_tests/index/test_search_legacy.py
@@ -57,7 +57,7 @@ def pseudo_ls8_type(index, ga_metadata_type):
 @pytest.fixture
 def pseudo_ls8_dataset(index, pseudo_ls8_type):
     id_ = str(uuid.uuid4())
-    with index._db._connect() as connection:
+    with index._active_connection() as connection:
         was_inserted = connection.insert_dataset(
             {
                 'id': id_,
@@ -110,7 +110,7 @@ def pseudo_ls8_dataset(index, pseudo_ls8_type):
 def pseudo_ls8_dataset2(index, pseudo_ls8_type):
     # Like the previous dataset, but a day later in time.
     id_ = str(uuid.uuid4())
-    with index._db._connect() as connection:
+    with index._active_connection() as connection:
         was_inserted = connection.insert_dataset(
             {
                 'id': id_,
@@ -173,7 +173,7 @@ def pseudo_ls8_dataset3(index: Index,
         'satellite_ref_point_end': {'x': 116, 'y': 87},
     }
 
-    with index._db._connect() as connection:
+    with index._active_connection() as connection:
         was_inserted = connection.insert_dataset(
             dataset_doc,
             id_,
@@ -199,7 +199,7 @@ def pseudo_ls8_dataset4(index: Index,
         'satellite_ref_point_end': {'x': 116, 'y': 87},
     }
 
-    with index._db._connect() as connection:
+    with index._active_connection() as connection:
         was_inserted = connection.insert_dataset(
             dataset_doc,
             id_,
@@ -853,7 +853,7 @@ def test_cli_info(index: Index,
     assert yaml_docs[1]['id'] == str(pseudo_ls8_dataset2.id)
 
 
-def test_cli_missing_info(clirunner, initialised_postgres_db):
+def test_cli_missing_info(clirunner, index):
     id_ = str(uuid.uuid4())
     result = clirunner(
         [

--- a/integration_tests/index/test_search_legacy.py
+++ b/integration_tests/index/test_search_legacy.py
@@ -55,9 +55,9 @@ def pseudo_ls8_type(index, ga_metadata_type):
 
 
 @pytest.fixture
-def pseudo_ls8_dataset(index, initialised_postgres_db, pseudo_ls8_type):
+def pseudo_ls8_dataset(index, pseudo_ls8_type):
     id_ = str(uuid.uuid4())
-    with initialised_postgres_db.connect() as connection:
+    with index._db._connect() as connection:
         was_inserted = connection.insert_dataset(
             {
                 'id': id_,
@@ -107,10 +107,10 @@ def pseudo_ls8_dataset(index, initialised_postgres_db, pseudo_ls8_type):
 
 
 @pytest.fixture
-def pseudo_ls8_dataset2(index, initialised_postgres_db, pseudo_ls8_type):
+def pseudo_ls8_dataset2(index, pseudo_ls8_type):
     # Like the previous dataset, but a day later in time.
     id_ = str(uuid.uuid4())
-    with initialised_postgres_db.connect() as connection:
+    with index._db._connect() as connection:
         was_inserted = connection.insert_dataset(
             {
                 'id': id_,
@@ -162,7 +162,6 @@ def pseudo_ls8_dataset2(index, initialised_postgres_db, pseudo_ls8_type):
 # Datasets 3 and 4 mirror 1 and 2 but have a different path/row.
 @pytest.fixture
 def pseudo_ls8_dataset3(index: Index,
-                        initialised_postgres_db: PostgresDb,
                         pseudo_ls8_type: Product,
                         pseudo_ls8_dataset: Dataset) -> Dataset:
     # Same as 1, but a different path/row
@@ -174,7 +173,7 @@ def pseudo_ls8_dataset3(index: Index,
         'satellite_ref_point_end': {'x': 116, 'y': 87},
     }
 
-    with initialised_postgres_db.connect() as connection:
+    with index._db._connect() as connection:
         was_inserted = connection.insert_dataset(
             dataset_doc,
             id_,
@@ -189,7 +188,6 @@ def pseudo_ls8_dataset3(index: Index,
 
 @pytest.fixture
 def pseudo_ls8_dataset4(index: Index,
-                        initialised_postgres_db: PostgresDb,
                         pseudo_ls8_type: Product,
                         pseudo_ls8_dataset2: Dataset) -> Dataset:
     # Same as 2, but a different path/row
@@ -201,7 +199,7 @@ def pseudo_ls8_dataset4(index: Index,
         'satellite_ref_point_end': {'x': 116, 'y': 87},
     }
 
-    with initialised_postgres_db.connect() as connection:
+    with index._db._connect() as connection:
         was_inserted = connection.insert_dataset(
             dataset_doc,
             id_,

--- a/integration_tests/index/test_search_legacy.py
+++ b/integration_tests/index/test_search_legacy.py
@@ -18,7 +18,6 @@ from dateutil import tz
 from psycopg2._range import NumericRange
 
 from datacube.config import LocalConfig
-from datacube.drivers.postgres import PostgresDb
 from datacube.drivers.postgres._connections import DEFAULT_DB_USER
 from datacube.index import Index
 from datacube.model import Dataset

--- a/integration_tests/index/test_update_columns.py
+++ b/integration_tests/index/test_update_columns.py
@@ -58,7 +58,7 @@ def test_added_column(clirunner, uninitialised_postgres_db):
     result = clirunner(["system", "init"])
     assert "Created." in result.output
 
-    with uninitialised_postgres_db.connect() as connection:
+    with uninitialised_postgres_db._connect() as connection:
         assert check_column(connection, _schema.METADATA_TYPE.name, "updated")
         assert not check_column(connection, _schema.METADATA_TYPE.name, "fake_column")
         assert check_column(connection, _schema.PRODUCT.name, "updated")
@@ -81,7 +81,7 @@ def test_readd_column(clirunner, uninitialised_postgres_db):
     result = clirunner(["system", "init"])
     assert "Created." in result.output
 
-    with uninitialised_postgres_db.connect() as connection:
+    with uninitialised_postgres_db._connect() as connection:
         # Drop all the columns for an init rerun
         drop_column(connection, _schema.METADATA_TYPE.name, "updated")
         drop_column(connection, _schema.PRODUCT.name, "updated")
@@ -95,7 +95,7 @@ def test_readd_column(clirunner, uninitialised_postgres_db):
 
     result = clirunner(["system", "init"])
 
-    with uninitialised_postgres_db.connect() as connection:
+    with uninitialised_postgres_db._connect() as connection:
         assert check_column(connection, _schema.METADATA_TYPE.name, "updated")
         assert check_column(connection, _schema.PRODUCT.name, "updated")
         assert check_column(connection, _schema.DATASET.name, "updated")

--- a/tests/index/test_api_index_dataset.py
+++ b/tests/index/test_api_index_dataset.py
@@ -214,6 +214,9 @@ class MockIndex:
         self._db = db
         self.products = MockTypesResource(product)
 
+    def thread_transaction(self):
+        return None
+
 
 def test_index_dataset():
     mock_db = MockDb()

--- a/tests/index/test_api_index_dataset.py
+++ b/tests/index/test_api_index_dataset.py
@@ -155,11 +155,6 @@ DatasetRecord = namedtuple('DatasetRecord', ['id', 'metadata', 'dataset_type_ref
                                              'added', 'added_by', 'archived'])
 
 
-class MockIndex(object):
-    def __init__(self, db):
-        self._db = db
-
-
 class MockDb(object):
     def __init__(self):
         self.dataset = {}
@@ -225,6 +220,10 @@ class MockIndex:
 
     def thread_transaction(self):
         return None
+
+    @contextmanager
+    def _active_connection(self, transaction=False):
+        yield self._db
 
 
 def test_index_dataset():

--- a/tests/index/test_api_index_dataset.py
+++ b/tests/index/test_api_index_dataset.py
@@ -166,12 +166,17 @@ class MockDb(object):
         self.dataset_source = set()
 
     @contextmanager
-    def begin(self):
+    def _connect(self):
         yield self
 
-    @contextmanager
-    def connect(self):
-        yield self
+    def begin(self):
+        pass
+
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass
 
     def get_dataset(self, id):
         return self.dataset.get(id, None)
@@ -207,6 +212,10 @@ class MockTypesResource:
 
     def get_by_name(self, *args, **kwargs):
         return self.type
+
+    @contextmanager
+    def _db_connection(self, transaction=False):
+        yield MockDb()
 
 
 class MockIndex:

--- a/tests/index/test_api_index_dataset.py
+++ b/tests/index/test_api_index_dataset.py
@@ -198,7 +198,7 @@ class MockDb(object):
         self.dataset_source.add((classifier, dataset_id, source_dataset_id))
 
 
-class MockTypesResource(object):
+class MockTypesResource:
     def __init__(self, type_):
         self.type = type_
 
@@ -209,10 +209,16 @@ class MockTypesResource(object):
         return self.type
 
 
+class MockIndex:
+    def __init__(self, db, product):
+        self._db = db
+        self.products = MockTypesResource(product)
+
+
 def test_index_dataset():
     mock_db = MockDb()
-    mock_types = MockTypesResource(_EXAMPLE_DATASET_TYPE)
-    datasets = DatasetResource(mock_db, mock_types)
+    mock_index = MockIndex(mock_db, _EXAMPLE_DATASET_TYPE)
+    datasets = DatasetResource(mock_db, mock_index)
     dataset = datasets.add(_EXAMPLE_NBAR_DATASET)
 
     ids = {d.id for d in mock_db.dataset.values()}
@@ -237,8 +243,8 @@ def test_index_dataset():
 
 def test_index_already_ingested_source_dataset():
     mock_db = MockDb()
-    mock_types = MockTypesResource(_EXAMPLE_DATASET_TYPE)
-    datasets = DatasetResource(mock_db, mock_types)
+    mock_index = MockIndex(mock_db, _EXAMPLE_DATASET_TYPE)
+    datasets = DatasetResource(mock_db, mock_index)
     dataset = datasets.add(_EXAMPLE_NBAR_DATASET.sources['ortho'])
 
     assert len(mock_db.dataset) == 2
@@ -251,8 +257,8 @@ def test_index_already_ingested_source_dataset():
 
 def test_index_two_levels_already_ingested():
     mock_db = MockDb()
-    mock_types = MockTypesResource(_EXAMPLE_DATASET_TYPE)
-    datasets = DatasetResource(mock_db, mock_types)
+    mock_index = MockIndex(mock_db, _EXAMPLE_DATASET_TYPE)
+    datasets = DatasetResource(mock_db, mock_index)
     dataset = datasets.add(_EXAMPLE_NBAR_DATASET.sources['ortho'].sources['satellite_telemetry_data'])
 
     assert len(mock_db.dataset) == 1


### PR DESCRIPTION
### Reason for this pull request

As discussed in [Enhancement Proposal 07](https://github.com/opendatacube/datacube-core/wiki/EP07-Database-transaction-API)


### Proposed changes

Simple example of new API:

```
with dc.index.transaction() as trans:
   # Archive old datasets and add new ones in single transaction
   dc.index.datasets.archive([old_ds1.id, old_ds2.id])
   dc.index.datasets.add(ds1)
   dc.index.datasets.add(ds2)

   # If execution gets to here, the transaction is committed.
   # If an exception was raised by any of the above methods, the transaction is rolled back.
```

Further details discussed in [Enhancement Propose 07](https://github.com/opendatacube/datacube-core/wiki/EP07-Database-transaction-API).  API is documented in docstrings.

MacOS and Windows Conda smoke tests are failing again - some issue with GDAL.

 - [x] Implements [EP07](https://github.com/opendatacube/datacube-core/wiki/EP07-Database-transaction-API)
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes


