### PR TITLE
Update conda environment to match setup.py dependencies.

### DIFF
--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -22,14 +22,15 @@ dependencies:
   - pyproj
   - shapely
   - jsonschema
-  - lark-parser
+  - lark
   - netcdf4
   - numpy
   - pandas
   - psycopg2
   - python-dateutil
   - pyyaml
-  - rasterio >=1.0.2
+  - rasterio >=1.3.2
   - sqlalchemy
-  - xarray >=0.9
+  - GeoAlchemy2
+  - xarray >=0.9,!=2022.6.0
   - toolz

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -37,6 +37,7 @@ v1.8.next
 - Implement `patch_url` argument to `dc.load()` and `dc.load_data()` to provide a way to sign dataset URIs, as
   is required to access some commercial archives (e.g. Microsoft Planetary Computer).  API is based on the `odc-stac`
   implementation. Only works for direct loading.  More work required for deferred (i.e. Dask) loading. (:pull: `1317`)
+- Update Conda environment to match dependencies in setup.py (:pull: `1319`)
 
 
 v1.8.7 (7 June 2022)


### PR DESCRIPTION
### Reason for this pull request

`conda-environment.yml` hasn't been updated in a while.

### Proposed changes

- Update `conda-environment.yml` to more closely match dependencies defined in setup.py

Kirill - is the rasterio constraint too severe?  Would you prefer `!=1.3.0,!=1.3.1`?

 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

