### PR TITLE
patch_url support for Dask load

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -657,7 +657,7 @@ class Datacube(object):
                                     chunks=chunks,
                                     skip_broken_datasets=skip_broken_datasets,
                                     extra_dims=extra_dims,
-                                    patch_url = patch_url)
+                                    patch_url=patch_url)
 
         return Datacube.create_storage(sources.coords, geobox, measurements, data_func, extra_dims)
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -9,7 +9,7 @@ v1.8.next
 =========
 
 - Performance improvements to CRS geometry class (:pull:`#1322`)
-- Extend `patch_url` argument to `dc.load()` and `dc.load_data()` to Dask loading.  (:pull: `???`)
+- Extend `patch_url` argument to `dc.load()` and `dc.load_data()` to Dask loading.  (:pull: `1323`)
 
 
 v1.8.8 (5 October 2022)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -5,6 +5,12 @@
 What's New
 **********
 
+v1.8.next
+=========
+
+- Performance improvements to CRS geometry class (:pull:`#1322`)
+
+
 v1.8.8 (5 October 2022)
 =======================
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -9,6 +9,7 @@ v1.8.next
 =========
 
 - Performance improvements to CRS geometry class (:pull:`#1322`)
+- Extend `patch_url` argument to `dc.load()` and `dc.load_data()` to Dask loading.  (:pull: `???`)
 
 
 v1.8.8 (5 October 2022)

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -118,6 +118,10 @@ def test_load_data_with_url_mangling(tmpdir):
     assert ds_data.aa.nodata == nodata
     np.testing.assert_array_equal(aa, ds_data.aa.values[0])
 
+    ds_data = Datacube.load_data(sources, gbox, mm, dask_chunks={'x': 8, 'y': 8}, patch_url=url_mangler)
+    assert ds_data.aa.nodata == nodata
+    np.testing.assert_array_equal(aa, ds_data.aa.values[0])
+
     custom_fuser_call_count = 0
 
     def custom_fuser(dest, delta):


### PR DESCRIPTION
### Reason for this pull request

A `patch_url` argument was added to `dc.load` and `dc.load_data` in PR #1317, but was initially only supported for direct loading.  This PR extends that functionality to Dask loading.

### Proposed changes

- Add `patch_url` argument to `Datacube._dask_load()`


 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
