### PR TITLE
setup readthedoc preview github ci for doc  preview before merge

### DIFF
--- a/.github/workflows/doc-qa.yaml
+++ b/.github/workflows/doc-qa.yaml
@@ -48,7 +48,7 @@ jobs:
           with:
               args: --short --error-format=github --cache-file=/github/workspace/.cache/doctor-rst.cache
 
-  documentation-links:
+  documentation-preview:
     runs-on: ubuntu-latest
     steps:
       - uses: readthedocs/actions/preview@v1

--- a/.github/workflows/doc-qa.yaml
+++ b/.github/workflows/doc-qa.yaml
@@ -47,3 +47,10 @@ jobs:
           uses: docker://oskarstark/doctor-rst
           with:
               args: --short --error-format=github --cache-file=/github/workspace/.cache/doctor-rst.cache
+
+  documentation-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: "datacube-core"

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -17,6 +17,7 @@ v1.8.next
 - Add what's new page link to menu and general doc fixes (:pull:`1335`)
 - Add `search_fields` to required for metadata type schema and update doc (:pull:`1339`)
 - Fix typo and update metadata documentation (:pull:`1340`)
+- Add readthedoc preview github action (:pull:`1344`)
 
 .. _PEP561: https://peps.python.org/pep-0561/
 


### PR DESCRIPTION
### Reason for this pull request

Multiple pull requests were raised to address syntax errors and typos, with previews syntax error caused rendering issue can be fixed before merging

### Proposed changes

- setup readthedocs preview ci



 - [x] Closes #1345 
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1344.org.readthedocs.build/en/1344/

<!-- readthedocs-preview datacube-core end -->