### PR TITLE
Add eo datasets to core doc

### DIFF
--- a/docs/about-core-concepts/extensions.rst
+++ b/docs/about-core-concepts/extensions.rst
@@ -73,3 +73,11 @@ Data Cube installation. It provides a command line application which uses a YAML
 data range and statistics to calculate.
 
 .. _`Data Cube Statistics`: https://github.com/opendatacube/datacube-stats
+
+
+EO Datasets
+------------
+
+`EO Datasets`_ is a tool to easily write, validate and convert ODC datasets and metadata.
+
+.. _`EO Datasets`: https://github.com/opendatacube/eo-datasets

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -19,6 +19,7 @@ v1.8.next
 - Fix typo and update metadata documentation (:pull:`1340`)
 - Add readthedoc preview github action (:pull:`1344`)
 - Update `nodata` in readthedoc for products page (:pull:`1347`)
+- Add `eo-datasets` to extensions & related software doc page (:pull:`1349`)
 
 .. _PEP561: https://peps.python.org/pep-0561/
 


### PR DESCRIPTION
### Reason for this pull request

Eo datasets repo offers `eo3-validate` for lint odc files. 

### Proposed changes

- add eo datasets to extensions related software doc page

 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1349.org.readthedocs.build/en/1349/

<!-- readthedocs-preview datacube-core end -->