### PR TITLE
Fix zero width range searches

### DIFF
--- a/datacube/drivers/postgis/_fields.py
+++ b/datacube/drivers/postgis/_fields.py
@@ -491,7 +491,7 @@ class RangeBetweenExpression(PgExpression):
     @property
     def alchemy_expression(self):
         return self.field.alchemy_expression.overlaps(
-            self._range_class(self.low_value, self.high_value)
+            self._range_class(self.low_value, self.high_value, bounds='[]')
         )
 
 

--- a/datacube/drivers/postgres/_fields.py
+++ b/datacube/drivers/postgres/_fields.py
@@ -491,7 +491,7 @@ class RangeBetweenExpression(PgExpression):
     @property
     def alchemy_expression(self):
         return self.field.alchemy_expression.overlaps(
-            self._range_class(self.low_value, self.high_value)
+            self._range_class(self.low_value, self.high_value, bounds="[]")
         )
 
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -20,6 +20,7 @@ v1.8.next
 - Add readthedoc preview github action (:pull:`1344`)
 - Update `nodata` in readthedoc for products page (:pull:`1347`)
 - Add `eo-datasets` to extensions & related software doc page (:pull:`1349`)
+- Fix bug affecting searches against range types of zero width (:pull:`1352`)
 
 .. _PEP561: https://peps.python.org/pep-0561/
 

--- a/integration_tests/data/eo3/ls8_dataset4.yaml
+++ b/integration_tests/data/eo3/ls8_dataset4.yaml
@@ -36,8 +36,6 @@ grids:
 properties:
   datetime: '2013-07-21T00:57:26.432563Z'
   dea:dataset_maturity: final
-  dtr:end_datetime: '2013-07-21T00:57:41.398421Z'
-  dtr:start_datetime: '2013-07-21T00:57:11.356786Z'
   eo:cloud_cover: 1.828773330949106e+01
   eo:gsd: 1.5e+01  # Ground sample distance (m)
   eo:instrument: OLI_TIRS

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -159,6 +159,7 @@ def test_field_expression_unchanged_postgis(
         default_metadata_type: MetadataType,
         telemetry_metadata_type: MetadataType) -> None:
     # We're checking for accidental changes here in our field-to-SQL code
+    # Dubious test as it uses non-EO3 metadata types
 
     # If we started outputting a different expression they would quietly no longer match the expression
     # indexes that exist in our DBs.

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -151,6 +151,27 @@ def test_search_dataset_ranges_eo3(index: Index, ls8_eo3_dataset: Dataset) -> No
     assert len(datasets) == 0
 
 
+def test_zero_width_range_search(index: Index, ls8_eo3_dataset4: Dataset) -> None:
+    # Test time search against zero-width time metadata
+    datasets = index.datasets.search_eager(time=Range(
+        begin=datetime.datetime(2013, 7, 21, 0, 57, 26, 432563, tzinfo=datetime.timezone.utc),
+        end=datetime.datetime(2013, 7, 21, 0, 57, 26, 432563, tzinfo=datetime.timezone.utc)
+    ))
+    assert len(datasets) == 1
+
+    datasets = index.datasets.search_eager(time=Range(
+        begin=datetime.datetime(2013, 7, 21, 0, 57, 26, 432563, tzinfo=datetime.timezone.utc),
+        end=datetime.datetime(2013, 7, 21, 0, 57, 27, 432563, tzinfo=datetime.timezone.utc)
+    ))
+    assert len(datasets) == 1
+
+    datasets = index.datasets.search_eager(time=Range(
+        begin=datetime.datetime(2013, 7, 21, 0, 57, 25, 432563, tzinfo=datetime.timezone.utc),
+        end=datetime.datetime(2013, 7, 21, 0, 57, 26, 432563, tzinfo=datetime.timezone.utc)
+    ))
+    assert len(datasets) == 1
+
+
 def test_search_globally_eo3(index: Index, ls8_eo3_dataset: Dataset) -> None:
     # No expressions means get all.
     results = list(index.datasets.search())


### PR DESCRIPTION
### Reason for this pull request

When constructing a query like: 
> Does the range value in a metadata field overlap with this provided range value? 

`datacube-core` does not explicitly specify the bounds of the range constructed from the values in the metadata. The default bounds from SQLAlchemy are `[)` - i.e. the start value is included in the search but the end value is not. Therefore if the range specified in metadata has start and end value identical (as is the case for time in Sentinel2 Collection3), then the search only matches if the provided range starts before and ends after the metadata value.

For explicit comparisons in memory, core always treats range bounds as `[]` (i.e. start and end both included) (and `[]` bounds are explicitly used when searching for a scale (non-range) value against a range field).

e.g.

Given a persisted dataset `ds` with a zero-width time range, in the following code `results` will NOT include ds.

```
ds = dc.index.datasets.get(ds_id)
assert ds.time.begin == ds.time.end
results = dc.index.datasets.search_eager(time=ds.time)
```

### Proposed changes

Explicitly make `RangeBetween` expressions use `[]` bounds.

 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1352.org.readthedocs.build/en/1352/

<!-- readthedocs-preview datacube-core end -->