### PR TITLE
add grid spec to list_products

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -98,8 +98,8 @@ class Datacube(object):
             'name'
             'description'
             'license'
-            'default_crs'
-            'default_resolution'
+            'default_crs' or 'grid_spec.crs'
+            'default_resolution' or 'grid_spec.crs'
             'dataset_count' (optional)
 
         :param bool with_pandas:
@@ -123,7 +123,11 @@ class Datacube(object):
         ]
         rows = [[
             getattr(pr, col, None)
+            # if 'default_crs' and 'default_resolution' are not None
+            # return 'default_crs' and 'default_resolution'
             if getattr(pr, col, None) and 'default' not in col
+            # else try 'grid_spec.crs' and 'grid_spec.resolution'
+            # as per output_geobox() handling logic
             else getattr(pr.grid_spec, col.replace('default_', ''), None)
             for col in cols]
             for pr in self.index.products.get_all()]

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -875,8 +875,8 @@ def output_geobox(like=None, output_crs=None, resolution=None, align=None,
         align = align or grid_spec.alignment
     else:
         raise ValueError(
-            "Product has no default CRS nor grid_spec. \n"
-            "Must specify 'output_crs' and 'resolution' or 'grid_spec'"
+            "Product has no default CRS. \n"
+            "Must specify 'output_crs' and 'resolution'"
         )
 
     # Try figuring out bounds

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -100,7 +100,6 @@ class Datacube(object):
             'license'
             'default_crs'
             'default_resolution'
-            'grid_spec'
             'dataset_count' (optional)
 
         :param bool with_pandas:
@@ -121,10 +120,13 @@ class Datacube(object):
             'license',
             'default_crs',
             'default_resolution',
-            'grid_spec',
         ]
-        rows = [[getattr(pr, col, None) for col in cols]
-                for pr in self.index.products.get_all()]
+        rows = [[
+            getattr(pr, col, None)
+            if getattr(pr, col, None) and 'default' not in col
+            else getattr(pr.grid_spec, col.replace('default_', ''), None)
+            for col in cols]
+            for pr in self.index.products.get_all()]
 
         # Optionally compute dataset count for each product and add to row/cols
         # Product lists are sorted by product name to ensure 1:1 match

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -100,6 +100,7 @@ class Datacube(object):
             'license'
             'default_crs'
             'default_resolution'
+            'grid_spec'
             'dataset_count' (optional)
 
         :param bool with_pandas:
@@ -120,6 +121,7 @@ class Datacube(object):
             'license',
             'default_crs',
             'default_resolution',
+            'grid_spec',
         ]
         rows = [[getattr(pr, col, None) for col in cols]
                 for pr in self.index.products.get_all()]
@@ -870,7 +872,10 @@ def output_geobox(like=None, output_crs=None, resolution=None, align=None,
             resolution = grid_spec.resolution
         align = align or grid_spec.alignment
     else:
-        raise ValueError("Product has no default CRS. Must specify 'output_crs' and 'resolution'")
+        raise ValueError(
+            "Product has no default CRS nor grid_spec. \n"
+            "Must specify 'output_crs' and 'resolution' or 'grid_spec'"
+        )
 
     # Try figuring out bounds
     #  1. Explicitly defined with geopolygon

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,8 @@ What's New
 v1.8.next
 =========
 
+- Add `grid_spec` to `list_products` (:pull:`1357`)
+
 v1.8.9 (17 November 2022)
 =========================
 


### PR DESCRIPTION
### Reason for this pull request

when calling `dc_load`, `output_geobox` function do a `load_hints` for `grid_spec` if `default_crs` and `default_resolution` is None, this isn't reflected in `list_products` result
https://github.com/opendatacube/datacube-core/blob/61c25d6745da9b391b33e9b26f9afeeaef059a99/datacube/api/core.py#L861-L873

### Proposed changes

- add  `grid_spec` crs and resolution to `default_crs` and `resolution` if None to `list_product` ap

 - [x] Closes #1356 
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1357.org.readthedocs.build/en/1357/

<!-- readthedocs-preview datacube-core end -->