### PR TITLE
fix schemaspy docker instruction

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,10 @@ When you create a Pull Request, there is a template defined that has required in
 
 **Using Docker**
 ```
-docker run -it --rm -v "$PWD:/output" --network="host" schemaspy/schemaspy -u dra547 -host localhost -port 15432 -db datacube -t pgsql -schemas agdc,cubedash -norows -noviews -pfp -imageformat svg
+docker run -it --rm -v "$PWD:/output" --network="host" schemaspy/schemaspy:snapshot -u $DB_USERNAME -host localhost -port $DB_PORT -db $DB_DATABASE -t pgsql11 -schemas agdc -norows -noviews -pfp -imageformat svg
 ```
+
+Grab the relationship diagram from agdc/diagrams/summary/relationships.real.large.svg
 
 **If SchemaSpy is downloaded Locally**
 ```

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -11,6 +11,7 @@ v1.8.next
 - Add `grid_spec` to `list_products` (:pull:`1357`)
 - Add database relationship diagram to doc (:pull:`1350`)
 - Change Github lint action to use ``conda`` and remove ``flake8`` from action (:pull:`1361`)
+- Fix database relationship diagram instruction for docker (:pull:`1362`)
 
 v1.8.9 (17 November 2022)
 =========================


### PR DESCRIPTION
### Reason for this pull request
the old command doesn't work, schemaspy docker image `latest` was released 3 years ago, the latest is tagged `snapshot` https://hub.docker.com/r/schemaspy/schemaspy/tags


### Proposed changes

- update docker to use `snapshot`
- update svg diagram folder location for docker output


 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1362.org.readthedocs.build/en/1362/

<!-- readthedocs-preview datacube-core end -->