### PR TITLE
Allow creating ODC objects without explicit configuration

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -39,6 +39,7 @@ class Datacube(object):
     Interface to search, read and write a datacube.
 
     :type index: datacube.index.index.Index
+
     """
 
     def __init__(self,

--- a/datacube/config.py
+++ b/datacube/config.py
@@ -41,6 +41,8 @@ index_driver: default
 # If a connection is unused for this length of time, expect it to be invalidated.
 db_connection_timeout: 60
 
+[default]
+
 [user]
 # Which environment to use when none is specified explicitly.
 #   note: will fail if default_environment points to non-existent section

--- a/datacube/config.py
+++ b/datacube/config.py
@@ -41,7 +41,7 @@ index_driver: default
 # If a connection is unused for this length of time, expect it to be invalidated.
 db_connection_timeout: 60
 
-[default]
+[datacube]
 
 [user]
 # Which environment to use when none is specified explicitly.

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -380,6 +380,7 @@ class Product:
 
     :param MetadataType metadata_type:
     :param dict definition:
+
     """
 
     def __init__(self,
@@ -524,6 +525,7 @@ class Product:
 
         :param definition: Dimension definition dict, typically retrieved from the product definition's
             `extra_dimensions` field.
+
         """
         # Dict of extra dimensions names and values in the product definition
         defined_extra_dimensions = OrderedDict(
@@ -581,6 +583,7 @@ class Product:
         Find measurements by name
 
         :param measurements: list of measurement names or a single measurement name, or None to get all
+
         """
         if measurements is None:
             return self.measurements
@@ -706,6 +709,7 @@ DatasetType = Product
 class IngestorConfig:
     """
     Ingestor configuration definition
+
     """
     pass
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -39,4 +39,4 @@ livehtml:
 
 clean:
 	rm -rf _build/
-	rm -rf dev/api/generate data-access-analysis/apis/generate api/indexed-data/generate api/geometry/generate
+	find . -name generate -type d -print0 | xargs -0 rm -rf

--- a/docs/about-core-concepts/products.rst
+++ b/docs/about-core-concepts/products.rst
@@ -1,5 +1,5 @@
 Products
-=============================
+========
 
 Products are collections of ``datasets`` that share the same set of measurements and some subset of metadata.
 
@@ -7,11 +7,11 @@ Products are collections of ``datasets`` that share the same set of measurements
 Product Definition
 ******************
 
-A product definition document describes the measurements and common metadata
+A Product Definition Document describes the measurements and common metadata
 for a collection of datasets.
 
 Example Product Definition
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. highlight:: language
 
@@ -20,7 +20,7 @@ Example Product Definition
 
 
 Product Definition API
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 .. bibliographic fields (which also require a transform):
 
@@ -188,9 +188,11 @@ extra_dimensions (required for 3D datasets)
 3D product definition
 ---------------------
 
+For example
 Example 3D product definition for GEDI L2B cover_z:
 
 .. literalinclude:: ../config_samples/dataset_types/gedi_l2b_cover_z.yaml
+   :emphasize-lines: 9-12
    :language: yaml
 
 .. note::

--- a/docs/api/indexed-data/dataset-querying.rst
+++ b/docs/api/indexed-data/dataset-querying.rst
@@ -3,7 +3,7 @@ Dataset Querying
 ================
 When connected to an ODC Database, these methods are available for searching and querying:
 
-.. code-block:: bash
+.. code-block::python
 
    dc = Datacube()
    dc.index.datasets.{method}

--- a/docs/api/indexed-data/dataset-writing.rst
+++ b/docs/api/indexed-data/dataset-writing.rst
@@ -3,7 +3,7 @@ Dataset Writing
 ===============
 When connected to an ODC Database, these methods are available for adding, updating and archiving datasets:
 
-.. code-block:: bash
+.. code-block::python
 
    dc = Datacube()
    dc.index.datasets.{method}
@@ -12,7 +12,6 @@ When connected to an ODC Database, these methods are available for adding, updat
 .. currentmodule:: datacube.index.abstract.AbstractDatasetResource
 
 .. autosummary::
-
    :toctree: generate/
 
    add

--- a/docs/api/indexed-data/product-querying.rst
+++ b/docs/api/indexed-data/product-querying.rst
@@ -1,9 +1,10 @@
 ================
 Product Querying
 ================
+
 When connected to an ODC Database, these methods are available for discovering information about Products:
 
-.. code-block:: bash
+.. code-block::python
 
    dc = Datacube()
    dc.index.products.{method}

--- a/docs/api/indexed-data/product-writing.rst
+++ b/docs/api/indexed-data/product-writing.rst
@@ -4,7 +4,7 @@ Product Writing
 
 When connected to an ODC Database, these methods are available for altering information about Products:
 
-.. code-block:: bash
+.. code-block::python
 
    dc = Datacube()
    dc.index.products.{method}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -90,8 +90,8 @@ autodoc_default_options = {
     'inherited-members': True
 }
 
-extlinks = {'issue': ('https://github.com/opendatacube/datacube-core/issues/%s', 'issue '),
-            'pull': ('https://github.com/opendatacube/datacube-core/pulls/%s', 'PR ')}
+extlinks = {'issue': ('https://github.com/opendatacube/datacube-core/issues/%s', 'issue %s'),
+            'pull': ('https://github.com/opendatacube/datacube-core/pulls/%s', 'PR %s')}
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),

--- a/docs/data-access-analysis/advanced-topics/virtual-products.rst
+++ b/docs/data-access-analysis/advanced-topics/virtual-products.rst
@@ -215,7 +215,7 @@ This combinator enables performing transformations to raster data in their nativ
 rasters to a common grid.
 
 Transform (Data modifying)
--------------------------
+--------------------------
 
 This node applies an on-the-fly data transformation on the loaded data. The recipe
 for a ``transform`` has the form:

--- a/docs/installation/database/setup.rst
+++ b/docs/installation/database/setup.rst
@@ -95,4 +95,4 @@ The ``datacube system init`` tool can create and populate the Data Cube database
    :prog: datacube system
 
 This creates a database schema, tables, indexes and roles, so requires admin
-prvileges to the Database Cluster.
+privileges to the Database Cluster.

--- a/docs/installation/database/setup.rst
+++ b/docs/installation/database/setup.rst
@@ -93,3 +93,6 @@ The ``datacube system init`` tool can create and populate the Data Cube database
 
 .. click::datacube.scripts.system:database_init
    :prog: datacube system
+
+This creates a database schema, tables, indexes and roles, so requires admin
+prvileges to the Database Cluster.

--- a/docs/installation/database/setup.rst
+++ b/docs/installation/database/setup.rst
@@ -91,6 +91,5 @@ The ``datacube system init`` tool can create and populate the Data Cube database
 
     datacube -v system init
 
-.. click:: datacube.scripts.system:database_init
-
+.. click::datacube.scripts.system:database_init
    :prog: datacube system

--- a/docs/installation/extending-odc.rst
+++ b/docs/installation/extending-odc.rst
@@ -93,30 +93,30 @@ Example code to implement a 3D read
         window: Optional[RasterWindow] = None,
         out_shape: Optional[RasterShape] = None,
     ) -> np.ndarray:
-    """
-    Reads a slice into the xr.DataArray.
+        """
+        Reads a slice into the xr.DataArray.
 
-    :param RasterWindow window: The slice to read
-    :param RasterShape out_shape: The desired output shape
-    :return: Requested data in a :class:`numpy.ndarray`
-    """
+        :param RasterWindow window: The slice to read
+        :param RasterShape out_shape: The desired output shape
+        :return: Requested data in a :class:`numpy.ndarray`
+        """
 
-    if window is None:
-        ix: Tuple = (...,)
-    else:
-        ix = tuple(slice(*w) if isinstance(w, tuple) else w for w in window)
+        if window is None:
+            ix: Tuple = (...,)
+        else:
+            ix = tuple(slice(*w) if isinstance(w, tuple) else w for w in window)
 
-    def fn() -> Any:
-        return self.da[ix].values
+        def fn() -> Any:
+            return self.da[ix].values
 
-    data = fn()
+        data = fn()
 
-    if out_shape and data.shape != out_shape:
-        raise ValueError(
-            f"Data shape does not match 'out_shape': {data.shape} != {out_shape}"
-        )
+        if out_shape and data.shape != out_shape:
+            raise ValueError(
+                f"Data shape does not match 'out_shape': {data.shape} != {out_shape}"
+            )
 
-    return data
+        return data
 
 Example Xarray Based 3D Driver
 ------------------------------

--- a/docs/installation/ingesting-data/index.rst
+++ b/docs/installation/ingesting-data/index.rst
@@ -1,26 +1,10 @@
 
+.. _ingestion:
 
 Ingesting Data
 **************
-.. _ingestion:
 
-.. note::
-
-    Ingestion is no longer recommended. While it was used as an optimised on-disk
-    storage mechanism, there are a range of reasons why this is no longer ideal. For example
-    the emergence of cloud optimised storage formats means that software such
-    as GDAL and Rasterio are optimised for reading many files over the network. Additionally
-    the limitation of NetCDF reading to a single thread means that reading from .TIF
-    files on disk could be faster in some situations.
-
-    In addition to limited performance improvements, ingestion leads to duplication
-    of data and opinionated decisions, such as reprojection of data, which can lead
-    to a loss of data fidelity.
-
-    The section below is being retained for completion, but should be considered optional.
-
-
-.. note::
+.. warning::
 
     Ingestion is no longer recommended. While it was used as an optimised on-disk
     storage mechanism, there are a range of reasons why this is no longer ideal. For example
@@ -41,10 +25,9 @@ you should already have some data :ref:`indexed <indexing>`, and want to
 tile it up into a faster storage format or projection system.
 
 .. figure:: ../../diagrams/f4.png
+   :name: ingest-data
 
-    :name: ingest-data
-
-        Ingest Data
+   Ingest Data
 
 .. _ingest-config:
 
@@ -71,6 +54,7 @@ different projections, resolutions, etc.
 
 Ingestion Config
 ================
+
 An ingestion config is a document which defines the way data should be prepared
 for high performance access. This can include  slicing the data into regular
 chunks, reprojecting into to the desired projection and compressing the data.
@@ -170,8 +154,7 @@ Ingest Some Data
 A command line tool is used to ingest data
 
 .. click:: datacube.scripts.ingest:ingest_cmd
-
-    :prog: datacube ingest
+   :prog: datacube ingest
 
 
 `Configuration samples <https://github.com/opendatacube/datacube-core/tree/develop/docs/config_samples>`_ are available as part of the open source Github repository.

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -43,7 +43,7 @@ _EXAMPLE_LS5_NBAR_DATASET_FILE = INTEGRATION_TESTS_DIR / 'example-ls5-nbar.yaml'
 NUM_TIME_SLICES = 3
 
 PROJECT_ROOT = Path(__file__).parents[1]
-CONFIG_SAMPLES = PROJECT_ROOT / 'docs' / 'config_samples'
+CONFIG_SAMPLES = PROJECT_ROOT / 'docs/config_samples'
 
 CONFIG_FILE_PATHS = [str(INTEGRATION_TESTS_DIR / 'agdcintegration.conf'),
                      os.path.expanduser('~/.datacube_integration.conf')]
@@ -56,7 +56,7 @@ settings.register_profile(
 )
 settings.load_profile('opendatacube')
 
-EO3_TESTDIR = INTEGRATION_TESTS_DIR / 'data' / 'eo3'
+EO3_TESTDIR = INTEGRATION_TESTS_DIR / 'data/eo3'
 
 
 def get_eo3_test_data_doc(path):


### PR DESCRIPTION
### Reason for this pull request
When testing downstream code, it can be useful to instantiate Datacube and Index (and LocalConfig) objects without having to actually create a configuration for them, by setting environment variables or creating configuration files.

At the moment, it's impossible, and raising an exception similar to:

```
  File "/home/omad/miniconda3/envs/datacube-explorer/lib/python3.9/site-packages/datacube/config.py", line 106, in __init__
    raise ValueError('No ODC environment, checked configurations for %s' % fallbacks)
ValueError: No ODC environment, checked configurations for ['default', 'datacube']
```

### Proposed changes

- Add an empty `[default]` section to the default configuration file, to make object instantiation not immediately fail if not explicitly configured.


I think this makes sense, to only fail that you can't connect to an ODC Index when you actually require one, and not earlier than that.

<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1365.org.readthedocs.build/en/1365/

<!-- readthedocs-preview datacube-core end -->