### PR TITLE
Product search by metadata

### DIFF
--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -234,7 +234,7 @@ def query_group_by(group_by='time', **kwargs):
         return group_by_map[group_by]
     except KeyError:
         raise LookupError(
-            f'No group by function for {group_by}, valid options are: {group_by_map.keys()}',
+            f'No group by function for {group_by}, valid options are: {group_by_map.keys()}', # pylint: disable=W1655
         )
 
 

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -234,7 +234,7 @@ def query_group_by(group_by='time', **kwargs):
         return group_by_map[group_by]
     except KeyError:
         raise LookupError(
-            f'No group by function for {group_by}, valid options are: {group_by_map.keys()}', # pylint: disable=W1655
+            f'No group by function for {group_by}, valid options are: {group_by_map.keys()}',# pylint: disable=W1655
         )
 
 

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -234,7 +234,7 @@ def query_group_by(group_by='time', **kwargs):
         return group_by_map[group_by]
     except KeyError:
         raise LookupError(
-            f'No group by function for {group_by}, valid options are: {group_by_map.keys()}',# pylint: disable=W1655
+            f'No group by function for {group_by}, valid options are: {group_by_map.keys()}',  # pylint: disable=W1655
         )
 
 

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -189,8 +189,6 @@ def extract_dataset_search_fields(ds_metadata, mdt_metadata):
         fld_type = field.type_name
         fld_val = field.search_value_to_alchemy(field.extract(ds_metadata))
         result[field_name] = (fld_type, fld_val)
-    for k, v in result.items():
-        _LOG.warning("field %s: %s", k, repr(v))
     return result
 
 
@@ -313,7 +311,6 @@ class PostgisDbAPI(object):
         """
         if isinstance(value, Range):
             value = list(value)
-        _LOG.warning("Inserting ds %s (%s): %s", dataset_id, key, repr(value))
         r = self._connection.execute(
             insert(
                 search_table
@@ -535,8 +532,9 @@ class PostgisDbAPI(object):
         :rtype: dict
         """
         # Find any storage types whose 'dataset_metadata' document is a subset of the metadata.
+        norm_metadata = {"properties": metadata}
         return self._connection.execute(
-            Product.select().where(Product.metadata.contains(metadata))
+            select(Product).where(Product.metadata_doc.contains(norm_metadata))
         ).fetchall()
 
     @staticmethod

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -532,9 +532,8 @@ class PostgisDbAPI(object):
         :rtype: dict
         """
         # Find any storage types whose 'dataset_metadata' document is a subset of the metadata.
-        norm_metadata = {"properties": metadata}
         return self._connection.execute(
-            select(Product).where(Product.metadata_doc.contains(norm_metadata))
+            select(Product).where(Product.metadata_doc.contains(metadata))
         ).fetchall()
 
     @staticmethod

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -527,6 +527,18 @@ class PostgisDbAPI(object):
             select(_dataset_select_fields()).where(Dataset.metadata_doc.contains(metadata))
         ).fetchall()
 
+    def search_products_by_metadata(self, metadata):
+        """
+        Find any datasets that have the given metadata.
+
+        :type metadata: dict
+        :rtype: dict
+        """
+        # Find any storage types whose 'dataset_metadata' document is a subset of the metadata.
+        return self._connection.execute(
+            Product.select().where(Product.metadata.contains(metadata))
+        ).fetchall()
+
     @staticmethod
     def _alchemify_expressions(expressions):
         def raw_expr(expression):

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -463,9 +463,9 @@ class PostgresDbAPI(object):
         :rtype: dict
         """
         # Find any products types whose metadata document contains the passed in metadata
-        return self._connection.execute(
-            PRODUCT.select().where(PRODUCT.c.metadata.contains(metadata))
-        ).fetchall()
+        norm_metadata = {"properties": metadata}
+        qry = PRODUCT.select().where(PRODUCT.c.metadata.contains(norm_metadata))
+        return self._connection.execute(qry).fetchall()
 
     @staticmethod
     def _alchemify_expressions(expressions):

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -463,9 +463,9 @@ class PostgresDbAPI(object):
         :rtype: dict
         """
         # Find any products types whose metadata document contains the passed in metadata
-        norm_metadata = {"properties": metadata}
-        qry = PRODUCT.select().where(PRODUCT.c.metadata.contains(norm_metadata))
-        return self._connection.execute(qry).fetchall()
+        return self._connection.execute(
+            PRODUCT.select().where(PRODUCT.c.metadata.contains(metadata))
+        ).fetchall()
 
     @staticmethod
     def _alchemify_expressions(expressions):

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -455,6 +455,18 @@ class PostgresDbAPI(object):
             select(_DATASET_SELECT_FIELDS).where(DATASET.c.metadata.contains(metadata))
         ).fetchall()
 
+    def search_products_by_metadata(self, metadata):
+        """
+        Find any products that have the given metadata.
+
+        :type metadata: dict
+        :rtype: dict
+        """
+        # Find any products types whose metadata document contains the passed in metadata
+        return self._connection.execute(
+            PRODUCT.select().where(PRODUCT.c.metadata.contains(metadata))
+        ).fetchall()
+
     @staticmethod
     def _alchemify_expressions(expressions):
         def raw_expr(expression):

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -465,6 +465,19 @@ class AbstractProductResource(ABC):
         """
 
     @abstractmethod
+    def search_by_metadata(self,
+                           metadata: Mapping[str, QueryField]
+                           ) -> Iterable[Dataset]:
+        """
+        Perform a search using arbitrary metadata, returning results as Product objects.
+
+        Caution – slow! This will usually not use indexes.
+
+        :param metadata: metadata dictionary representing arbitrary search query
+        :return: Matching product models
+        """
+
+    @abstractmethod
     def get_all(self) -> Iterable[Product]:
         """
         Retrieve all Products

--- a/datacube/index/memory/_products.py
+++ b/datacube/index/memory/_products.py
@@ -167,7 +167,7 @@ class ProductResource(AbstractProductResource):
                 yield prod, unmatched
 
     def search_by_metadata(self, metadata: Mapping[str, QueryField]):
-        for prod in self.active_by_id.values():
+        for prod in self.get_all():
             if metadata_subset(metadata, prod.metadata_doc):
                 yield prod
 

--- a/datacube/index/memory/_products.py
+++ b/datacube/index/memory/_products.py
@@ -15,7 +15,6 @@ from datacube.utils.changes import AllowPolicy, Change, Offset, check_doc_unchan
 from datacube.utils.documents import metadata_subset
 
 
-
 _LOG = logging.getLogger(__name__)
 
 

--- a/datacube/index/memory/_products.py
+++ b/datacube/index/memory/_products.py
@@ -167,8 +167,9 @@ class ProductResource(AbstractProductResource):
                 yield prod, unmatched
 
     def search_by_metadata(self, metadata: Mapping[str, QueryField]):
+        norm_meta = {"properties": metadata}
         for prod in self.get_all():
-            if metadata_subset(metadata, prod.metadata_doc):
+            if metadata_subset(norm_meta, prod.metadata_doc):
                 yield prod
 
     def get_all(self) -> Iterable[Product]:

--- a/datacube/index/memory/_products.py
+++ b/datacube/index/memory/_products.py
@@ -4,13 +4,17 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 
+from typing import Iterable, Iterator, Mapping, Tuple, cast
+
 from datacube.index.fields import as_expression
 from datacube.index.abstract import AbstractProductResource, QueryField
 from datacube.index.memory._metadata_types import MetadataTypeResource
 from datacube.model import DatasetType as Product
 from datacube.utils import changes, jsonify_document, _readable_offset
 from datacube.utils.changes import AllowPolicy, Change, Offset, check_doc_unchanged, get_doc_changes, classify_changes
-from typing import Iterable, Iterator, Mapping, Tuple, cast
+from datacube.utils.documents import metadata_subset
+
+
 
 _LOG = logging.getLogger(__name__)
 
@@ -161,6 +165,11 @@ class ProductResource(AbstractProductResource):
                     break
             else:
                 yield prod, unmatched
+
+    def search_by_metadata(self, metadata: Mapping[str, QueryField]):
+        for prod in self.active_by_id.values():
+            if metadata_subset(metadata, prod.metadata_doc):
+                yield prod
 
     def get_all(self) -> Iterable[Product]:
         return (self.clone(prod) for prod in self.by_id.values())

--- a/datacube/index/null/_products.py
+++ b/datacube/index/null/_products.py
@@ -37,5 +37,8 @@ class ProductResource(AbstractProductResource):
     def search_robust(self, **query):
         return []
 
+    def search_by_metadata(self, metadata):
+        return []
+
     def get_all(self) -> Iterable[DatasetType]:
         return []

--- a/datacube/index/postgis/_products.py
+++ b/datacube/index/postgis/_products.py
@@ -303,12 +303,25 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
             else:
                 yield type_, remaining_matchable
 
+    def search_by_metadata(self, metadata):
+        """
+        Perform a search using arbitrary metadata, returning results as Product objects.
+
+        Caution – slow! This will usually not use indexes.
+
+        :param dict metadata:
+        :rtype: list[Product]
+        """
+        with self._db_connection() as connection:
+            for dataset in self._make_many(connection.search_products_by_metadata(metadata)):
+                yield dataset
+
     def get_all(self) -> Iterable[Product]:
         """
         Retrieve all Products
         """
         with self._db_connection() as connection:
-            return (self._make(record) for record in connection.get_all_products())
+            return self._make_many(connection.get_all_products())
 
     def _make_many(self, query_rows):
         return (self._make(c) for c in query_rows)

--- a/datacube/index/postgres/_products.py
+++ b/datacube/index/postgres/_products.py
@@ -305,6 +305,19 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
             else:
                 yield type_, remaining_matchable
 
+    def search_by_metadata(self, metadata):
+        """
+        Perform a search using arbitrary metadata, returning results as Product objects.
+
+        Caution – slow! This will usually not use indexes.
+
+        :param dict metadata:
+        :rtype: list[Product]
+        """
+        with self._db_connection() as connection:
+            for dataset in self._make_many(connection.search_products_by_metadata(metadata)):
+                yield dataset
+
     def get_all(self) -> Iterable[DatasetType]:
         """
         Retrieve all Products

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -14,6 +14,7 @@ v1.8.next
 - Change Github lint action to use ``conda`` and remove ``flake8`` from action (:pull:`1361`)
 - Fix database relationship diagram instruction for docker (:pull:`1362`)
 - Document ``group_by`` for ``dataset.load`` (:pull:`1364`)
+- Add search_by_metadata facility for products (:pull:`1366`)
 
 v1.8.9 (17 November 2022)
 =========================

--- a/docs/api/indexed-data/product-querying.rst
+++ b/docs/api/indexed-data/product-querying.rst
@@ -22,4 +22,5 @@ When connected to an ODC Database, these methods are available for discovering i
    get_with_fields
    search
    search_robust
+   search_by_metadata
    get_all

--- a/integration_tests/index/test_memory_index.py
+++ b/integration_tests/index/test_memory_index.py
@@ -141,6 +141,14 @@ def test_mem_product_resource(mem_index_fresh,
             assert unmatched == {}
         else:
             assert unmatched["platform"] == 'landsat-8'
+    lds = list(mem_index_fresh.index.products.search_by_metadata({"product_family": "ard"}))
+    assert len(lds) == 0
+    lds = list(mem_index_fresh.index.products.search_by_metadata({"odc:product_family": "ard"}))
+    assert len(lds) == 1
+    lds = list(mem_index_fresh.index.products.search_by_metadata({"platform": "landsat-8"}))
+    assert len(lds) == 0
+    lds = list(mem_index_fresh.index.products.search_by_metadata({"eo:platform": "landsat-8"}))
+    assert len(lds) == 1
 
 
 # Hand crafted tests with recent real-world eo3 examples

--- a/integration_tests/index/test_memory_index.py
+++ b/integration_tests/index/test_memory_index.py
@@ -481,13 +481,13 @@ def test_mem_ds_search_returning_datasets_light(mem_eo3_data):
 
 def test_mem_ds_search_by_metadata(mem_eo3_data):
     dc, ls8_id, wo_id = mem_eo3_data
-    lds = list(dc.index.datasets.search_by_metadata({"product_family": "ard"}))
+    lds = list(dc.index.datasets.search_by_metadata({"properties": {"product_family": "ard"}}))
     assert len(lds) == 0
-    lds = list(dc.index.datasets.search_by_metadata({"odc:product_family": "ard"}))
+    lds = list(dc.index.datasets.search_by_metadata({"properties": {"odc:product_family": "ard"}}))
     assert len(lds) == 1
-    lds = list(dc.index.datasets.search_by_metadata({"platform": "landsat-8"}))
+    lds = list(dc.index.datasets.search_by_metadata({"properties": {"platform": "landsat-8"}}))
     assert len(lds) == 0
-    lds = list(dc.index.datasets.search_by_metadata({"eo:platform": "landsat-8"}))
+    lds = list(dc.index.datasets.search_by_metadata({"properties": {"eo:platform": "landsat-8"}}))
     assert len(lds) == 2
 
 

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -25,13 +25,13 @@ from .search_utils import assume_utc, _cli_csv_search, _csv_search_raw, _load_pr
 
 
 def test_search_by_metadata(index: Index, ls8_eo3_product, wo_eo3_product):
-    lds = list(index.products.search_by_metadata({"product_family": "ard"}))
+    lds = list(index.products.search_by_metadata({"properties": {"product_family": "ard"}}))
     assert len(lds) == 0
-    lds = list(index.products.search_by_metadata({"odc:product_family": "ard"}))
+    lds = list(index.products.search_by_metadata({"properties": {"odc:product_family": "ard"}}))
     assert len(lds) == 1
-    lds = list(index.products.search_by_metadata({"platform": "landsat-8"}))
+    lds = list(index.products.search_by_metadata({"properties": {"platform": "landsat-8"}}))
     assert len(lds) == 0
-    lds = list(index.products.search_by_metadata({"eo:platform": "landsat-8"}))
+    lds = list(index.products.search_by_metadata({"properties": {"eo:platform": "landsat-8"}}))
     assert len(lds) == 1
 
 

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -24,6 +24,17 @@ from datacube import Datacube
 from .search_utils import assume_utc, _cli_csv_search, _csv_search_raw, _load_product_query
 
 
+def test_search_by_metadata(index: Index, ls8_eo3_product, wo_eo3_product):
+    lds = list(index.products.search_by_metadata({"product_family": "ard"}))
+    assert len(lds) == 0
+    lds = list(index.products.search_by_metadata({"odc:product_family": "ard"}))
+    assert len(lds) == 1
+    lds = list(index.products.search_by_metadata({"platform": "landsat-8"}))
+    assert len(lds) == 0
+    lds = list(index.products.search_by_metadata({"eo:platform": "landsat-8"}))
+    assert len(lds) == 1
+
+
 def test_search_dataset_equals_eo3(index: Index, ls8_eo3_dataset: Dataset):
     datasets = index.datasets.search_eager(
         platform='landsat-8'


### PR DESCRIPTION
### Reason for this pull request

Support for product searches is minimal.

### Proposed changes

- Add Generic search-by-metadata facility for products.
- Make in-memory driver search-by-metadata methods compatible with postgres/postgis drivers.



 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1366.org.readthedocs.build/en/1366/

<!-- readthedocs-preview datacube-core end -->