### PR TITLE
Nested transactions

### DIFF
--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -15,7 +15,7 @@ v1.8.next
 - Fix database relationship diagram instruction for docker (:pull:`1362`)
 - Document ``group_by`` for ``dataset.load`` (:pull:`1364`)
 - Add search_by_metadata facility for products (:pull:`1366`)
-- Add support for nested database transactions (:pull:`????`)
+- Add support for nested database transactions (:pull:`1369`)
 
 v1.8.9 (17 November 2022)
 =========================

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -15,6 +15,7 @@ v1.8.next
 - Fix database relationship diagram instruction for docker (:pull:`1362`)
 - Document ``group_by`` for ``dataset.load`` (:pull:`1364`)
 - Add search_by_metadata facility for products (:pull:`1366`)
+- Add support for nested database transactions (:pull:`????`)
 
 v1.8.9 (17 November 2022)
 =========================

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -303,10 +303,10 @@ def test_transactions_api_ctx_mgr(index,
 
 
 def test_transactions_api_ctx_mgr_nested(index,
-                                  extended_eo3_metadata_type_doc,
-                                  ls8_eo3_product,
-                                  eo3_ls8_dataset_doc,
-                                  eo3_ls8_dataset2_doc):
+                                         extended_eo3_metadata_type_doc,
+                                         ls8_eo3_product,
+                                         eo3_ls8_dataset_doc,
+                                         eo3_ls8_dataset2_doc):
     from datacube.index.hl import Doc2Dataset
     resolver = Doc2Dataset(index, products=[ls8_eo3_product.name], verify_lineage=False)
     ds1, err = resolver(*eo3_ls8_dataset_doc)


### PR DESCRIPTION
### Reason for this pull request

Transaction API did not allow for nested transactions which makes certain use cases problematic.


### Proposed changes

- Nested transactions using context manager API now supported.  Only the outermost context manager does an actual commit or rollback.
- Manual transaction API hopefully operates in the manner of least-surprise, but trying to do manual transaction management in a nested environment is almost always a bad idea.



 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1369.org.readthedocs.build/en/1369/

<!-- readthedocs-preview datacube-core end -->