### PR TITLE
Enforce eo3 in postgis driver, and related refactors

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -411,7 +411,7 @@ class Datacube(object):
             return xarray.Dataset()
 
         ds, *_ = datasets
-        datacube_product = ds.type
+        datacube_product = ds.product
 
         # Retrieve extra_dimension from product definition
         extra_dims = None

--- a/datacube/api/grid_workflow.py
+++ b/datacube/api/grid_workflow.py
@@ -73,7 +73,7 @@ class Tile(object):
         """
         :rtype: datacube.model.DatasetType
         """
-        return self.sources.values[0][0].type
+        return self.sources.values[0][0].product
 
     def __getitem__(self, chunk):
         sources = _fast_slice(self.sources, chunk[:len(self.sources.shape)])

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -431,16 +431,17 @@ class PostgisDbAPI(object):
         return self._connection.execute(query).fetchall()
 
     def insert_dataset_source(self, classifier, dataset_id, source_dataset_id):
-        r = self._connection.execute(
-            insert(DatasetSource).on_conflict_do_nothing(
-                index_elements=['classifier', 'dataset_ref']
-            ).values(
-                classifier=classifier,
-                dataset_ref=dataset_id,
-                source_dataset_ref=source_dataset_id
-            )
-        )
-        return r.rowcount > 0
+        # r = self._connection.execute(
+        #     insert(DatasetSource).on_conflict_do_nothing(
+        #         index_elements=['classifier', 'dataset_ref']
+        #     ).values(
+        #         classifier=classifier,
+        #         dataset_ref=dataset_id,
+        #         source_dataset_ref=source_dataset_id
+        #     )
+        # )
+        # return r.rowcount > 0
+        return False
 
     def archive_dataset(self, dataset_id):
         r = self._connection.execute(

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -430,7 +430,8 @@ class PostgisDbAPI(object):
             )
         return self._connection.execute(query).fetchall()
 
-    def insert_dataset_source(self, classifier, dataset_id, source_dataset_id):
+    # Not currently implemented.
+    # def insert_dataset_source(self, classifier, dataset_id, source_dataset_id):
         # r = self._connection.execute(
         #     insert(DatasetSource).on_conflict_do_nothing(
         #         index_elements=['classifier', 'dataset_ref']
@@ -441,7 +442,6 @@ class PostgisDbAPI(object):
         #     )
         # )
         # return r.rowcount > 0
-        return False
 
     def archive_dataset(self, dataset_id):
         r = self._connection.execute(

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -79,9 +79,9 @@ class AbstractUserResource(ABC):
 _DEFAULT_METADATA_TYPES_PATH = Path(__file__).parent.joinpath('default-metadata-types.yaml')
 
 
-def default_metadata_type_docs() -> List[MetadataType]:
+def default_metadata_type_docs(path=_DEFAULT_METADATA_TYPES_PATH) -> List[MetadataType]:
     """A list of the bare dictionary format of default :class:`datacube.model.MetadataType`"""
-    return [doc for (path, doc) in read_documents(_DEFAULT_METADATA_TYPES_PATH)]
+    return [doc for (path, doc) in read_documents(path)]
 
 
 class AbstractMetadataTypeResource(ABC):
@@ -1340,6 +1340,8 @@ class AbstractIndexDriver(ABC):
     def metadata_type_from_doc(definition: dict
                               ) -> MetadataType:
         ...
+
+
 
 
 # The special handling of grid_spatial, etc appears to NOT apply to EO3.

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -1342,8 +1342,6 @@ class AbstractIndexDriver(ABC):
         ...
 
 
-
-
 # The special handling of grid_spatial, etc appears to NOT apply to EO3.
 # Does EO3 handle it in metadata?
 class DatasetSpatialMixin:

--- a/datacube/index/eo3.py
+++ b/datacube/index/eo3.py
@@ -188,7 +188,7 @@ def is_doc_geo(doc: Dict[str, Any], check_eo3: bool = True) -> bool:
     """ Is this document geospatial?
 
     :param doc: Parsed ODC Dataset metadata document
-    :param check_url: Set to false to skip the EO3 check and assume doc isn't EO3.
+    :param check_eo3: Set to false to skip the EO3 check and assume doc isn't EO3.
 
     :returns:
         True if this document specifies geospatial dimensions

--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -99,7 +99,7 @@ def check_dataset_consistent(dataset: Dataset) -> Tuple[bool, Optional[str]]:
     :return: (Is consistent, [error message|None])
     :rtype: (bool, str or None)
     """
-    product_measurements = set(dataset.type.measurements.keys())
+    product_measurements = set(dataset.product.measurements.keys())
 
     if len(product_measurements) == 0:
         return True, None
@@ -113,7 +113,7 @@ def check_dataset_consistent(dataset: Dataset) -> Tuple[bool, Optional[str]]:
         not_measured = {
             m
             for m in product_measurements - set(dataset.measurements.keys())
-            if "extra_dim" not in dataset.type.measurements.get(m, [])
+            if "extra_dim" not in dataset.product.measurements.get(m, [])
         }
 
         if not_measured:
@@ -219,7 +219,7 @@ def dataset_resolver(index: AbstractIndex,
 
             db_ds = db_dss.get(ds.id)
             if db_ds:
-                product = db_ds.type
+                product = db_ds.product
             else:
                 product = match_product(doc)
 

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -169,7 +169,8 @@ class DatasetResource(AbstractDatasetResource):
             )
         if dataset.product.name != existing.product.name:
             raise ValueError(
-                f'Changing product is not supported. From {existing.product.name} to {dataset.product.name} in {dataset.id}'
+                'Changing product is not supported. '
+                f'From {existing.product.name} to {dataset.product.name} in {dataset.id}'
             )
         # TODO: Determine (un)safe changes from metadata type
         allowed: Dict[Offset, AllowPolicy] = {

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -713,7 +713,7 @@ class DatasetResource(AbstractDatasetResource):
         else:
             uris = []
         return Dataset(
-            type_=self.product_resource.clone(orig.type),
+            product=self.product_resource.clone(orig.type),
             metadata_doc=jsonify_document(orig.metadata_doc_without_lineage()),
             uris=uris,
             indexed_by="user" if for_save and orig.indexed_by is None else orig.indexed_by,

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -20,7 +20,6 @@ from datacube.index.abstract import AbstractDatasetResource, DatasetSpatialMixin
 from datacube.index.postgis._transaction import IndexResourceAddIn
 from datacube.model import Dataset, Product
 from datacube.model.fields import Field
-from datacube.model.utils import flatten_datasets
 from datacube.utils import jsonify_document, _readable_offset, changes
 from datacube.utils.changes import get_doc_changes
 from datacube.utils.geometry import CRS, Geometry
@@ -159,15 +158,15 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             return dataset
 
         with self._db_connection(transaction=True) as transaction:
-                # 1a. insert (if not already exists)
-                is_new = transaction.insert_dataset(dataset.metadata_doc_without_lineage(), dataset.id, dataset.type.id)
-                if is_new:
-                    # 1b. Prepare spatial index extents
-                    transaction.update_spindex(dsids=[dataset.id])
-                    transaction.update_search_index(dsids=[dataset.id])
-                    # 1c. Store locations
-                    if dataset.uris is not None:
-                        self._ensure_new_locations(dataset, transaction=transaction)
+            # 1a. insert (if not already exists)
+            is_new = transaction.insert_dataset(dataset.metadata_doc_without_lineage(), dataset.id, dataset.type.id)
+            if is_new:
+                # 1b. Prepare spatial index extents
+                transaction.update_spindex(dsids=[dataset.id])
+                transaction.update_search_index(dsids=[dataset.id])
+                # 1c. Store locations
+                if dataset.uris is not None:
+                    self._ensure_new_locations(dataset, transaction=transaction)
 
         return dataset
 

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -452,7 +452,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         product = product or self.types.get(dataset_res.product_ref)
 
         return Dataset(
-            type_=product,
+            product=product,
             metadata_doc=dataset_res.metadata,
             uris=uris,
             indexed_by=dataset_res.added_by if full_info else None,

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -149,6 +149,9 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         :rtype: Dataset
         """
 
+        if with_lineage:
+            raise ValueError("Lineage is not yet supported by the postgis driver")
+
         sp_crses = self._db.spatial_indexes()
 
         def process_bunch(dss, main_ds, transaction):

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -159,7 +159,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
         with self._db_connection(transaction=True) as transaction:
             # 1a. insert (if not already exists)
-            is_new = transaction.insert_dataset(dataset.metadata_doc_without_lineage(), dataset.id, dataset.type.id)
+            is_new = transaction.insert_dataset(dataset.metadata_doc_without_lineage(), dataset.id, dataset.product.id)
             if is_new:
                 # 1b. Prepare spatial index extents
                 transaction.update_spindex(dsids=[dataset.id])
@@ -211,9 +211,9 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         if not existing:
             raise ValueError('Unknown dataset %s, cannot update – did you intend to add it?' % dataset.id)
 
-        if dataset.type.name != existing.type.name:
-            raise ValueError('Changing product is not supported. From %s to %s in %s' % (existing.type.name,
-                                                                                         dataset.type.name,
+        if dataset.product.name != existing.product.name:
+            raise ValueError('Changing product is not supported. From %s to %s in %s' % (existing.product.name,
+                                                                                         dataset.product.name,
                                                                                          dataset.id))
 
         # TODO: figure out (un)safe changes from metadata type?
@@ -259,7 +259,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
         _LOG.info("Updating dataset %s", dataset.id)
 
-        product = self.types.get_by_name(dataset.type.name)
+        product = self.types.get_by_name(dataset.product.name)
         with self._db_connection(transaction=True) as transaction:
             if not transaction.update_dataset(dataset.metadata_doc_without_lineage(), dataset.id, product.id):
                 raise ValueError("Failed to update dataset %s..." % dataset.id)

--- a/datacube/index/postgis/_metadata_types.py
+++ b/datacube/index/postgis/_metadata_types.py
@@ -43,7 +43,7 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
         :param dict definition:
         :rtype: datacube.model.MetadataType
         """
-        MetadataType.validate(definition)
+        MetadataType.validate_eo3(definition)
         return self._make(definition)
 
     def add(self, metadata_type, allow_table_lock=False):

--- a/datacube/index/postgis/default-metadata-types.yaml
+++ b/datacube/index/postgis/default-metadata-types.yaml
@@ -1,0 +1,92 @@
+---
+name: eo3
+description: Default EO3 with no custom fields
+dataset:
+  id: [id] # No longer configurable in newer ODCs.
+  sources: [lineage, source_datasets] # No longer configurable in newer ODCs.
+
+  grid_spatial: [grid_spatial, projection]
+  measurements: [measurements]
+  creation_dt: [properties, 'odc:processing_datetime']
+  label: [label]
+  format: [properties, 'odc:file_format']
+
+  search_fields:
+    platform:
+      description: Platform code
+      offset: [properties, 'eo:platform']
+      indexed: false
+
+    instrument:
+      description: Instrument name
+      offset: [properties, 'eo:instrument']
+      indexed: false
+
+    product_family:
+      description: Product family code
+      offset: [properties, 'odc:product_family']
+      indexed: false
+
+    region_code:
+      description: >
+        Spatial reference code from the provider.
+        For Landsat region_code is a scene path row:
+                '{:03d}{:03d}.format(path,row)'.
+        For Sentinel it is MGRS code.
+        In general it is a unique string identifier that datasets
+        covering roughly the same spatial region share.
+
+      offset: [properties, 'odc:region_code']
+
+    dataset_maturity:
+      description: One of - final|interim|nrt  (near real time)
+      offset: [properties, 'dea:dataset_maturity']
+      indexed: false
+
+    cloud_cover:
+      description: Cloud cover percentage [0, 100]
+      type: double
+      offset: [properties, 'eo:cloud_cover']
+      indexed: false
+
+    time:
+      description: Acquisition time range
+      type: datetime-range
+      min_offset:
+        - [properties, 'dtr:start_datetime']
+        - [properties, datetime]
+      max_offset:
+        - [properties, 'dtr:end_datetime']
+        - [properties, datetime]
+
+    # LonLat bounding box, generated on the fly from:
+    #  `grids`, `crs` and `geometry` of the new metadata format
+    #
+    # Bounding box is defined by two ranges:
+    #   [lon.begin, lon.end] -- Longitude
+    #   [lat.begin, lat.end] -- Latitude
+    #
+    # Note that STAC is using `bbox` for the same thing as following:
+    #
+    #     bbox: [left, bottom, right, top]
+    #              0      1      2     3
+    #             lon    lat    lon   lat
+    #
+    # But MetadataType does not support integer index keys, so...
+    #   BoundingBox: [lon.begin, lat.begin, lon.end, lat.end]
+
+    lon:
+      description: Longitude range
+      type: double-range
+      min_offset:
+        - [extent, lon, begin]
+      max_offset:
+        - [extent, lon, end]
+
+    lat:
+      description: Latitude range
+      type: double-range
+      min_offset:
+        - [extent, lat, begin]
+      max_offset:
+        - [extent, lat, end]

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 from contextlib import contextmanager
-from typing import Iterable, Sequence
+from pathlib import Path
+from typing import Iterable, List, Sequence
 
 from datacube.drivers.postgis import PostGisDb, PostgisDbAPI
 from datacube.index.postgis._transaction import PostgisTransaction
@@ -12,11 +13,14 @@ from datacube.index.postgis._datasets import DatasetResource, DSID  # type: igno
 from datacube.index.postgis._metadata_types import MetadataTypeResource
 from datacube.index.postgis._products import ProductResource
 from datacube.index.postgis._users import UserResource
-from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, default_metadata_type_docs, AbstractTransaction
+from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, AbstractTransaction, default_metadata_type_docs
 from datacube.model import MetadataType
 from datacube.utils.geometry import CRS
 
 _LOG = logging.getLogger(__name__)
+
+
+_DEFAULT_METADATA_TYPES_PATH = Path(__file__).parent.joinpath('default-metadata-types.yaml')
 
 
 class Index(AbstractIndex):
@@ -99,7 +103,7 @@ WARNING: Database schema and internal APIs may change significantly between rele
 
         if is_new and with_default_types:
             _LOG.info('Adding default metadata types.')
-            for doc in default_metadata_type_docs():
+            for doc in default_metadata_type_docs(_DEFAULT_METADATA_TYPES_PATH):
                 self.metadata_types.add(self.metadata_types.from_doc(doc), allow_table_lock=True)
 
         if is_new and with_default_spatial_index:

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -5,7 +5,7 @@
 import logging
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterable, List, Sequence
+from typing import Iterable, Sequence
 
 from datacube.drivers.postgis import PostGisDb, PostgisDbAPI
 from datacube.index.postgis._transaction import PostgisTransaction

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -150,7 +150,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
             # First insert all new datasets
             for ds in dss:
-                is_new = transaction.insert_dataset(ds.metadata_doc_without_lineage(), ds.id, ds.type.id)
+                is_new = transaction.insert_dataset(ds.metadata_doc_without_lineage(), ds.id, ds.product.id)
                 sources = ds.sources
                 if is_new and sources is not None:
                     edges.extend((name, ds.id, src.id)
@@ -228,9 +228,9 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         if not existing:
             raise ValueError('Unknown dataset %s, cannot update – did you intend to add it?' % dataset.id)
 
-        if dataset.type.name != existing.type.name:
-            raise ValueError('Changing product is not supported. From %s to %s in %s' % (existing.type.name,
-                                                                                         dataset.type.name,
+        if dataset.product.name != existing.product.name:
+            raise ValueError('Changing product is not supported. From %s to %s in %s' % (existing.product.name,
+                                                                                         dataset.product.name,
                                                                                          dataset.id))
 
         # TODO: figure out (un)safe changes from metadata type?
@@ -276,7 +276,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
         _LOG.info("Updating dataset %s", dataset.id)
 
-        product = self.types.get_by_name(dataset.type.name)
+        product = self.types.get_by_name(dataset.product.name)
         with self._db_connection(transaction=True) as transaction:
             if not transaction.update_dataset(dataset.metadata_doc_without_lineage(), dataset.id, product.id):
                 raise ValueError("Failed to update dataset %s..." % dataset.id)

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -467,7 +467,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         product = product or self.types.get(dataset_res.dataset_type_ref)
 
         return Dataset(
-            type_=product,
+            product=product,
             metadata_doc=dataset_res.metadata,
             uris=uris,
             indexed_by=dataset_res.added_by if full_info else None,

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -85,7 +85,7 @@ class Dataset:
 
     @property
     def metadata_type(self) -> 'MetadataType':
-        return self.type.metadata_type
+        return self.product.metadata_type
 
     @property
     def local_uri(self) -> Optional[str]:
@@ -117,7 +117,7 @@ class Dataset:
 
     @property
     def managed(self) -> bool:
-        return self.type.managed
+        return self.product.managed
 
     @property
     def format(self) -> str:
@@ -281,7 +281,7 @@ class Dataset:
     def __str__(self):
         str_loc = 'not available' if not self.uris else self.uris[0]
         return "Dataset <id={id} product={type} location={loc}>".format(id=self.id,
-                                                                        type=self.type.name,
+                                                                        type=self.product.name,
                                                                         loc=str_loc)
 
     def __repr__(self) -> str:

--- a/datacube/model/eo3.py
+++ b/datacube/model/eo3.py
@@ -1,0 +1,77 @@
+from datacube.utils.documents import get_doc_offset_safe
+
+required_sys_field_values = [
+    "id", "label", "creation_dt", "sources",
+    # Add format here?
+    # Drop sources as it appears to be ignored?
+]
+
+expected_sys_field_values = {
+    # Enforce exactly
+    "id": lambda x: x == ["id"],
+    "measurements": lambda x: x == ["measurements"],
+    "label": lambda x: x == ["label"],
+    "creation_dt": lambda x: x == ["properties", "odc:processing_datetime"],
+    "format": lambda x: x == ["properties", "odc:file_format"],
+    # EO3 mdy has sources at [lineage,source_datasets], but it is actually expected at [lineage],
+    # so accept anything vaguely right
+    "sources": lambda x: x[0] == "lineage",
+    # Actually kept under geometry and grids.  Ignore - why is this even here?
+    "grid_spatial": lambda x: True,
+    # Placeholder for search fields section
+    "search_fields": lambda x: True,
+}
+
+
+def validate_eo3_offset(field_name, mdt_name, offset):
+    if not all(isinstance(element, str) for element in offset):
+        # Not a simple offset, assume a compound offset
+        for element in offset:
+            validate_eo3_offset(field_name, mdt_name, element)
+        return
+    # Simple offset validation
+    # Special EO3 offsets
+    if offset in [
+        ["crs"],
+        # Others??
+    ]:
+        return
+    # Everything else should stored flat in properties
+    if offset[0] != "properties" or len(offset) != 2:
+        raise ValueError(
+            f"Search_field {field_name} in metadata type {mdt_name} is not stored in an EO3-compliant location: {offset!r}")
+
+
+def validate_eo3_offsets(field_name, mdt_name, defn):
+    if defn.get("type", "string").endswith("-range"):
+        # Range Type
+        if "min_offset" in defn:
+            validate_eo3_offset(field_name, mdt_name, defn["min_offset"])
+        else:
+            raise ValueError(f"No min_offset supplied for field {field_name} in metadata type {mdt_name}")
+        if "max_offset" in defn:
+            validate_eo3_offset(field_name, mdt_name, defn["min_offset"])
+        else:
+            raise ValueError(f"No max_offset supplied for field {field_name} in metadata type {mdt_name}")
+    else:
+        # Scalar Type
+        if "offset" in defn:
+            validate_eo3_offset(field_name, mdt_name, defn["offset"])
+        else:
+            raise ValueError(f"No offset supplied for field {field_name} in metadata type {mdt_name}")
+
+
+def validate_eo3_compatible_type(doc):
+    name = doc["name"]
+    # Validate system field offsets
+    for k, v in doc["dataset"].items():
+        try:
+            if not expected_sys_field_values[k](v):
+                raise ValueError(f"Offset for system field {k} ({v!r}) in metadata type {name} does not match EO3 standard")
+        except KeyError as e:
+            raise ValueError(f"Unexpected system field in metadata type {name}: {k}")
+    # Validate search field offsets
+    for k, v in doc["dataset"]["search_fields"].items():
+        if k in ["lat", "lon"]:
+            continue
+        validate_eo3_offsets(k, name, v)

--- a/datacube/model/eo3.py
+++ b/datacube/model/eo3.py
@@ -1,4 +1,7 @@
-from datacube.utils.documents import get_doc_offset_safe
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2022 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
 
 required_sys_field_values = [
     "id", "label", "creation_dt", "sources",
@@ -39,7 +42,8 @@ def validate_eo3_offset(field_name, mdt_name, offset):
     # Everything else should stored flat in properties
     if offset[0] != "properties" or len(offset) != 2:
         raise ValueError(
-            f"Search_field {field_name} in metadata type {mdt_name} is not stored in an EO3-compliant location: {offset!r}")
+            f"Search_field {field_name} in metadata type {mdt_name} "
+            f"is not stored in an EO3-compliant location: {offset!r}")
 
 
 def validate_eo3_offsets(field_name, mdt_name, defn):
@@ -67,7 +71,9 @@ def validate_eo3_compatible_type(doc):
     for k, v in doc["dataset"].items():
         try:
             if not expected_sys_field_values[k](v):
-                raise ValueError(f"Offset for system field {k} ({v!r}) in metadata type {name} does not match EO3 standard")
+                raise ValueError(
+                    f"Offset for system field {k} ({v!r}) in metadata type {name} does not match EO3 standard"
+                )
         except KeyError as e:
             raise ValueError(f"Unexpected system field in metadata type {name}: {k}")
     # Validate search field offsets

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -202,7 +202,7 @@ def index_cmd(index, product_names,
         dss = dataset_stream(doc_stream, ds_resolve)
         index_datasets(dss,
                        index,
-                       auto_add_lineage=auto_add_lineage,
+                       auto_add_lineage=auto_add_lineage and not confirm_ignore_lineage,
                        dry_run=dry_run)
 
     # If outputting directly to terminal, show a progress bar.

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -111,7 +111,7 @@ def load_datasets_for_update(doc_stream, index):
         ds = SimpleDocNav(prep_eo3(ds.doc, auto_skip=True))
 
         # TODO: what about sources=?
-        return Dataset(existing.type,
+        return Dataset(existing.product,
                        ds.doc_without_lineage_sources,
                        uris=[uri]), existing, None
 
@@ -342,7 +342,7 @@ def build_dataset_info(index: Index, dataset: Dataset,
                        max_depth: int = 99) -> Mapping[str, Any]:
     info: MutableMapping[str, Any] = OrderedDict((
         ('id', str(dataset.id)),
-        ('product', dataset.type.name),
+        ('product', dataset.product.name),
         ('status', 'archived' if dataset.is_archived else 'active')
     ))
 
@@ -591,7 +591,7 @@ def restore_cmd(index: Index, restore_derived: bool, derived_tolerance_seconds: 
             _LOG.debug("%s selected were archived within the tolerance", len(to_process))
 
         for d in to_process:
-            click.echo('restoring %s %s %s' % (d.type.name, d.id, d.local_uri))
+            click.echo('restoring %s %s %s' % (d.product.name, d.id, d.local_uri))
         if not dry_run:
             index.datasets.restore(d.id for d in to_process)
 

--- a/datacube/storage/_base.py
+++ b/datacube/storage/_base.py
@@ -85,7 +85,7 @@ class BandInfo:
                  extra_dim_index: Optional[int] = None,
                  patch_url: Optional[Callable[[str], str]] = None):
         try:
-            mp, = ds.type.lookup_measurements([band]).values()
+            mp, = ds.product.lookup_measurements([band]).values()
         except KeyError:
             raise ValueError('No such band: {}'.format(band))
 

--- a/datacube/testutils/__init__.py
+++ b/datacube/testutils/__init__.py
@@ -6,6 +6,7 @@
 Useful methods for tests (particularly: reading/writing and checking files)
 """
 import atexit
+import math
 import os
 import shutil
 import tempfile
@@ -475,3 +476,16 @@ def remove_crs(xx):
                 x.attrs.pop(attribute_to_remove, None)
 
     return xx
+
+
+def sanitise_doc(d):
+    if isinstance(d, str):
+        if d == "NaN":
+            return math.nan
+        return d
+    elif isinstance(d, dict):
+        return {k: sanitise_doc(v) for k, v in d.items()}
+    elif isinstance(d, list):
+        return [sanitise_doc(i) for i in d]
+    else:
+        return d

--- a/datacube/testutils/io.py
+++ b/datacube/testutils/io.py
@@ -53,14 +53,14 @@ def get_raster_info(ds: Dataset, measurements=None):
     :param measurements: List of band names to load
     """
     if measurements is None:
-        measurements = list(ds.type.measurements)
+        measurements = list(ds.product.measurements)
 
     return {n: _raster_metadata(BandInfo(ds, n))
             for n in measurements}
 
 
 def eo3_geobox(ds: Dataset, band: str) -> GeoBox:
-    mm = ds.measurements.get(ds.type.canonical_measurement(band),
+    mm = ds.measurements.get(ds.product.canonical_measurement(band),
                              None)
     if mm is None:
         raise ValueError(f"No such band: {band}")
@@ -88,7 +88,7 @@ def native_geobox(ds, measurements=None, basis=None):
 
     :return: GeoBox describing native storage coordinates.
     """
-    gs = ds.type.grid_spec
+    gs = ds.product.grid_spec
     if gs is not None:
         # Dataset is from ingested product, figure out GeoBox of the tile this dataset covers
         bb = [gbox for _, gbox in gs.tiles(ds.bounds)]
@@ -98,7 +98,7 @@ def native_geobox(ds, measurements=None, basis=None):
         return bb[0]
 
     if measurements is None and basis is None:
-        measurements = list(ds.type.measurements)
+        measurements = list(ds.product.measurements)
 
     if is_doc_eo3(ds.metadata_doc):
         if basis is not None:
@@ -134,9 +134,9 @@ def native_load(ds, measurements=None, basis=None, **kw):
     from datacube import Datacube
     geobox = native_geobox(ds, measurements, basis)  # early exit via exception if no compatible grid exists
     if measurements is not None:
-        mm = ds.type.lookup_measurements(measurements)
+        mm = ds.product.lookup_measurements(measurements)
     else:
-        mm = ds.type.measurements
+        mm = ds.product.measurements
 
     return Datacube.load_data(Datacube.group_datasets([ds], 'time'),
                               geobox,

--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -8,6 +8,7 @@ Functions for working with YAML documents and configurations
 import gzip
 import json
 import logging
+import math
 import sys
 import collections.abc
 from collections import OrderedDict
@@ -283,6 +284,30 @@ def get_doc_offset_safe(offset, document, value_if_missing=None):
 
     """
     return toolz.get_in(offset, document, default=value_if_missing)
+
+
+def documents_equal(d1, d2):
+    if d1.__class__ != d2.__class__:
+        return False
+    if isinstance(d1, str):
+        return d1 == d2
+    elif isinstance(d1, dict):
+        if set(d1.keys()) != set(d2.keys()):
+            return False
+        return all(documents_equal(d1[k], d2[k]) for k in d1)
+    elif isinstance(d1, list):
+        if len(d1) != len(d2):
+            return False
+        for i in range(len(d1)):
+            if not documents_equal(d1[i], d2[i]):
+                return False
+        return True
+    elif isinstance(d1, float):
+        if math.isnan(d1) and math.isnan(d2):
+            return True
+        return math.isclose(d1, d2, abs_tol=1e-10)
+    else:
+        return d1 == d2
 
 
 def transform_object_tree(f, o, key_transform=lambda k: k):

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -18,6 +18,8 @@ v1.8.next
 - Postgis driver cleanup - remove faux support for lineage (:pull:`1368`)
 - Add support for nested database transactions (:pull:`1369`)
 - Fix Github doc lint action (:pull:`1370`)
+- Tighten EO3 enforcement in postgis driver, refactor tests, and rename Dataset.type to Dataset.product
+  (with type alias for compatibility) (:pull:`1372`)
 
 v1.8.9 (17 November 2022)
 =========================

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -15,7 +15,9 @@ v1.8.next
 - Fix database relationship diagram instruction for docker (:pull:`1362`)
 - Document ``group_by`` for ``dataset.load`` (:pull:`1364`)
 - Add search_by_metadata facility for products (:pull:`1366`)
+- Postgis driver cleanup - remove faux support for lineage (:pull:`1368`)
 - Add support for nested database transactions (:pull:`1369`)
+- Fix Github doc lint action (:pull:`1370`)
 
 v1.8.9 (17 November 2022)
 =========================

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -169,7 +169,7 @@ def doc_to_ds(index, product_name, ds_doc, ds_path):
     resolver = Doc2Dataset(index, products=[product_name], verify_lineage=False)
     ds, err = resolver(ds_doc, ds_path)
     assert err is None and ds is not None
-    index.datasets.add(ds)
+    index.datasets.add(ds, with_lineage=False)
     return index.datasets.get(ds.id)
 
 

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -106,6 +106,11 @@ def eo3_dataset_paths():
 
 
 @pytest.fixture
+def eo3_dataset_update_path():
+    return str(EO3_TESTDIR / "ls8_dataset_update.yaml")
+
+
+@pytest.fixture
 def dataset_with_lineage_doc():
     return (
         get_eo3_test_data_doc("wo_ds_with_lineage.odc-metadata.yaml"),

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -6,7 +6,6 @@
 Common methods for index integration tests.
 """
 import itertools
-import math
 import os
 from copy import copy, deepcopy
 from datetime import timedelta
@@ -58,19 +57,6 @@ settings.register_profile(
 settings.load_profile('opendatacube')
 
 EO3_TESTDIR = INTEGRATION_TESTS_DIR / 'data' / 'eo3'
-
-
-def sanitise_doc(d):
-    if isinstance(d, str):
-        if d == "NaN":
-            return math.nan
-        return d
-    elif isinstance(d, dict):
-        return {k: sanitise_doc(v) for k, v in d.items()}
-    elif isinstance(d, list):
-        return [sanitise_doc(i) for i in d]
-    else:
-        return d
 
 
 def get_eo3_test_data_doc(path):

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -663,5 +663,6 @@ def dataset_add_configs():
                            datasets_bad1=str(B / 'datasets_bad1.yml'),
                            datasets_no_id=str(B / 'datasets_no_id.yml'),
                            datasets_eo3=str(B / 'datasets_eo3.yml'),
+                           datasets_eo3_updated=str(B / 'datasets_eo3_updated.yml'),
                            datasets=str(B / 'datasets.yml'),
                            empty_file=str(B / 'empty_file.yml'))

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -6,6 +6,7 @@
 Common methods for index integration tests.
 """
 import itertools
+import math
 import os
 from copy import copy, deepcopy
 from datetime import timedelta
@@ -59,10 +60,49 @@ settings.load_profile('opendatacube')
 EO3_TESTDIR = INTEGRATION_TESTS_DIR / 'data' / 'eo3'
 
 
+def sanitise_doc(d):
+    if isinstance(d, str):
+        if d == "NaN":
+            return math.nan
+        return d
+    elif isinstance(d, dict):
+        return {k: sanitise_doc(v) for k, v in d.items()}
+    elif isinstance(d, list):
+        return [sanitise_doc(i) for i in d]
+    else:
+        return d
+
+
 def get_eo3_test_data_doc(path):
     from datacube.utils import read_documents
     for path, doc in read_documents(EO3_TESTDIR / path):
         return doc
+
+
+@pytest.fixture
+def ext_eo3_mdt_path():
+    return str(EO3_TESTDIR / "eo3_landsat_ard.odc-type.yaml")
+
+
+@pytest.fixture
+def eo3_product_paths():
+    return [
+        str(EO3_TESTDIR / "ard_ls8.odc-product.yaml"),
+        str(EO3_TESTDIR / "ga_ls_wo_3.odc-product.yaml"),
+        str(EO3_TESTDIR / "s2_africa_product.yaml"),
+    ]
+
+
+@pytest.fixture
+def eo3_dataset_paths():
+    return [
+        str(EO3_TESTDIR / "ls8_dataset.yaml"),
+        str(EO3_TESTDIR / "ls8_dataset2.yaml"),
+        str(EO3_TESTDIR / "ls8_dataset3.yaml"),
+        str(EO3_TESTDIR / "ls8_dataset4.yaml"),
+        str(EO3_TESTDIR / "wo_dataset.yaml"),
+        str(EO3_TESTDIR / "s2_africa_dataset.yaml"),
+    ]
 
 
 @pytest.fixture
@@ -193,6 +233,17 @@ def wo_eo3_product(index, base_eo3_product_doc):
 @pytest.fixture
 def africa_s2_eo3_product(index, africa_s2_product_doc):
     return index.products.add_document(africa_s2_product_doc)
+
+
+@pytest.fixture
+def eo3_products(index, extended_eo3_metadata_type,
+                 ls8_eo3_product, wo_eo3_product,
+                 africa_s2_eo3_product):
+    return [
+        africa_s2_eo3_product,
+        ls8_eo3_product,
+        wo_eo3_product,
+    ]
 
 
 @pytest.fixture
@@ -551,6 +602,21 @@ def default_metadata_type_doc():
 
 
 @pytest.fixture
+def eo3_metadata_type_docs(eo3_base_metadata_type_doc, extended_eo3_metadata_type_doc):
+    return [eo3_base_metadata_type_doc, extended_eo3_metadata_type_doc]
+
+
+@pytest.fixture
+def eo3_base_metadata_type_doc():
+    return [doc for doc in default_metadata_type_docs() if doc['name'] == 'eo3'][0]
+
+
+@pytest.fixture
+def default_metadata_type_doc():
+    return [doc for doc in default_metadata_type_docs() if doc['name'] == 'eo'][0]
+
+
+@pytest.fixture
 def telemetry_metadata_type_doc():
     return [doc for doc in default_metadata_type_docs() if doc['name'] == 'telemetry'][0]
 
@@ -563,9 +629,13 @@ def ga_metadata_type_doc():
 
 
 @pytest.fixture
-def default_metadata_types(index):
+def default_metadata_types(index, eo3_metadata_type_docs):
     """Inserts the default metadata types into the Index"""
-    for d in default_metadata_type_docs():
+    if index.supports_legacy:
+        type_docs = default_metadata_type_docs()
+    else:
+        type_docs = eo3_metadata_type_docs
+    for d in type_docs:
         index.metadata_types.add(index.metadata_types.from_doc(d))
     return index.metadata_types.get_all()
 
@@ -577,7 +647,10 @@ def ga_metadata_type(index, ga_metadata_type_doc):
 
 @pytest.fixture
 def default_metadata_type(index, default_metadata_types):
-    return index.metadata_types.get_by_name('eo')
+    if index.supports_legacy:
+        return index.metadata_types.get_by_name('eo')
+    else:
+        return index.metadata_types.get_by_name('eo3')
 
 
 @pytest.fixture

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -617,11 +617,6 @@ def eo3_base_metadata_type_doc():
 
 
 @pytest.fixture
-def default_metadata_type_doc():
-    return [doc for doc in default_metadata_type_docs() if doc['name'] == 'eo'][0]
-
-
-@pytest.fixture
 def telemetry_metadata_type_doc():
     return [doc for doc in default_metadata_type_docs() if doc['name'] == 'telemetry'][0]
 

--- a/integration_tests/data/dataset_add/datasets_eo3_updated.yml
+++ b/integration_tests/data/dataset_add/datasets_eo3_updated.yml
@@ -1,0 +1,46 @@
+---
+# change capture time
+$schema: https://schemas.opendatacube.org/dataset
+id: 7d41a4d0-2ab3-4da1-a010-ef48662ae8ef
+product:
+  name: eo3_test
+
+location: "http://example.com/a.yml"
+
+crs: "epsg:3857"
+properties:
+    datetime: 2020-04-20 00:27:43Z
+    odc:processing_datetime: 2020-05-16 10:56:18Z
+
+grids:
+    default:
+       shape: [100, 200]
+       transform: [10, 0, 100000, 0, -10, 200000, 0, 0, 1]
+lineage:
+  a: [f80c30a5-1036-5607-a62f-fde5e3fec985]
+  bc:
+    - fb077e47-f62e-5869-9bd1-03584c2d7380
+    - 13d3d75a-1d90-5ec0-8b86-e8be78275660
+
+---
+# No changes
+$schema: https://schemas.opendatacube.org/dataset
+id: f884df9b-4458-47fd-a9d2-1a52a2db8a1a
+product:
+  name: eo3_test
+
+crs: "epsg:32660"
+properties:
+    datetime: 2020-04-20 00:26:43Z
+    odc:processing_datetime: 2020-05-16 10:56:18Z
+
+grids:
+    default:
+       shape: [7811, 7691]
+       transform: [30, 0, 618285, 0, -30, -1642485, 0, 0, 1]
+    pan:
+       shape: [15621, 15381]
+       transform: [15, 0, 618292.5, 0, -15, -1642492.5, 0, 0, 1]
+lineage: {}
+
+...

--- a/integration_tests/data/eo3/ls8_dataset_update.yaml
+++ b/integration_tests/data/eo3/ls8_dataset_update.yaml
@@ -1,0 +1,130 @@
+---
+# Dataset
+$schema: https://schemas.opendatacube.org/dataset
+id: c21648b1-a6fa-4de0-9dc3-9c445d8b295a
+
+label: ga_ls8c_ard_3-0-0_090086_2016-05-12_final
+product:
+  name: ga_ls8c_ard_3
+
+crs: epsg:32655
+geometry:
+  type: Polygon
+  coordinates: [[[557897.0, -4219717.0], [557843.0, -4219702.0], [557903.0, -4219399.0], [558668.0, -4216459.0],
+                 [570053.0, -4172809.0], [603128.0, -4046644.0], [607268.0, -4030879.0], [607313.0, -4030777.0],
+                 [607383.0, -4030796.0], [607395.0, -4030785.0], [792773.0, -4079206.0], [794286.0, -4079634.0],
+                 [794286.0, -4079636.0], [794403.0, -4079667.0], [794377.0, -4079831.0], [745188.0, -4268613.0],
+                 [745114.0, -4268617.0], [745011.0, -4268590.0], [744938.0, -4268594.0], [740677.0, -4267484.0],
+                 [557895.0, -4219725.0], [557897.0, -4219717.0]]]
+
+grids:
+  default:
+    shape: [7941, 7901]
+    transform: [30.0, 0.0, 557385.0, 0.0, -30.0, -4030485.0, 0.0, 0.0, 1.0]
+  panchromatic:
+    shape: [15881, 15801]
+    transform: [15.0, 0.0, 557392.5, 0.0, -15.0, -4030492.5, 0.0, 0.0, 1.0]
+
+properties:
+  datetime: 2016-05-12 23:55:39.127536Z
+  dea:dataset_maturity: final
+  dtr:end_datetime: 2016-05-12 23:50:52.031499Z
+  dtr:start_datetime: 2016-05-12 23:50:23.054165Z
+  eo:cloud_cover: 58.910716655901616
+  eo:gsd: 15.0  # Ground sample distance (m)
+  eo:instrument: OLI_TIRS
+  eo:platform: landsat-8
+  eo:sun_azimuth: 34.58516815
+  eo:sun_elevation: 26.29614366
+  fmask:clear: 22.3973998672305
+  fmask:cloud: 58.910716655901616
+  fmask:cloud_shadow: 1.3150997463296996
+  fmask:snow: 0.0006217170293219306
+  fmask:water: 17.376162013508864
+  gqa:abs_iterative_mean_x: 0.19
+  gqa:abs_iterative_mean_xy: 0.25
+  gqa:abs_iterative_mean_y: 0.16
+  gqa:abs_x: 0.43
+  gqa:abs_xy: 0.51
+  gqa:abs_y: 0.28
+  gqa:cep90: 0.49
+  gqa:iterative_mean_x: -0.1
+  gqa:iterative_mean_xy: 0.15
+  gqa:iterative_mean_y: 0.11
+  gqa:iterative_stddev_x: 0.24
+  gqa:iterative_stddev_xy: 0.3
+  gqa:iterative_stddev_y: 0.17
+  gqa:mean_x: -0.1
+  gqa:mean_xy: 0.11
+  gqa:mean_y: 0.05
+  gqa:stddev_x: 1.15
+  gqa:stddev_xy: 1.28
+  gqa:stddev_y: 0.56
+  landsat:collection_category: T1
+  landsat:collection_number: 1
+  landsat:landsat_product_id: LC08_L1TP_090086_20160512_20180203_01_T1
+  landsat:landsat_scene_id: LC80900862016133LGN02
+  landsat:wrs_path: 90
+  landsat:wrs_row: 86
+  odc:dataset_version: 3.0.0
+  odc:file_format: GeoTIFF
+  odc:processing_datetime: 2019-10-07T20:19:19.218290
+  odc:producer: ga.gov.au
+  odc:product_family: ard
+  odc:region_code: '090086'
+
+measurements:
+  nbart_blue:
+    path: ga_ls8c_nbart_3-0-0_090086_2016-05-12_final_band02.tif
+  nbart_coastal_aerosol:
+    path: ga_ls8c_nbart_3-0-0_090086_2016-05-12_final_band01.tif
+  nbart_green:
+    path: ga_ls8c_nbart_3-0-0_090086_2016-05-12_final_band03.tif
+  nbart_nir:
+    path: ga_ls8c_nbart_3-0-0_090086_2016-05-12_final_band05.tif
+  nbart_panchromatic:
+    path: ga_ls8c_nbart_3-0-0_090086_2016-05-12_final_band08.tif
+    grid: panchromatic
+  nbart_red:
+    path: ga_ls8c_nbart_3-0-0_090086_2016-05-12_final_band04.tif
+  nbart_swir_1:
+    path: ga_ls8c_nbart_3-0-0_090086_2016-05-12_final_band06.tif
+  nbart_swir_2:
+    path: ga_ls8c_nbart_3-0-0_090086_2016-05-12_final_band07.tif
+  oa_azimuthal_exiting:
+    path: ga_ls8c_oa_3-0-0_090086_2016-05-12_final_azimuthal-exiting.tif
+  oa_azimuthal_incident:
+    path: ga_ls8c_oa_3-0-0_090086_2016-05-12_final_azimuthal-incident.tif
+  oa_combined_terrain_shadow:
+    path: ga_ls8c_oa_3-0-0_090086_2016-05-12_final_combined-terrain-shadow.tif
+  oa_exiting_angle:
+    path: ga_ls8c_oa_3-0-0_090086_2016-05-12_final_exiting-angle.tif
+  oa_fmask:
+    path: ga_ls8c_oa_3-0-0_090086_2016-05-12_final_fmask.tif
+  oa_incident_angle:
+    path: ga_ls8c_oa_3-0-0_090086_2016-05-12_final_incident-angle.tif
+  oa_nbart_contiguity:
+    path: ga_ls8c_oa_3-0-0_090086_2016-05-12_final_nbart-contiguity.tif
+  oa_relative_azimuth:
+    path: ga_ls8c_oa_3-0-0_090086_2016-05-12_final_relative-azimuth.tif
+  oa_relative_slope:
+    path: ga_ls8c_oa_3-0-0_090086_2016-05-12_final_relative-slope.tif
+  oa_satellite_azimuth:
+    path: ga_ls8c_oa_3-0-0_090086_2016-05-12_final_satellite-azimuth.tif
+  oa_satellite_view:
+    path: ga_ls8c_oa_3-0-0_090086_2016-05-12_final_satellite-view.tif
+  oa_solar_azimuth:
+    path: ga_ls8c_oa_3-0-0_090086_2016-05-12_final_solar-azimuth.tif
+  oa_solar_zenith:
+    path: ga_ls8c_oa_3-0-0_090086_2016-05-12_final_solar-zenith.tif
+  oa_time_delta:
+    path: ga_ls8c_oa_3-0-0_090086_2016-05-12_final_time-delta.tif
+
+accessories:
+  thumbnail:nbart:
+    path: ga_ls8c_nbart_3-0-0_090086_2016-05-12_final_thumbnail.jpg
+  checksum:sha1:
+    path: ga_ls8c_ard_3-0-0_090086_2016-05-12_final.sha1
+  metadata:processor:
+    path: ga_ls8c_ard_3-0-0_090086_2016-05-12_final.proc-info.yaml
+...

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -183,6 +183,7 @@ def test_idempotent_add_dataset_type(index, ls5_telem_type, ls5_telem_doc):
         # TODO: Support for adding/changing search fields?
 
 
+@pytest.mark.parametrize('datacube_env_name', ('datacube', ))
 def test_update_dataset(index, ls5_telem_doc, example_ls5_nbar_metadata_doc):
     """
     :type index: datacube.index.Index

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -10,7 +10,6 @@ import copy
 import pytest
 import yaml
 
-from ..conftest import sanitise_doc
 from datacube.drivers.postgres._fields import NumericRangeDocField as PgrNumericRangeDocField, PgField as PgrPgField
 from datacube.drivers.postgis._fields import NumericRangeDocField as PgsNumericRangeDocField, PgField as PgsPgField
 from datacube.index import Index
@@ -19,6 +18,7 @@ from datacube.model import MetadataType, DatasetType
 from datacube.model import Range, Dataset
 from datacube.utils import changes
 from datacube.utils.documents import documents_equal
+from datacube.testutils import sanitise_doc
 
 _DATASET_METADATA = {
     'id': 'f7018d80-8807-11e5-aeaa-1040f381a756',

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -217,18 +217,18 @@ def test_transactions_api_ctx_mgr(index,
     with pytest.raises(Exception) as e:
         with index.transaction() as trans:
             assert index.datasets.get(ds1.id) is None
-            index.datasets.add(ds1, False)
+            index.datasets.add(ds1, with_lineage=False)
             assert index.datasets.get(ds1.id) is not None
             raise Exception("Rollback!")
     assert "Rollback!" in str(e.value)
     assert index.datasets.get(ds1.id) is None
     with index.transaction() as trans:
         assert index.datasets.get(ds1.id) is None
-        index.datasets.add(ds1, False)
+        index.datasets.add(ds1, with_lineage=False)
         assert index.datasets.get(ds1.id) is not None
     assert index.datasets.get(ds1.id) is not None
     with index.transaction() as trans:
-        index.datasets.add(ds2, False)
+        index.datasets.add(ds2, with_lineage=False)
         assert index.datasets.get(ds2.id) is not None
         raise trans.rollback_exception("Rollback")
     assert index.datasets.get(ds1.id) is not None
@@ -376,14 +376,14 @@ def test_index_dataset_with_location(index: Index, default_metadata_type: Metada
     first_file = Path('/tmp/first/something.yaml').absolute()
     second_file = Path('/tmp/second/something.yaml').absolute()
 
-    type_ = index.products.add_document(_pseudo_telemetry_dataset_type)
-    dataset = Dataset(type_, _telemetry_dataset, uris=[first_file.as_uri()], sources={})
+    product = index.products.add_document(_pseudo_telemetry_dataset_type)
+    dataset = Dataset(product, _telemetry_dataset, uris=[first_file.as_uri()], sources={})
     index.datasets.add(dataset)
     stored = index.datasets.get(dataset.id)
 
     assert stored.id == _telemetry_uuid
     # TODO: Dataset types?
-    assert stored.product.id == type_.id
+    assert stored.product.id == product.id
     assert stored.metadata_type.id == default_metadata_type.id
     assert stored.local_path == Path(first_file)
 

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -481,7 +481,7 @@ def test_index_dataset_with_location(index: Index, default_metadata_type: Metada
     # Check order of uris is preserved when indexing with more than one
     second_ds_doc = copy.deepcopy(_telemetry_dataset)
     second_ds_doc['id'] = '366f32d8-e1f8-11e6-94b4-185e0f80a589'
-    index.datasets.add(Dataset(type_, second_ds_doc, uris=['file:///a', 'file:///b'], sources={}))
+    index.datasets.add(Dataset(product, second_ds_doc, uris=['file:///a', 'file:///b'], sources={}))
 
     # test order using get_locations function
     assert index.datasets.get_locations(second_ds_doc['id']) == ['file:///a', 'file:///b']
@@ -490,7 +490,7 @@ def test_index_dataset_with_location(index: Index, default_metadata_type: Metada
     assert index.datasets.get(second_ds_doc['id']).uris == ['file:///a', 'file:///b']
 
     # test update, this should prepend file:///c, file:///d to the existing list
-    index.datasets.update(Dataset(type_, second_ds_doc, uris=['file:///a', 'file:///c', 'file:///d'], sources={}))
+    index.datasets.update(Dataset(product, second_ds_doc, uris=['file:///a', 'file:///c', 'file:///d'], sources={}))
     assert index.datasets.get_locations(second_ds_doc['id']) == ['file:///c', 'file:///d', 'file:///a', 'file:///b']
     assert index.datasets.get(second_ds_doc['id']).uris == ['file:///c', 'file:///d', 'file:///a', 'file:///b']
 
@@ -498,7 +498,7 @@ def test_index_dataset_with_location(index: Index, default_metadata_type: Metada
     # Add a second dataset with a different location (to catch lack of joins, filtering etc)
     second_ds_doc = copy.deepcopy(_telemetry_dataset)
     second_ds_doc['id'] = '366f32d8-e1f8-11e6-94b4-185e0f80a5c0'
-    index.datasets.add(Dataset(type_, second_ds_doc, uris=[second_file.as_uri()], sources={}))
+    index.datasets.add(Dataset(product, second_ds_doc, uris=[second_file.as_uri()], sources={}))
     for mode in ('exact', 'prefix', None):
         dataset_ids = [d.id for d in index.datasets.get_datasets_for_location(first_file.as_uri(), mode=mode)]
         assert dataset_ids == [dataset.id]

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -383,7 +383,7 @@ def test_index_dataset_with_location(index: Index, default_metadata_type: Metada
 
     assert stored.id == _telemetry_uuid
     # TODO: Dataset types?
-    assert stored.type.id == type_.id
+    assert stored.product.id == type_.id
     assert stored.metadata_type.id == default_metadata_type.id
     assert stored.local_path == Path(first_file)
 

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -284,18 +284,18 @@ def test_transactions_api_ctx_mgr(index,
     with pytest.raises(Exception) as e:
         with index.transaction() as trans:
             assert index.datasets.get(ds1.id) is None
-            index.datasets.add(ds1)
+            index.datasets.add(ds1, False)
             assert index.datasets.get(ds1.id) is not None
             raise Exception("Rollback!")
     assert "Rollback!" in str(e.value)
     assert index.datasets.get(ds1.id) is None
     with index.transaction() as trans:
         assert index.datasets.get(ds1.id) is None
-        index.datasets.add(ds1)
+        index.datasets.add(ds1, False)
         assert index.datasets.get(ds1.id) is not None
     assert index.datasets.get(ds1.id) is not None
     with index.transaction() as trans:
-        index.datasets.add(ds2)
+        index.datasets.add(ds2, False)
         assert index.datasets.get(ds2.id) is not None
         raise trans.rollback_exception("Rollback")
     assert index.datasets.get(ds1.id) is not None
@@ -345,17 +345,17 @@ def test_transactions_api_manual(index,
     ds1, err = resolver(*eo3_ls8_dataset_doc)
     ds2, err = resolver(*eo3_ls8_dataset2_doc)
     trans = index.transaction()
-    index.datasets.add(ds1)
+    index.datasets.add(ds1, False)
     assert index.datasets.get(ds1.id) is not None
     trans.begin()
-    index.datasets.add(ds2)
+    index.datasets.add(ds2, False)
     assert index.datasets.get(ds1.id) is not None
     assert index.datasets.get(ds2.id) is not None
     trans.rollback()
     assert index.datasets.get(ds1.id) is not None
     assert index.datasets.get(ds2.id) is None
     trans.begin()
-    index.datasets.add(ds2)
+    index.datasets.add(ds2, False)
     trans.commit()
     assert index.datasets.get(ds1.id) is not None
     assert index.datasets.get(ds2.id) is not None
@@ -372,18 +372,18 @@ def test_transactions_api_hybrid(index,
     ds2, err = resolver(*eo3_ls8_dataset2_doc)
     with index.transaction() as trans:
         assert index.datasets.get(ds1.id) is None
-        index.datasets.add(ds1)
+        index.datasets.add(ds1, False)
         assert index.datasets.get(ds1.id) is not None
         trans.rollback()
         assert index.datasets.get(ds1.id) is None
         trans.begin()
         assert index.datasets.get(ds1.id) is None
-        index.datasets.add(ds1)
+        index.datasets.add(ds1, False)
         assert index.datasets.get(ds1.id) is not None
         trans.commit()
         assert index.datasets.get(ds1.id) is not None
         trans.begin()
-        index.datasets.add(ds2)
+        index.datasets.add(ds2, False)
         assert index.datasets.get(ds2.id) is not None
         trans.rollback()
     assert index.datasets.get(ds1.id) is not None

--- a/integration_tests/index/test_memory_index.py
+++ b/integration_tests/index/test_memory_index.py
@@ -194,13 +194,13 @@ def test_mem_ds_lineage(mem_eo3_data):
     derived = list(dc.index.datasets.get_derived(ls8_id))
     assert len(derived) == 1
     assert derived[0].id == wo_id
-    assert "cloud_cover" in dc.index.datasets.get_field_names(ls8_ds.type.name)
+    assert "cloud_cover" in dc.index.datasets.get_field_names(ls8_ds.product.name)
 
 
 def test_mem_ds_search_dups(mem_eo3_data):
     dc, ls8_id, wo_id = mem_eo3_data
     ls8_ds = dc.index.datasets.get(ls8_id)
-    dup_results = dc.index.datasets.search_product_duplicates(ls8_ds.type, "cloud_cover", "dataset_maturity")
+    dup_results = dc.index.datasets.search_product_duplicates(ls8_ds.product, "cloud_cover", "dataset_maturity")
     assert len(dup_results) == 1
     assert dup_results[0][0].cloud_cover == ls8_ds.metadata.cloud_cover
     assert ls8_id in dup_results[0][1]
@@ -437,7 +437,7 @@ def test_mem_ds_search_and_count_by_product(mem_eo3_data):
     assert len(lds) == 2
     for dss, product in lds:
         for ds in dss:
-            assert ds.type.name == product.name
+            assert ds.product.name == product.name
     lds = list(dc.index.datasets.count_by_product(platform='landsat-8'))
     assert len(lds) == 2
     for prod, count in lds:

--- a/integration_tests/index/test_postgis_index.py
+++ b/integration_tests/index/test_postgis_index.py
@@ -32,7 +32,7 @@ def test_spatial_index_maintain(index: Index, ls8_eo3_product, eo3_ls8_dataset_d
     resolver = Doc2Dataset(index, products=[ls8_eo3_product.name], verify_lineage=False)
     ds, err = resolver(*eo3_ls8_dataset_doc)
     assert err is None and ds is not None
-    ds = index.datasets.add(ds)
+    ds = index.datasets.add(ds, False)
     assert ds
     index.datasets.archive([ds.id])
     index.datasets.purge([ds.id])

--- a/integration_tests/index/test_postgis_index.py
+++ b/integration_tests/index/test_postgis_index.py
@@ -161,7 +161,7 @@ def test_spatial_search(index,
     index.update_spatial_index(crses=[epsg3577])
     # Test old style lat/lon search
     dss = index.datasets.search_eager(
-        product=ls8_eo3_dataset.type.name,
+        product=ls8_eo3_dataset.product.name,
         lat=Range(begin=-37.5, end=37.0),
         lon=Range(begin=148.5, end=149.0)
     )
@@ -174,19 +174,19 @@ def test_spatial_search(index,
     exact1_3577 = ls8_eo3_dataset.extent.to_crs(epsg3577)
     exact3_4326 = ls8_eo3_dataset3.extent.to_crs(epsg4326)
     exact3_3577 = ls8_eo3_dataset3.extent.to_crs(epsg3577)
-    dssids = set(ds.id for ds in index.datasets.search(product=ls8_eo3_dataset.type.name, geometry=exact1_4326))
+    dssids = set(ds.id for ds in index.datasets.search(product=ls8_eo3_dataset.product.name, geometry=exact1_4326))
     assert len(dssids) == 2
     assert ls8_eo3_dataset.id in dssids
     assert ls8_eo3_dataset2.id in dssids
-    dssids = [ds.id for ds in index.datasets.search(product=ls8_eo3_dataset.type.name, geometry=exact1_3577)]
+    dssids = [ds.id for ds in index.datasets.search(product=ls8_eo3_dataset.product.name, geometry=exact1_3577)]
     assert len(dssids) == 2
     assert ls8_eo3_dataset.id in dssids
     assert ls8_eo3_dataset2.id in dssids
-    dssids = [ds.id for ds in index.datasets.search(product=ls8_eo3_dataset.type.name, geometry=exact3_4326)]
+    dssids = [ds.id for ds in index.datasets.search(product=ls8_eo3_dataset.product.name, geometry=exact3_4326)]
     assert len(dssids) == 2
     assert ls8_eo3_dataset3.id in dssids
     assert ls8_eo3_dataset3.id in dssids
-    dssids = [ds.id for ds in index.datasets.search(product=ls8_eo3_dataset.type.name, geometry=exact3_3577)]
+    dssids = [ds.id for ds in index.datasets.search(product=ls8_eo3_dataset.product.name, geometry=exact3_3577)]
     assert len(dssids) == 2
     assert ls8_eo3_dataset3.id in dssids
     assert ls8_eo3_dataset3.id in dssids

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -213,7 +213,7 @@ def test_search_by_product_eo3(index: Index,
 
 
 def test_search_limit_eo3(index, ls8_eo3_dataset, ls8_eo3_dataset2, wo_eo3_dataset):
-    prod = ls8_eo3_dataset.type.name
+    prod = ls8_eo3_dataset.product.name
     datasets = list(index.datasets.search(product=prod))
     assert len(datasets) == 2
     datasets = list(index.datasets.search(limit=1, product=prod))
@@ -283,7 +283,7 @@ def test_search_or_expressions_eo3(index: Index,
 
     # OR both products: return all
     datasets = index.datasets.search_eager(
-        product=[ls8_eo3_dataset.type.name, wo_eo3_dataset.type.name]
+        product=[ls8_eo3_dataset.product.name, wo_eo3_dataset.product.name]
     )
     assert len(datasets) == 3
     ids = set(dataset.id for dataset in datasets)
@@ -305,7 +305,7 @@ def test_search_or_expressions_eo3(index: Index,
 
     # Redundant ORs should have no effect.
     datasets = index.datasets.search_eager(
-        product=[wo_eo3_dataset.type.name, wo_eo3_dataset.type.name, wo_eo3_dataset.type.name]
+        product=[wo_eo3_dataset.product.name, wo_eo3_dataset.product.name, wo_eo3_dataset.product.name]
     )
     assert len(datasets) == 1
     assert datasets[0].id == wo_eo3_dataset.id
@@ -425,7 +425,7 @@ def test_searches_only_type_eo3(index: Index,
 
     # One result in the product
     datasets = index.datasets.search_eager(
-        product=wo_eo3_dataset.type.name,
+        product=wo_eo3_dataset.product.name,
         platform='landsat-8'
     )
     assert len(datasets) == 1
@@ -466,7 +466,7 @@ def test_search_special_fields_eo3(index: Index,
                                    wo_eo3_dataset: Dataset) -> None:
     # 'product' is a special case
     datasets = index.datasets.search_eager(
-        product=ls8_eo3_dataset.type.name
+        product=ls8_eo3_dataset.product.name
     )
     assert len(datasets) == 1
     assert datasets[0].id == ls8_eo3_dataset.id
@@ -480,11 +480,11 @@ def test_search_special_fields_eo3(index: Index,
 
 
 def test_search_by_uri_eo3(index, ls8_eo3_dataset, ls8_eo3_dataset2, eo3_ls8_dataset_doc):
-    datasets = index.datasets.search_eager(product=ls8_eo3_dataset.type.name,
+    datasets = index.datasets.search_eager(product=ls8_eo3_dataset.product.name,
                                            uri=eo3_ls8_dataset_doc[1])
     assert len(datasets) == 1
 
-    datasets = index.datasets.search_eager(product=ls8_eo3_dataset.type.name,
+    datasets = index.datasets.search_eager(product=ls8_eo3_dataset.product.name,
                                            uri='file:///x/yz')
     assert len(datasets) == 0
 
@@ -493,7 +493,7 @@ def test_search_conflicting_types(index, ls8_eo3_dataset):
     # Should return no results.
     with pytest.raises(ValueError):
         index.datasets.search_eager(
-            product=ls8_eo3_dataset.type.name,
+            product=ls8_eo3_dataset.product.name,
             # The ls8 type is not of type storage_unit.
             metadata_type='storage_unit'
         )
@@ -509,7 +509,7 @@ def test_fetch_all_of_md_type(index: Index, ls8_eo3_dataset: Dataset) -> None:
     assert results[0].id == ls8_eo3_dataset.id
     # Get every dataset of the type.
     results = index.datasets.search_eager(
-        product=ls8_eo3_dataset.type.name
+        product=ls8_eo3_dataset.product.name
     )
     assert len(results) == 1
     assert results[0].id == ls8_eo3_dataset.id
@@ -525,7 +525,7 @@ def test_count_searches(index: Index,
                         ls8_eo3_dataset: Dataset) -> None:
     # One result in the telemetry type
     datasets = index.datasets.count(
-        product=ls8_eo3_dataset.type.name,
+        product=ls8_eo3_dataset.product.name,
         platform='landsat-8',
         instrument='OLI_TIRS',
     )
@@ -569,17 +569,17 @@ def test_count_by_product_searches_eo3(index: Index,
                                        wo_eo3_dataset: Dataset) -> None:
     # Two result in the ls8 type
     products = tuple(index.datasets.count_by_product(
-        product=ls8_eo3_dataset.type.name,
+        product=ls8_eo3_dataset.product.name,
         platform='landsat-8'
     ))
-    assert products == ((ls8_eo3_dataset.type, 2),)
+    assert products == ((ls8_eo3_dataset.product, 2),)
 
     # Two results in the metadata type
     products = tuple(index.datasets.count_by_product(
         metadata_type=ls8_eo3_dataset.metadata_type.name,
         platform='landsat-8',
     ))
-    assert products == ((ls8_eo3_dataset.type, 2),)
+    assert products == ((ls8_eo3_dataset.product, 2),)
 
     # No results when searching for a different dataset type.
     products = tuple(index.datasets.count_by_product(
@@ -592,7 +592,7 @@ def test_count_by_product_searches_eo3(index: Index,
     products = set(index.datasets.count_by_product(
         platform='landsat-8',
     ))
-    assert products == {(ls8_eo3_dataset.type, 2), (wo_eo3_dataset.type, 1)}
+    assert products == {(ls8_eo3_dataset.product, 2), (wo_eo3_dataset.product, 1)}
 
     # No results for different metadata type.
     products = tuple(index.datasets.count_by_product(
@@ -605,7 +605,7 @@ def test_count_time_groups(index: Index,
                            ls8_eo3_dataset: Dataset) -> None:
     timeline = list(index.datasets.count_product_through_time(
         '1 day',
-        product=ls8_eo3_dataset.type.name,
+        product=ls8_eo3_dataset.product.name,
         time=Range(
             datetime.datetime(2016, 5, 11, tzinfo=tz.tzutc()),
             datetime.datetime(2016, 5, 13, tzinfo=tz.tzutc())
@@ -638,7 +638,7 @@ def test_count_time_groups_cli(clirunner: Any,
         verbose_flag=''
     )
     expected_out = (
-        f'{ls8_eo3_dataset.type.name}\n'
+        f'{ls8_eo3_dataset.product.name}\n'
         '    2016-05-11: 0\n'
         '    2016-05-12: 1\n'
     )
@@ -750,20 +750,20 @@ def test_find_duplicates_eo3(index,
     # Specifying groups as fields:
     f = ls8_eo3_dataset.metadata_type.dataset_fields.get
     field_res = sorted(index.datasets.search_product_duplicates(
-        ls8_eo3_dataset.type,
+        ls8_eo3_dataset.product,
         f('region_code'), f('dataset_maturity')
     ))
     assert field_res == expected_ls8_path_row_duplicates
     # Field names as strings
     product_res = sorted(index.datasets.search_product_duplicates(
-        ls8_eo3_dataset.type,
+        ls8_eo3_dataset.product,
         'region_code', 'dataset_maturity'
     ))
     assert product_res == expected_ls8_path_row_duplicates
 
     # No WO duplicates: there's only one
     sat_res = sorted(index.datasets.search_product_duplicates(
-        wo_eo3_dataset.type,
+        wo_eo3_dataset.product,
         'region_code', 'dataset_maturity'
     ))
     assert sat_res == []
@@ -794,7 +794,7 @@ def test_csv_search_via_cli_eo3(clirunner: Any,
             _cli_csv_search(('datasets',) + args, clirunner)
 
     matches_both('lat in [-40, -10]')
-    matches_both('product=' + ls8_eo3_dataset.type.name)
+    matches_both('product=' + ls8_eo3_dataset.product.name)
 
     # Don't return on a mismatch
     matches_none('lat in [150, 160]')

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -210,6 +210,8 @@ def test_search_by_product_eo3(index: Index,
     assert len(products) == 1
     [dataset] = products[base_eo3_product_doc["name"]]
     assert dataset.id == wo_eo3_dataset.id
+    assert dataset.is_eo3
+    assert dataset.type == dataset.product
 
 
 def test_search_limit_eo3(index, ls8_eo3_dataset, ls8_eo3_dataset2, wo_eo3_dataset):

--- a/integration_tests/index/test_search_legacy.py
+++ b/integration_tests/index/test_search_legacy.py
@@ -103,7 +103,7 @@ def pseudo_ls8_dataset(index, pseudo_ls8_type):
     assert was_inserted
     d = index.datasets.get(id_)
     # The dataset should have been matched to the telemetry type.
-    assert d.type.id == pseudo_ls8_type.id
+    assert d.product.id == pseudo_ls8_type.id
 
     return d
 
@@ -156,7 +156,7 @@ def pseudo_ls8_dataset2(index, pseudo_ls8_type):
     assert was_inserted
     d = index.datasets.get(id_)
     # The dataset should have been matched to the telemetry type.
-    assert d.type.id == pseudo_ls8_type.id
+    assert d.product.id == pseudo_ls8_type.id
 
     return d
 
@@ -184,7 +184,7 @@ def pseudo_ls8_dataset3(index: Index,
     assert was_inserted
     d = index.datasets.get(id_)
     # The dataset should have been matched to the telemetry type.
-    assert d.type.id == pseudo_ls8_type.id
+    assert d.product.id == pseudo_ls8_type.id
     return d
 
 
@@ -210,7 +210,7 @@ def pseudo_ls8_dataset4(index: Index,
         assert was_inserted
         d = index.datasets.get(id_)
         # The dataset should have been matched to the telemetry type.
-        assert d.type.id == pseudo_ls8_type.id
+        assert d.product.id == pseudo_ls8_type.id
         return d
 
 
@@ -225,7 +225,7 @@ def ls5_dataset_w_children(index, clirunner, example_ls5_dataset_path, indexed_l
 def ls5_dataset_nbar_type(ls5_dataset_w_children: Dataset,
                           indexed_ls5_scene_products: List[Product]) -> Product:
     for dataset_type in indexed_ls5_scene_products:
-        if dataset_type.name == ls5_dataset_w_children.type.name:
+        if dataset_type.name == ls5_dataset_w_children.product.name:
             return dataset_type
     else:
         raise RuntimeError("LS5 type was not among types")
@@ -599,7 +599,7 @@ def test_searches_only_type(index: Index,
                             pseudo_ls8_dataset: Dataset,
                             ls5_telem_type) -> None:
     # The dataset should have been matched to the telemetry type.
-    assert pseudo_ls8_dataset.type.id == pseudo_ls8_type.id
+    assert pseudo_ls8_dataset.product.id == pseudo_ls8_type.id
     assert index.datasets.search_eager()
 
     # One result in the telemetry type
@@ -667,11 +667,11 @@ def test_search_special_fields(index: Index,
 
 @pytest.mark.parametrize('datacube_env_name', ('datacube', ))
 def test_search_by_uri(index, ls5_dataset_w_children):
-    datasets = index.datasets.search_eager(product=ls5_dataset_w_children.type.name,
+    datasets = index.datasets.search_eager(product=ls5_dataset_w_children.product.name,
                                            uri=ls5_dataset_w_children.local_uri)
     assert len(datasets) == 1
 
-    datasets = index.datasets.search_eager(product=ls5_dataset_w_children.type.name,
+    datasets = index.datasets.search_eager(product=ls5_dataset_w_children.product.name,
                                            uri='file:///x/yz')
     assert len(datasets) == 0
 
@@ -706,7 +706,7 @@ def test_count_by_product_searches(index: Index,
                                    pseudo_ls8_dataset: Dataset,
                                    ls5_telem_type: Product) -> None:
     # The dataset should have been matched to the telemetry type.
-    assert pseudo_ls8_dataset.type.id == pseudo_ls8_type.id
+    assert pseudo_ls8_dataset.product.id == pseudo_ls8_type.id
     assert index.datasets.search_eager()
 
     # One result in the telemetry type
@@ -940,7 +940,7 @@ def test_find_duplicates(index, pseudo_ls8_type,
 
     # No LS5 duplicates: there's only one of each
     sat_res = sorted(index.datasets.search_product_duplicates(
-        ls5_dataset_w_children.type,
+        ls5_dataset_w_children.product,
         'sat_path', 'sat_row'
     ))
     assert sat_res == []

--- a/integration_tests/test_3d.py
+++ b/integration_tests/test_3d.py
@@ -260,9 +260,6 @@ def test_indexing(clirunner, index, product_def):
     clirunner(["-v", "dataset", "add", "--dry-run", str(index_yaml)])
 
     #  - do actual indexing
-    clirunner(["-v", "dataset", "add", str(index_yaml)])
-
-    #  - this will be no-op but with ignore lineage
     clirunner(
         [
             "-v",
@@ -318,7 +315,7 @@ def test_indexing_with_spectral_map(clirunner, index, dataset_types):
     clirunner(["-v", "product", "add", str(dataset_types)])
 
     # Index the Dataset
-    clirunner(["-v", "dataset", "add", str(index_yaml)])
+    clirunner(["-v", "dataset", "add", '--confirm-ignore-lineage', str(index_yaml)])
     dc = Datacube(index=index)
     check_open_with_dc_simple(dc, product_def, [product_id], measurement)
 
@@ -338,7 +335,7 @@ def test_end_to_end_multitime(clirunner, index, product_def, original_data):
                 measurement=measurement,
             )
             # Index the Datasets
-            clirunner(["-v", "dataset", "add", str(index_yaml)])
+            clirunner(["-v", "dataset", "add", '--confirm-ignore-lineage', str(index_yaml)])
 
         if idx == 0:  # Full check for the first measurement only
             # Check data for all product IDs

--- a/integration_tests/test_cli_output.py
+++ b/integration_tests/test_cli_output.py
@@ -138,5 +138,6 @@ def test_readd_and_update_metadata_product_dataset_command(index_empty, clirunne
     assert "WARNING Dataset" in rerun_add.output
     assert "is already in the database" in rerun_add.output
 
-    update = clirunner(['dataset', 'update', '--allow-any', 'properties.datetime', dataset_add_configs.datasets_eo3_updated])
+    update = clirunner(['dataset', 'update', '--allow-any', 'properties.datetime',
+                        dataset_add_configs.datasets_eo3_updated])
     assert "2 successful, 0 failed" in update.output

--- a/integration_tests/test_cli_output.py
+++ b/integration_tests/test_cli_output.py
@@ -41,6 +41,8 @@ def test_cli_metadata_subcommand(index_empty, clirunner, dataset_add_configs):
     assert runner.exit_code == 1
 
 
+# TODO Rewrite with EO3 test data
+@pytest.mark.parametrize('datacube_env_name', ('datacube', ))
 def test_cli_dataset_subcommand(index_empty, clirunner, dataset_add_configs):
     clirunner(['metadata', 'add', dataset_add_configs.metadata])
     clirunner(['product', 'add', dataset_add_configs.products])
@@ -111,6 +113,8 @@ def test_cli_dataset_subcommand(index_empty, clirunner, dataset_add_configs):
     assert runner.exit_code == 0
 
 
+# TODO Rewrite with EO3 test data
+@pytest.mark.parametrize('datacube_env_name', ('datacube', ))
 def test_readd_and_update_metadata_product_dataset_command(index_empty, clirunner, dataset_add_configs):
     clirunner(['metadata', 'add', dataset_add_configs.metadata])
     rerun_add = clirunner(['metadata', 'add', dataset_add_configs.metadata])

--- a/integration_tests/test_cli_output.py
+++ b/integration_tests/test_cli_output.py
@@ -75,7 +75,7 @@ def test_cli_dataset_subcommand(index_empty, clirunner, dataset_add_configs):
             # Expect to fail with legacy datasets
             clirunner(['dataset', 'add', dataset_add_configs.datasets])
         # Use EO3 datasets to allow subsequent tests to run.
-        clirunner(['dataset', 'add', dataset_add_configs.datasets_eo3])
+        result = clirunner(['dataset', 'add', "--confirm-ignore-lineage", dataset_add_configs.datasets_eo3])
 
     runner = clirunner(['dataset', 'archive'], verbose_flag=False, expect_success=False)
     assert "Completed dataset archival." not in runner.output
@@ -93,7 +93,6 @@ def test_cli_dataset_subcommand(index_empty, clirunner, dataset_add_configs):
     assert "Usage:  [OPTIONS] [IDS]" in runner.output
     assert "Restore datasets" in runner.output
     assert runner.exit_code == 1
-
     runner = clirunner(['dataset', 'restore', "--all"], verbose_flag=False)
     assert "restoring" in runner.output
     assert "Usage:  [OPTIONS] [IDS]" not in runner.output
@@ -129,10 +128,10 @@ def test_readd_and_update_metadata_product_dataset_command(index_empty, clirunne
     update = clirunner(['product', 'update', dataset_add_configs.products])
     assert "WARNING No changes detected for product" in update.output
 
-    clirunner(['dataset', 'add', dataset_add_configs.datasets_eo3])
-    rerun_add = clirunner(['dataset', 'add', dataset_add_configs.datasets_eo3])
+    clirunner(['dataset', 'add', '--confirm-ignore-lineage', dataset_add_configs.datasets_eo3])
+    rerun_add = clirunner(['dataset', 'add', '--confirm-ignore-lineage', dataset_add_configs.datasets_eo3])
     assert "WARNING Dataset" in rerun_add.output
     assert "is already in the database" in rerun_add.output
 
     update = clirunner(['dataset', 'update', dataset_add_configs.datasets_eo3])
-    assert "1 successful, 0 failed" in update.output
+    assert "2 successful, 0 failed" in update.output

--- a/integration_tests/test_cli_output.py
+++ b/integration_tests/test_cli_output.py
@@ -128,6 +128,11 @@ def test_readd_and_update_metadata_product_dataset_command(index_empty, clirunne
     update = clirunner(['product', 'update', dataset_add_configs.products])
     assert "WARNING No changes detected for product" in update.output
 
+    # Update before add
+    update = clirunner(['dataset', 'update', dataset_add_configs.datasets_eo3])
+    assert "No such dataset in the database" in update.output
+    assert "Failure while processing" in update.output
+
     clirunner(['dataset', 'add', '--confirm-ignore-lineage', dataset_add_configs.datasets_eo3])
     rerun_add = clirunner(['dataset', 'add', '--confirm-ignore-lineage', dataset_add_configs.datasets_eo3])
     assert "WARNING Dataset" in rerun_add.output

--- a/integration_tests/test_cli_output.py
+++ b/integration_tests/test_cli_output.py
@@ -138,5 +138,5 @@ def test_readd_and_update_metadata_product_dataset_command(index_empty, clirunne
     assert "WARNING Dataset" in rerun_add.output
     assert "is already in the database" in rerun_add.output
 
-    update = clirunner(['dataset', 'update', dataset_add_configs.datasets_eo3])
+    update = clirunner(['dataset', 'update', '--allow-any', 'properties.datetime', dataset_add_configs.datasets_eo3_updated])
     assert "2 successful, 0 failed" in update.output

--- a/integration_tests/test_cli_output.py
+++ b/integration_tests/test_cli_output.py
@@ -18,6 +18,14 @@ def test_cli_product_subcommand(index_empty, clirunner, dataset_add_configs):
     assert "Add or update products in" in runner.output
     assert runner.exit_code == 1
 
+    runner = clirunner(['product', 'list'], verbose_flag=False, expect_success=False)
+    assert "Usage:  [OPTIONS] [FILES]" not in runner.output
+    assert runner.exit_code == 0
+
+    runner = clirunner(['product', 'show', 'ga_ls8c_ard_3'], verbose_flag=False, expect_success=False)
+    assert "No products" not in runner.output
+    assert runner.exit_code == 1
+
     runner = clirunner(['product', 'add', dataset_add_configs.empty_file], verbose_flag=False, expect_success=False)
     assert "All files are empty, exit" in runner.output
     assert runner.exit_code == 1
@@ -141,6 +149,11 @@ def test_readd_and_update_metadata_product_dataset_command(index, clirunner,
         rerun_add = clirunner(['dataset', 'add', '--confirm-ignore-lineage', ds_path])
         assert "WARNING Dataset" in rerun_add.output
         assert "is already in the database" in rerun_add.output
+
+    update = clirunner(['dataset', 'update',
+                        eo3_dataset_update_path])
+    assert "Unsafe changes in" in update.output
+    assert "0 successful, 1 failed" in update.output
 
     update = clirunner(['dataset', 'update', '--allow-any', 'properties.datetime',
                         eo3_dataset_update_path])

--- a/integration_tests/test_cli_output.py
+++ b/integration_tests/test_cli_output.py
@@ -1,5 +1,7 @@
-import pytest
-
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2022 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
 
 def test_cli_product_subcommand(index_empty, clirunner, dataset_add_configs):
     runner = clirunner(['product', 'update'], verbose_flag=False, expect_success=False)

--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -309,7 +309,7 @@ def check_legacy_open(index):
     sources = dc.group_datasets(dss, query_group_by('time'))
 
     gbox = data_array.geobox
-    mm = [dss[0].type.measurements['blue']]
+    mm = [dss[0].product.measurements['blue']]
     xx = dc.load_data(sources, gbox, mm)
     assert (xx == data_array).all()
 

--- a/integration_tests/test_model.py
+++ b/integration_tests/test_model.py
@@ -2,10 +2,13 @@
 #
 # Copyright (c) 2015-2020 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+import pytest
+
 from datacube.model import Dataset, DatasetType
 from typing import List
 
 
+@pytest.mark.parametrize('datacube_env_name', ('datacube', ))
 def test_crs_parse(indexed_ls5_scene_products: List[DatasetType]) -> None:
     product = indexed_ls5_scene_products[2]
 

--- a/integration_tests/test_validate_ingestion.py
+++ b/integration_tests/test_validate_ingestion.py
@@ -11,6 +11,7 @@ COMPLIANCE_CHECKER_NORMAL_LIMIT = 2
 
 
 @pytest.mark.timeout(20)
+@pytest.mark.parametrize('datacube_env_name', ('datacube', ))
 @pytest.mark.usefixtures('default_metadata_type',
                          'indexed_ls5_scene_products')
 def test_invalid_ingestor_config(clirunner, index, tmpdir):

--- a/tests/api/test_grid_workflow.py
+++ b/tests/api/test_grid_workflow.py
@@ -197,8 +197,8 @@ def test_gridworkflow():
     # so only thing to check here is the call interface.
 
     measurement = dict(nodata=0, dtype=numpy.int)
-    fakedataset.type.lookup_measurements.return_value = {"dummy": measurement}
-    fakedataset2.type = fakedataset.type
+    fakedataset.product.lookup_measurements.return_value = {"dummy": measurement}
+    fakedataset2.product = fakedataset.product
 
     from unittest.mock import patch
 

--- a/tests/index/test_postgis_fields.py
+++ b/tests/index/test_postgis_fields.py
@@ -1,0 +1,27 @@
+import datetime
+from decimal import Decimal
+
+from datacube.drivers.postgis._fields import NumericDocField, IntDocField, DoubleDocField, DateDocField
+from datacube.drivers.postgis._schema import Dataset
+
+
+def test_numeric_parse():
+    fld = NumericDocField("test_fld", "field for testing", Dataset.metadata_doc, True)
+    assert isinstance(fld.parse_value("55.88"), Decimal)
+
+
+def test_int_parse():
+    fld = IntDocField("test_fld", "field for testing", Dataset.metadata_doc, True)
+    assert fld.parse_value("55") == 55
+
+
+def test_float_parse():
+    fld = DoubleDocField("test_fld", "field for testing", Dataset.metadata_doc, True)
+    assert isinstance(fld.parse_value("55.88"), float)
+
+
+def test_date_parse():
+    fld = DateDocField("test_fld", "field for testing", Dataset.metadata_doc, True)
+    assert fld.parse_value("2020-07-22T14:45:22.452434+0000") == datetime.datetime(
+        2020, 7, 22, 14, 45, 22, 452434, tzinfo=datetime.timezone.utc
+    )

--- a/tests/index/test_postgis_fields.py
+++ b/tests/index/test_postgis_fields.py
@@ -1,3 +1,8 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2022 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 import datetime
 from decimal import Decimal
 

--- a/tests/storage/test_storage_load.py
+++ b/tests/storage/test_storage_load.py
@@ -69,7 +69,7 @@ def test_new_xr_load(data_folder):
     sources = Datacube.group_datasets([ds], 'time')
 
     im, meta = rio_slurp(str(data_folder) + '/test.tif')
-    measurements = [ds.type.measurements[n] for n in ('a', 'b')]
+    measurements = [ds.product.measurements[n] for n in ('a', 'b')]
     measurements[1]['fuser'] = lambda dst, src: _default_fuser(dst, src, measurements[1].nodata)
 
     xx, _ = xr_load(sources, meta.gbox, measurements, rdr)

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -48,7 +48,7 @@ def test_load_data(tmpdir):
     sources2 = Datacube.group_datasets([ds, ds2], group_by)
 
     mm = ['aa']
-    mm = [ds.type.measurements[k] for k in mm]
+    mm = [ds.product.measurements[k] for k in mm]
 
     ds_data = Datacube.load_data(sources, gbox, mm)
     assert ds_data.aa.nodata == nodata
@@ -112,7 +112,7 @@ def test_load_data_with_url_mangling(tmpdir):
     sources2 = Datacube.group_datasets([ds, ds2], group_by)
 
     mm = ['aa']
-    mm = [ds.type.measurements[k] for k in mm]
+    mm = [ds.product.measurements[k] for k in mm]
 
     ds_data = Datacube.load_data(sources, gbox, mm, patch_url=url_mangler)
     assert ds_data.aa.nodata == nodata
@@ -178,7 +178,7 @@ def test_load_data_cbk(tmpdir):
     def progress_cbk(n, nt):
         progress_call_data.append((n, nt))
 
-    ds_data = Datacube.load_data(sources, gbox, ds.type.measurements,
+    ds_data = Datacube.load_data(sources, gbox, ds.product.measurements,
                                  progress_cbk=progress_cbk)
 
     assert progress_call_data == [(1, 4), (2, 4), (3, 4), (4, 4)]
@@ -195,7 +195,7 @@ def test_load_data_cbk(tmpdir):
             raise KeyboardInterrupt()
 
     progress_call_data = []
-    ds_data = Datacube.load_data(sources, gbox, ds.type.measurements,
+    ds_data = Datacube.load_data(sources, gbox, ds.product.measurements,
                                  progress_cbk=progress_cbk_fail_early)
 
     assert progress_call_data == [(1, 4)]
@@ -204,7 +204,7 @@ def test_load_data_cbk(tmpdir):
     np.testing.assert_array_equal(nodata, ds_data.bb.values[0])
 
     progress_call_data = []
-    ds_data = Datacube.load_data(sources, gbox, ds.type.measurements,
+    ds_data = Datacube.load_data(sources, gbox, ds.product.measurements,
                                  progress_cbk=progress_cbk_fail_early2)
 
     assert ds_data.dc_partial_load is True

--- a/tests/test_utils_docs.py
+++ b/tests/test_utils_docs.py
@@ -684,3 +684,13 @@ def test_document_subset_full_recursion():
 
     assert metadata_subset([35, 47, 58], [0, 35, 47, 58, 102], full_recursion=True)
     assert metadata_subset([35, 47, 58], {"a": "foo", "b": [35, 47, 52, 58]}, full_recursion=True)
+
+
+def test_documents_equal():
+    from datacube.utils.documents import documents_equal
+    assert not documents_equal(7, "seven")
+    assert not documents_equal({"a": "ok", "b": "mediocre"}, {"c": "great", "b": "mediocre", "a": "ok"})
+    assert not documents_equal([0, 1, 2], [0, 1, 2, 3])
+    assert not documents_equal([0, 1, 2], [0, 2, 1])
+    assert not documents_equal(0.5, 0.50001)
+    assert documents_equal(0.5, 0.50000000001)


### PR DESCRIPTION
### Reason for this pull request

Postgis driver is intended to be EO3-compatible metadata only, but this was poorly enforced. 

Model layer still talks about dataset "type", where the term recognised by users is "product".

Continues work started in #1368

### Proposed changes

- Validate that new metadata types (to the Postgis driver) are eo3 compatible.
- Remove from postgis driver the old implementation for adding lineage inherited from legacy driver.
- Rename `Dataset.type` to `Dataset.product`, with `type` as an alias for backwards compatibility.
- Test refactors to use EO3 test fixtures where possible.


 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1372.org.readthedocs.build/en/1372/

<!-- readthedocs-preview datacube-core end -->