### PR TITLE
pin xarray version < 2022.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ setup(
         'sqlalchemy',
         'GeoAlchemy2',
         'toolz',
-        'xarray>=0.9,!=2022.6.0',  # >0.9 fixes most problems with `crs` attributes being lost
+        'xarray>=0.9,<2022.6',  # >0.9 fixes most problems with `crs` attributes being lost
     ],
     extras_require=extras_require,
     tests_require=tests_require,


### PR DESCRIPTION
### Reason for this pull request

There exist versions of xarray past 2022.6, none of which are currently compatible due to a known bug: pydata/xarray#6836

### Proposed changes

- Pin xarray version at < 2022.6 


 - [x] Closes #1373
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1374.org.readthedocs.build/en/1374/

<!-- readthedocs-preview datacube-core end -->