### PR TITLE
replace distutils version with packaging.version

### DIFF
--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -10,7 +10,7 @@ import warnings
 from collections import namedtuple, OrderedDict
 from typing import Tuple, Iterable, List, Union, Optional, Any, Callable, Hashable, Dict, Iterator
 from collections.abc import Sequence
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import cachetools
 import numpy
@@ -150,7 +150,7 @@ class CRS:
     """
     Wrapper around `pyproj.CRS` for backwards compatibility.
     """
-    DEFAULT_WKT_VERSION = (WktVersion.WKT1_GDAL if LooseVersion(rasterio.__gdal_version__) < LooseVersion("3.0.0")
+    DEFAULT_WKT_VERSION = (WktVersion.WKT1_GDAL if Version(rasterio.__gdal_version__) < Version("3.0.0")
                            else WktVersion.WKT2_2019)
 
     __slots__ = ('_crs', '_epsg', '_str')

--- a/integration_tests/test_cli_output.py
+++ b/integration_tests/test_cli_output.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2015-2022 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 
+
 def test_cli_product_subcommand(index_empty, clirunner, dataset_add_configs):
     runner = clirunner(['product', 'update'], verbose_flag=False, expect_success=False)
     assert "Usage:  [OPTIONS] [FILES]" in runner.output

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,7 @@ setup(
         'GeoAlchemy2',
         'toolz',
         'xarray>=0.9,<2022.6',  # >0.9 fixes most problems with `crs` attributes being lost
+        'packaging',
     ],
     extras_require=extras_require,
     tests_require=tests_require,


### PR DESCRIPTION
### Reason for this pull request

Fix deprecation message due to distutils Version classes


### Proposed changes

- Repalce distutils LooseVersion with pacakging.version as suggested in deprecation warning.



 - [x] Closes #1351
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1375.org.readthedocs.build/en/1375/

<!-- readthedocs-preview datacube-core end -->