### PR TITLE
Bulk read/write operations and rapid cloning between indexes

### DIFF
--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -201,7 +201,11 @@ def extract_dataset_search_fields(ds_metadata, mdt_metadata):
 
     :return: A dictionary mapping search field names to (type_name, value) tuples.
     """
-    fields = {name: field for name, field in get_dataset_fields(mdt_metadata).items() if not isinstance(field, NativeField)}
+    fields = {
+        name: field
+        for name, field in get_dataset_fields(mdt_metadata).items()
+        if not isinstance(field, NativeField)
+    }
     return extract_dataset_fields(ds_metadata, fields)
 
 
@@ -698,8 +702,6 @@ class PostgisDbAPI(object):
         dataset_location or dataset_source tables. Joining with other tables would not
         result in multiple records per dataset due to the direction of cardinality.
         """
-
-
         select_query = self.search_unique_datasets_query(expressions, select_fields, limit)
 
         return self._connection.execute(select_query)

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -32,7 +32,7 @@ from ._fields import parse_fields, Expression, PgField, PgExpression, Unindexabl
 from ._fields import NativeField, DateDocField, SimpleDocField
 from ._schema import MetadataType, Product, \
     Dataset, DatasetSource, DatasetLocation, SelectedDatasetLocation, \
-    search_field_index_map, search_field_tables
+    search_field_index_map, search_field_indexes
 from ._spatial import geom_alchemy, generate_dataset_spatial_values, extract_geometry_from_eo3_projection
 from .sql import escape_pg_identifier
 
@@ -41,6 +41,27 @@ from .sql import escape_pg_identifier
 def _dataset_select_fields():
     return (
         Dataset,
+        # All active URIs, from newest to oldest
+        func.array(
+            select(
+                SelectedDatasetLocation.uri
+            ).where(
+                and_(
+                    SelectedDatasetLocation.dataset_ref == Dataset.id,
+                    SelectedDatasetLocation.archived == None
+                )
+            ).order_by(
+                SelectedDatasetLocation.added.desc(),
+                SelectedDatasetLocation.id.desc()
+            ).label('uris')
+        ).label('uris')
+    )
+
+
+def _dataset_bulk_select_fields():
+    return (
+        Dataset.product_ref,
+        Dataset.metadata_doc,
         # All active URIs, from newest to oldest
         func.array(
             select(
@@ -320,6 +341,11 @@ class PostgisDbAPI(object):
         )
         return r.rowcount > 0
 
+    def insert_dataset_search_bulk(self, search_type, values):
+        search_table = search_field_index_map[search_type]
+        r = self._connection.execute(insert(search_table).values(values))
+        return r.rowcount
+
     def insert_dataset_spatial(self, dataset_id, crs, extent):
         """
         Add/update a spatial index entry for a dataset
@@ -474,7 +500,7 @@ class PostgisDbAPI(object):
                 DatasetSource.dataset_ref == dataset_id
             )
         )
-        for table in search_field_tables:
+        for table in search_field_indexes.values():
             self._connection.execute(
                 delete(table).where(table.dataset_ref == dataset_id)
             )
@@ -614,6 +640,14 @@ class PostgisDbAPI(object):
                                                   limit, geom=geom)
         _LOG.debug("search_datasets SQL: %s", str(select_query))
         return self._connection.execute(select_query)
+
+    def bulk_simple_dataset_search(self, products):
+        query = select(
+            _dataset_bulk_select_fields()
+        ).select_from(Dataset)
+        if products:
+            query = query.where(Dataset.product_ref in products)
+        return self._connection.execute(query)
 
     @staticmethod
     def search_unique_datasets_query(expressions, select_fields, limit):

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -29,7 +29,7 @@ from datacube.utils import geometry
 from datacube.utils.geometry import CRS, Geometry
 from datacube.index.abstract import DSID
 from . import _core
-from ._fields import parse_fields, Expression, PgField, PgExpression  # noqa: F401
+from ._fields import parse_fields, Expression, PgField, PgExpression, UnindexableValue  # noqa: F401
 from ._fields import NativeField, DateDocField, SimpleDocField
 from ._schema import MetadataType, Product, \
     Dataset, DatasetSource, DatasetLocation, SelectedDatasetLocation, \
@@ -186,9 +186,12 @@ def extract_dataset_search_fields(ds_metadata, mdt_metadata):
     for field_name, field in fields.items():
         if isinstance(field, NativeField):
             continue
-        fld_type = field.type_name
-        fld_val = field.search_value_to_alchemy(field.extract(ds_metadata))
-        result[field_name] = (fld_type, fld_val)
+        try:
+            fld_type = field.type_name
+            fld_val = field.search_value_to_alchemy(field.extract(ds_metadata))
+            result[field_name] = (fld_type, fld_val)
+        except UnindexableValue:
+            continue
     return result
 
 

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -957,6 +957,21 @@ class PostgisDbAPI(object):
             type_id, name, search_fields, concurrently=concurrently
         )
 
+    def insert_metadata_bulk(self, definitions):
+        res = self._connection.execute(
+            insert(MetadataType),
+            [
+                {"name": defn["name"], "definition": defn}
+                for defn in definitions
+            ]
+        )
+        type_ids = list(res.inserted_primary_key)
+        for type_id, definition in zip(type_ids, definitions):
+            search_fields = get_dataset_fields(definition)
+            self._setup_metadata_type_fields(
+                type_id, definition["name"], search_fields, concurrently=True
+            )
+
     def update_metadata_type(self, name, definition, concurrently=False):
         res = self._connection.execute(
             update(MetadataType).returning(MetadataType.id).where(
@@ -1024,6 +1039,10 @@ class PostgisDbAPI(object):
 
     def get_all_metadata_types(self):
         return self._connection.execute(select(MetadataType).order_by(MetadataType.name.asc())).fetchall()
+
+    def get_all_metadata_type_defs(self):
+        for r in self._connection.execute(select(MetadataType.definition).order_by(MetadataType.name.asc())):
+            yield r[0]
 
     def get_locations(self, dataset_id):
         return [

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -227,22 +227,30 @@ class PostgisDbAPI(object):
     def __init__(self, parentdb, connection):
         self._db = parentdb
         self._connection = connection
+        self._sqla_txn = None
 
     @property
     def in_transaction(self):
-        return self._connection.in_transaction()
+        in_txn = self._connection.in_transaction()
+        if in_txn:
+            assert self._sqla_txn is not None
+        else:
+            assert self._sqla_txn is None
+        return in_txn
 
     def begin(self):
-        assert not self._connection.in_transaction()
-        print("Calling begin??")
-        self._connection.execute(text('BEGIN'))
-        # assert self._connection.in_transaction()
+        self._connection.execution_options(isolation_level="SERIALIZABLE")
+        self._sqla_txn = self._connection.begin()
 
     def commit(self):
-        self._connection.execute(text('COMMIT'))
+        self._sqla_txn.commit()
+        self._sqla_txn = None
+        self._connection.execution_options(isolation_level="AUTOCOMMIT")
 
     def rollback(self):
-        self._connection.execute(text('ROLLBACK'))
+        self._sqla_txn.rollback()
+        self._sqla_txn = None
+        self._connection.execution_options(isolation_level="AUTOCOMMIT")
 
     def execute(self, command):
         return self._connection.execute(command)
@@ -501,22 +509,27 @@ class PostgisDbAPI(object):
         return r.rowcount > 0
 
     def delete_dataset(self, dataset_id):
+        _LOG.warning("Deleting locations")
         self._connection.execute(
             delete(DatasetLocation).where(
                 DatasetLocation.dataset_ref == dataset_id
             )
         )
+        _LOG.warning("Deleting sources")
         self._connection.execute(
             delete(DatasetSource).where(
                 DatasetSource.dataset_ref == dataset_id
             )
         )
+        _LOG.warning("Deleting search fields")
         for table in search_field_indexes.values():
             self._connection.execute(
                 delete(table).where(table.dataset_ref == dataset_id)
             )
+        _LOG.warning("Deleting spatial index entries")
         for crs in self._db.spatial_indexes():
             SpatialIndex = self._db.spatial_index(crs)  # noqa: N806
+            _LOG.warning("Deleting spatial index entries for %s", crs)
             self._connection.execute(
                 delete(
                     SpatialIndex
@@ -525,6 +538,7 @@ class PostgisDbAPI(object):
                 )
             )
 
+        _LOG.warning("Deleting datasets")
         r = self._connection.execute(
             delete(Dataset).where(
                 Dataset.id == dataset_id

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -231,26 +231,23 @@ class PostgisDbAPI(object):
 
     @property
     def in_transaction(self):
-        in_txn = self._connection.in_transaction()
-        if in_txn:
-            assert self._sqla_txn is not None
-        else:
-            assert self._sqla_txn is None
-        return in_txn
+        return self._connection.in_transaction()
 
     def begin(self):
         self._connection.execution_options(isolation_level="SERIALIZABLE")
         self._sqla_txn = self._connection.begin()
 
-    def commit(self):
-        self._sqla_txn.commit()
+    def _end_transaction(self):
         self._sqla_txn = None
         self._connection.execution_options(isolation_level="AUTOCOMMIT")
 
+    def commit(self):
+        self._sqla_txn.commit()
+        self._end_transaction()
+
     def rollback(self):
         self._sqla_txn.rollback()
-        self._sqla_txn = None
-        self._connection.execution_options(isolation_level="AUTOCOMMIT")
+        self._end_transaction()
 
     def execute(self, command):
         return self._connection.execute(command)

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -60,7 +60,7 @@ def _dataset_select_fields():
 
 def _dataset_bulk_select_fields():
     return (
-        Dataset.product_ref,
+        Product.name,
         Dataset.metadata_doc,
         # All active URIs, from newest to oldest
         func.array(
@@ -644,9 +644,15 @@ class PostgisDbAPI(object):
     def bulk_simple_dataset_search(self, products):
         query = select(
             _dataset_bulk_select_fields()
-        ).select_from(Dataset)
+        ).select_from(
+            Dataset
+        ).join(
+            Product
+        ).where(
+            Dataset.archived == None
+        )
         if products:
-            query = query.where(Dataset.product_ref in products)
+            query = query.where(Product.name.in_(products))
         return self._connection.execute(query)
 
     @staticmethod
@@ -672,6 +678,7 @@ class PostgisDbAPI(object):
         dataset_location or dataset_source tables. Joining with other tables would not
         result in multiple records per dataset due to the direction of cardinality.
         """
+
 
         select_query = self.search_unique_datasets_query(expressions, select_fields, limit)
 
@@ -1041,6 +1048,11 @@ class PostgisDbAPI(object):
         return self._connection.execute(
             select(Product).order_by(Product.name.asc())
         ).fetchall()
+
+    def get_all_product_docs(self):
+        return self._connection.execute(
+            select(Product.definition)
+        )
 
     def _get_products_for_metadata_type(self, id_):
         return self._connection.execute(

--- a/datacube/drivers/postgis/_connections.py
+++ b/datacube/drivers/postgis/_connections.py
@@ -243,7 +243,6 @@ class PostGisDb(object):
         if refresh:
             self._refresh_spindexes()
         ispidx_list = list(self.spindexes.keys())
-        _LOG.warning("index_list=%s", repr(ispidx_list))
         return ispidx_list
 
     @contextmanager

--- a/datacube/drivers/postgis/_connections.py
+++ b/datacube/drivers/postgis/_connections.py
@@ -242,7 +242,9 @@ class PostGisDb(object):
     def spatial_indexes(self, refresh=False) -> Iterable[CRS]:
         if refresh:
             self._refresh_spindexes()
-        return list(self.spindexes.keys())
+        ispidx_list = list(self.spindexes.keys())
+        _LOG.warning("index_list=%s", repr(ispidx_list))
+        return ispidx_list
 
     @contextmanager
     def _connect(self):
@@ -263,6 +265,7 @@ class PostGisDb(object):
         """
         with self._engine.connect() as connection:
             try:
+                connection.execution_options(isolation_level="AUTOCOMMIT")
                 yield _api.PostgisDbAPI(self, connection)
             finally:
                 connection.close()

--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -265,5 +265,3 @@ def from_pg_role(pg_role):
         raise ValueError('Not a pg role: %r. Expected one of %r' % (pg_role, USER_ROLES))
 
     return pg_role.split('_')[1]
-
-

--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -8,15 +8,15 @@ Core SQL schema settings.
 
 import logging
 
+from sqlalchemy import MetaData
+from sqlalchemy.engine import Engine
+from sqlalchemy.schema import CreateSchema
+
 from datacube.drivers.postgis.sql import (INSTALL_TRIGGER_SQL_TEMPLATE,
                                           SCHEMA_NAME, TYPES_INIT_SQL,
                                           UPDATE_COLUMN_MIGRATE_SQL_TEMPLATE,
                                           UPDATE_TIMESTAMP_SQL,
                                           escape_pg_identifier)
-from sqlalchemy import MetaData
-from sqlalchemy.engine import Engine
-from sqlalchemy.schema import CreateSchema
-
 
 USER_ROLES = ('odc_user', 'odc_ingest', 'odc_manage', 'odc_admin')
 
@@ -265,3 +265,5 @@ def from_pg_role(pg_role):
         raise ValueError('Not a pg role: %r. Expected one of %r' % (pg_role, USER_ROLES))
 
     return pg_role.split('_')[1]
+
+

--- a/datacube/drivers/postgis/_fields.py
+++ b/datacube/drivers/postgis/_fields.py
@@ -254,7 +254,7 @@ class NumericDocField(SimpleDocField):
         if isinstance(value, float) and math.isnan(value):
             raise UnindexableValue("Cannot index NaNs")
         return func.numrange(
-            value, value,
+            self.value_to_alchemy(value), self.value_to_alchemy(value),
             # Inclusive on both sides.
             '[]',
             type_=NUMRANGE,

--- a/datacube/drivers/postgis/_fields.py
+++ b/datacube/drivers/postgis/_fields.py
@@ -376,6 +376,7 @@ class RangeDocField(PgDocField):
 class UnindexableValue(Exception):
     pass
 
+
 class NumericRangeDocField(RangeDocField):
     FIELD_CLASS = NumericDocField
     type_name = 'numeric-range'

--- a/datacube/drivers/postgis/_fields.py
+++ b/datacube/drivers/postgis/_fields.py
@@ -382,8 +382,6 @@ class NumericRangeDocField(RangeDocField):
 
     def value_to_alchemy(self, value):
         low, high = value
-        if math.isnan(low) or math.isnan(high):
-            raise UnindexableValue("Cannot index NaN numeric values")
         return func.numrange(
             low, high,
             # Inclusive on both sides.

--- a/datacube/drivers/postgis/_schema.py
+++ b/datacube/drivers/postgis/_schema.py
@@ -281,6 +281,7 @@ class DatasetSearchDateTime:
                         nullable=True,
                         comment="The value of the datetime search field")
 
+
 search_field_map = {
     'numeric-range': "numeric",
     'double-range': "numeric",

--- a/datacube/drivers/postgis/_schema.py
+++ b/datacube/drivers/postgis/_schema.py
@@ -118,6 +118,7 @@ class DatasetLocation:
     __table_args__ = (
         _core.METADATA,
         UniqueConstraint('uri_scheme', 'uri_body', 'dataset_ref'),
+        Index("ix_loc_ds_added", "dataset_ref", "added"),
         {
             "schema": sql.SCHEMA_NAME,
             "comment": "Where data for the dataset can be found (uri)."
@@ -138,7 +139,7 @@ eg 'file:///g/data/datasets/LS8_NBAR/odc-metadata.yaml' or 'ftp://eo.something.c
 'file' is a scheme, '///g/data/datasets/LS8_NBAR/odc-metadata.yaml' is a body.""")
     added = Column(DateTime(timezone=True), server_default=func.now(), nullable=False, comment="when added")
     added_by = Column(Text, server_default=func.current_user(), nullable=False, comment="added by whom")
-    archived = Column(DateTime(timezone=True), default=None, nullable=True,
+    archived = Column(DateTime(timezone=True), default=None, nullable=True, index=True,
                       comment="when archived, null for the active location")
     uri = column_property(uri_scheme + ':' + uri_body)
     dataset = relationship("Dataset")

--- a/datacube/drivers/postgis/_schema.py
+++ b/datacube/drivers/postgis/_schema.py
@@ -275,24 +275,31 @@ class DatasetSearchDateTime:
                         nullable=True,
                         comment="The value of the datetime search field")
 
+search_field_map = {
+    'numeric-range': "numeric",
+    'double-range': "numeric",
+    'integer-range': "numeric",
+    'datetime-range': "datetime",
 
-search_field_index_map = {
-    'numeric-range': DatasetSearchNumeric,
-    'double-range': DatasetSearchNumeric,
-    'integer-range': DatasetSearchNumeric,
-    'datetime-range': DatasetSearchDateTime,
-
-    'string': DatasetSearchString,
-    'numeric': DatasetSearchNumeric,
-    'double': DatasetSearchNumeric,
-    'integer': DatasetSearchNumeric,
-    'datetime': DatasetSearchDateTime,
+    'string': "string",
+    'numeric': "numeric",
+    'double': "numeric",
+    'integer': "numeric",
+    'datetime': "datetime",
 
     # For backwards compatibility (alias for numeric-range)
-    'float-range': DatasetSearchNumeric,
+    'float-range': "numeric",
 }
 
-search_field_tables = set(search_field_index_map.values())
+search_field_indexes = {
+    'string': DatasetSearchString,
+    'numeric': DatasetSearchNumeric,
+    'datetime': DatasetSearchDateTime,
+}
+
+search_field_index_map = {
+    k: search_field_indexes[v] for k, v in search_field_map.items()
+}
 
 ALL_STATIC_TABLES = [
     MetadataType.__table__, Product.__table__, Dataset.__table__,

--- a/datacube/drivers/postgis/_spatial.py
+++ b/datacube/drivers/postgis/_spatial.py
@@ -125,6 +125,7 @@ def ensure_spindex(engine: Connectable, sp_idx: Type[SpatialIndex]) -> None:
         orm_registry.metadata.create_all(engine, [sp_idx.__table__])
         # ... and add a SpatialIndexRecord
         session.add(SpatialIndexRecord.from_spindex(sp_idx))
+        session.commit()
         session.flush()
     return
 
@@ -134,7 +135,6 @@ def spindexes(engine: Connectable) -> Mapping[CRS, Type[SpatialIndex]]:
     Return a CRS-to-Spatial Index ORM class mapping for indexes that exist in a particular database.
     """
     out = {}
-    sir = SpatialIndexORMRegistry()
     with Session(engine) as session:
         results = session.execute(select(SpatialIndexRecord.srid))
         for result in results:

--- a/datacube/drivers/postgis/_spatial.py
+++ b/datacube/drivers/postgis/_spatial.py
@@ -165,11 +165,15 @@ def geom_alchemy(geom: Geom) -> str:
     return f"SRID={geom.crs.epsg};{geom.wkt}"
 
 
-def sanitise_extent(extent, crs):
+def sanitise_extent(extent, crs, geo_extent=None):
     if not crs.valid_region:
         # No valid region on CRS, just reproject
         return extent.to_crs(crs)
-    geo_extent = extent.to_crs(CRS("EPSG:4326"))
+    if geo_extent is None:
+        geo_extent = extent.to_crs(CRS("EPSG:4326"))
+    if crs.epsg == 4326:
+        # geo_extent is what we want anyway - shortcut
+        return geo_extent
     if crs.valid_region.contains(geo_extent):
         # Valid region contains extent, just reproject
         return extent.to_crs(crs)
@@ -184,8 +188,8 @@ def sanitise_extent(extent, crs):
     return valid_extent.to_crs(crs)
 
 
-def generate_dataset_spatial_values(dataset_id, crs, extent):
-    extent = sanitise_extent(extent, crs)
+def generate_dataset_spatial_values(dataset_id, crs, extent, geo_extent=None):
+    extent = sanitise_extent(extent, crs, geo_extent=geo_extent)
     if extent is None:
         return None
     geom_alch = geom_alchemy(extent)

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -960,6 +960,14 @@ class PostgresDbAPI(object):
     def get_all_metadata_types(self):
         return self._connection.execute(METADATA_TYPE.select().order_by(METADATA_TYPE.c.name.asc())).fetchall()
 
+    def get_all_metadata_defs(self):
+        return [
+            r[0]
+            for r in self._connection.execute(
+                METADATA_TYPE.select(METADATA_TYPE.c.definition).order_by(METADATA_TYPE.c.name.asc())
+            ).fetchall()
+        ]
+
     def get_locations(self, dataset_id):
         return [
             record[0]

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -612,17 +612,21 @@ class PostgresDbAPI(object):
         return self._connection.execute(select_query)
 
     def bulk_simple_dataset_search(self, products):
+        if products:
+            query = select(PRODUCT.c.id).select_from(PRODUCT).where(PRODUCT.c.name.in_(products))
+            products = [row[0] for row in self._connection.execute(query)]
+            if not products:
+                return []
+        else:
+            products = None
         query = select(
             _DATASET_BULK_SELECT_FIELDS
-        ).select_from(
-            DATASET
-        ).join(
-            PRODUCT
-        ).where(
+        ).select_from(DATASET).join(PRODUCT).where(
             DATASET.c.archived == None
         )
         if products:
-            query = query.where(PRODUCT.c.name.in_(products))
+            query = query.where(DATASET.c.dataset_type_ref.in_(products))
+
         return self._connection.execute(query)
 
 

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -636,7 +636,6 @@ class PostgresDbAPI(object):
             query = query.where(DATASET.c.dataset_type_ref.in_(products))
         return self._connection.execution_options(stream_results=True, yield_per=batch_size).execute(query)
 
-
     @staticmethod
     def search_unique_datasets_query(expressions, select_fields, limit):
         """

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -622,7 +622,7 @@ class PostgresDbAPI(object):
                                                   select_fields, with_source_ids, limit)
         return self._connection.execute(select_query)
 
-    def bulk_simple_dataset_search(self, products):
+    def bulk_simple_dataset_search(self, products, batch_size=1000):
         if products:
             query = select(PRODUCT.c.id).select_from(PRODUCT).where(PRODUCT.c.name.in_(products))
             products = [row[0] for row in self._connection.execute(query)]
@@ -637,8 +637,7 @@ class PostgresDbAPI(object):
         )
         if products:
             query = query.where(DATASET.c.dataset_type_ref.in_(products))
-
-        return self._connection.execute(query)
+        return self._connection.execution_options(stream_results=True, yield_per=batch_size).execute(query)
 
 
     @staticmethod

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -948,6 +948,11 @@ class PostgresDbAPI(object):
             PRODUCT.select().order_by(PRODUCT.c.name.asc())
         ).fetchall()
 
+    def get_all_product_docs(self):
+        return self._connection.execute(
+            select(PRODUCT.c.definition)
+        )
+
     def _get_products_for_metadata_type(self, id_):
         return self._connection.execute(
             PRODUCT.select(
@@ -959,6 +964,11 @@ class PostgresDbAPI(object):
 
     def get_all_metadata_types(self):
         return self._connection.execute(METADATA_TYPE.select().order_by(METADATA_TYPE.c.name.asc())).fetchall()
+
+    def get_all_metadata_type_docs(self):
+        return self._connection.execute(
+            select(METADATA_TYPE.c.definition)
+        )
 
     def get_all_metadata_defs(self):
         return [

--- a/datacube/drivers/postgres/_connections.py
+++ b/datacube/drivers/postgres/_connections.py
@@ -225,6 +225,7 @@ class PostgresDb(object):
         """
         with self._engine.connect() as connection:
             try:
+                connection.execution_options(isolation_level="AUTOCOMMIT")
                 yield _api.PostgresDbAPI(connection)
             finally:
                 connection.close()

--- a/datacube/drivers/postgres/_schema.py
+++ b/datacube/drivers/postgres/_schema.py
@@ -8,7 +8,7 @@ Tables for indexing the datasets which were ingested into the AGDC.
 
 import logging
 
-from sqlalchemy import ForeignKey, UniqueConstraint, PrimaryKeyConstraint, CheckConstraint, SmallInteger
+from sqlalchemy import ForeignKey, UniqueConstraint, PrimaryKeyConstraint, CheckConstraint, SmallInteger, Index
 from sqlalchemy import Table, Column, Integer, String, DateTime
 from sqlalchemy.dialects import postgresql as postgres
 from sqlalchemy.sql import func
@@ -86,6 +86,12 @@ DATASET = Table(
     # Note that the `updated` column is not included here to maintain backwards-compatibility
     # with pre-1.8.3 datacubes (and it is not used by any internal ODC functionality yet anyway)
 )
+
+
+Index("ix_ds_isactive", DATASET.c.archived == None)
+Index("ix_ds_prod_isactive", DATASET.c.dataset_type_ref, DATASET.c.archived == None)
+Index("ix_ds_mdt_isactive", DATASET.c.metadata_type_ref, DATASET.c.archived == None)
+
 
 DATASET_LOCATION = Table(
     'dataset_location', _core.METADATA,

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -124,6 +124,26 @@ class AbstractMetadataTypeResource(ABC):
         :return: Persisted Metadatatype model.
         """
 
+    def bulk_add(self, metadata_docs: Iterable[Mapping[str, Any]]) -> Iterable[MetadataType]:
+        """
+        Add a group of Metadata Type documents in bulk.
+
+        :param metadata_docs: An sequence of metadata type metadata docs.
+        :param allow_table_lock:
+            Allow an exclusive lock to be taken on the table while creating the indexes.
+            This will halt other user's requests until completed.
+
+            If false, creation will be slightly slower and cannot be done in a transaction.
+
+            raise NotImplementedError if set to True, and this behaviour is not applicable
+            for the implementing driver.
+        :return:  A Sequence of (persisted) MetadataType objects
+
+        Default implementation simply calls from_doc and add in a loop in a transaction.
+        """
+        for doc in metadata_docs:
+            yield self.add(self.from_doc(doc), allow_table_lock=True)
+
     @abstractmethod
     def can_update(self,
                    metadata_type: MetadataType,
@@ -244,6 +264,17 @@ class AbstractMetadataTypeResource(ABC):
 
         :returns: All available MetadataType models
         """
+
+    def get_all_docs(self) -> Iterable[Mapping[str, Any]]:
+        """
+        Retrieve all Metadata Types as documents only
+
+        :returns: All available MetadataType definition documents
+
+        Default implementation calls get_all()
+        """
+        for mdt in self.get():
+            yield mdt.definition
 
 
 QueryField = Union[str, float, int, Range, datetime.datetime]
@@ -1246,6 +1277,15 @@ class AbstractIndex(ABC):
         :return: true if the database was created, false if already exists
         """
 
+    def clone(self, origin_index: "AbstractIndexDriver") -> Sequence[str]:
+        """
+
+        :param origin_index:
+        :return:
+        """
+        errors = []
+        return errors
+
     @abstractmethod
     def close(self) -> None:
         """
@@ -1340,6 +1380,7 @@ class AbstractIndexDriver(ABC):
     def metadata_type_from_doc(definition: dict
                               ) -> MetadataType:
         ...
+
 
 
 # The special handling of grid_spatial, etc appears to NOT apply to EO3.

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -30,6 +30,7 @@ from datacube.utils.documents import UnknownMetadataType
 
 _LOG = logging.getLogger(__name__)
 
+
 # A named tuple representing the results of a batch operation:
 #   Number of records completed, Number of records skipped,
 class BatchStatus(NamedTuple):
@@ -423,7 +424,6 @@ class AbstractProductResource(ABC):
         :return: Persisted Product model.
         """
 
-
     def _add_batch(self, batch_products: Iterable[Product]) -> BatchStatus:
         # Add a "batch" of products.  Default implementation is simple loop of add
         b_skipped = 0
@@ -440,7 +440,6 @@ class AbstractProductResource(ABC):
                 _LOG.warning("%s: Skipping", str(e))
                 b_skipped += 1
         return BatchStatus(b_added, b_skipped, monotonic()-b_started)
-
 
     def bulk_add(self,
                  product_docs: Iterable[Mapping[str, Any]],
@@ -692,6 +691,7 @@ class AbstractProductResource(ABC):
 # Non-strict Dataset ID representation
 DSID = Union[str, UUID]
 
+
 # A named tuple representing a complete dataset. (Product, metadata document, sequence of uris)
 class DatasetTuple(NamedTuple):
     product: Product
@@ -720,7 +720,7 @@ class AbstractDatasetResource(ABC):
     def __init__(self, index):
         self._index = index
         self.products = self._index.products
-        self.types = self.products # types is compatibility alias for products
+        self.types = self.products  # types is compatibility alias for products
 
     @abstractmethod
     def get(self,
@@ -1701,7 +1701,6 @@ class AbstractIndexDriver(ABC):
     def metadata_type_from_doc(definition: dict
                               ) -> MetadataType:
         ...
-
 
 
 # The special handling of grid_spatial, etc appears to NOT apply to EO3.

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -246,7 +246,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                     connection.insert_dataset_spatial_bulk(crs, crs_values)
             for search_type, values in batch["search_indexes"].items():
                 connection.insert_dataset_search_bulk(search_type, values)
-        return (b_added, b_skipped, monotonic() - b_started)
+        return BatchStatus(b_added, b_skipped, monotonic() - b_started)
 
     def search_product_duplicates(self, product: Product, *args):
         """
@@ -956,4 +956,4 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             for row in connection.bulk_simple_dataset_search(products=product_search_key):
                 prod_name, metadata_doc, uris = tuple(row)
                 prod = products[prod_name]
-                yield(prod, metadata_doc, uris)
+                yield DatasetTuple(prod, metadata_doc, uris)

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -10,7 +10,7 @@ import logging
 import warnings
 from collections import namedtuple
 from time import monotonic
-from typing import Iterable, List, Mapping, Union, Optional, Tuple, Any, Sequence
+from typing import Iterable, List, Mapping, Union, Optional, Any
 from uuid import UUID
 
 from sqlalchemy import select, func
@@ -174,7 +174,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
     def _init_bulk_add_cache(self):
         return {}
 
-    def _add_batch(self, batch_ds: Iterable[DatasetTuple], cache:Mapping[str, Any]) -> BatchStatus:
+    def _add_batch(self, batch_ds: Iterable[DatasetTuple], cache: Mapping[str, Any]) -> BatchStatus:
         # Add a "batch" of datasets.
         b_started = monotonic()
         crses = self._db.spatial_indexes()

--- a/datacube/index/postgis/_metadata_types.py
+++ b/datacube/index/postgis/_metadata_types.py
@@ -80,18 +80,9 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
 
     def _add_batch(self, batch_types: Iterable[MetadataType]) -> Tuple[int, int]:
         # Add a "batch" of mdts.  Simple loop in a transaction for now.
-        b_skipped = 0
-        b_added = 0
-        with self._db_connection(transaction=True) as connection:
-            for mdt in batch_types:
-                try:
-                    self.add(mdt)
-                    b_added += 1
-                except DocumentMismatchError:
-                    b_skipped += 1
-                except:
-                    b_skipped += 1
-        return (b_added, b_skipped)
+        values = [{"name": mdt.name, "definition": mdt.definition} for mdt in batch_types]
+        with self._db_connection() as connection:
+            return connection.insert_metadata_bulk(values)
 
     def can_update(self, metadata_type, allow_unsafe_updates=False):
         """

--- a/datacube/index/postgis/_metadata_types.py
+++ b/datacube/index/postgis/_metadata_types.py
@@ -12,6 +12,7 @@ from datacube.index.postgis._transaction import IndexResourceAddIn
 from datacube.model import MetadataType
 from datacube.utils import jsonify_document, changes, _readable_offset
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes, DocumentMismatchError
+from datacube.utils import InvalidDocException
 
 _LOG = logging.getLogger(__name__)
 
@@ -102,7 +103,7 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
                 mdt = self.from_doc(doc)
                 batch.append(mdt)
                 n_in_batch += 1
-            except ValueError as e:
+            except InvalidDocException as e:
                 _LOG.warning("%s: Skipped", str(e))
                 skipped += 1
             if n_in_batch >= batch_size:

--- a/datacube/index/postgis/_metadata_types.py
+++ b/datacube/index/postgis/_metadata_types.py
@@ -84,7 +84,7 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
         values = [{"name": mdt.name, "definition": mdt.definition} for mdt in batch_types]
         with self._db_connection() as connection:
             added, skipped = connection.insert_metadata_bulk(values)
-            return (added, skipped, monotonic() - b_started)
+            return BatchStatus(added, skipped, monotonic() - b_started)
 
     def can_update(self, metadata_type, allow_unsafe_updates=False):
         """

--- a/datacube/index/postgis/_metadata_types.py
+++ b/datacube/index/postgis/_metadata_types.py
@@ -210,6 +210,11 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
         with self._db_connection() as connection:
             return self._make_many(connection.get_all_metadata_types())
 
+    def get_all_docs(self):
+        with self._db_connection() as connection:
+            for defn in connection.get_all_metadata_type_defs():
+                yield defn
+
     def _make_many(self, query_rows):
         """
         :rtype: list[datacube.model.MetadataType]

--- a/datacube/index/postgis/_metadata_types.py
+++ b/datacube/index/postgis/_metadata_types.py
@@ -82,7 +82,7 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
         # Add a "batch" of mdts.  Simple loop in a transaction for now.
         b_skipped = 0
         b_added = 0
-        with self._db_connection() as connection:
+        with self._db_connection(transaction=True) as connection:
             for mdt in batch_types:
                 try:
                     self.add(mdt)

--- a/datacube/index/postgis/_products.py
+++ b/datacube/index/postgis/_products.py
@@ -13,7 +13,7 @@ from datacube.model import Product, MetadataType
 from datacube.utils import jsonify_document, changes, _readable_offset
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes, DocumentMismatchError
 
-from typing import Iterable, cast
+from typing import Iterable, Tuple, cast
 
 _LOG = logging.getLogger(__name__)
 
@@ -338,6 +338,10 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
         """
         with self._db_connection() as connection:
             return self._make_many(connection.get_all_products())
+
+    def get_all_docs(self) -> Iterable[Product]:
+        with self._db_connection() as connection:
+            return connection.get_all_products()
 
     def _make_many(self, query_rows):
         return (self._make(c) for c in query_rows)

--- a/datacube/index/postgis/_products.py
+++ b/datacube/index/postgis/_products.py
@@ -340,7 +340,8 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
 
     def get_all_docs(self) -> Iterable[Mapping[str, Any]]:
         with self._db_connection() as connection:
-            return connection.get_all_products()
+            for row in connection.get_all_product_docs():
+                yield row[0]
 
     def _make_many(self, query_rows):
         return (self._make(c) for c in query_rows)

--- a/datacube/index/postgis/_products.py
+++ b/datacube/index/postgis/_products.py
@@ -12,9 +12,9 @@ from datacube.index.abstract import AbstractProductResource, BatchStatus
 from datacube.index.postgis._transaction import IndexResourceAddIn
 from datacube.model import Product, MetadataType
 from datacube.utils import jsonify_document, changes, _readable_offset
-from datacube.utils.changes import check_doc_unchanged, get_doc_changes, DocumentMismatchError
+from datacube.utils.changes import check_doc_unchanged, get_doc_changes
 
-from typing import Iterable, Tuple, cast, Mapping, Any
+from typing import Iterable, cast, Mapping, Any
 
 _LOG = logging.getLogger(__name__)
 

--- a/datacube/index/postgis/_products.py
+++ b/datacube/index/postgis/_products.py
@@ -102,7 +102,7 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
         ]
         with self._db_connection() as connection:
             added, skipped = connection.insert_product_bulk(values)
-            return (added, skipped, monotonic() - b_started)
+            return BatchStatus(added, skipped, monotonic() - b_started)
 
     def can_update(self, product, allow_unsafe_updates=False):
         """

--- a/datacube/index/postgis/_transaction.py
+++ b/datacube/index/postgis/_transaction.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from contextlib import contextmanager
-from sqlalchemy import text
 from typing import Any
 
 from datacube.drivers.postgis import PostGisDb

--- a/datacube/index/postgis/_transaction.py
+++ b/datacube/index/postgis/_transaction.py
@@ -19,8 +19,8 @@ class PostgisTransaction(AbstractTransaction):
 
     def _new_connection(self) -> Any:
         dbconn = self._db.give_me_a_connection()
-        dbconn.execute(text('BEGIN'))
         conn = PostgisDbAPI(self._db, dbconn)
+        conn.begin()
         return conn
 
     def _commit(self) -> None:

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -174,7 +174,6 @@ WARNING: Database schema and internal APIs may change significantly between rele
             yield trans._connection
         elif transaction:
             closing = True
-            print("Starting a transaction...")
             with self._db._connect() as conn:
                 conn.begin()
                 # assert conn.in_transaction

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -174,8 +174,10 @@ WARNING: Database schema and internal APIs may change significantly between rele
             yield trans._connection
         elif transaction:
             closing = True
+            print("Starting a transaction...")
             with self._db._connect() as conn:
                 conn.begin()
+                # assert conn.in_transaction
                 try:
                     yield conn
                     conn.commit()

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -221,7 +221,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                 b_added, b_skipped = connection.insert_dataset_bulk(batch["datasets"])
             if batch["uris"]:
                 connection.insert_dataset_location_bulk(batch["uris"])
-        return (b_added, b_skipped, monotonic() - b_started)
+        return BatchStatus(b_added, b_skipped, monotonic() - b_started)
 
     def search_product_duplicates(self, product: Product, *args):
         """
@@ -931,4 +931,4 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             for row in connection.bulk_simple_dataset_search(products=product_search_key):
                 prod_name, metadata_doc, uris = tuple(row)
                 prod = products[prod_name]
-                yield(prod, metadata_doc, uris)
+                yield DatasetTuple(prod, metadata_doc, uris)

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -10,7 +10,7 @@ import logging
 import warnings
 from collections import namedtuple
 from time import monotonic
-from typing import Iterable, List, Union, Mapping, Optional, Any
+from typing import Iterable, List, Union, Mapping, Any
 from uuid import UUID
 
 from sqlalchemy import select, func

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -922,7 +922,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
     def get_all_docs_for_product(self, product: Product, batch_size: int = 1000) -> Iterable[DatasetTuple]:
         product_search_key = [product.name]
-        with self._db_connection() as connection:
-            for row in connection.bulk_simple_dataset_search(products=product_search_key, batch_siz=batch_size):
+        with self._db_connection(transaction=True) as connection:
+            for row in connection.bulk_simple_dataset_search(products=product_search_key, batch_size=batch_size):
                 prod_name, metadata_doc, uris = tuple(row)
                 yield DatasetTuple(product, metadata_doc, uris)

--- a/datacube/index/postgres/_metadata_types.py
+++ b/datacube/index/postgres/_metadata_types.py
@@ -211,6 +211,11 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
         with self._db_connection() as connection:
             return self._make_many(connection.get_all_metadata_types())
 
+    def get_all_docs(self):
+        with self._db_connection() as connection:
+            for row in connection.get_all_metadata_type_docs():
+                yield row[0]
+
     def _make_many(self, query_rows):
         """
         :rtype: list[datacube.model.MetadataType]

--- a/datacube/index/postgres/_products.py
+++ b/datacube/index/postgres/_products.py
@@ -5,15 +5,14 @@
 import logging
 
 from cachetools.func import lru_cache
+from typing import Iterable, cast, Any, Mapping
 
 from datacube.index import fields
 from datacube.index.abstract import AbstractProductResource
 from datacube.index.postgres._transaction import IndexResourceAddIn
-from datacube.model import DatasetType, MetadataType
+from datacube.model import MetadataType, Product
 from datacube.utils import jsonify_document, changes, _readable_offset
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes
-
-from typing import Iterable, cast
 
 
 _LOG = logging.getLogger(__name__)
@@ -59,10 +58,10 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
 
             If false (and there is no already active transaction), creation will be slightly slower
             and cannot be done in a transaction.
-        :param DatasetType product: Product to add
-        :rtype: DatasetType
+        :param Product product: Product to add
+        :rtype: Product
         """
-        DatasetType.validate(product.definition)
+        Product.validate(product.definition)
 
         existing = self.get_by_name(product.name)
         if existing:
@@ -96,11 +95,11 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
         (An unsafe change is anything that may potentially make the product
         incompatible with existing datasets of that type)
 
-        :param DatasetType product: Product to update
+        :param Product product: Product to update
         :param bool allow_unsafe_updates: Allow unsafe changes. Use with caution.
         :rtype: bool,list[change],list[change]
         """
-        DatasetType.validate(product.definition)
+        Product.validate(product.definition)
 
         existing = self.get_by_name(product.name)
         if not existing:
@@ -133,21 +132,21 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
 
         return allow_unsafe_updates or not bad_changes, good_changes, bad_changes
 
-    def update(self, product: DatasetType, allow_unsafe_updates=False, allow_table_lock=False):
+    def update(self, product: Product, allow_unsafe_updates=False, allow_table_lock=False):
         """
         Update a product. Unsafe changes will throw a ValueError by default.
 
         (An unsafe change is anything that may potentially make the product
         incompatible with existing datasets of that type)
 
-        :param DatasetType product: Product to update
+        :param Product product: Product to update
         :param bool allow_unsafe_updates: Allow unsafe changes. Use with caution.
         :param allow_table_lock:
             Allow an exclusive lock to be taken on the table while creating the indexes.
             This will halt other user's requests until completed.
 
             If false, creation will be slower and cannot be done in a transaction.
-        :rtype: DatasetType
+        :rtype: Product
         """
 
         can_update, safe_changes, unsafe_changes = self.can_update(product, allow_unsafe_updates)
@@ -166,7 +165,7 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
 
         _LOG.info("Updating product %s", product.name)
 
-        existing = cast(DatasetType, self.get_by_name(product.name))
+        existing = cast(Product, self.get_by_name(product.name))
         changing_metadata_type = product.metadata_type.name != existing.metadata_type.name
         if changing_metadata_type:
             raise ValueError("Unsafe change: cannot (currently) switch metadata types for a product")
@@ -216,7 +215,7 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
             This will halt other user's requests until completed.
 
             If false, creation will be slower and cannot be done in a transaction.
-        :rtype: DatasetType
+        :rtype: Product
         """
         type_ = self.from_doc(definition)
         return self.update(
@@ -248,7 +247,7 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
         Return dataset types that have all the given fields.
 
         :param tuple[str] field_names:
-        :rtype: __generator[DatasetType]
+        :rtype: __generator[Product]
         """
         for type_ in self.get_all():
             for name in field_names:
@@ -262,7 +261,7 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
         Return dataset types that match match-able fields and dict of remaining un-matchable fields.
 
         :param dict query:
-        :rtype: __generator[(DatasetType, dict)]
+        :rtype: __generator[(Product, dict)]
         """
 
         def _listify(v):
@@ -318,18 +317,26 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
             for dataset in self._make_many(connection.search_products_by_metadata(metadata)):
                 yield dataset
 
-    def get_all(self) -> Iterable[DatasetType]:
+    def get_all(self) -> Iterable[Product]:
         """
         Retrieve all Products
         """
         with self._db_connection() as connection:
             return (self._make(record) for record in connection.get_all_products())
 
+    def get_all_docs(self) -> Iterable[Mapping[str, Any]]:
+        """
+        Retrieve all Products
+        """
+        with self._db_connection() as connection:
+            for record in connection.get_all_product_docs():
+                yield record[0]
+
     def _make_many(self, query_rows):
         return (self._make(c) for c in query_rows)
 
-    def _make(self, query_row) -> DatasetType:
-        return DatasetType(
+    def _make(self, query_row) -> Product:
+        return Product(
             definition=query_row['definition'],
             metadata_type=cast(MetadataType, self.metadata_type_resource.get(query_row['metadata_type_ref'])),
             id_=query_row['id'],

--- a/datacube/index/postgres/_transaction.py
+++ b/datacube/index/postgres/_transaction.py
@@ -19,8 +19,8 @@ class PostgresTransaction(AbstractTransaction):
 
     def _new_connection(self) -> Any:
         dbconn = self._db.give_me_a_connection()
-        dbconn.execute(text('BEGIN'))
         conn = PostgresDbAPI(dbconn)
+        conn.begin()
         return conn
 
     def _commit(self) -> None:

--- a/datacube/index/postgres/_transaction.py
+++ b/datacube/index/postgres/_transaction.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from contextlib import contextmanager
-from sqlalchemy import text
 from typing import Any
 
 from datacube.drivers.postgres import PostgresDb

--- a/datacube/model/eo3.py
+++ b/datacube/model/eo3.py
@@ -17,7 +17,7 @@ expected_sys_field_values = {
     "label": lambda x: x == ["label"],
     "creation_dt": lambda x: x == ["properties", "odc:processing_datetime"],
     "format": lambda x: x == ["properties", "odc:file_format"],
-    # EO3 mdy has sources at [lineage,source_datasets], but it is actually expected at [lineage],
+    # EO3 mdt has sources at [lineage,source_datasets], but it is actually expected at [lineage],
     # so accept anything vaguely right
     "sources": lambda x: x[0] == "lineage",
     # Actually kept under geometry and grids.  Ignore - why is this even here?
@@ -67,6 +67,16 @@ def validate_eo3_offsets(field_name, mdt_name, defn):
 
 
 def validate_eo3_compatible_type(doc):
+    """
+    Valdate that a metadata type document is EO3 compatible.
+
+    N.B. Assumes the document has already been validated as a valid ODC metadata type document.
+
+    :param doc: A metadata type document
+
+    Raises InvalidDocException if not EO3 compatible
+    """
+    # Validate that a metadata type doc is EO3 compatible.
     name = doc["name"]
     # Validate system field offsets
     for k, v in doc["dataset"].items():

--- a/datacube/model/eo3.py
+++ b/datacube/model/eo3.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2015-2022 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from datacube.utils.documents import InvalidDocException
 
 required_sys_field_values = [
     "id", "label", "creation_dt", "sources",
@@ -41,7 +42,7 @@ def validate_eo3_offset(field_name, mdt_name, offset):
         return
     # Everything else should stored flat in properties
     if offset[0] != "properties" or len(offset) != 2:
-        raise ValueError(
+        raise InvalidDocException(
             f"Search_field {field_name} in metadata type {mdt_name} "
             f"is not stored in an EO3-compliant location: {offset!r}")
 
@@ -52,17 +53,17 @@ def validate_eo3_offsets(field_name, mdt_name, defn):
         if "min_offset" in defn:
             validate_eo3_offset(field_name, mdt_name, defn["min_offset"])
         else:
-            raise ValueError(f"No min_offset supplied for field {field_name} in metadata type {mdt_name}")
+            raise InvalidDocException(f"No min_offset supplied for field {field_name} in metadata type {mdt_name}")
         if "max_offset" in defn:
             validate_eo3_offset(field_name, mdt_name, defn["min_offset"])
         else:
-            raise ValueError(f"No max_offset supplied for field {field_name} in metadata type {mdt_name}")
+            raise InvalidDocException(f"No max_offset supplied for field {field_name} in metadata type {mdt_name}")
     else:
         # Scalar Type
         if "offset" in defn:
             validate_eo3_offset(field_name, mdt_name, defn["offset"])
         else:
-            raise ValueError(f"No offset supplied for field {field_name} in metadata type {mdt_name}")
+            raise InvalidDocException(f"No offset supplied for field {field_name} in metadata type {mdt_name}")
 
 
 def validate_eo3_compatible_type(doc):
@@ -71,11 +72,11 @@ def validate_eo3_compatible_type(doc):
     for k, v in doc["dataset"].items():
         try:
             if not expected_sys_field_values[k](v):
-                raise ValueError(
+                raise InvalidDocException(
                     f"Offset for system field {k} ({v!r}) in metadata type {name} does not match EO3 standard"
                 )
         except KeyError as e:
-            raise ValueError(f"Unexpected system field in metadata type {name}: {k}")
+            raise InvalidDocException(f"Unexpected system field in metadata type {name}: {k}")
     # Validate search field offsets
     for k, v in doc["dataset"]["search_fields"].items():
         if k in ["lat", "lon"]:

--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -268,6 +268,10 @@ class InvalidDocException(Exception):  # noqa: N818
     pass
 
 
+class UnknownMetadataType(InvalidDocException):
+    pass
+
+
 def get_doc_offset(offset, document):
     """
     :type offset: list[str]

--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -269,6 +269,7 @@ class InvalidDocException(Exception):  # noqa: N818
 
 
 class UnknownMetadataType(InvalidDocException):
+    # Specific exception to raise on a product with an unknown metadata type
     pass
 
 

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -11,6 +11,7 @@ from copy import copy, deepcopy
 from datetime import timedelta
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Union
 from uuid import uuid4
 
 import pytest
@@ -245,21 +246,21 @@ def ls8_eo3_dataset(index, extended_eo3_metadata_type, ls8_eo3_product, eo3_ls8_
 
 
 @pytest.fixture
-def ls8_eo3_dataset2(index, extended_eo3_metadata_type_doc, ls8_eo3_product, eo3_ls8_dataset2_doc):
+def ls8_eo3_dataset2(index, extended_eo3_metadata_type, ls8_eo3_product, eo3_ls8_dataset2_doc):
     return doc_to_ds(index,
                      ls8_eo3_product.name,
                      *eo3_ls8_dataset2_doc)
 
 
 @pytest.fixture
-def ls8_eo3_dataset3(index, extended_eo3_metadata_type_doc, ls8_eo3_product, eo3_ls8_dataset3_doc):
+def ls8_eo3_dataset3(index, extended_eo3_metadata_type, ls8_eo3_product, eo3_ls8_dataset3_doc):
     return doc_to_ds(index,
                      ls8_eo3_product.name,
                      *eo3_ls8_dataset3_doc)
 
 
 @pytest.fixture
-def ls8_eo3_dataset4(index, extended_eo3_metadata_type_doc, ls8_eo3_product, eo3_ls8_dataset4_doc):
+def ls8_eo3_dataset4(index, extended_eo3_metadata_type, ls8_eo3_product, eo3_ls8_dataset4_doc):
     return doc_to_ds(index,
                      ls8_eo3_product.name,
                      *eo3_ls8_dataset4_doc)
@@ -325,6 +326,11 @@ def datacube_env_name(request):
     return request.param
 
 
+@pytest.fixture(params=[("datacube", "experimental"), ("datacube", "experimental")])
+def datacube_env_name_pair(request):
+    return request.param
+
+
 @pytest.fixture
 def local_config(datacube_env_name):
     """Provides a :class:`LocalConfig` configured with suitable config file paths.
@@ -334,6 +340,16 @@ def local_config(datacube_env_name):
         The :func:`integration_config_paths` fixture sets up the config files.
     """
     return LocalConfig.find(CONFIG_FILE_PATHS, env=datacube_env_name)
+
+
+@pytest.fixture
+def local_config_pair(datacube_env_name_pair):
+    """Provides a pair of :class:`LocalConfig` configured with suitable config file paths.
+    """
+    return tuple(
+        LocalConfig.find(CONFIG_FILE_PATHS, env=env)
+        for env in datacube_env_name_pair
+    )
 
 
 @pytest.fixture
@@ -360,50 +376,74 @@ def ingest_configs(datacube_env_name):
     }
 
 
-@pytest.fixture(params=["US/Pacific", "UTC", ])
-def uninitialised_postgres_db(local_config, request):
-    """
-    Return a connection to an empty PostgreSQL or PostGIS database
-    """
-    timezone = request.param
-
-    if local_config._env == "datacube":
+def reset_db(local_cfg, tz=None) -> Union[PostgresDb, PostGisDb]:
+    if local_cfg._env in ('datacube', 'default', 'postgres'):
         db = PostgresDb.from_config(
-            local_config,
+            local_cfg,
             application_name='test-run',
             validate_connection=False
         )
         # Drop tables so our tests have a clean db.
         # with db.begin() as c:  # Creates a new PostgresDbAPI, by passing a new connection to it
         pgres_core.drop_db(db._engine)
-        db._engine.execute('alter database %s set timezone = %r' % (local_config['db_database'], timezone))
+        if tz:
+            db._engine.execute('alter database %s set timezone = %r' % (local_cfg['db_database'], tz))
         # We need to run this as well, I think because SQLAlchemy grabs them into it's MetaData,
         # and attempts to recreate them. WTF TODO FIX
         remove_postgres_dynamic_indexes()
     else:
         db = PostGisDb.from_config(
-            local_config,
+            local_cfg,
             application_name='test-run',
             validate_connection=False
         )
         pgis_core.drop_db(db._engine)
-        db._engine.execute('alter database %s set timezone = %r' % (local_config['db_database'], timezone))
+        if tz:
+            db._engine.execute('alter database %s set timezone = %r' % (local_cfg['db_database'], tz))
         remove_postgis_dynamic_indexes()
+    return db
+
+
+def cleanup_db(local_cfg, db):
+    if local_cfg._env in ('datacube', 'default', 'postgres'):
+        # with db.begin() as c:  # Drop SCHEMA
+        pgres_core.drop_db(db._engine)
+    else:
+        pgis_core.drop_db(db._engine)
+    db.close()
+
+
+@pytest.fixture(params=["US/Pacific", "UTC", ])
+def uninitialised_postgres_db(local_config, request):
+    """
+    Return a connection to an empty PostgreSQL or PostGIS database
+    """
+    # Setup
+    timezone = request.param
+    db = reset_db(local_config, timezone)
 
     yield db
 
-    if local_config._env in ('default', 'postgres'):
-        # with db.begin() as c:  # Drop SCHEMA
-        pgres_core.drop_db(db._engine)
-        db.close()
-    else:
-        pgis_core.drop_db(db._engine)
-        db.close()
+    # Cleanup
+    cleanup_db(local_config, db)
+
+
+@pytest.fixture
+def uninitialised_postgres_db_pair(local_config_pair):
+    """
+    Return a pair connections to empty PostgreSQL or PostGIS databases
+    """
+    dbs = tuple(reset_db(local_config) for local_config in local_config_pair)
+
+    yield dbs
+
+    for local_cfg, db in zip(local_config_pair, dbs):
+        cleanup_db(local_cfg, db)
 
 
 @pytest.fixture
 def index(local_config,
-          uninitialised_postgres_db: PostgresDb):
+          uninitialised_postgres_db: Union[PostGisDb, PostgresDb]):
     index = index_connect(local_config, validate_connection=False)
     index.init_db()
     yield index
@@ -411,7 +451,41 @@ def index(local_config,
 
 
 @pytest.fixture
-def index_empty(local_config, uninitialised_postgres_db: PostgresDb):
+def index_pair_populated_empty(local_config_pair, uninitialised_postgres_db_pair,
+                               extended_eo3_metadata_type_doc,
+                               base_eo3_product_doc, extended_eo3_product_doc, africa_s2_product_doc,
+                               eo3_ls8_dataset_doc, eo3_ls8_dataset2_doc,
+                               eo3_ls8_dataset3_doc, eo3_ls8_dataset4_doc,
+                               eo3_wo_dataset_doc, eo3_africa_dataset_doc):
+    populated_cfg, empty_cfg = local_config_pair
+    populated_idx = index_connect(populated_cfg, validate_connection=False)
+    empty_idx = index_connect(empty_cfg, validate_connection=False)
+    populated_idx.init_db()
+    empty_idx.init_db(with_default_types=False)
+    assert list(empty_idx.products.get_all()) == []
+    assert list(populated_idx.products.get_all()) == []
+    # Populate the populated index
+    populated_idx.metadata_types.add(
+        populated_idx.metadata_types.from_doc(extended_eo3_metadata_type_doc)
+    )
+    for prod_doc in (base_eo3_product_doc, extended_eo3_product_doc, africa_s2_product_doc):
+        populated_idx.products.add_document(prod_doc)
+    for ds_doc, ds_path in (eo3_ls8_dataset_doc, eo3_ls8_dataset2_doc,
+                            eo3_ls8_dataset3_doc, eo3_ls8_dataset4_doc,
+                            eo3_wo_dataset_doc, eo3_africa_dataset_doc):
+        doc_to_ds(populated_idx, ds_doc['product']['name'], ds_doc, ds_path)
+    assert list(populated_idx.products.get_all()) != list(empty_idx.products.get_all())
+    assert list(empty_idx.products.get_all()) == []
+    assert list(populated_idx.products.get_all()) != []
+
+    yield (populated_idx, empty_idx)
+
+    del populated_idx
+    del empty_idx
+
+
+@pytest.fixture
+def index_empty(local_config, uninitialised_postgres_db: Union[PostGisDb, PostgresDb]):
     index = index_connect(local_config, validate_connection=False)
     index.init_db(with_default_types=False)
     yield index

--- a/integration_tests/index/test_index_cloning.py
+++ b/integration_tests/index/test_index_cloning.py
@@ -1,0 +1,20 @@
+import pytest
+
+
+def test_index_clone(index_pair_populated_empty):
+    pop_idx, empty_idx = index_pair_populated_empty
+    assert list(empty_idx.products.get_all()) == []
+    results = empty_idx.clone(pop_idx)
+    assert "eo3" in results["metadata_types"].safe
+    assert "ga_ls8c_ard_3" in results["products"].safe
+    assert results["products"].skipped == 0
+    assert results["datasets"].skipped == 0
+
+
+def test_index_clone_cli(local_config_pair, index_pair_populated_empty, clirunner_raw):
+    source_cfg, target_cfg = local_config_pair
+    clirunner_raw([
+        '-E', target_cfg._env,
+        'system', 'clone',
+        source_cfg._env
+    ], expect_success=False)

--- a/integration_tests/index/test_index_cloning.py
+++ b/integration_tests/index/test_index_cloning.py
@@ -1,5 +1,7 @@
-import pytest
-
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2023 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
 
 def test_index_clone(index_pair_populated_empty):
     pop_idx, empty_idx = index_pair_populated_empty

--- a/integration_tests/index/test_postgis_index.py
+++ b/integration_tests/index/test_postgis_index.py
@@ -108,10 +108,12 @@ def test_spatial_index_crs_santise():
         (135.22, -25.7),
         (103.15, -25.7)), crs=epsg4326)
 
-    assert PostgisDbAPI._sanitise_extent(entire, epsg3577) == entire.to_crs("EPSG:3577")
-    assert PostgisDbAPI._sanitise_extent(valid, epsg3577) == valid.to_crs("EPSG:3577")
-    assert PostgisDbAPI._sanitise_extent(invalid, epsg3577) is None
-    assert PostgisDbAPI._sanitise_extent(partial, epsg3577).area < partial.to_crs("EPSG:3577").area
+    from datacube.drivers.postgis._spatial import sanitise_extent
+
+    assert sanitise_extent(entire, epsg3577) == entire.to_crs("EPSG:3577")
+    assert sanitise_extent(valid, epsg3577) == valid.to_crs("EPSG:3577")
+    assert sanitise_extent(invalid, epsg3577) is None
+    assert sanitise_extent(partial, epsg3577).area < partial.to_crs("EPSG:3577").area
 
 
 @pytest.mark.parametrize('datacube_env_name', ('experimental',))

--- a/integration_tests/index/test_postgis_index.py
+++ b/integration_tests/index/test_postgis_index.py
@@ -73,10 +73,9 @@ def test_spatial_index_crs_validity(index: Index,
     assert index.update_spatial_index(crses=[epsg3577]) == 2
 
 
-def test_spatial_index_crs_santise():
+def test_spatial_index_crs_sanitise():
     epsg4326 = CRS("EPSG:4326")
     epsg3577 = CRS("EPSG:3577")
-    from datacube.drivers.postgis._api import PostgisDbAPI
     from datacube.utils.geometry import polygon
     # EPSG:4326 polygons to be converted in EPSG:3577
     # Equal to entire valid region

--- a/tests/index/test_fields.py
+++ b/tests/index/test_fields.py
@@ -8,7 +8,7 @@ Module
 
 from datacube.drivers.postgres._fields import SimpleDocField, NumericRangeDocField, parse_fields, RangeDocField, \
     IntDocField
-from datacube.drivers.postgres._api import _split_uri
+from datacube.drivers.postgres._api import split_uri
 from datacube.drivers.postgres._schema import DATASET
 from datacube.model import Range
 import pytest
@@ -20,15 +20,15 @@ def _assert_same(obj1, obj2):
 
 
 def test_split_uri():
-    assert _split_uri('http://test.com/something.txt') == ('http', '//test.com/something.txt')
-    assert _split_uri('eods:LS7_ETM_SYS_P31_GALPGS01-002_101_065_20160127') == (
+    assert split_uri('http://test.com/something.txt') == ('http', '//test.com/something.txt')
+    assert split_uri('eods:LS7_ETM_SYS_P31_GALPGS01-002_101_065_20160127') == (
         'eods', 'LS7_ETM_SYS_P31_GALPGS01-002_101_065_20160127')
-    assert _split_uri('file://rhe-test-dev.prod.lan/data/fromASA/LANDSAT-7.89274.S4A2C1D3R3') == (
+    assert split_uri('file://rhe-test-dev.prod.lan/data/fromASA/LANDSAT-7.89274.S4A2C1D3R3') == (
         'file', '//rhe-test-dev.prod.lan/data/fromASA/LANDSAT-7.89274.S4A2C1D3R3')
-    assert _split_uri('file:///C:/tmp/first/something.yaml') == ('file', '///C:/tmp/first/something.yaml')
+    assert split_uri('file:///C:/tmp/first/something.yaml') == ('file', '///C:/tmp/first/something.yaml')
 
     with pytest.raises(ValueError):
-        _split_uri('/no/semicolon')
+        split_uri('/no/semicolon')
 
 
 def test_get_single_field():


### PR DESCRIPTION
### Reason for this pull request

As discussed in the ODCv2 roadmap, this PR implements: API methods for bulk reading and bulk writing, and a method for "cloning" indexes (i.e. copying either all data or all compatible data from an existing ODC index to a new empty one, potentially using a different index driver implementation).

### Proposed changes

- New bulk read/write API methods
- An index cloning API method,
- A `datacube system clone` CLI method
 
This has wound up a very large PR, including several bug-fixes in the Transaction API implementations, and adds several new API methods that have not been formally discussed with or approved by the ODC steering council, and does not yet include adequate documentation.

This is a draft PR mainly for taking stock of the work done so far, and checking test coverage.  It may be broken up into smaller PRs before being marked ready for approval, or may be "promoted" to become a larger datacube-1.9.x branch.  Comments are welcome, but please be aware this is still a work in progress.

### Cloning Performance

On my local development system with a postgres/postgis instance, I am getting index cloning speeds of approximately:

* 90,000 datasets/minute when writing to the old (postgres/legacy) index driver
* 20,000 datasets/minute when writing to the new (postgis/experimental) index driver.

This difference is expected given the more complex query-optimised schema of the new index driver.

### Caveats

The cloning process currently does not preserve lineage information.  This is mostly because the new (postgis/experimental) index driver does not yet fully support lineage.

 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes



<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1377.org.readthedocs.build/en/1377/

<!-- readthedocs-preview datacube-core end -->