### PR TITLE
Remove unused definitions and consolidate split_uri

### DIFF
--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -41,6 +41,7 @@ _LOG = logging.getLogger(__name__)
 def _dataset_uri_field(table):
     return table.c.uri_scheme + ':' + table.c.uri_body
 
+
 # Fields for selecting dataset with uris
 # Need to alias the table, as queries may join the location table for filtering.
 SELECTED_DATASET_LOCATION = DATASET_LOCATION.alias('selected_dataset_location')

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -26,6 +26,7 @@ from sqlalchemy.exc import IntegrityError
 from datacube.index.exceptions import MissingRecordError
 from datacube.index.fields import OrExpression
 from datacube.model import Range
+from datacube.utils.uris import split_uri
 from . import _core
 from . import _dynamic as dynamic
 from ._fields import parse_fields, Expression, PgField, PgExpression  # noqa: F401
@@ -33,10 +34,12 @@ from ._fields import NativeField, DateDocField, SimpleDocField
 from ._schema import DATASET, DATASET_SOURCE, METADATA_TYPE, DATASET_LOCATION, PRODUCT
 from .sql import escape_pg_identifier
 
+PGCODE_FOREIGN_KEY_VIOLATION = '23503'
+_LOG = logging.getLogger(__name__)
+
 
 def _dataset_uri_field(table):
     return table.c.uri_scheme + ':' + table.c.uri_body
-
 
 # Fields for selecting dataset with uris
 # Need to alias the table, as queries may join the location table for filtering.
@@ -58,23 +61,6 @@ _DATASET_SELECT_FIELDS = (
         ).label('uris')
     ).label('uris')
 )
-
-PGCODE_UNIQUE_CONSTRAINT = '23505'
-PGCODE_FOREIGN_KEY_VIOLATION = '23503'
-
-_LOG = logging.getLogger(__name__)
-
-
-def _split_uri(uri):
-    """
-    Split the scheme and the remainder of the URI.
-
-    """
-    idx = uri.find(':')
-    if idx < 0:
-        raise ValueError("Not a URI")
-
-    return uri[:idx], uri[idx+1:]
 
 
 def get_native_fields():
@@ -255,7 +241,7 @@ class PostgresDbAPI(object):
         :rtype bool:
         """
 
-        scheme, body = _split_uri(uri)
+        scheme, body = split_uri(uri)
 
         r = self._connection.execute(
             insert(DATASET_LOCATION).on_conflict_do_nothing(
@@ -290,7 +276,7 @@ class PostgresDbAPI(object):
                 )).fetchall()]
 
     def get_datasets_for_location(self, uri, mode=None):
-        scheme, body = _split_uri(uri)
+        scheme, body = split_uri(uri)
 
         if mode is None:
             mode = 'exact' if body.count('#') > 0 else 'prefix'
@@ -998,7 +984,7 @@ class PostgresDbAPI(object):
 
         :returns bool: Was the location deleted?
         """
-        scheme, body = _split_uri(uri)
+        scheme, body = split_uri(uri)
         res = self._connection.execute(
             delete(DATASET_LOCATION).where(
                 and_(
@@ -1011,7 +997,7 @@ class PostgresDbAPI(object):
         return res.rowcount > 0
 
     def archive_location(self, dataset_id, uri):
-        scheme, body = _split_uri(uri)
+        scheme, body = split_uri(uri)
         res = self._connection.execute(
             DATASET_LOCATION.update().where(
                 and_(
@@ -1027,7 +1013,7 @@ class PostgresDbAPI(object):
         return res.rowcount > 0
 
     def restore_location(self, dataset_id, uri):
-        scheme, body = _split_uri(uri)
+        scheme, body = split_uri(uri)
         res = self._connection.execute(
             DATASET_LOCATION.update().where(
                 and_(

--- a/datacube/utils/uris.py
+++ b/datacube/utils/uris.py
@@ -14,6 +14,16 @@ from pathlib import Path
 
 URL_RE = re.compile(r'\A\s*[\w\d\+]+://')
 
+def split_uri(uri):
+    """
+    Split the scheme and the remainder of the URI.
+
+    """
+    idx = uri.find(':')
+    if idx < 0:
+        raise ValueError("Not a URI")
+
+    return uri[:idx], uri[idx+1:]
 
 def is_url(url_str: str) -> bool:
     """

--- a/datacube/utils/uris.py
+++ b/datacube/utils/uris.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 URL_RE = re.compile(r'\A\s*[\w\d\+]+://')
 
+
 def split_uri(uri):
     """
     Split the scheme and the remainder of the URI.
@@ -24,6 +25,7 @@ def split_uri(uri):
         raise ValueError("Not a URI")
 
     return uri[:idx], uri[idx+1:]
+
 
 def is_url(url_str: str) -> bool:
     """

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -20,6 +20,9 @@ v1.8.next
 - Fix Github doc lint action (:pull:`1370`)
 - Tighten EO3 enforcement in postgis driver, refactor tests, and rename Dataset.type to Dataset.product
   (with type alias for compatibility) (:pull:`1372`)
+- Fix deprecation message due to distutils Version classes (:pull: `1375`)
+- Postgresql drivers cleanup - consolidate split_uri into utils and removed unused constants (:pull: `1378`)
+
 
 v1.8.9 (17 November 2022)
 =========================

--- a/tests/index/test_fields.py
+++ b/tests/index/test_fields.py
@@ -8,7 +8,7 @@ Module
 
 from datacube.drivers.postgres._fields import SimpleDocField, NumericRangeDocField, parse_fields, RangeDocField, \
     IntDocField
-from datacube.drivers.postgres._api import _split_uri
+from datacube.utils.uris import split_uri
 from datacube.drivers.postgres._schema import DATASET
 from datacube.model import Range
 import pytest
@@ -20,15 +20,15 @@ def _assert_same(obj1, obj2):
 
 
 def test_split_uri():
-    assert _split_uri('http://test.com/something.txt') == ('http', '//test.com/something.txt')
-    assert _split_uri('eods:LS7_ETM_SYS_P31_GALPGS01-002_101_065_20160127') == (
+    assert split_uri('http://test.com/something.txt') == ('http', '//test.com/something.txt')
+    assert split_uri('eods:LS7_ETM_SYS_P31_GALPGS01-002_101_065_20160127') == (
         'eods', 'LS7_ETM_SYS_P31_GALPGS01-002_101_065_20160127')
-    assert _split_uri('file://rhe-test-dev.prod.lan/data/fromASA/LANDSAT-7.89274.S4A2C1D3R3') == (
+    assert split_uri('file://rhe-test-dev.prod.lan/data/fromASA/LANDSAT-7.89274.S4A2C1D3R3') == (
         'file', '//rhe-test-dev.prod.lan/data/fromASA/LANDSAT-7.89274.S4A2C1D3R3')
-    assert _split_uri('file:///C:/tmp/first/something.yaml') == ('file', '///C:/tmp/first/something.yaml')
+    assert split_uri('file:///C:/tmp/first/something.yaml') == ('file', '///C:/tmp/first/something.yaml')
 
     with pytest.raises(ValueError):
-        _split_uri('/no/semicolon')
+        split_uri('/no/semicolon')
 
 
 def test_get_single_field():

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -117,6 +117,7 @@ df
 digitalearth
 digitalearthafrica
 Dingley
+distutils
 Dockerfile
 dropdb
 ds


### PR DESCRIPTION
### Reason for this pull request:

Split off from #1377 

`drivers/.../_api.py` had separate implementations for `_split_uri` and unused constants.

### Proposed changes

- Remove unused constants
- Consolidate _split_uris into `datacube.utils.uris.split_uri`


 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1379.org.readthedocs.build/en/1379/

<!-- readthedocs-preview datacube-core end -->