### PR TITLE
fix indentation for example product

### DIFF
--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -23,7 +23,7 @@ v1.8.next
 - Fix deprecation message due to distutils Version classes (:pull: `1375`)
 - Postgresql drivers cleanup - consolidate split_uri into utils and removed unused constants (:pull: `1378`)
 - Postgresql drivers cleanup - Handle NaNs in search fields and allow caching in sanitise_extent (:pull: `1379`)
-
+- Fix example product yaml documentation (:pull: `1384`)
 
 v1.8.9 (17 November 2022)
 =========================

--- a/docs/installation/product-definitions.rst
+++ b/docs/installation/product-definitions.rst
@@ -16,11 +16,11 @@ and some very basic information about the product
     metadata_type: eo3
 
     metadata:
-        product:
+      product:
         name: dem_srtm
 
     measurements:
-        - name: elevation
+      - name: elevation
         dtype: int16
         nodata: -32768.0
         units: "metre"
@@ -39,17 +39,20 @@ known when loading data.
     license: CC-BY-4.0
 
     metadata:
-        product:
+      product:
         name: dem_srtm
 
     storage:
         crs: EPSG:4326
+        tile_size:
+          x: 100000.0
+          y: 100000.0
         resolution:
-        longitude: 0.000277777777780
-        latitude: -0.000277777777780
+          longitude: 0.000277777777780
+          latitude: -0.000277777777780
 
     measurements:
-        - name: elevation
+      - name: elevation
         dtype: int16
         nodata: -32768.0
         units: "metre"


### PR DESCRIPTION
### Reason for this pull request

The example written in doc was from a product in digitalearth Africa, https://explorer.digitalearth.africa/products/dem_srtm. As per this comment, https://github.com/opendatacube/datacube-core/issues/1382#issuecomment-1386180662, it is missing essential `tile_size`


### Proposed changes

- add `tile_size` to storage
- fix indentation for yaml file



 - [x] Closes #1382 
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1384.org.readthedocs.build/en/1384/

<!-- readthedocs-preview datacube-core end -->