### PR TITLE
DB hostname comment for Ubuntu based installation

### DIFF
--- a/docs/installation/setup/common_install.rst
+++ b/docs/installation/setup/common_install.rst
@@ -92,6 +92,7 @@ Then edit the ``~/.datacube_integration.conf`` with a text editor and add the fo
     db_username: <foo>
     db_password: <foobar>
 
+Note: For Ubuntu Setup the db_hostname should be set to "/var/run/postgresql". For more refer: https://github.com/opendatacube/datacube-core/issues/1329
 
 Verify it all works
 ===================


### PR DESCRIPTION

### Reason for this pull request
- Updating documentation based on the issues faced during installation
- 
If the DB hostname in the datacube_integration.conf file is set to localhost, the integration tests fail with the message that implies database connectivity issue. This is because for Ubuntu, postgres uses /var/run/postgresql folder. 
The fix was mentioned in this issue: https://github.com/opendatacube/datacube-core/issues/1329


### Proposed changes
- Added a line to comment for Ubuntu based installation

