### PR TITLE
Make compatible with the latest  `xarray`, `numpy` and `shapely` libraries

### DIFF
--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -32,5 +32,5 @@ dependencies:
   - rasterio >=1.3.2
   - sqlalchemy
   - GeoAlchemy2
-  - xarray >=0.9,!=2022.6.0
+  - xarray >=0.9
   - toolz

--- a/datacube/api/grid_workflow.py
+++ b/datacube/api/grid_workflow.py
@@ -17,14 +17,13 @@ _LOG = logging.getLogger(__name__)
 def _fast_slice(array, indexers):
     data = array.values[indexers]
     dims = [dim for dim, indexer in zip(array.dims, indexers) if isinstance(indexer, slice)]
-    variable = xarray.Variable(dims, data, attrs=array.attrs, fastpath=True)
     coords = OrderedDict((dim,
                           xarray.Variable((dim,),
                                           array.coords[dim].values[indexer],
                                           attrs=array.coords[dim].attrs,
                                           fastpath=True))
                          for dim, indexer in zip(array.dims, indexers) if isinstance(indexer, slice))
-    return xarray.DataArray(variable, coords=coords, fastpath=True)
+    return xarray.DataArray(data, dims=dims, coords=coords, attrs=array.attrs)
 
 
 class Tile(object):

--- a/datacube/virtual/impl.py
+++ b/datacube/virtual/impl.py
@@ -543,6 +543,7 @@ class Aggregate(VirtualProduct):
             data = self._input.fetch(value, **load_settings)
             result = self._statistic.compute(data)
             result.coords[dim] = coords[dim]
+            result = result.drop_indexes(dim, errors="ignore")
             return result
 
         groups = list(xr_map(grouped.box, statistic))

--- a/docker/constraints.in
+++ b/docker/constraints.in
@@ -1,5 +1,5 @@
 # datacube dependencies
-Sphinx
+Sphinx<6.0.0 # be compatible to sphinx_rtd_theme
 affine
 # boto is too huge, need to set lower bound
 boto3>1.17.0
@@ -35,8 +35,7 @@ sphinx_autodoc_typehints
 sphinx_rtd_theme
 sqlalchemy
 toolz
-# FOR INVESTIGATION: xarray 2022.6.0 breaks virtual products tests.
-xarray>=0.18,!=2022.6.0
+xarray>=0.18
 
 # Previous pins were to very old versions
 # pytest Py3.10 requires >6.2.5

--- a/docker/constraints.txt
+++ b/docker/constraints.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile --strip-extras constraints.in
 #
-affine==2.3.1
+affine==2.4.0
     # via
     #   -r constraints.in
     #   rasterio
-alabaster==0.7.12
+alabaster==0.7.13
     # via sphinx
 antlr4-python3-runtime==4.7.2
     # via cf-units
@@ -16,31 +16,31 @@ astroid==2.3.3
     # via pylint
 async-timeout==4.0.2
     # via redis
-attrs==22.1.0
+attrs==22.2.0
     # via
     #   fiona
     #   hypothesis
     #   jsonschema
     #   pytest
     #   rasterio
-babel==2.10.3
+babel==2.11.0
     # via sphinx
-bleach==5.0.1
+bleach==6.0.0
     # via readme-renderer
-boto3==1.24.56
+boto3==1.26.56
     # via
     #   -r constraints.in
     #   moto
-botocore==1.27.56
+botocore==1.29.56
     # via
     #   boto3
     #   moto
     #   s3transfer
-bottleneck==1.3.5
+bottleneck==1.3.6
     # via -r constraints.in
-cachetools==5.2.0
+cachetools==5.3.0
     # via -r constraints.in
-certifi==2022.6.15
+certifi==2022.12.7
     # via
     #   fiona
     #   pyproj
@@ -50,20 +50,21 @@ cf-units==3.1.1
     # via compliance-checker
 cffi==1.15.1
     # via cryptography
-cftime==1.6.1
+cftime==1.6.2
     # via
     #   cf-units
     #   compliance-checker
     #   netcdf4
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via requests
-ciso8601==2.2.0
+ciso8601==2.3.0
     # via -r constraints.in
 click==8.1.3
     # via
     #   -r constraints.in
     #   click-plugins
     #   cligj
+    #   dask
     #   distributed
     #   fiona
     #   rasterio
@@ -76,34 +77,32 @@ cligj==0.7.2
     # via
     #   fiona
     #   rasterio
-cloudpickle==2.1.0
+cloudpickle==2.2.1
     # via
     #   -r constraints.in
     #   dask
     #   distributed
 commonmark==0.9.1
-    # via
-    #   recommonmark
-    #   rich
+    # via recommonmark
 compliance-checker==4.3.4
     # via -r constraints.in
-coverage==6.4.4
+contourpy==1.0.7
+    # via matplotlib
+coverage==7.1.0
     # via pytest-cov
-cryptography==37.0.4
+cryptography==39.0.0
     # via
     #   moto
     #   secretstorage
 cycler==0.11.0
     # via matplotlib
-dask==2022.8.1
+dask==2023.1.0
     # via
     #   -r constraints.in
     #   distributed
 decorator==5.1.1
     # via validators
-deprecated==1.2.13
-    # via redis
-distributed==2022.8.1
+distributed==2023.1.0
     # via -r constraints.in
 docutils==0.17.1
     # via
@@ -112,34 +111,40 @@ docutils==0.17.1
     #   sphinx
     #   sphinx-click
     #   sphinx-rtd-theme
-exceptiongroup==1.0.0rc8
-    # via hypothesis
-fiona==1.8.21
+exceptiongroup==1.1.0
+    # via
+    #   hypothesis
+    #   pytest
+fiona==1.8.22
     # via -r constraints.in
-fonttools==4.36.0
+fonttools==4.38.0
     # via matplotlib
-fsspec==2022.7.1
+fsspec==2023.1.0
     # via dask
-geoalchemy2==0.12.3
+geoalchemy2==0.13.1
     # via -r constraints.in
-greenlet==1.1.2
+greenlet==2.0.1
     # via sqlalchemy
 heapdict==1.0.1
     # via zict
-hypothesis==6.54.4
+hypothesis==6.65.0
     # via -r constraints.in
-idna==3.3
+idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==4.12.0
-    # via twine
-iniconfig==1.1.1
+importlib-metadata==6.0.0
+    # via
+    #   keyring
+    #   twine
+iniconfig==2.0.0
     # via pytest
 isodate==0.6.1
     # via compliance-checker
 isort==4.3.21
     # via pylint
+jaraco-classes==3.2.3
+    # via keyring
 jeepney==0.8.0
     # via
     #   keyring
@@ -155,13 +160,13 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.14.0
+jsonschema==4.17.3
     # via -r constraints.in
-keyring==23.8.2
+keyring==23.13.1
     # via twine
 kiwisolver==1.4.4
     # via matplotlib
-lark==1.1.2
+lark==1.1.5
     # via -r constraints.in
 lazy-object-proxy==1.4.3
     # via astroid
@@ -169,76 +174,81 @@ locket==1.0.0
     # via
     #   distributed
     #   partd
-lxml==4.9.1
+lxml==4.9.2
     # via compliance-checker
-markupsafe==2.1.1
+markdown-it-py==2.1.0
+    # via rich
+markupsafe==2.1.2
     # via
     #   jinja2
-    #   moto
-matplotlib==3.5.3
+    #   werkzeug
+matplotlib==3.6.3
     # via -r constraints.in
 mccabe==0.6.1
     # via pylint
-moto==4.0.0
+mdurl==0.1.2
+    # via markdown-it-py
+more-itertools==9.0.0
+    # via jaraco-classes
+moto==4.1.1
     # via -r constraints.in
 msgpack==1.0.4
     # via distributed
 munch==2.5.0
     # via fiona
-netcdf4==1.6.0
+netcdf4==1.6.2
     # via
     #   -r constraints.in
     #   compliance-checker
-numpy==1.23.2
+numpy==1.24.1
     # via
     #   -r constraints.in
     #   bottleneck
     #   cf-units
     #   cftime
+    #   contourpy
     #   matplotlib
     #   netcdf4
     #   pandas
     #   rasterio
+    #   shapely
     #   snuggs
     #   xarray
-owslib==0.26.0
+owslib==0.27.2
     # via compliance-checker
-packaging==21.3
+packaging==23.0
     # via
     #   dask
     #   distributed
     #   geoalchemy2
     #   matplotlib
     #   pytest
-    #   redis
     #   setuptools-scm
     #   sphinx
     #   xarray
-pandas==1.4.3
+pandas==1.5.3
     # via xarray
 partd==1.3.0
     # via dask
 pendulum==2.1.2
     # via compliance-checker
-pillow==9.2.0
+pillow==9.4.0
     # via matplotlib
-pkginfo==1.8.3
+pkginfo==1.9.6
     # via twine
 pluggy==1.0.0
     # via pytest
-psutil==5.9.1
+psutil==5.9.4
     # via distributed
-psycopg2==2.9.3
+psycopg2==2.9.5
     # via -r constraints.in
-py==1.11.0
-    # via pytest
 pycodestyle==2.5.0
     # via -r constraints.in
 pycparser==2.21
     # via cffi
-pygeoif==0.7
+pygeoif==1.0.0
     # via compliance-checker
-pygments==2.13.0
+pygments==2.14.0
     # via
     #   readme-renderer
     #   rich
@@ -248,23 +258,21 @@ pylint==2.4.4
 pyparsing==3.0.9
     # via
     #   matplotlib
-    #   packaging
     #   snuggs
-pyproj==3.2.1
+pyproj==3.4.1
     # via
     #   -r constraints.in
     #   compliance-checker
-    #   owslib
-pyrsistent==0.18.1
+pyrsistent==0.19.3
     # via jsonschema
-pytest==7.1.2
+pytest==7.2.1
     # via
     #   -r constraints.in
     #   pytest-cov
     #   pytest-timeout
-pytest-cov==3.0.0
+pytest-cov==4.0.0
     # via -r constraints.in
-pytest-httpserver==1.0.5
+pytest-httpserver==1.0.6
     # via -r constraints.in
 pytest-timeout==2.1.0
     # via -r constraints.in
@@ -277,10 +285,9 @@ python-dateutil==2.8.2
     #   owslib
     #   pandas
     #   pendulum
-pytz==2022.2.1
+pytz==2022.7.1
     # via
     #   babel
-    #   moto
     #   owslib
     #   pandas
 pytzdata==2020.1
@@ -291,17 +298,17 @@ pyyaml==6.0
     #   dask
     #   distributed
     #   owslib
-rasterio==1.3.2
+rasterio==1.3.4
     # via -r constraints.in
-readme-renderer==37.0
+readme-renderer==37.3
     # via twine
 recommonmark==0.7.1
     # via -r constraints.in
-redis==4.3.4
+redis==4.4.2
     # via -r constraints.in
-regex==2022.8.17
+regex==2022.10.31
     # via compliance-checker
-requests==2.28.1
+requests==2.28.2
     # via
     #   compliance-checker
     #   moto
@@ -310,21 +317,21 @@ requests==2.28.1
     #   responses
     #   sphinx
     #   twine
-requests-toolbelt==0.9.1
+requests-toolbelt==0.10.1
     # via twine
-responses==0.21.0
+responses==0.22.0
     # via moto
 rfc3986==2.0.0
     # via twine
-rich==12.5.1
+rich==13.2.0
     # via twine
 s3transfer==0.6.0
     # via boto3
 secretstorage==3.3.3
     # via keyring
-setuptools-scm==7.0.5
+setuptools-scm==7.1.0
     # via -r constraints.in
-shapely==1.8.4
+shapely==2.0.0
     # via -r constraints.in
 six==1.16.0
     # via
@@ -342,20 +349,20 @@ sortedcontainers==2.4.0
     # via
     #   distributed
     #   hypothesis
-sphinx==5.1.1
+sphinx==5.3.0
     # via
     #   -r constraints.in
     #   recommonmark
     #   sphinx-autodoc-typehints
     #   sphinx-click
     #   sphinx-rtd-theme
-sphinx-autodoc-typehints==1.19.2
+sphinx-autodoc-typehints==1.21.8
     # via -r constraints.in
-sphinx-click==4.3.0
+sphinx-click==4.4.0
     # via -r constraints.in
-sphinx-rtd-theme==1.0.0
+sphinx-rtd-theme==1.1.1
     # via -r constraints.in
-sphinxcontrib-applehelp==1.0.2
+sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
     # via sphinx
@@ -367,14 +374,16 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==1.4.40
+sqlalchemy==1.4.46
     # via
     #   -r constraints.in
     #   geoalchemy2
 tblib==1.7.0
     # via distributed
 toml==0.10.2
-    # via -r constraints.in
+    # via
+    #   -r constraints.in
+    #   responses
 tomli==2.0.1
     # via
     #   coverage
@@ -386,13 +395,17 @@ toolz==0.12.0
     #   dask
     #   distributed
     #   partd
-tornado==6.1
+tornado==6.2
     # via distributed
-twine==4.0.1
+twine==4.0.2
     # via -r constraints.in
-typing-extensions==4.3.0
-    # via setuptools-scm
-urllib3==1.26.11
+types-toml==0.10.8.1
+    # via responses
+typing-extensions==4.4.0
+    # via
+    #   pygeoif
+    #   setuptools-scm
+urllib3==1.26.14
     # via
     #   botocore
     #   distributed
@@ -403,23 +416,21 @@ validators==0.20.0
     # via compliance-checker
 webencodings==0.5.1
     # via bleach
-werkzeug==2.1.2
+werkzeug==2.2.2
     # via
     #   moto
     #   pytest-httpserver
-wheel==0.37.1
+wheel==0.38.4
     # via -r constraints.in
 wrapt==1.11.2
-    # via
-    #   astroid
-    #   deprecated
-xarray==2022.3.0
+    # via astroid
+xarray==2023.1.0
     # via -r constraints.in
 xmltodict==0.13.0
     # via moto
 zict==2.2.0
     # via distributed
-zipp==3.8.1
+zipp==3.11.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
     install_requires=[
         'affine',
         'pyproj>=2.5',
-        'shapely>=1.6.4',
+        'shapely>=2.0',
         'cachetools',
         'click>=5.0',
         'cloudpickle>=0.4',

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ setup(
         'sqlalchemy',
         'GeoAlchemy2',
         'toolz',
-        'xarray>=0.9,<2022.6',  # >0.9 fixes most problems with `crs` attributes being lost
+        'xarray>=0.9',  # >0.9 fixes most problems with `crs` attributes being lost
         'packaging',
     ],
     extras_require=extras_require,

--- a/tests/api/test_grid_workflow.py
+++ b/tests/api/test_grid_workflow.py
@@ -196,7 +196,7 @@ def test_gridworkflow():
     # to ultimately convert geobox,sources,measurements to xarray,
     # so only thing to check here is the call interface.
 
-    measurement = dict(nodata=0, dtype=numpy.int)
+    measurement = dict(nodata=0, dtype=numpy.int32)
     fakedataset.product.lookup_measurements.return_value = {"dummy": measurement}
     fakedataset2.product = fakedataset.product
 

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -248,7 +248,7 @@ def test_ops():
 
     # test array interface
     assert line.__array_interface__ is not None
-    assert np.array(line).shape == (3, 2)
+    assert np.array(line.coords).shape == (3, 2)
 
     # test simplify
     poly = geometry.polygon([(0, 0), (0, 5), (10, 5)], epsg4326)


### PR DESCRIPTION
### Reason for this pull request

Fix the broken parts due to newer version `xarray`, `numpy` and `shapely`


### Proposed changes

- Upgrade the versions of dependencies
- Fix the issues due to `xarray.Index`
- Be specific with `numpy types`
- Be compatible with `shapely >= 2.0` 

Note:

The test will fail on the current `latest` docker image. Correct working sequence should be:
docker image built and push -> run test on the latest `latest` docker image

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1389.org.readthedocs.build/en/1389/

<!-- readthedocs-preview datacube-core end -->