### PR TITLE
Pin SQLAlchemy to `<2.0` 

### DIFF
--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -28,7 +28,7 @@ v1.8.next
   and new API methods may be subject to change. (:pull:`1381`)
 - Documentation update. (:pull:`1385`)
 - Clean up datetime functions (:pull:`1387`)
-- Dependency updates (:pull:`1388`, :pull:`13??`)
+- Dependency updates (:pull:`1388`, :pull:`1391`)
 
 v1.8.9 (17 November 2022)
 =========================

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -26,7 +26,9 @@ v1.8.next
 - Fix example product yaml documentation (:pull:`1384`)
 - Bulk read/write API methods and fast whole-index cloning. Cloning does NOT include lineage information yet,
   and new API methods may be subject to change. (:pull:`1381`)
+- Documentation update. (:pull:`1385`)
 - Clean up datetime functions (:pull:`1387`)
+- Dependency updates (:pull:`1388`, :pull:`13??`)
 
 v1.8.9 (17 November 2022)
 =========================

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
         'pyyaml',
         'rasterio>=1.3.2',  # Warping broken in 1.3.0 and 1.3.1
         'ruamel.yaml',
-        'sqlalchemy>=1.4,<2.0', # GeoAlchemy2 requires >=1.4  postgres driver implementation is not 2.0 compatible.
+        'sqlalchemy>=1.4,<2.0',  # GeoAlchemy2 requires >=1.4  postgres driver implementation is not 2.0 compatible.
         'GeoAlchemy2',
         'toolz',
         'xarray>=0.9,<2022.6',  # >0.9 fixes most problems with `crs` attributes being lost

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
         'pyyaml',
         'rasterio>=1.3.2',  # Warping broken in 1.3.0 and 1.3.1
         'ruamel.yaml',
-        'sqlalchemy',
+        'sqlalchemy>=1.4,<2.0', # GeoAlchemy2 requires >=1.4  postgres driver implementation is not 2.0 compatible.
         'GeoAlchemy2',
         'toolz',
         'xarray>=0.9,<2022.6',  # >0.9 fixes most problems with `crs` attributes being lost


### PR DESCRIPTION
Pin SQLAlchemy dependency

### Reason for this pull request

SQLAlchemy 2.0 was released on 26th Jan.  The postgres driver is incompatible with this new release.  I have therefore pinned SQLAlchemy to `<2.0` (and `>=1.4` for GeoAlchemy2 compatibility.)


### Proposed changes

- pin SQLAlchemy to `<2.0` (and `>=1.4` for GeoAlchemy2 compatibility.)

 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1391.org.readthedocs.build/en/1391/

<!-- readthedocs-preview datacube-core end -->