### PR TITLE
Push a new docker image instead of always pulling an existing one

### DIFF
--- a/.github/workflows/docker-test-runner.yml
+++ b/.github/workflows/docker-test-runner.yml
@@ -49,16 +49,8 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-buildx-
 
-    - name: DockerHub Login
-      id: login
-      uses: docker/login-action@v2
-      with:
-        username: ${DOCKER_USER}
-        password: ${{ secrets.DockerPassword }}
-
     - name: Build Docker
       uses: docker/build-push-action@v3
-      if: steps.login.outcome == 'success'
       with:
         file: docker/Dockerfile
         context: .
@@ -70,7 +62,6 @@ jobs:
         cache-from: |
           type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new
-        push: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/develop') }}
 
     # This ugly bit is necessary if you don't want your cache to grow forever
     # till it hits GitHub's limit of 5GB.
@@ -83,6 +74,7 @@ jobs:
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
     - name: Verify Docker Image
+      id: verify
       run: |
         # Make sure we test docker image we built
         if [[ "${{ steps.cfg.outputs.docker_image }}" != "opendatacube/datacube-tests:latest" ]]; then
@@ -93,3 +85,21 @@ jobs:
 
         echo "Verify that twine is installed"
         docker run --rm opendatacube/datacube-tests:latest twine --version
+
+    # if tests passed, login and push to DockerHub
+    - name: DockerHub Login
+      id: login
+      if: |
+        github.event_name == 'push' && (
+          github.ref == 'refs/heads/develop'
+          ) && steps.verify.outcome == 'success'
+      uses: docker/login-action@v2
+      with:
+        username: ${DOCKER_USER}
+        password: ${{ secrets.DockerPassword }}
+
+    - name: DockerHub Push
+      if: |
+        steps.login.outcome == 'success'
+      run: | 
+        docker push "${{ steps.cfg.outputs.docker_image }}"

--- a/.github/workflows/docker-test-runner.yml
+++ b/.github/workflows/docker-test-runner.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -39,7 +39,7 @@ jobs:
 
     # This is the a separate action that sets up buildx runner
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: Cache Docker layers
       uses: pat-s/always-upload-cache@v2.1.5
@@ -49,8 +49,16 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-buildx-
 
+    - name: DockerHub Login
+      id: login
+      uses: docker/login-action@v2
+      with:
+        username: ${DOCKER_USER}
+        password: ${{ secrets.DockerPassword }}
+
     - name: Build Docker
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
+      if: steps.login.outcome == 'success'
       with:
         file: docker/Dockerfile
         context: .
@@ -62,6 +70,7 @@ jobs:
         cache-from: |
           type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new
+        push: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/develop') }}
 
     # This ugly bit is necessary if you don't want your cache to grow forever
     # till it hits GitHub's limit of 5GB.
@@ -84,28 +93,3 @@ jobs:
 
         echo "Verify that twine is installed"
         docker run --rm opendatacube/datacube-tests:latest twine --version
-
-    - name: DockerHub Login
-      id: dkr
-      if: |
-        github.event_name == 'push' && (
-          github.ref == 'refs/heads/develop'
-          )
-      run: |
-        if [ -n "${{ secrets.DockerPassword }}" ]; then
-           echo "Login to DockerHub as ${DOCKER_USER}"
-           echo "${{ secrets.DockerPassword }}" | docker login -u "${DOCKER_USER}" --password-stdin
-           echo "logged_in=yes" >> $GITHUB_OUTPUT
-        else
-           echo "Set DockerPassword secret to push to docker"
-        fi
-
-    - name: DockerHub Push
-      if: |
-        github.event_name == 'push' && (
-          github.ref == 'refs/heads/develop'
-          ) && steps.dkr.outputs.logged_in == 'yes'
-      run: |
-        if [ -n "${{ secrets.DockerPassword }}" ]; then
-           docker push "${{ steps.cfg.outputs.docker_image }}"
-        fi

--- a/.github/workflows/docker-test-runner.yml
+++ b/.github/workflows/docker-test-runner.yml
@@ -74,7 +74,6 @@ jobs:
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
     - name: Verify Docker Image
-      id: verify
       run: |
         # Make sure we test docker image we built
         if [[ "${{ steps.cfg.outputs.docker_image }}" != "opendatacube/datacube-tests:latest" ]]; then
@@ -92,7 +91,7 @@ jobs:
       if: |
         github.event_name == 'push' && (
           github.ref == 'refs/heads/develop'
-          ) && steps.verify.outcome == 'success'
+          )
       uses: docker/login-action@v2
       with:
         username: ${DOCKER_USER}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,13 @@ on:
       - '!docker/**'
       - '!docs/**'
       - '!contrib/**'
+  
+  # build and push new docker image first if necessary
+  workflow_run:
+    workflows:
+      - Docker (test runner)
+    types:
+      - completed
 
 jobs:
   main:


### PR DESCRIPTION
### Reason for this pull request

Currently, the test suite is run on an existing docker image before the new one is pushed, making it so that any dependency updates require a separate PR to be merged first before the tests can pass for any subsequent changes.


### Proposed changes

- Simplify docker login and push jobs by replacing bash code with actions where applicable (build-and-push action does not support pushing without rebuilding)
- Don't run main.yml until docker-test-runner has been run (or skipped) so that docker pull will retrieve the newly-created docker image


 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1393.org.readthedocs.build/en/1393/

<!-- readthedocs-preview datacube-core end -->