### PR TITLE
Get conda and pip dependencies in sync

### DIFF
--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -30,7 +30,8 @@ dependencies:
   - python-dateutil
   - pyyaml
   - rasterio >=1.3.2
-  - sqlalchemy
+  - ruamel.yaml
+  - sqlalchemy <2.0
   - GeoAlchemy2
-  - xarray >=0.9
+  - xarray >=0.9,!=2022.6.0
   - toolz

--- a/docs/about/release_process.rst
+++ b/docs/about/release_process.rst
@@ -4,6 +4,8 @@ Release Process
 #. Decide to do a release, and check with regular contributors on Slack that
    they don't have anything pending.
 
+#. Ensure version pins in setup.py and conda-environment.yml are in sync and up to date.
+
 #. Update the release notes in the ``develop`` branch via a PR.
 
 #. Create a new **Tag** and **Release** using the `GitHub Releases Web UI`_

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -9,6 +9,8 @@ v1.8.next
 =========
 
 - Update conda create environment README (:pull:`1394`)
+- Update conda environment file and add notes to release process to ensure pip and conda
+  dependencies are in sync and up-to-date. (:pull:`1395`)
 
 
 v1.8.10 (30 January 2023)


### PR DESCRIPTION
### Reason for this pull request

Conda dependencies were out of sync with pip dependencies when the 1.8.10 release was tagged, necessitating manual intervention to ensure a working conda-forge release of 1.8.10.


### Proposed changes

- Backport conda dependency pins from conda-forge to this repo.
- Add note to release process to check pip and conda dependencies are in sync and up-to-date.
- Comment in whats_new.rst.



 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1395.org.readthedocs.build/en/1395/

<!-- readthedocs-preview datacube-core end -->