### PR TITLE
Remote lineage

### DIFF
--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -1234,9 +1234,9 @@ class PostgisDbAPI(object):
             ))
         )
         for rel in results:
-            yield LineageRelation(classifier=DatasetLineage.classifier,
-                                  source_id=DatasetLineage.source_dataset_ref,
-                                  derived_id=DatasetLineage.source_dataset_ref)
+            yield LineageRelation(classifier=rel["classifier"],
+                                  source_id=rel["source_dataset_ref"],
+                                  derived_id=rel["derived_dataset_ref"])
 
     def write_relations(self, relations: Iterable[LineageRelation], allow_updates: bool):
         if allow_updates:

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -32,7 +32,7 @@ from . import _core
 from ._fields import parse_fields, Expression, PgField, PgExpression  # noqa: F401
 from ._fields import NativeField, DateDocField, SimpleDocField, UnindexableValue
 from ._schema import MetadataType, Product, \
-    Dataset, DatasetSource, DatasetLocation, SelectedDatasetLocation, \
+    Dataset, DatasetLineage, DatasetLocation, SelectedDatasetLocation, \
     search_field_index_map, search_field_indexes
 from ._spatial import geom_alchemy, generate_dataset_spatial_values, extract_geometry_from_eo3_projection
 from .sql import escape_pg_identifier
@@ -502,8 +502,8 @@ class PostgisDbAPI(object):
             )
         )
         self._connection.execute(
-            delete(DatasetSource).where(
-                DatasetSource.dataset_ref == dataset_id
+            delete(DatasetLineage).where(
+                DatasetLineage.derived_dataset_ref == dataset_id
             )
         )
         for table in search_field_indexes.values():

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -1215,3 +1215,12 @@ class PostgisDbAPI(object):
             delete(DatasetHome).where(DatasetHome.dataset_ref.in_(ids))
         )
         return res.rowcount
+
+    def select_homes(self, ids):
+        results = self._connection.execute(
+            select(DatasetHome).where(DatasetHome.dataset_ref.in_(ids))
+        )
+        return {
+            row.dataset_ref: row.home
+            for row in results
+        }

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -503,11 +503,6 @@ class PostgisDbAPI(object):
                 DatasetLocation.dataset_ref == dataset_id
             )
         )
-        self._connection.execute(
-            delete(DatasetLineage).where(
-                DatasetLineage.derived_dataset_ref == dataset_id
-            )
-        )
         for table in search_field_indexes.values():
             self._connection.execute(
                 delete(table).where(table.dataset_ref == dataset_id)

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -1311,3 +1311,14 @@ class PostgisDbAPI(object):
         if recurse and next_lvl_ids:
             relations.extend(self.load_lineage_relations(next_lvl_ids, direction, next_depth, ids_so_far))
         return relations
+
+    def remove_lineage_relations(self,
+                                 ids: Iterable[DSID],
+                                 direction: LineageDirection) -> int:
+        qry = delete(DatasetLineage)
+        if direction == LineageDirection.SOURCES:
+            qry = qry.where(DatasetLineage.derived_dataset_ref.in_(ids))
+        else:
+            qry = qry.where(DatasetLineage.source_dataset_ref.in_(ids))
+        results = self._connection.execute(qry)
+        return results.rowcount

--- a/datacube/drivers/postgis/_schema.py
+++ b/datacube/drivers/postgis/_schema.py
@@ -328,8 +328,10 @@ search_field_index_map = {
 }
 
 ALL_STATIC_TABLES = [
-    MetadataType.__table__, Product.__table__, Dataset.__table__,
-    DatasetLocation.__table__, DatasetLineage.__table__, SpatialIndexRecord.__table__,
+    MetadataType.__table__, Product.__table__,
+    Dataset.__table__, DatasetLocation.__table__,
+    DatasetLineage.__table__, DatasetHome.__table__,
+    SpatialIndexRecord.__table__,
     DatasetSearchString.__table__, DatasetSearchNumeric.__table__,
     DatasetSearchDateTime.__table__,
 ]

--- a/datacube/drivers/postgis/_schema.py
+++ b/datacube/drivers/postgis/_schema.py
@@ -158,7 +158,7 @@ class DatasetLineage:
     __tablename__ = "dataset_lineage"
     __table_args__ = (
         _core.METADATA,
-        PrimaryKeyConstraint('derived_dataset_ref', 'derived_dataset_ref'),
+        PrimaryKeyConstraint('source_dataset_ref', 'derived_dataset_ref'),
         Index("ix_lin_derived_classifier", "derived_dataset_ref", "classifier"),
         {
             "schema": sql.SCHEMA_NAME,

--- a/datacube/drivers/postgis/_schema.py
+++ b/datacube/drivers/postgis/_schema.py
@@ -165,8 +165,11 @@ class DatasetLineage:
             "comment": "Represents a source-lineage relationship between two datasets"
         }
     )
-    derived_dataset_ref = Column(postgres.UUID(as_uuid=True), nullable=False, index=True,
-                         comment="The downstream derived dataset produced from the upstream source dataset.")
+    derived_dataset_ref = Column(
+        postgres.UUID(as_uuid=True),
+        nullable=False, index=True,
+        comment="The downstream derived dataset produced from the upstream source dataset."
+    )
     source_dataset_ref = Column(
         postgres.UUID(as_uuid=True), nullable=False, index=True,
         comment="An upstream source dataset that the downstream derived dataset was produced from."
@@ -187,8 +190,8 @@ class DatasetHome:
         }
     )
     dataset_ref = Column(postgres.UUID(as_uuid=True), primary_key=True,
-                comment="The dataset ID - no referential integrity enforced to dataset table.")
-    home = Column(Text, nullable=False, comment="""The 'home' index where this dataset can be found. 
+                         comment="The dataset ID - no referential integrity enforced to dataset table.")
+    home = Column(Text, nullable=False, comment="""The 'home' index where this dataset can be found.
 Not interpreted directly by ODC, provided as a convenience to database administrators.""")
 
 

--- a/datacube/drivers/postgis/_schema.py
+++ b/datacube/drivers/postgis/_schema.py
@@ -154,18 +154,18 @@ SelectedDatasetLocation = aliased(DatasetLocation, name="sel_loc")
 
 
 @orm_registry.mapped
-class DatasetSource:
+class DatasetLineage:
     __tablename__ = "dataset_lineage"
     __table_args__ = (
         _core.METADATA,
-        PrimaryKeyConstraint('dataset_ref', 'classifier'),
-        UniqueConstraint('source_dataset_ref', 'dataset_ref'),
+        PrimaryKeyConstraint('derived_dataset_ref', 'derived_dataset_ref'),
+        Index("ix_lin_derived_classifier", "derived_dataset_ref", "classifier"),
         {
             "schema": sql.SCHEMA_NAME,
             "comment": "Represents a source-lineage relationship between two datasets"
         }
     )
-    dataset_ref = Column(postgres.UUID(as_uuid=True), nullable=False, index=True,
+    derived_dataset_ref = Column(postgres.UUID(as_uuid=True), nullable=False, index=True,
                          comment="The downstream derived dataset produced from the upstream source dataset.")
     source_dataset_ref = Column(
         postgres.UUID(as_uuid=True), nullable=False, index=True,
@@ -174,6 +174,22 @@ class DatasetSource:
     classifier = Column(String, nullable=False, comment="""An identifier for this source dataset.
 E.g. the dataset type ('ortho', 'nbar'...) if there's only one source of each type, or a datestamp
 for a time-range summary.""")
+
+
+@orm_registry.mapped
+class DatasetHome:
+    __tablename__ = "dataset_home"
+    __table_args__ = (
+        _core.METADATA,
+        {
+            "schema": sql.SCHEMA_NAME,
+            "comment": "Represents an optional 'home index' for an external datasets"
+        }
+    )
+    dataset_ref = Column(postgres.UUID(as_uuid=True), primary_key=True,
+                comment="The dataset ID - no referential integrity enforced to dataset table.")
+    home = Column(Text, nullable=False, comment="""The 'home' index where this dataset can be found. 
+Not interpreted directly by ODC, provided as a convenience to database administrators.""")
 
 
 class SpatialIndex:
@@ -310,7 +326,7 @@ search_field_index_map = {
 
 ALL_STATIC_TABLES = [
     MetadataType.__table__, Product.__table__, Dataset.__table__,
-    DatasetLocation.__table__, DatasetSource.__table__, SpatialIndexRecord.__table__,
+    DatasetLocation.__table__, DatasetLineage.__table__, SpatialIndexRecord.__table__,
     DatasetSearchString.__table__, DatasetSearchNumeric.__table__,
     DatasetSearchDateTime.__table__,
 ]

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -793,7 +793,7 @@ class AbstractLineageResource(ABC):
         """
 
     @abstractmethod
-    def add(self, tree: LineageTree, max_depth: int = 0, replace: bool = False) -> None:
+    def add(self, tree: LineageTree, max_depth: int = 0, allow_updates: bool = False) -> None:
         """
         Add or update a LineageTree into the Index.
 
@@ -804,7 +804,8 @@ class AbstractLineageResource(ABC):
 
         :param tree: The LineageTree to add to the index
         :param max_depth: Maximum recursion depth. Default/Zero = unlimited depth
-        :param replace: If True, update database to match tree exactly.
+        :param allow_updates: If False and the tree would require index updates to fully
+                              add, then raise an InconsistentLineageException.
         """
 
     @abstractmethod
@@ -812,9 +813,32 @@ class AbstractLineageResource(ABC):
         """
         Remove lineage information from the Index.
 
+        Removes lineage relation data only. Home values not affected.
+
         :param id_: The Dataset ID to start removing lineage from.
         :param direction: The direction in which to remove lineage (from id_)
         :param max_depth: The maximum depth to which to remove lineage (0/default = no limit)
+        """
+
+    @abstractmethod
+    def set_home(self, home: str, *args: DSID) -> int:
+        """
+        Set the home for one or more dataset ids.
+
+        :param home: The home string
+        :param args: One or more dataset ids
+        :returns: The number of records affected.  Normally len(args) or zero.
+        """
+
+    @abstractmethod
+    def clear_home(self, *args: DSID, home: Optional[str] = None) -> int:
+        """
+        Clear the home for one or more dataset ids, or all dataset ids that currently have
+        a particular home value.
+
+        :param args: One or more dataset ids
+        :param home: The home string.  Supply home or args - not both.
+        :returns: The number of home records deleted.
         """
 
 

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -1558,7 +1558,11 @@ class AbstractIndex(ABC):
     supports_nongeo = True
     #   supports lineage
     supports_lineage = True
-    supports_source_filters = True
+    #   supports external lineage API (as described in EP-08)
+    #   IF support_lineage is True and supports_external_lineage is False THEN legacy lineage API.
+    supports_external_lineage = False
+    #   supports an external lineage home field.  Only valid if also supports_external_lineage
+    supports_external_home = False
     # Supports ACID transactions
     supports_transactions = False
 

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -32,18 +32,17 @@ from datacube.model import LineageTree, LineageDirection
 _LOG = logging.getLogger(__name__)
 
 
-# A named tuple representing the results of a batch add operation:
-# - completed: Number of objects added to theMay be None for internal functions and for datasets.
-# - skipped: Number of objects skipped, either because they already exist
-#   or the documents are invalid for this driver.
-# - seconds_elapsed: seconds elapsed during the bulk add operation;
-# - safe: an optional list of names of bulk added objects that are safe to be
-#   used for lower level bulk adds. Includes objects added, and objects skipped
-#   because they already exist in the index and are identical to the version
-#   being added.  May be None for internal functions and for datasets.
 class BatchStatus(NamedTuple):
     """
-
+    A named tuple representing the results of a batch add operation:
+    - completed: Number of objects added to theMay be None for internal functions and for datasets.
+    - skipped: Number of objects skipped, either because they already exist
+      or the documents are invalid for this driver.
+    - seconds_elapsed: seconds elapsed during the bulk add operation;
+    - safe: an optional list of names of bulk added objects that are safe to be
+      used for lower level bulk adds. Includes objects added, and objects skipped
+      because they already exist in the index and are identical to the version
+      being added.  May be None for internal functions and for datasets.
     """
     completed: int
     skipped: int

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -27,7 +27,7 @@ from datacube.utils.changes import AllowPolicy, Change, Offset, DocumentMismatch
 from datacube.utils.generic import thread_local_cache
 from datacube.utils.geometry import CRS, Geometry, box
 from datacube.utils.documents import UnknownMetadataType
-from model import LineageTree, LineageDirection
+from datacube.model import LineageTree, LineageDirection
 
 _LOG = logging.getLogger(__name__)
 
@@ -42,6 +42,9 @@ _LOG = logging.getLogger(__name__)
 #   because they already exist in the index and are identical to the version
 #   being added.  May be None for internal functions and for datasets.
 class BatchStatus(NamedTuple):
+    """
+
+    """
     completed: int
     skipped: int
     seconds_elapsed: float

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -848,13 +848,25 @@ class LegacyLineageResource(AbstractLineageResource):
        for all methods.
     """
     def __init__(self, index) -> None:
-        self.index = self.index
+        self.index = index
         assert not self.index.supports_external_lineage
 
     def get_derived_tree(self, id: DSID, max_depth: int = 0) -> LineageTree:
         raise NotImplementedError()
 
     def get_source_tree(self, id: DSID, max_depth: int = 0) -> LineageTree:
+        raise NotImplementedError()
+
+    def add(self, tree: LineageTree, max_depth: int = 0, allow_updates: bool = False) -> None:
+        raise NotImplementedError()
+
+    def remove(self, id_: DSID, direction: LineageDirection, max_depth: int = 0) -> None:
+        raise NotImplementedError()
+
+    def set_home(self, home: str, *args: DSID) -> int:
+        raise NotImplementedError()
+
+    def clear_home(self, *args: DSID, home: Optional[str] = None) -> int:
         raise NotImplementedError()
 
 
@@ -1700,6 +1712,11 @@ class AbstractIndex(ABC):
     @abstractmethod
     def products(self) -> AbstractProductResource:
         """A Product Resource instance for the index"""
+
+    @property
+    @abstractmethod
+    def lineage(self) -> AbstractLineageResource:
+        """A Lineage Resource instance for the index"""
 
     @property
     @abstractmethod

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -793,7 +793,7 @@ class AbstractLineageResource(ABC):
         """
 
     @abstractmethod
-    def merge(self, rels: LineageRelations, allow_updates: bool=False, validate_only=False) -> None:
+    def merge(self, rels: LineageRelations, allow_updates: bool = False, validate_only: bool = False) -> None:
         """
         Merge an entire LineageRelations collection into the databse.
 
@@ -886,7 +886,7 @@ class LegacyLineageResource(AbstractLineageResource):
     def add(self, tree: LineageTree, max_depth: int = 0, allow_updates: bool = False) -> None:
         raise NotImplementedError()
 
-    def merge(self, rels: LineageRelations, allow_updates: bool=False, validate_only=False) -> None:
+    def merge(self, rels: LineageRelations, allow_updates: bool = False, validate_only = False) -> None:
         raise NotImplementedError()
 
     def remove(self, id_: DSID, direction: LineageDirection, max_depth: int = 0) -> None:

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -823,7 +823,7 @@ class LegacyLineageResource(AbstractLineageResource):
     Minimal implementation of AbstractLineageResource that raises "not implemented"
        for all methods.
     """
-    def __init__(self, index) -> None :
+    def __init__(self, index) -> None:
         self.index = self.index
         assert not self.index.supports_external_lineage
 

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -757,9 +757,9 @@ class AbstractLineageResource(ABC):
     which is a minimal implementation of this resource that raises a NotImplementedError for all methods.
     """
     def __init__(self, index) -> None:
-        self.index = index
+        self._index = index
         # THis is explicitly for indexes that do not support the External Lineage API.
-        assert self.index.supports_external_lineage
+        assert self._index.supports_external_lineage
 
     @abstractmethod
     def get_derived_tree(self, id: DSID, max_depth: int = 0) -> LineageTree:
@@ -821,13 +821,14 @@ class AbstractLineageResource(ABC):
         """
 
     @abstractmethod
-    def set_home(self, home: str, *args: DSID) -> int:
+    def set_home(self, home: str, *args: DSID, allow_updates: bool = False) -> int:
         """
         Set the home for one or more dataset ids.
 
         :param home: The home string
         :param args: One or more dataset ids
-        :returns: The number of records affected.  Normally len(args) or zero.
+        :param allow_updates: Allow datasets with existing homes to be updated.
+        :returns: The number of records affected.  Between zero and len(args).
         """
 
     @abstractmethod
@@ -848,8 +849,8 @@ class LegacyLineageResource(AbstractLineageResource):
        for all methods.
     """
     def __init__(self, index) -> None:
-        self.index = index
-        assert not self.index.supports_external_lineage
+        self._index = index
+        assert not self._index.supports_external_lineage
 
     def get_derived_tree(self, id: DSID, max_depth: int = 0) -> LineageTree:
         raise NotImplementedError()
@@ -863,7 +864,7 @@ class LegacyLineageResource(AbstractLineageResource):
     def remove(self, id_: DSID, direction: LineageDirection, max_depth: int = 0) -> None:
         raise NotImplementedError()
 
-    def set_home(self, home: str, *args: DSID) -> int:
+    def set_home(self, home: str, *args: DSID, allow_updates: bool = False) -> int:
         raise NotImplementedError()
 
     def clear_home(self, *args: DSID, home: Optional[str] = None) -> int:

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -839,7 +839,20 @@ class AbstractLineageResource(ABC):
 
         :param args: One or more dataset ids
         :param home: The home string.  Supply home or args - not both.
-        :returns: The number of home records deleted.
+        :returns: The number of home records deleted. Usually len(args).
+        """
+
+    @abstractmethod
+    def get_homes(self, *args: DSID) -> Mapping[UUID, str]:
+        """
+        Obtain a dictionary mapping UUIDs to home strings for the passed in DSIDs.
+
+        If a passed in DSID does not have a home set in the database, it will not
+        be included in the returned mapping.  i.e. a database index with no homes
+        recorded will always return an empty mapping.
+
+        :param args: One or more dataset ids
+        :return: Mapping of dataset ids to home strings.
         """
 
 
@@ -869,6 +882,9 @@ class LegacyLineageResource(AbstractLineageResource):
 
     def clear_home(self, *args: DSID, home: Optional[str] = None) -> int:
         raise NotImplementedError()
+
+    def get_homes(self, *args: DSID) -> Mapping[UUID, str]:
+        return {}
 
 
 class DatasetTuple(NamedTuple):

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -886,7 +886,7 @@ class LegacyLineageResource(AbstractLineageResource):
     def add(self, tree: LineageTree, max_depth: int = 0, allow_updates: bool = False) -> None:
         raise NotImplementedError()
 
-    def merge(self, rels: LineageRelations, allow_updates: bool = False, validate_only = False) -> None:
+    def merge(self, rels: LineageRelations, allow_updates: bool = False, validate_only: bool = False) -> None:
         raise NotImplementedError()
 
     def remove(self, id_: DSID, direction: LineageDirection, max_depth: int = 0) -> None:

--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -251,7 +251,7 @@ def dataset_resolver(index: AbstractIndex,
                      verify_lineage: bool = True,
                      skip_lineage: bool = False,
                      home_index: Optional[str] = None,
-                     source_tree: Optional[LineageTree] = None) -> Callable[[SimpleDocNav, str], DatasetOrError]
+                     source_tree: Optional[LineageTree] = None) -> Callable[[SimpleDocNav, str], DatasetOrError]:
     if skip_lineage or not index.supports_lineage:
         resolver = resolve_no_lineage
         extra_kwargs = {

--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -10,7 +10,7 @@ import toolz
 from uuid import UUID
 from typing import cast, Any, Callable, Optional, Iterable, List, Mapping, Sequence, Tuple, Union, MutableMapping
 
-from datacube.model import Dataset, DatasetType as Product
+from datacube.model import Dataset, LineageTree, Product
 from datacube.index.abstract import AbstractIndex
 from datacube.utils import changes, InvalidDocException, SimpleDocNav, jsonify_document
 from datacube.model.utils import BadMatch, dedup_lineage, remap_lineage_doc, flatten_datasets
@@ -48,7 +48,10 @@ def load_rules_from_types(index: AbstractIndex,
     return [ProductRule(p, p.metadata_doc) for p in products], None
 
 
-def product_matcher(rules: Sequence[ProductRule]) -> Callable[[Mapping[str, Any]], Product]:
+ProductMatcher = Callable[[Mapping[str, Any]], Product]
+
+
+def product_matcher(rules: Sequence[ProductRule]) -> ProductMatcher:
     """Given product matching rules return a function mapping a document to a
     matching product.
 
@@ -142,93 +145,135 @@ DatasetOrError = Union[
 ]
 
 
+def resolve_no_lineage(ds: SimpleDocNav, uri: str, matcher: ProductMatcher) -> DatasetOrError:
+    doc = ds.doc_without_lineage_sources
+    try:
+        product = matcher(doc)
+    except BadMatch as e:
+        return None, e
+    return Dataset(product, doc, uris=[uri], sources={}), None
+
+
+def resolve_with_lineage(doc: SimpleDocNav, uri: str, matcher: ProductMatcher,
+                         home_index: Optional[str] = None) -> DatasetOrError:
+    uuid_ = doc.id
+    if not uuid_:
+        return None, "No id defined in dataset doc"
+    if not is_doc_eo3(doc):
+        return None, "Not an EO3 dataset"
+    try:
+        product = matcher(doc)
+    except BadMatch as e:
+        return None, e
+    return Dataset(product, doc,
+                   uris=[uri],
+                   source_tree=LineageTree.sources(uuid_, doc.sources, home=home_index)
+    )
+
+def resolve_legacy_lineage(main_ds_doc: SimpleDocNav, uri: str, matcher: ProductMatcher,
+                           index: AbstractIndex,
+                           fail_on_missing_lineage: bool,
+                           verify_lineage: bool,
+                           ) -> DatasetOrError:
+    try:
+        main_ds = SimpleDocNav(dedup_lineage(main_ds_doc))
+    except InvalidDocException as e:
+        return None, e
+
+    main_uuid = main_ds.id
+    if not main_uuid:
+        return None, "No id defined in dataset doc"
+
+    ds_by_uuid = toolz.valmap(toolz.first, flatten_datasets(main_ds))
+    all_uuid = list(ds_by_uuid)
+    db_dss = {ds.id: ds for ds in index.datasets.bulk_get(all_uuid)}
+
+    lineage_uuids = set(filter(lambda x: x != main_uuid, all_uuid))
+    missing_lineage = lineage_uuids - set(db_dss)
+
+    if missing_lineage and fail_on_missing_lineage:
+        return None, "Following lineage datasets are missing from DB: %s" % (
+            ','.join(str(m) for m in missing_lineage))
+
+    if not is_doc_eo3(main_ds.doc):
+        if is_doc_geo(main_ds.doc, check_eo3=False):
+            if not index.supports_legacy:
+                return None, "Legacy metadata formats not supported by the current index driver."
+        else:
+            if not index.supports_nongeo:
+                return None, "Non-geospatial metadata formats not supported by the current index driver."
+        if verify_lineage:
+            bad_lineage = []
+
+            for uuid in lineage_uuids:
+                if uuid in db_dss:
+                    ok, err = check_consistent(jsonify_document(ds_by_uuid[uuid].doc_without_lineage_sources),
+                                               db_dss[uuid].metadata_doc)
+                    if not ok:
+                        bad_lineage.append((uuid, err))
+
+            if len(bad_lineage) > 0:
+                error_report = '\n'.join('Inconsistent lineage dataset {}:\n> {}'.format(uuid, err)
+                                         for uuid, err in bad_lineage)
+                return None, error_report
+
+    def with_cache(v: Dataset, k: UUID, cache: MutableMapping[UUID, Dataset]) -> Dataset:
+        cache[k] = v
+        return v
+
+    def resolve_ds(ds: SimpleDocNav,
+                   sources: Optional[Mapping[UUID, Dataset]],
+                   cache: MutableMapping[UUID, Dataset]) -> Dataset:
+        cached = cache.get(ds.id)
+        if cached is not None:
+            return cached
+
+        uris = [uri] if ds.id == main_uuid else []
+
+        doc = ds.doc
+
+        db_ds = db_dss.get(ds.id)
+        if db_ds:
+            product = db_ds.product
+        else:
+            product = matcher(doc)
+
+        return with_cache(Dataset(product, doc, uris=uris, sources=sources), ds.id, cache)
+    try:
+        return remap_lineage_doc(main_ds, resolve_ds, cache={}), None
+    except BadMatch as e:
+        return None, e
+
+
 def dataset_resolver(index: AbstractIndex,
-                     product_matching_rules: Sequence[ProductRule],
+                     match_product: Callable[[Mapping[str, Any]], Product],
                      fail_on_missing_lineage: bool = False,
                      verify_lineage: bool = True,
-                     skip_lineage: bool = False) -> Callable[[SimpleDocNav, str], DatasetOrError]:
-    match_product = product_matcher(product_matching_rules)
+                     skip_lineage: bool = False,
+                     home_index: Optional[str] = None,
+                     source_tree: Optional[LineageTree] = None) -> Callable[[SimpleDocNav, str], DatasetOrError]
+    if skip_lineage or not index.supports_lineage:
+        resolver = resolve_no_lineage
+        extra_kwargs = {
+            "matcher": match_product,
+        }
+    elif index.supports_external_lineage:
+        resolver = resolve_with_lineage
+        extra_kwargs = {
+            "matcher": match_product,
+            "home_index": home_index,
+        }
+    else:
+        resolver = resolve_legacy_lineage
+        extra_kwargs = {
+            "index": index,
+            "fail_on_missing_lineage": fail_on_missing_lineage,
+            "verify_lineage": verify_lineage,
+        }
+    def resolve(doc: SimpleDocNav, uri: str) -> DatasetOrError:
+        return resolver(doc, uri, **extra_kwargs)
 
-    def resolve_no_lineage(ds: SimpleDocNav, uri: str) -> DatasetOrError:
-        doc = ds.doc_without_lineage_sources
-        try:
-            product = match_product(doc)
-        except BadMatch as e:
-            return None, e
-
-        return Dataset(product, doc, uris=[uri], sources={}), None
-
-    def resolve(main_ds_doc: SimpleDocNav, uri: str) -> DatasetOrError:
-        try:
-            main_ds = SimpleDocNav(dedup_lineage(main_ds_doc))
-        except InvalidDocException as e:
-            return None, e
-
-        main_uuid = main_ds.id
-
-        if not main_uuid:
-            return None, "No id defined in dataset doc"
-
-        ds_by_uuid = toolz.valmap(toolz.first, flatten_datasets(main_ds))
-        all_uuid = list(ds_by_uuid)
-        db_dss = {ds.id: ds for ds in index.datasets.bulk_get(all_uuid)}
-
-        lineage_uuids = set(filter(lambda x: x != main_uuid, all_uuid))
-        missing_lineage = lineage_uuids - set(db_dss)
-
-        if missing_lineage and fail_on_missing_lineage:
-            return None, "Following lineage datasets are missing from DB: %s" % (
-                ','.join(str(m) for m in missing_lineage))
-
-        if not is_doc_eo3(main_ds.doc):
-            if is_doc_geo(main_ds.doc, check_eo3=False):
-                if not index.supports_legacy:
-                    return None, "Legacy metadata formats not supported by the current index driver."
-            else:
-                if not index.supports_nongeo:
-                    return None, "Non-geospatial metadata formats not supported by the current index driver."
-            if verify_lineage:
-                bad_lineage = []
-
-                for uuid in lineage_uuids:
-                    if uuid in db_dss:
-                        ok, err = check_consistent(jsonify_document(ds_by_uuid[uuid].doc_without_lineage_sources),
-                                                   db_dss[uuid].metadata_doc)
-                        if not ok:
-                            bad_lineage.append((uuid, err))
-
-                if len(bad_lineage) > 0:
-                    error_report = '\n'.join('Inconsistent lineage dataset {}:\n> {}'.format(uuid, err)
-                                             for uuid, err in bad_lineage)
-                    return None, error_report
-
-        def with_cache(v: Dataset, k: UUID, cache: MutableMapping[UUID, Dataset]) -> Dataset:
-            cache[k] = v
-            return v
-
-        def resolve_ds(ds: SimpleDocNav,
-                       sources: Optional[Mapping[UUID, Dataset]],
-                       cache: MutableMapping[UUID, Dataset]) -> Dataset:
-            cached = cache.get(ds.id)
-            if cached is not None:
-                return cached
-
-            uris = [uri] if ds.id == main_uuid else []
-
-            doc = ds.doc
-
-            db_ds = db_dss.get(ds.id)
-            if db_ds:
-                product = db_ds.product
-            else:
-                product = match_product(doc)
-
-            return with_cache(Dataset(product, doc, uris=uris, sources=sources), ds.id, cache)
-        try:
-            return remap_lineage_doc(main_ds, resolve_ds, cache={}), None
-        except BadMatch as e:
-            return None, e
-    return resolve_no_lineage if skip_lineage else resolve
+    return resolve
 
 
 class Doc2Dataset:
@@ -258,12 +303,27 @@ class Doc2Dataset:
     :param fail_on_missing_lineage: If True fail resolve if any lineage
                                     datasets are missing from the DB
 
+                                    Only False supported if index.supports_external_lineage is True.
+
     :param verify_lineage: If True check that lineage datasets in the
                            supplied document are identical to DB versions
+
+                           Ignored for EO3 documents.  Will be dropped in ODCv2 as only eo3 documents
+                           will be supported.
 
     :param skip_lineage: If True ignore lineage sub-tree in the supplied
                          document and construct dataset without lineage datasets
     :param eo3: 'auto'/True/False by default auto-detect EO3 datasets and pre-process them
+
+                Cannot be 'False' if index.supports_legacy is False.
+                Will be dropped in ODCv2 as only eo3 documents will be supported
+    :param home_index: Ignored if index.supports_exernal_home is False.  Defaults to None.
+                Optional string labelling the "home index" for lineage datasets.
+                home_index cannot be used with source_tree.
+    :param source_tree: Optional source-direction LineageTree.
+                        Must be null if index.supports_external_lineage is False.
+                        If provided, this lineage tree is used for source lineage, instead
+                        of being taken from the dataset document.
     """
     def __init__(self,
                  index: AbstractIndex,
@@ -272,23 +332,45 @@ class Doc2Dataset:
                  fail_on_missing_lineage: bool = False,
                  verify_lineage: bool = True,
                  skip_lineage: bool = False,
-                 eo3: Union[bool, str] = 'auto'):
-        if not index.supports_legacy and not index.supports_nongeo:
-            if not eo3:
-                raise ValueError("EO3 cannot be set to False for a non-legacy geo-only index.")
-            eo3 = True
+                 eo3: Union[bool, str] = 'auto',
+                 home_index: Optional[str] = None,
+                 source_tree: Optional[LineageTree] = None):
+        if not index.supports_lineage:
+            skip_lineage = True
+            verify_lineage = False
+            fail_on_missing_lineage = False
+            home_index = None
+            source_tree = None
+        else:
+            if not index.supports_legacy and not index.supports_nongeo:
+                if not eo3:
+                    raise ValueError("EO3 cannot be set to False for a non-legacy geo-only index.")
+                eo3 = True
+            if index.supports_external_lineage and fail_on_missing_lineage:
+                raise ValueError("fail_on_missing_lineage is not supported for this index driver.")
+            if not index.supports_external_lineage and source_tree:
+                raise ValueError("source_tree is not supported for this index driver.")
+            if home_index and source_tree:
+                raise ValueError("Cannot provide both an explicit source_tree and a home_index.")
+            if (home_index or source_tree) and skip_lineage:
+                raise ValueError("Cannot provide an explicit source_tree or home_index when skip_lineage is set.")
+
         rules, err_msg = load_rules_from_types(index,
                                                product_names=products,
                                                excluding=exclude_products)
         if rules is None:
             raise ValueError(err_msg)
 
+        self.index = index
         self._eo3 = eo3
+        matcher = product_matcher(rules)
         self._ds_resolve = dataset_resolver(index,
-                                            rules,
+                                            matcher,
                                             fail_on_missing_lineage=fail_on_missing_lineage,
                                             verify_lineage=verify_lineage,
-                                            skip_lineage=skip_lineage)
+                                            skip_lineage=skip_lineage,
+                                            home_index=home_index,
+                                            source_tree=source_tree)
 
     def __call__(self, doc_in: Union[SimpleDocNav, Mapping[str, Any]], uri: str) -> DatasetOrError:
         """Attempt to construct dataset from metadata document and a uri.
@@ -306,7 +388,13 @@ class Doc2Dataset:
 
         if self._eo3:
             auto_skip = self._eo3 == 'auto'
-            doc = SimpleDocNav(prep_eo3(doc.doc, auto_skip=auto_skip))
+            doc = SimpleDocNav(
+                prep_eo3(
+                    doc.doc,
+                    auto_skip=auto_skip,
+                    remap_lineage=not self.index.supports_external_lineage
+                )
+            )
 
         dataset, err = self._ds_resolve(doc, uri)
         if dataset is None:

--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -179,8 +179,6 @@ def resolve_with_lineage(doc: SimpleDocNav, uri: str, matcher: ProductMatcher,
     uuid_ = doc.id
     if not uuid_:
         return None, "No id defined in dataset doc"
-    if not is_doc_eo3(doc.doc):
-        return None, "Not an EO3 dataset"
     try:
         product = matcher(doc.doc)
     except BadMatch as e:

--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -266,6 +266,7 @@ def dataset_resolver(index: AbstractIndex,
     else:
         resolver = resolve_legacy_lineage
         extra_kwargs = {
+            "matcher": match_product,
             "index": index,
             "fail_on_missing_lineage": fail_on_missing_lineage,
             "verify_lineage": verify_lineage,

--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -167,7 +167,7 @@ def resolve_with_lineage(doc: SimpleDocNav, uri: str, matcher: ProductMatcher,
         return None, e
     return Dataset(product, doc.doc,
                    uris=[uri],
-                   source_tree=LineageTree.sources(uuid_, doc.sources, home=home_index)
+                   source_tree=LineageTree.from_eo3_doc(uuid_, sources=doc.sources, home=home_index)
     ), None
 
 

--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -383,7 +383,7 @@ class Doc2Dataset:
             if index.supports_external_lineage and fail_on_missing_lineage:
                 raise ValueError("fail_on_missing_lineage is not supported for this index driver.")
             if home_index and skip_lineage:
-                raise ValueError("Cannot provide an explicit source_tree or home_index when skip_lineage is set.")
+                raise ValueError("Cannot provide a default home_index when skip_lineage is set.")
 
         rules, err_msg = load_rules_from_types(index,
                                                product_names=products,

--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -185,7 +185,7 @@ def resolve_with_lineage(doc: SimpleDocNav, uri: str, matcher: ProductMatcher,
         return None, e
     if source_tree is None:
         # Get sources from EO3 document, use home_index as home of source id's
-        source_tree = LineageTree.from_eo3_doc(uuid_, sources=doc.sources, home=home_index)
+        source_tree = LineageTree.from_data(uuid_, sources=doc.sources, home=home_index)
     else:
         # May be None
         if source_tree.direction == LineageDirection.DERIVED:

--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -170,6 +170,7 @@ def resolve_with_lineage(doc: SimpleDocNav, uri: str, matcher: ProductMatcher,
                    source_tree=LineageTree.sources(uuid_, doc.sources, home=home_index)
     ), None
 
+
 def resolve_legacy_lineage(main_ds_doc: SimpleDocNav, uri: str, matcher: ProductMatcher,
                            index: AbstractIndex,
                            fail_on_missing_lineage: bool,
@@ -271,6 +272,7 @@ def dataset_resolver(index: AbstractIndex,
             "fail_on_missing_lineage": fail_on_missing_lineage,
             "verify_lineage": verify_lineage,
         }
+
     def resolve(doc: SimpleDocNav, uri: str) -> DatasetOrError:
         return resolver(doc, uri, **extra_kwargs)
 

--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -310,8 +310,8 @@ def dataset_resolver(index: AbstractIndex,
             "verify_lineage": verify_lineage,
         }
 
-    def resolve(doc: SimpleDocNav, uri: str) -> DatasetOrError:
-        return resolver(doc, uri, **extra_kwargs)
+    def resolve(doc: SimpleDocNav, uri: str, source_tree: Optional[LineageTree] = None) -> DatasetOrError:
+        return resolver(doc, uri, source_tree=source_tree, **extra_kwargs)
 
     return resolve
 

--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -159,16 +159,16 @@ def resolve_with_lineage(doc: SimpleDocNav, uri: str, matcher: ProductMatcher,
     uuid_ = doc.id
     if not uuid_:
         return None, "No id defined in dataset doc"
-    if not is_doc_eo3(doc):
+    if not is_doc_eo3(doc.doc):
         return None, "Not an EO3 dataset"
     try:
-        product = matcher(doc)
+        product = matcher(doc.doc)
     except BadMatch as e:
         return None, e
-    return Dataset(product, doc,
+    return Dataset(product, doc.doc,
                    uris=[uri],
                    source_tree=LineageTree.sources(uuid_, doc.sources, home=home_index)
-    )
+    ), None
 
 def resolve_legacy_lineage(main_ds_doc: SimpleDocNav, uri: str, matcher: ProductMatcher,
                            index: AbstractIndex,

--- a/datacube/index/memory/index.py
+++ b/datacube/index/memory/index.py
@@ -10,7 +10,7 @@ from datacube.index.memory._fields import get_dataset_fields
 from datacube.index.memory._metadata_types import MetadataTypeResource
 from datacube.index.memory._products import ProductResource
 from datacube.index.memory._users import UserResource
-from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, UnhandledTransaction
+from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, UnhandledTransaction, LegacyLineageResource
 from datacube.model import MetadataType
 from datacube.utils.geometry import CRS
 
@@ -30,6 +30,7 @@ class Index(AbstractIndex):
         self._users = UserResource()
         self._metadata_types = MetadataTypeResource()
         self._products = ProductResource(self.metadata_types)
+        self._lineage = LegacyLineageResource(self)
         self._datasets = DatasetResource(self.products)
         global counter
         with counter_lock:
@@ -47,6 +48,10 @@ class Index(AbstractIndex):
     @property
     def products(self) -> ProductResource:
         return self._products
+
+    @property
+    def lineage(self) -> LegacyLineageResource:
+        return self._lineage
 
     @property
     def datasets(self) -> DatasetResource:

--- a/datacube/index/null/index.py
+++ b/datacube/index/null/index.py
@@ -8,7 +8,7 @@ from datacube.index.null._datasets import DatasetResource  # type: ignore
 from datacube.index.null._metadata_types import MetadataTypeResource
 from datacube.index.null._products import ProductResource
 from datacube.index.null._users import UserResource
-from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, UnhandledTransaction
+from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, UnhandledTransaction, LegacyLineageResource
 from datacube.model import MetadataType
 from datacube.model.fields import get_dataset_fields
 from datacube.utils.geometry import CRS
@@ -27,6 +27,7 @@ class Index(AbstractIndex):
         self._users = UserResource()
         self._metadata_types = MetadataTypeResource()
         self._products = ProductResource(self.metadata_types)
+        self._lineage = LegacyLineageResource(self)
         self._datasets = DatasetResource(self.products)
 
     @property
@@ -40,6 +41,10 @@ class Index(AbstractIndex):
     @property
     def products(self) -> ProductResource:
         return self._products
+
+    @property
+    def lineage(self) -> LegacyLineageResource:
+        return self._lineage
 
     @property
     def datasets(self) -> DatasetResource:

--- a/datacube/index/postgis/_lineage.py
+++ b/datacube/index/postgis/_lineage.py
@@ -1,0 +1,41 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2023 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+from typing import Optional
+
+from datacube.index.abstract import AbstractIndex, AbstractLineageResource, DSID, dsid_to_uuid
+from datacube.index.postgis._transaction import IndexResourceAddIn
+from datacube.model import LineageTree, LineageDirection
+
+
+class LineageResource(AbstractLineageResource, IndexResourceAddIn):
+    def __init__(self, db: "datacube.drivers.postgis.PostGisDb", index: AbstractIndex) -> None:
+        """
+        :type db: datacube.drivers.postgis._connections.PostgresDb
+        :type metadata_type_resource: datacube.index._metadata_types.MetadataTypeResource
+        """
+        self._db = db
+        super().__init__(index)
+
+    def get_derived_tree(self, id: DSID, max_depth: int = 0) -> LineageTree:
+        raise NotImplementedError("TODO")
+
+    def get_source_tree(self, id: DSID, max_depth: int = 0) -> LineageTree:
+        raise NotImplementedError("TODO")
+
+    def add(self, tree: LineageTree, max_depth: int = 0, allow_updates: bool = False) -> None:
+        raise NotImplementedError("TODO")
+
+    def remove(self, id_: DSID, direction: LineageDirection, max_depth: int = 0) -> None:
+        raise NotImplementedError("TODO")
+
+    def set_home(self, home: str, *args: DSID, allow_updates: bool = False) -> int:
+        with self._db_connection() as connection:
+            ids = (dsid_to_uuid(id_) for id_ in args)
+            return connection.insert_home(home, ids, allow_updates)
+
+    def clear_home(self, *args: DSID, home: Optional[str] = None) -> int:
+        with self._db_connection() as connection:
+            ids = [dsid_to_uuid(id_) for id_ in args]
+            return connection.delete_home(ids)

--- a/datacube/index/postgis/_lineage.py
+++ b/datacube/index/postgis/_lineage.py
@@ -9,6 +9,7 @@ from datacube.index.abstract import AbstractIndex, AbstractLineageResource, DSID
 from datacube.index.postgis._transaction import IndexResourceAddIn
 from datacube.drivers.postgis._api import PostgisDbAPI
 from datacube.model import LineageTree, LineageDirection
+from model.lineage import LineageRelations, LineageRelation
 
 
 class LineageResource(AbstractLineageResource, IndexResourceAddIn):
@@ -20,14 +21,66 @@ class LineageResource(AbstractLineageResource, IndexResourceAddIn):
         self._db = db
         super().__init__(index)
 
-    def get_derived_tree(self, id: DSID, max_depth: int = 0) -> LineageTree:
-        raise NotImplementedError("TODO")
+    def get_derived_tree(self, id_: DSID, max_depth: int = 0) -> LineageTree:
+        with self._db_connection() as connection:
+            relations = connection.load_lineage_relations([id_],
+                                                          LineageDirection.DERIVED,
+                                                          max_depth)
+        rels = LineageRelations(relations=relations)
+        return rels.extract_tree(id_, LineageTree.DERIVED)
 
-    def get_source_tree(self, id: DSID, max_depth: int = 0) -> LineageTree:
-        raise NotImplementedError("TODO")
+    def get_source_tree(self, id_: DSID, max_depth: int = 0) -> LineageTree:
+        with self._db_connection() as connection:
+            relations = connection.load_lineage_relations([id_],
+                                                          LineageDirection.SOURCES,
+                                                          max_depth)
+        rels = LineageRelations(relations=relations)
+        return rels.extract_tree(id_, LineageTree.SOURCES)
 
     def add(self, tree: LineageTree, max_depth: int = 0, allow_updates: bool = False) -> None:
-        raise NotImplementedError("TODO")
+        # Convert to a relations collection
+        relations = LineageRelations(tree=tree, max_depth=max_depth)
+        with self._db_connection() as connection:
+            # Get all current relations one step forwards and backwards from all dataset ids in the tree.
+            db_relations = LineageRelations(
+                relations=connection.get_all_relations(relations.dataset_ids),
+                homes=connection.get_homes(*relations.dataset_ids)
+            )
+            # Check for consistency:
+            new_rels, update_rels, new_homes, update_homes = relations.relations_diff(
+                existing_relations=db_relations,
+                allow_updates=allow_updates
+            )
+            # Merge homes data
+            if new_homes:
+                homes_new = {}
+                for id_, home in new_homes.items():
+                    if id_ in homes_new:
+                        homes_new[home].append(id_)
+                    else:
+                        homes_new[home] = [id_]
+                for home, ids in homes_new.items():
+                    connection.insert_home(home, ids, allow_updates=False)
+            if update_homes:
+                homes_update = {}
+                for id_, home in update_homes.items():
+                    if id_ in homes_update:
+                        homes_update[home].append(id_)
+                    else:
+                        homes_update[home] = [id_]
+                for home, ids in homes_update.items():
+                    connection.insert_home(home, ids, allow_updates=allow_updates)
+            # Merge Relations data
+            rels_new = [
+                LineageRelation(classifier=classifier, derived_id=derived, source_id=src)
+                for (derived, src), classifier in new_rels.items()
+            ]
+            rels_update = [
+                LineageRelation(classifier=classifier, derived_id=derived, source_id=src)
+                for (derived, src), classifier in new_rels.items()
+            ]
+            connection.write_relations(rels_new, allow_updates=False)
+            connection.write_relations(rels_update, allow_updates=True)
 
     def remove(self, id_: DSID, direction: LineageDirection, max_depth: int = 0) -> None:
         raise NotImplementedError("TODO")

--- a/datacube/index/postgis/_lineage.py
+++ b/datacube/index/postgis/_lineage.py
@@ -72,12 +72,12 @@ class LineageResource(AbstractLineageResource, IndexResourceAddIn):
                     connection.insert_home(home, ids, allow_updates=allow_updates)
             # Merge Relations data
             rels_new = [
-                LineageRelation(classifier=classifier, derived_id=derived, source_id=src)
-                for (derived, src), classifier in new_rels.items()
+                LineageRelation(classifier=classifier, derived_id=ids.derived_id, source_id=ids.source_id)
+                for ids, classifier in new_rels.items()
             ]
             rels_update = [
-                LineageRelation(classifier=classifier, derived_id=derived, source_id=src)
-                for (derived, src), classifier in update_rels.items()
+                LineageRelation(classifier=classifier, derived_id=ids.derived_id, source_id=ids.source_id)
+                for ids, classifier in update_rels.items()
             ]
             connection.write_relations(rels_new, allow_updates=False)
             connection.write_relations(rels_update, allow_updates=True)

--- a/datacube/index/postgis/_lineage.py
+++ b/datacube/index/postgis/_lineage.py
@@ -45,7 +45,7 @@ class LineageResource(AbstractLineageResource, IndexResourceAddIn):
         relations = LineageRelations(tree=tree, max_depth=max_depth)
         self.merge(relations, allow_updates=allow_updates)
 
-    def merge(self, rels: LineageRelations, allow_updates: bool=False, validate_only=False) -> None:
+    def merge(self, rels: LineageRelations, allow_updates: bool = False, validate_only = False) -> None:
         if allow_updates and validate_only:
             raise ValueError("Cannot validate-only AND allow updates")
         with self._db_connection() as connection:

--- a/datacube/index/postgis/_lineage.py
+++ b/datacube/index/postgis/_lineage.py
@@ -86,7 +86,16 @@ class LineageResource(AbstractLineageResource, IndexResourceAddIn):
             connection.write_relations(rels_update, allow_updates=True)
 
     def remove(self, id_: DSID, direction: LineageDirection, max_depth: int = 0) -> None:
-        raise NotImplementedError("TODO")
+        with self._db_connection() as connection:
+            relations = connection.load_lineage_relations([id_],
+                                                          direction,
+                                                          max_depth)
+            rels = LineageRelations(relations=relations)
+            if direction == LineageDirection.SOURCES:
+                ids = list(rels.by_derived.keys())
+            else:
+                ids = list(rels.by_source.keys())
+            connection.remove_lineage_relations(ids, direction)
 
     def set_home(self, home: str, *args: DSID, allow_updates: bool = False) -> int:
         with self._db_connection() as connection:

--- a/datacube/index/postgis/_lineage.py
+++ b/datacube/index/postgis/_lineage.py
@@ -45,7 +45,7 @@ class LineageResource(AbstractLineageResource, IndexResourceAddIn):
         relations = LineageRelations(tree=tree, max_depth=max_depth)
         self.merge(relations, allow_updates=allow_updates)
 
-    def merge(self, rels: LineageRelations, allow_updates: bool = False, validate_only = False) -> None:
+    def merge(self, rels: LineageRelations, allow_updates: bool = False, validate_only: bool = False) -> None:
         if allow_updates and validate_only:
             raise ValueError("Cannot validate-only AND allow updates")
         with self._db_connection() as connection:

--- a/datacube/index/postgis/_lineage.py
+++ b/datacube/index/postgis/_lineage.py
@@ -2,15 +2,17 @@
 #
 # Copyright (c) 2015-2023 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from typing import Optional
+from typing import Mapping, Optional
+from uuid import UUID
 
 from datacube.index.abstract import AbstractIndex, AbstractLineageResource, DSID, dsid_to_uuid
 from datacube.index.postgis._transaction import IndexResourceAddIn
+from datacube.drivers.postgis._api import PostgisDbAPI
 from datacube.model import LineageTree, LineageDirection
 
 
 class LineageResource(AbstractLineageResource, IndexResourceAddIn):
-    def __init__(self, db: "datacube.drivers.postgis.PostGisDb", index: AbstractIndex) -> None:
+    def __init__(self, db: PostgisDbAPI, index: AbstractIndex) -> None:
         """
         :type db: datacube.drivers.postgis._connections.PostgresDb
         :type metadata_type_resource: datacube.index._metadata_types.MetadataTypeResource
@@ -36,6 +38,11 @@ class LineageResource(AbstractLineageResource, IndexResourceAddIn):
             return connection.insert_home(home, ids, allow_updates)
 
     def clear_home(self, *args: DSID, home: Optional[str] = None) -> int:
+        ids = [dsid_to_uuid(id_) for id_ in args]
         with self._db_connection() as connection:
-            ids = [dsid_to_uuid(id_) for id_ in args]
             return connection.delete_home(ids)
+
+    def get_homes(self, *args: DSID) -> Mapping[UUID, str]:
+        ids = [dsid_to_uuid(id_) for id_ in args]
+        with self._db_connection() as connection:
+            return connection.select_homes(ids)

--- a/datacube/index/postgis/_lineage.py
+++ b/datacube/index/postgis/_lineage.py
@@ -34,7 +34,10 @@ class LineageResource(AbstractLineageResource, IndexResourceAddIn):
             relations = connection.load_lineage_relations([id_],
                                                           LineageDirection.SOURCES,
                                                           max_depth)
-        rels = LineageRelations(relations=relations)
+            rels = LineageRelations(relations=relations)
+            homes = connection.select_homes(rels.dataset_ids)
+        for dsid, home in homes.items():
+            rels.merge_new_home(dsid, home)
         return rels.extract_tree(id_, LineageDirection.SOURCES)
 
     def add(self, tree: LineageTree, max_depth: int = 0, allow_updates: bool = False) -> None:
@@ -55,7 +58,7 @@ class LineageResource(AbstractLineageResource, IndexResourceAddIn):
             if new_homes:
                 homes_new = {}
                 for id_, home in new_homes.items():
-                    if id_ in homes_new:
+                    if home in homes_new:
                         homes_new[home].append(id_)
                     else:
                         homes_new[home] = [id_]
@@ -64,7 +67,7 @@ class LineageResource(AbstractLineageResource, IndexResourceAddIn):
             if update_homes:
                 homes_update = {}
                 for id_, home in update_homes.items():
-                    if id_ in homes_update:
+                    if home in homes_update:
                         homes_update[home].append(id_)
                     else:
                         homes_update[home] = [id_]

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -11,6 +11,7 @@ from datacube.drivers.postgis import PostGisDb, PostgisDbAPI
 from datacube.index.postgis._transaction import PostgisTransaction
 from datacube.index.postgis._datasets import DatasetResource, DSID  # type: ignore
 from datacube.index.postgis._metadata_types import MetadataTypeResource
+from datacube.index.postgis._lineage import LineageResource
 from datacube.index.postgis._products import ProductResource
 from datacube.index.postgis._users import UserResource
 from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, AbstractTransaction, default_metadata_type_docs
@@ -68,6 +69,7 @@ WARNING: Database schema and internal APIs may change significantly between rele
         self._users = UserResource(db, self)
         self._metadata_types = MetadataTypeResource(db, self)
         self._products = ProductResource(db, self)
+        self._lineage = LineageResource(db, self)
         self._datasets = DatasetResource(db, self)
 
     @property
@@ -81,6 +83,10 @@ WARNING: Database schema and internal APIs may change significantly between rele
     @property
     def products(self) -> ProductResource:
         return self._products
+
+    @property
+    def lineage(self) -> LineageResource:
+        return self._lineage
 
     @property
     def datasets(self) -> DatasetResource:

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -51,9 +51,11 @@ class Index(AbstractIndex):
     supports_legacy = False
     # Hopefully can reinstate non-geo support, but dropping for now will make progress easier.
     supports_nongeo = False
-    # Hopefully can reinstate a simpler form of lineage support, but leave for now
-    supports_lineage = False
-    supports_source_filters = False
+    # Postgis driver supports the new lineage data model and API, as per EP-08.
+    supports_lineage = True
+    supports_external_lineage = True
+    supports_external_home = True
+    # Postgis driver supports ACID database transactions
     supports_transactions = True
 
     def __init__(self, db: PostGisDb) -> None:

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -11,8 +11,8 @@ from datacube.index.postgres._datasets import DatasetResource  # type: ignore
 from datacube.index.postgres._metadata_types import MetadataTypeResource
 from datacube.index.postgres._products import ProductResource
 from datacube.index.postgres._users import UserResource
-from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, default_metadata_type_docs, AbstractTransaction, \
-    LegacyLineageResource
+from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, AbstractTransaction, \
+     default_metadata_type_docs, LegacyLineageResource
 from datacube.model import MetadataType
 from datacube.utils.geometry import CRS
 

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -11,7 +11,8 @@ from datacube.index.postgres._datasets import DatasetResource  # type: ignore
 from datacube.index.postgres._metadata_types import MetadataTypeResource
 from datacube.index.postgres._products import ProductResource
 from datacube.index.postgres._users import UserResource
-from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, default_metadata_type_docs, AbstractTransaction
+from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, default_metadata_type_docs, AbstractTransaction, \
+    LegacyLineageResource
 from datacube.model import MetadataType
 from datacube.utils.geometry import CRS
 
@@ -50,6 +51,7 @@ class Index(AbstractIndex):
         self._users = UserResource(db, self)
         self._metadata_types = MetadataTypeResource(db, self)
         self._products = ProductResource(db, self)
+        self._lineage = LegacyLineageResource(self)
         self._datasets = DatasetResource(db, self)
 
     @property
@@ -63,6 +65,10 @@ class Index(AbstractIndex):
     @property
     def products(self) -> ProductResource:
         return self._products
+
+    @property
+    def lineage(self) -> LegacyLineageResource:
+        return self._lineage
 
     @property
     def datasets(self) -> DatasetResource:

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -12,7 +12,7 @@ from datacube.index.postgres._metadata_types import MetadataTypeResource
 from datacube.index.postgres._products import ProductResource
 from datacube.index.postgres._users import UserResource
 from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, AbstractTransaction, \
-     default_metadata_type_docs, LegacyLineageResource
+    default_metadata_type_docs, LegacyLineageResource
 from datacube.model import MetadataType
 from datacube.utils.geometry import CRS
 

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -23,7 +23,7 @@ from datacube.index.eo3 import is_doc_eo3
 from .fields import Field, get_dataset_fields
 from ._base import Range, ranges_overlap  # noqa: F401
 from .eo3 import validate_eo3_compatible_type
-from .lineage import LineageDirection, LineageTree, InconsistentLineageException
+from .lineage import LineageDirection, LineageTree, InconsistentLineageException  # noqa: F401
 
 __all__ = [
     "Field", "get_dataset_fields",

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -51,7 +51,9 @@ class Dataset:
                  sources: Optional[Mapping[str, 'Dataset']] = None,
                  indexed_by: Optional[str] = None,
                  indexed_time: Optional[datetime] = None,
-                 archived_time: Optional[datetime] = None):
+                 archived_time: Optional[datetime] = None,
+                 source_tree: Optional[LineageTree] = None,
+                 derived_tree: Optional[LineageTree] = None):
         assert isinstance(product, Product)
 
         self.product = product
@@ -68,6 +70,9 @@ class Dataset:
 
         if self.sources is not None:
             assert set(self.metadata.sources.keys()) == set(self.sources.keys())
+
+        self.source_tree = source_tree
+        self.derived_tree = derived_tree
 
         #: The User who indexed this dataset
         self.indexed_by = indexed_by

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -28,7 +28,7 @@ from .lineage import LineageDirection, LineageTree, InconsistentLineageException
 __all__ = [
     "Field", "get_dataset_fields",
     "Range", "ranges_overlap",
-    "LineageTree", "LineageTree", "InconsistentLineageException",
+    "LineageDirection", "LineageTree", "InconsistentLineageException",
     "Dataset", "Product", "MetadataType", "Measurement", "GridSpec",
     "metadata_from_doc",
     "ExtraDimensions", "IngestorConfig"

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -23,7 +23,7 @@ from datacube.index.eo3 import is_doc_eo3
 from .fields import Field, get_dataset_fields
 from ._base import Range, ranges_overlap  # noqa: F401
 from .eo3 import validate_eo3_compatible_type
-from .lineage import LineageDirection, LineageTree
+from .lineage import LineageDirection, LineageTree, InconsistentLineageException
 
 _LOG = logging.getLogger(__name__)
 

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -1,6 +1,6 @@
 # This file is part of the Open Data Cube, see https://opendatacube.org for more information
 #
-# Copyright (c) 2015-2020 ODC Contributors
+# Copyright (c) 2015-2023 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 """
 Core classes used across modules.
@@ -23,6 +23,7 @@ from datacube.index.eo3 import is_doc_eo3
 from .fields import Field, get_dataset_fields
 from ._base import Range, ranges_overlap  # noqa: F401
 from .eo3 import validate_eo3_compatible_type
+from .lineage import LineageDirection, LineageTree
 
 _LOG = logging.getLogger(__name__)
 

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -25,6 +25,15 @@ from ._base import Range, ranges_overlap  # noqa: F401
 from .eo3 import validate_eo3_compatible_type
 from .lineage import LineageDirection, LineageTree, InconsistentLineageException
 
+__all__ = [
+    "Field", "get_dataset_fields",
+    "Range", "ranges_overlap",
+    "LineageTree", "LineageTree", "InconsistentLineageException",
+    "Dataset", "Product", "MetadataType", "Measurement", "GridSpec",
+    "metadata_from_doc",
+    "ExtraDimensions", "IngestorConfig"
+]
+
 _LOG = logging.getLogger(__name__)
 
 DEFAULT_SPATIAL_DIMS = ('y', 'x')  # Used when product lacks grid_spec

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -49,6 +49,9 @@ class Dataset:
 
     Most important parts are the metadata_doc and uri.
 
+    Dataset objects should be constructed by an index driver, or with the
+    datacube.index.hl.Doc2Dataset
+
     :param metadata_doc: the document (typically a parsed json/yaml)
     :param uris: All active uris for the dataset
     """

--- a/datacube/model/lineage.py
+++ b/datacube/model/lineage.py
@@ -1,0 +1,43 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2023 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+from dataclasses import dataclass
+from enum import Enum
+from uuid import UUID
+from typing import Mapping, Optional, Sequence
+
+
+class LineageDirection(Enum):
+    """
+    Enumeration specifying the direction sense of a LineageTree (source-ward or derived-ward)
+
+     - SOURCES indicates a lineage tree that contains the source datasets of the root node
+     - DERIVED indicates a lineage tree that contains the derived datasets of the root node
+    """
+    SOURCES = 1
+    DERIVED = 2
+
+
+@dataclass
+class LineageTree:
+    """
+    A node in a Dataset Lineage tree.
+
+     - direction (LineageDirection): Whether this is a node in a source tree or a derived tree
+     - dataset_id (UUID): The dataset id associated with this node
+     - children (Optional[Mapping[str, Sequence[LineageTree]]]):
+          An optional mapping of lineage nodes of the same direction as this node.
+          The keys of the mapping are classifier strings.
+          children=None means that there may be children in the database.
+          children={} means there are no children in the database.
+          children represent source datasets or derived datasets depending on the direction.
+    home (Optional[str]):
+          The home index associated with this node's dataset.
+          Optional. Index drivers may not implement a home table, in which case this value
+          will always be None.
+    """
+    direction: LineageDirection
+    dataset_id: UUID
+    children: Optional[Mapping[str, Sequence["LineageTree"]]] = None
+    home: Optional[str] = None

--- a/datacube/model/lineage.py
+++ b/datacube/model/lineage.py
@@ -5,7 +5,7 @@
 from dataclasses import dataclass
 from enum import Enum
 from uuid import UUID
-from typing import Mapping, Optional, Sequence, MutableMapping, Set, Tuple, Iterable, Any, Union
+from typing import Mapping, Optional, Sequence, MutableMapping, Set, Tuple, Iterable, Any
 
 
 class LineageDirection(Enum):
@@ -23,6 +23,7 @@ class LineageDirection(Enum):
             return self.DERIVED
         else:
             return self.SOURCES
+
     @property
     def label(self):
         if self == self.SOURCES:

--- a/datacube/model/lineage.py
+++ b/datacube/model/lineage.py
@@ -41,3 +41,17 @@ class LineageTree:
     dataset_id: UUID
     children: Optional[Mapping[str, Sequence["LineageTree"]]] = None
     home: Optional[str] = None
+
+    @classmethod
+    def sources(cls, dsid: UUID, sources: Mapping[str, Sequence[UUID]], home=None) -> "LineageTree":
+        return cls(
+            direction=LineageDirection.SOURCES,
+            dataset_id=dsid,
+            children={
+                classifier: [
+                    cls(direction=LineageDirection.SOURCES, dataset_id=src, home=home)
+                    for src in srcs
+                ]
+                for classifier, srcs in sources.items()
+            },
+        )

--- a/datacube/model/lineage.py
+++ b/datacube/model/lineage.py
@@ -58,8 +58,8 @@ class LineageTree:
         else:
             children = {
                 classifier: [
-                 cls(direction=direction, dataset_id=der, home=home)
-                 for der in ders
+                    cls(direction=direction, dataset_id=der, home=home)
+                    for der in ders
                 ]
                 for classifier, ders in sources.items()
             }
@@ -289,12 +289,11 @@ class LineageRelations:
         return
 
     def relations_diff(self,
-                  existing_relations: Optional["LineageRelations"] = None,
-                  allow_updates: bool = False
-                 ) -> Tuple[Mapping[Tuple[UUID, UUID], str],
-                            Mapping[Tuple[UUID, UUID], str],
-                            Mapping[UUID, str],
-                            Mapping[UUID, str]]:
+                       existing_relations: Optional["LineageRelations"] = None,
+                       allow_updates: bool = False) -> Tuple[Mapping[Tuple[UUID, UUID], str],
+                                                             Mapping[Tuple[UUID, UUID], str],
+                                                             Mapping[UUID, str],
+                                                             Mapping[UUID, str]]:
         """
         Compare to another LineageRelations object, returning records to be added to or updated in
         the other LinearRelations collection to consistently merge this collection into it.

--- a/datacube/model/lineage.py
+++ b/datacube/model/lineage.py
@@ -375,8 +375,10 @@ class LineageRelations:
 
         :param root: The dataset id at the root of the extracted LineageTree
         :param direction: The direction of the extracted tree
-        :param parents: Used to detect cyclic dependencies in recursive mode - should be None on initial call.
-        :param so_far: Used to detect duplication from diamond dependencies in recursive mode - should be None on initial call.
+        :param parents: Used to detect cyclic dependencies in recursive mode
+                        - should be None on initial call.
+        :param so_far: Used to detect duplication from diamond dependencies in recursive mode
+                       - should be None on initial call.
         :return: the extracted LineageTree.
         """
         # Trees are extracted from the root down, so the leaf-up cycle-detection of tree.child_datasets

--- a/datacube/model/lineage.py
+++ b/datacube/model/lineage.py
@@ -50,8 +50,8 @@ class LineageTree:
 
     @classmethod
     def from_eo3_doc(cls, dsid: UUID,
-                     direction: LineageDirection = LineageDirection.SOURCES,
                      sources: Optional[Mapping[str, Sequence[UUID]]] = None,
+                     direction: LineageDirection = LineageDirection.SOURCES,
                      home=None) -> "LineageTree":
         if sources is None:
             children = None

--- a/datacube/model/lineage.py
+++ b/datacube/model/lineage.py
@@ -267,8 +267,7 @@ class LineageRelations:
         next_max_depth = max_depth - 1
         if nodes is None:
             nodes = {}
-            next_max_depth = max_depth
-        elif max_depth == 0:
+        if max_depth == 0:
             next_max_depth = 0
         elif max_depth == 1:
             recurse = False
@@ -294,10 +293,10 @@ class LineageRelations:
                 self._merge_new_relation(ids, classifier)
                 if recurse:
                     self.merge_tree(
-                        child,
-                        nodes=nodes,
-                        max_depth=next_max_depth
-                    )
+                    child,
+                    nodes=nodes,
+                    max_depth=next_max_depth
+                )
         return
 
     def relations_diff(self,
@@ -325,7 +324,7 @@ class LineageRelations:
         """
         if not existing_relations:
             return (
-                self.relations_idx, {},
+                self._relations_idx, {},
                 self._homes, {}
             )
         relations_to_add = {}

--- a/datacube/model/lineage.py
+++ b/datacube/model/lineage.py
@@ -21,6 +21,12 @@ class LineageDirection(Enum):
     SOURCES = 1
     DERIVED = 2
 
+    def opposite(self):
+        if self == self.SOURCES:
+            return self.DERIVED
+        else:
+            return self.SOURCES
+
 
 @dataclass
 class LineageTree:
@@ -68,9 +74,12 @@ class LineageTree:
 
     def child_datasets(self) -> Set[UUID]:
         child_dsids = set()
+        if self.children is None:
+            return child_dsids
         for classifier, children in self.children.items():
             for child in children:
                 subchildren = child.child_datasets()
+                subchildren.add(child.dataset_id)
                 if self.dataset_id in subchildren:
                     raise InconsistentLineageException("LineageTrees must be acyclic")
                 child_dsids.update(subchildren)
@@ -78,7 +87,9 @@ class LineageTree:
 
 
 class InconsistentLineageException(Exception):
-    pass
+    """
+    Raised when a method would result in an inconsistent/invalid LineageTree or LineageRelations collection.
+    """
 
 
 @dataclass
@@ -92,22 +103,64 @@ class LineageRelation:
 
 
 class LineageRelations:
+    """
+    An indexed collection of LineageRelations.
+
+    For converting between iterables of LineageRelations and LineageTrees.
+    Enforces all lineage chains are acyclic.
+    """
     def __init__(self,
                  tree: Optional[LineageTree] = None,
                  max_depth: int = 0,
-                 merge_with: Optional["LineageRelations"] = None) -> None:
+                 clone: Optional["LineageRelations"] = None) -> None:
+        """
+        All arguments are optional.  Default gives an empty LineageRelations, and:
+
+             rels = LineageRelations(tree, max_depth=max_depth, clone=clone)
+
+        is equivalent to:
+
+             rels = LineageRelations()
+             rels.merge(clone)
+             rels.merge_tree(tree, max_depth=max_depth)
+
+        :param tree: Initially merge a LineageTree
+        :param max_depth: The maximum depth to read the LineageTree.
+                          Default/0: no limit.  Not used if tree is None.
+
+        :param clone: Initially clone this other LineageRelations object
+        """
+        # Internal index of id/home relations
         self._homes: MutableMapping[UUID, str] = {}
+        # Tuple[UUID, UUID]'s are always (derived, source)
+        # Mapping  (derived, source): classifier - Allow search by source, derived pair.
         self._relations_idx: MutableMapping[Tuple[UUID, UUID], str] = {}
+        # Mapping  (derived, source): list of LineageTree objects merged so far - prevent infinite loops in merging
         self._trees_idx: MutableMapping[Tuple[UUID, UUID], Sequence[LineageTree]] = {}
+        # Sequence of the distinct LineageRelation objects this object represents.
         self.relations: Sequence[LineageRelation] = []
+        # Mapping source to mapping derived to classifier.  Allow search by source
         self.by_source: MutableMapping[UUID, Mapping[UUID, str]] = {}
+        # Mapping source to mapping derived to classifier.  Allow search by derived
         self.by_derived: MutableMapping[UUID] = {}
-        if merge_with is not None:
-            self.merge(merge_with)
+        # Dataset ids known to this object
+        self.dataset_ids: Set[UUID] = set()
+
+        # Merge initial arguments
+        if clone is not None:
+            self.merge(clone)
         if tree is not None:
             self.merge_tree(tree, max_depth=max_depth)
 
-    def _merge_new_home(self, id_: UUID, home: str) -> None:
+    def merge_new_home(self, id_: UUID, home: str) -> None:
+        """
+        Merge a new home relation
+
+        Raises InconsistentLineageException if we already have this id with a different home
+
+        :param id_: The dataet id
+        :param home: The home string
+        """
         if id_ in self._homes:
             if self._homes[id_] and self._homes[id_] != home:
                 raise InconsistentLineageException(f"Tree contains inconsistent homes for dataset {id_}")
@@ -115,9 +168,18 @@ class LineageRelations:
             self._homes[id_] = home
 
     def _merge_new_relation(self, ids: Tuple[UUID, UUID], classifier: str) -> None:
+        """
+        Internal convenience wrapper to merge_new_lineage_relation
+        """
         self.merge_new_lineage_relation(LineageRelation(classifier=classifier, source_id=ids[0], derived_id=ids[1]))
 
     def merge_new_lineage_relation(self, rel: LineageRelation) -> None:
+        """
+        Merge a new LineageRelation object
+
+        Raises InconsistentLineageException if we already have this relation with a different classifier, or
+        this relation would result in a cyclic relation.
+        """
         ids = (rel.source_id, rel.derived_id)
         if ids in self._relations_idx:
             if self._relations_idx[ids] != rel.classifier:
@@ -133,56 +195,98 @@ class LineageRelations:
                 self.by_derived[rel.derived_id] = {}
             self.by_source[rel.source_id][rel.derived_id] = rel.classifier
             self.by_derived[rel.derived_id][rel.source_id] = rel.classifier
+            # Check for cyclic dependencies:
+            new_ids = set([rel.source_id, rel.derived_id])
+            if new_ids & self.dataset_ids:
+                # We already know about these ids so need to confirm we are still acyclic
+                # Extract sourcewards from derived and vice versa for full tree coverage
+                self.extract_tree(rel.derived_id, direction=LineageDirection.SOURCES)
+                self.extract_tree(rel.source_id, direction=LineageDirection.DERIVED)
+            self.dataset_ids.update(new_ids)
 
-    def _merge_new_node(self, ids: Tuple[UUID, UUID], node):
-        if ids in self._trees_idx:
-            got_grandchildren = bool(node.children)
-            for prev_tree in self._trees_idx[ids]:
-                if prev_tree.children and got_grandchildren:
-                    raise InconsistentLineageException(
-                        f"Self-reference or duplicate subtrees detected: risk of infinite recursion."
-                    )
-            self._trees_idx[ids].append(node)
-        else:
-            self._trees_idx[ids] = [node]
+    def _merge_new_node(self, ids: Tuple[UUID, UUID], node: LineageTree):
+        """
+        Check for self-reference/infinite recursion.
+
+        If a dataset is repeated in a LineageTree e.g. because of "diamond" relation:
+
+            A -> B     B -> D
+            A -> C     C -> D
+
+        then only one can explicitly have grandchildren - the rest must be "placeholder" LineageTrees
+        with children=None.
+
+        :param ids:
+        :param node:
+        :return:
+        """
+        got_grandchildren = bool(node.children)
+        if got_grandchildren:
+            if ids in self._trees_idx:
+                raise InconsistentLineageException(
+                    f"Self-reference or duplicate subtrees detected: risk of infinite recursion."
+                )
+            else:
+                self._trees_idx[ids] = node
 
     def merge(self, pool: "LineageRelations") -> None:
+        """
+        Merge in another LineageRelations collection, ensuring it is consistent with this one.
+
+        :param pool: The other LineageRelations object
+        """
         for id_, home in pool._homes.items():
-            self._merge_new_home(id_, home)
+            self.merge_new_home(id_, home)
         for ids, classifier in pool._relations_idx.items():
             self._merge_new_relation(ids, classifier)
         for ids, node in pool._trees_idx.items():
             self._merge_new_node(ids, node)
 
     def merge_tree(self, tree: LineageTree,
-                                     parent_id: Optional[UUID] = None,
+                                     parent_node: Optional[LineageTree] = None,
                                      max_depth: int = 0) -> None:
-        # Check acyclic
+        """
+        Merge in a LineageTree, ensuring it is consistent with the collection so far.
+
+        Raises InconsistentLineageException if tree contains cyclic depenedencies or inconsistent direction
+
+        :param tree: The LineageTree to merge
+        :param parent_node: The parent node (used to mark recursive traversal - should be None on first call)
+        :param max_depth: The depth to traverse the tree to.  default/zero = unlimited
+        """
+        # Check new tree is acyclic within itself
         tree.child_datasets()
-        self._merge_new_home(tree.dataset_id, tree.home)
+        self.merge_new_home(tree.dataset_id, tree.home)
+        # Determine recursion behaviour
         recurse = True
         next_max_depth = max_depth - 1
-        if not parent_id:
+        if not parent_node:
             next_max_depth = max_depth
         elif max_depth == 0:
             next_max_depth = 0
         elif max_depth == 1:
             recurse = False
+        if not tree.children:
+            # tree.children is {} or None (i.e. leaf node of original input tree).
+            # Try to extract a reverse-direction tree to check for cyclic dependencies
+            self.extract_tree(tree.dataset_id, direction=tree.direction.opposite())
+        if tree.children is None:
+            return
+        # Perform recursion, as determined above
         for classifier, children in tree.children.items():
             for child in children:
                 if child.direction != tree.direction:
                     raise InconsistentLineageException("Tree contains both derived and source nodes")
-                if parent_id:
-                    if tree.direction == LineageDirection.SOURCES:
-                        ids = (parent_id, child.dataset_id)
-                    else:
-                        ids = (child.dataset_id, parent_id)
-                    self._merge_new_relation(ids, classifier)
-                    self._merge_new_node(ids, child)
+                if tree.direction == LineageDirection.SOURCES:
+                    ids = (tree.dataset_id, child.dataset_id)
+                else:
+                    ids = (child.dataset_id, tree.dataset_id)
+                self._merge_new_relation(ids, classifier)
+                self._merge_new_node(ids, child)
                 if recurse:
                     self.merge_tree(
                         child,
-                        parent_id = tree.dataset_id,
+                        parent_node=tree,
                         max_depth=next_max_depth
                     )
         return
@@ -196,6 +300,23 @@ class LineageRelations:
                       Mapping[UUID, str],
                       Mapping[UUID, str]
                       ]:
+        """
+        Compare to another LineageRelations object, returning records to be added to or updated in
+        the other LinearRelations collection to consistently merge this collection into it.
+
+        Intended to be used by index drivers when adding lineage data to an index.
+
+        Raises InconsistentLineageException if updates are required and allow_updates is False, or if
+        merging the two LineageRelations would result in cyclic depenedencies.
+
+        :param existing_relations: The relations currently in an index.
+        :param allow_updates: Whether updates to existing records are allowed.
+        :return: Tuple containing:
+            Relations that need to be added to existing_relations to merge with this collection.
+            Relations that need to be updated in existing_relations to merge with this collection.
+            Homes that need to be added to existing_relations to merge with this collection.
+            Homes that need to up updated in existing_relations to merge with this collection.
+        """
         if not existing_relations:
             return (
                 self.relations, {},
@@ -208,8 +329,9 @@ class LineageRelations:
 
         if not allow_updates:
             # Ensure no inconsistencies
-            merged = LineageRelations(merge_with=self)
+            merged = LineageRelations(clone=self)
             merged.merge(existing_relations)
+            # Determine homes and relations to add
             for id_, home in self._homes:
                 if id_ not in existing_relations._homes:
                     homes_to_add[id_] = home
@@ -217,11 +339,13 @@ class LineageRelations:
                 if ids not in existing_relations._relations_idx:
                     relations_to_add[ids] = classifier
         else:
+            # Determine homes to add and update
             for id_, home in self._homes:
                 if id_ not in existing_relations._homes:
                     homes_to_add[id_] = home
                 elif home != existing_relations._homes[id_]:
                     homes_to_update[id_] = home
+            # Determine relations to add and update
             for ids, classifier in self._relations_idx:
                 if ids not in existing_relations._relations_idx:
                     relations_to_add[ids] = classifier
@@ -234,14 +358,33 @@ class LineageRelations:
 
     def extract_tree(self,
                      root: UUID,
-                     direction: LineageDirection = LineageDirection.SOURCES) -> LineageTree:
+                     direction: LineageDirection = LineageDirection.SOURCES,
+                     so_far: Optional[Set[UUID]] = None
+                     ) -> LineageTree:
+        """
+        Extract a LineageTree from this LineageRelations collection.
+
+        Used to detect cyclic dependencies.
+
+        :param root: The dataset id at the root of the extracted LineageTree
+        :param direction: The direction of the extracted tree
+        :param so_far: Used to detect cyclic dependencies in recursive mode - should be None on initial call.
+        :return: the extracted LineageTree.
+        """
+        # Trees are extracted from the root down, so the leaf-up cycle-detection of tree.child_datasets
+        # is insufficient here
+        if so_far is None:
+            so_far = set()
+        if root in so_far:
+            raise InconsistentLineageException(f"LineageTrees must be acyclic: {root}")
+        so_far.add(root)
         children = {}
         if direction == LineageDirection.SOURCES:
             subtrees = self.by_source.get(root, {})
         else:
             subtrees = self.by_derived.get(root, {})
         for dsid, classifier in subtrees.items():
-            subtree = self.extract_tree(dsid, direction)
+            subtree = self.extract_tree(dsid, direction, set(so_far))
             if classifier in children:
                 children[classifier].append(subtree)
             else:
@@ -250,7 +393,6 @@ class LineageRelations:
             dataset_id=root,
             direction=direction,
             children=children,
-            home=self._homes[root]
+            home=self._homes.get(root)
         )
-        # Check acyclic
-        tree.child_datasets()
+        return tree

--- a/datacube/model/lineage.py
+++ b/datacube/model/lineage.py
@@ -261,7 +261,8 @@ class LineageRelations:
         """
         # Check new tree is acyclic within itself
         tree.child_datasets()
-        self.merge_new_home(tree.dataset_id, tree.home)
+        if tree.home is not None:
+            self.merge_new_home(tree.dataset_id, tree.home)
         # Determine recursion behaviour
         recurse = True
         next_max_depth = max_depth - 1

--- a/datacube/model/lineage.py
+++ b/datacube/model/lineage.py
@@ -293,10 +293,10 @@ class LineageRelations:
                 self._merge_new_relation(ids, classifier)
                 if recurse:
                     self.merge_tree(
-                    child,
-                    nodes=nodes,
-                    max_depth=next_max_depth
-                )
+                        child,
+                        nodes=nodes,
+                        max_depth=next_max_depth
+                    )
         return
 
     def relations_diff(self,

--- a/datacube/model/lineage.py
+++ b/datacube/model/lineage.py
@@ -7,9 +7,6 @@ from enum import Enum
 from uuid import UUID
 from typing import Mapping, Optional, Sequence, MutableMapping, Set, Tuple
 
-from datacube.utils import cached_property
-
-
 
 class LineageDirection(Enum):
     """
@@ -52,20 +49,20 @@ class LineageTree:
     home: Optional[str] = None
 
     @classmethod
-    def from_eo3_doc(cls, dsid:UUID,
-              direction: LineageDirection = LineageDirection.SOURCES,
-              sources: Optional[Mapping[str, Sequence[UUID]]] = None,
-              home=None) -> "LineageTree":
+    def from_eo3_doc(cls, dsid: UUID,
+                     direction: LineageDirection = LineageDirection.SOURCES,
+                     sources: Optional[Mapping[str, Sequence[UUID]]] = None,
+                     home=None) -> "LineageTree":
         if sources is None:
-            children=None
+            children = None
         else:
-            children={
-                         classifier: [
-                             cls(direction=direction, dataset_id=der, home=home)
-                             for der in ders
-                         ]
-                         for classifier, ders in sources.items()
-                     }
+            children = {
+                classifier: [
+                 cls(direction=direction, dataset_id=der, home=home)
+                 for der in ders
+                ]
+                for classifier, ders in sources.items()
+            }
         return cls(
             direction=direction,
             dataset_id=dsid,
@@ -224,7 +221,7 @@ class LineageRelations:
         if got_grandchildren:
             if ids in self._trees_idx:
                 raise InconsistentLineageException(
-                    f"Self-reference or duplicate subtrees detected: risk of infinite recursion."
+                    "Self-reference or duplicate subtrees detected: risk of infinite recursion."
                 )
             else:
                 self._trees_idx[ids] = node
@@ -243,8 +240,8 @@ class LineageRelations:
             self._merge_new_node(ids, node)
 
     def merge_tree(self, tree: LineageTree,
-                                     parent_node: Optional[LineageTree] = None,
-                                     max_depth: int = 0) -> None:
+                   parent_node: Optional[LineageTree] = None,
+                   max_depth: int = 0) -> None:
         """
         Merge in a LineageTree, ensuring it is consistent with the collection so far.
 
@@ -294,12 +291,10 @@ class LineageRelations:
     def relations_diff(self,
                   existing_relations: Optional["LineageRelations"] = None,
                   allow_updates: bool = False
-                 ) -> Tuple[
-                      Mapping[Tuple[UUID, UUID], str],
-                      Mapping[Tuple[UUID, UUID], str],
-                      Mapping[UUID, str],
-                      Mapping[UUID, str]
-                      ]:
+                 ) -> Tuple[Mapping[Tuple[UUID, UUID], str],
+                            Mapping[Tuple[UUID, UUID], str],
+                            Mapping[UUID, str],
+                            Mapping[UUID, str]]:
         """
         Compare to another LineageRelations object, returning records to be added to or updated in
         the other LinearRelations collection to consistently merge this collection into it.

--- a/datacube/model/lineage.py
+++ b/datacube/model/lineage.py
@@ -5,7 +5,10 @@
 from dataclasses import dataclass
 from enum import Enum
 from uuid import UUID
-from typing import Mapping, Optional, Sequence
+from typing import Mapping, Optional, Sequence, MutableMapping, Set, Tuple
+
+from datacube.utils import cached_property
+
 
 
 class LineageDirection(Enum):
@@ -54,4 +57,168 @@ class LineageTree:
                 ]
                 for classifier, srcs in sources.items()
             },
+        )
+
+    @classmethod
+    def deriveds(cls, dsid: UUID, sources: Mapping[str, Sequence[UUID]], home=None) -> "LineageTree":
+        return cls(
+            direction=LineageDirection.DERIVED,
+            dataset_id=dsid,
+            children={
+                classifier: [
+                    cls(direction=LineageDirection.DERIVED, dataset_id=der, home=home)
+                    for der in ders
+                ]
+                for classifier, ders in sources.items()
+            },
+        )
+
+
+class InconsistentLineageException(Exception):
+    pass
+
+
+@dataclass
+class LineageRelation:
+    """
+    LineageRelation
+    """
+    classifier: str
+    source_id: UUID
+    derived_id: UUID
+
+
+class LineageRelations:
+    def __init__(self,
+                 tree: Optional[LineageTree] = None,
+                 max_depth: int = 0,
+                 merge_with: Optional["LineageRelations"] = None) -> None:
+        self._homes: MutableMapping[UUID, str] = {}
+        self._relations_idx: MutableMapping[Tuple[UUID, UUID], str] = {}
+        self._trees_idx: MutableMapping[Tuple[UUID, UUID], Sequence[LineageTree]] = {}
+        self.relations: Sequence[LineageRelation] = []
+        self.source_ids: Set[UUID] = set()
+        self.derived_ids: Set[UUID] = set()
+        if merge_with is not None:
+            self.merge(merge_with)
+        if tree is not None:
+            self.merge_tree(tree, max_depth=max_depth)
+
+    def _merge_new_home(self, id_: UUID, home: str) -> None:
+        if id_ in self._homes:
+            if self._homes[id_] and self._homes[id_] != home:
+                raise InconsistentLineageException(f"Tree contains inconsistent homes for dataset {id_}")
+        else:
+            self._homes[id_] = home
+
+    def _merge_new_relation(self, ids: Tuple[UUID, UUID], classifier: str) -> None:
+        self._merge_new_lineage_relation(LineageRelation(classifier=classifier, source_id=ids[0], derived_id=ids[1]))
+
+    def merge_new_lineage_relation(self, rel: LineageRelation) -> None:
+        ids = (rel.source_id, rel.derived_id)
+        if ids in self._relations_idx:
+            if self._relations_idx[ids] != rel.classifier:
+                raise InconsistentLineageException(
+                    f"Dataset {ids[0]} depends on {ids[1]} with inconsistent classifiers."
+                )
+        else:
+            self._relations_idx[ids] = rel.classifier
+            self.relations.append(rel)
+            self.source_ids.add(rel.source_id)
+            self.derived_ids.add(rel.derived_id)
+
+    def _merge_new_node(self, ids: Tuple[UUID, UUID], node):
+        if ids in self._trees_idx:
+            got_grandchildren = bool(node.children)
+            for prev_tree in self._trees_idx[ids]:
+                if prev_tree.children and got_grandchildren:
+                    raise InconsistentLineageException(
+                        f"Self-reference or duplicate subtrees detected: risk of infinite recursion."
+                    )
+            self._trees_idx[ids].append(node)
+        else:
+            self._trees_idx[ids] = [node]
+
+    def merge(self, pool: "LineageRelations") -> None:
+        for id_, home in pool._homes.items():
+            self._merge_new_home(id_, home)
+        for ids, classifier in pool._relations_idx.items():
+            self._merge_new_relation(ids, classifier)
+        for ids, node in pool._trees_idx.items():
+            self._merge_new_node(ids, node)
+
+    def merge_tree(self, tree: LineageTree,
+                                     parent_id: Optional[UUID] = None,
+                                     max_depth: int = 0) -> None:
+        self._merge_new_home(tree.dataset_id.home)
+        recurse = True
+        next_max_depth = max_depth - 1
+        if not parent_id:
+            next_max_depth = max_depth
+        elif max_depth == 0:
+            next_max_depth = 0
+        elif max_depth == 1:
+            recurse = False
+        for classifier, children in tree.children.items():
+            for child in children:
+                if child.direction != tree.direction:
+                    raise InconsistentLineageException("Tree contains both derived and source nodes")
+                if parent_id:
+                    if tree.direction == LineageDirection.SOURCES:
+                        ids = [parent_id, child.dataset_id]
+                    else:
+                        ids = [child.dataset_id, parent_id]
+                    self._merge_new_relation(ids, classifier)
+                    self._merge_new_node(ids, child)
+                if recurse:
+                    self.merge_tree(
+                        child,
+                        parent_id = tree.dataset_id,
+                        max_depth=next_max_depth
+                    )
+        return
+
+    def relations_diff(self,
+                  existing_relations: Optional["LineageRelations"] = None,
+                  allow_updates: bool = False
+                 ) -> Tuple[
+                      Mapping[Tuple[UUID, UUID], str],
+                      Mapping[Tuple[UUID, UUID], str],
+                      Mapping[UUID, str],
+                      Mapping[UUID, str]
+                      ]:
+        if not existing_relations:
+            return (
+                self.relations, {},
+                self._homes, {}
+            )
+        relations_to_add = []
+        relations_to_update = []
+        homes_to_add = {}
+        homes_to_update = {}
+
+        if not allow_updates:
+            # Ensure no inconsistencies
+            merged = LineageRelations(merge_with=self)
+            merged.merge(existing_relations)
+            for id_, home in self._homes:
+                if id_ not in existing_relations._homes:
+                    homes_to_add[id_] = home
+            for ids, classifier in self._relations_idx:
+                if ids not in existing_relations._relations_idx:
+                    relations_to_add[ids] = classifier
+        else:
+            for id_, home in self._homes:
+                if id_ not in existing_relations._homes:
+                    homes_to_add[id_] = home
+                elif home != existing_relations._homes[id_]:
+                    homes_to_update[id_] = home
+            for ids, classifier in self._relations_idx:
+                if ids not in existing_relations._relations_idx:
+                    relations_to_add[ids] = classifier
+                elif classifier != existing_relations._relations_idx[ids]:
+                    relations_to_update[ids] = classifier
+        return (
+            relations_to_add, relations_to_update,
+            homes_to_add, homes_to_update
         )

--- a/datacube/model/lineage.py
+++ b/datacube/model/lineage.py
@@ -5,7 +5,7 @@
 from dataclasses import dataclass
 from enum import Enum
 from uuid import UUID
-from typing import Mapping, Optional, Sequence, MutableMapping, Set, Tuple, Iterable, Union, Any
+from typing import Mapping, Optional, Sequence, MutableMapping, Set, Tuple, Iterable, Any
 
 
 class LineageDirection(Enum):
@@ -107,10 +107,10 @@ class LineageTree:
 
     @classmethod
     def from_data(cls, dsid: UUID,
-                     sources: Optional[Mapping[str, Sequence[UUID]]] = None,
-                     direction: LineageDirection = LineageDirection.SOURCES,
-                     home=None,
-                     home_derived=None) -> "LineageTree":
+                  sources: Optional[Mapping[str, Sequence[UUID]]] = None,
+                  direction: LineageDirection = LineageDirection.SOURCES,
+                  home=None,
+                  home_derived=None) -> "LineageTree":
         """
         Generate a shallow (depth=1) LineageTree from the sort of data found in an EO3 dataset
 

--- a/datacube/model/lineage.py
+++ b/datacube/model/lineage.py
@@ -5,7 +5,7 @@
 from dataclasses import dataclass
 from enum import Enum
 from uuid import UUID
-from typing import Mapping, Optional, Sequence, MutableMapping, Set, Tuple, Iterable
+from typing import Mapping, Optional, Sequence, MutableMapping, Set, Tuple, Iterable, Union, Any
 
 
 class LineageDirection(Enum):
@@ -86,10 +86,41 @@ class LineageTree:
         return None
 
     @classmethod
-    def from_eo3_doc(cls, dsid: UUID,
+    def from_eo3_doc(cls, doc: Mapping[str, Any],
+                     home=None,
+                     home_derived=None) -> "LineageTree":
+        """
+        Generate a shallow (depth=1) LineageTree from an EO3 dataset document
+
+        :param dsid: The (derived) dataset id
+        :param sources: A dictionary of classifiers to list of source IDs
+        :param direction: Tree direction (default SOURCEwards, as per an EO3 dataset)
+        :param home: Home database for source datasets (defaults to None).
+        :param home_derived: Home database for the derived dataset (defaults to None).
+        :return: A depth==1 LineageTree
+
+        :param doc_in:
+        :return:
+        """
+        lineage = doc.get("lineage", {})
+        return cls.from_data(doc["id"], lineage, home=home, home_derived=home_derived)
+
+    @classmethod
+    def from_data(cls, dsid: UUID,
                      sources: Optional[Mapping[str, Sequence[UUID]]] = None,
                      direction: LineageDirection = LineageDirection.SOURCES,
-                     home=None) -> "LineageTree":
+                     home=None,
+                     home_derived=None) -> "LineageTree":
+        """
+        Generate a shallow (depth=1) LineageTree from the sort of data found in an EO3 dataset
+
+        :param dsid: The (derived) dataset id
+        :param sources: A dictionary of classifiers to list of source IDs
+        :param direction: Tree direction (default SOURCEwards, as per an EO3 dataset)
+        :param home: Home database for source datasets (defaults to None).
+        :param home_derived: Home database for the derived dataset (defaults to None).
+        :return: A depth==1 LineageTree
+        """
         if sources is None:
             children = None
         else:
@@ -104,6 +135,7 @@ class LineageTree:
             direction=direction,
             dataset_id=dsid,
             children=children,
+            home=home_derived
         )
 
     def child_datasets(self) -> Set[UUID]:

--- a/datacube/model/lineage.py
+++ b/datacube/model/lineage.py
@@ -5,7 +5,7 @@
 from dataclasses import dataclass
 from enum import Enum
 from uuid import UUID
-from typing import Mapping, Optional, Sequence, MutableMapping, Set, Tuple
+from typing import Mapping, Optional, Sequence, MutableMapping, Set, Tuple, Iterable
 
 
 class LineageDirection(Enum):
@@ -146,17 +146,21 @@ class LineageRelations:
     def __init__(self,
                  tree: Optional[LineageTree] = None,
                  max_depth: int = 0,
+                 relations: Optional[Iterable[LineageRelation]] = None,
+                 homes: Optional[Mapping[UUID, str]] = None,
                  clone: Optional["LineageRelations"] = None) -> None:
         """
         All arguments are optional.  Default gives an empty LineageRelations, and:
 
-             rels = LineageRelations(tree, max_depth=max_depth, clone=clone)
+             rels = LineageRelations(tree, max_depth=max_depth, relations=lrels, clone=clone)
 
         is equivalent to:
 
              rels = LineageRelations()
-             rels.merge(clone)
              rels.merge_tree(tree, max_depth=max_depth)
+             rels.merge(clone)
+             for rel in lrels:
+                rels.merge_new_lineage_relation(rel)
 
         :param tree: Initially merge a LineageTree
         :param max_depth: The maximum depth to read the LineageTree.
@@ -183,6 +187,12 @@ class LineageRelations:
             self.merge(clone)
         if tree is not None:
             self.merge_tree(tree, max_depth=max_depth)
+        if relations is not None:
+            for rel in relations:
+                self.merge_new_lineage_relation(rel)
+        if homes is not None:
+            for id_, home in homes.items():
+                self.merge_new_home(id_, home)
 
     def merge_new_home(self, id_: UUID, home: str) -> None:
         """

--- a/datacube/model/lineage.py
+++ b/datacube/model/lineage.py
@@ -213,7 +213,7 @@ class LineageRelations:
         """
         Internal convenience wrapper to merge_new_lineage_relation
         """
-        self.merge_new_lineage_relation(LineageRelation(classifier=classifier, source_id=ids[0], derived_id=ids[1]))
+        self.merge_new_lineage_relation(LineageRelation(classifier=classifier, derived_id=ids[0], source_id=ids[1]))
 
     def merge_new_lineage_relation(self, rel: LineageRelation) -> None:
         """
@@ -222,7 +222,7 @@ class LineageRelations:
         Raises InconsistentLineageException if we already have this relation with a different classifier, or
         this relation would result in a cyclic relation.
         """
-        ids = (rel.source_id, rel.derived_id)
+        ids = (rel.derived_id, rel.source_id)
         if ids in self._relations_idx:
             if self._relations_idx[ids] != rel.classifier:
                 raise InconsistentLineageException(
@@ -407,9 +407,9 @@ class LineageRelations:
 
         children = {}
         if direction == LineageDirection.SOURCES:
-            subtrees = self.by_source.get(root, {})
-        else:
             subtrees = self.by_derived.get(root, {})
+        else:
+            subtrees = self.by_source.get(root, {})
         for dsid, classifier in subtrees.items():
             subtree = self.extract_tree(dsid, direction, set(parents), so_far)
             if classifier in children:

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -840,20 +840,24 @@ def src_lineage_tree(src_tree_ids):
                         "l1": [
                             LineageTree(
                                 dataset_id=ids["l1_1"], direction=direction,
+                                home="level1",
                                 children={}
                             ),
                             LineageTree(
                                 dataset_id=ids["l1_2"], direction=direction,
+                                home="level1",
                                 children={}
                             ),
                             LineageTree(
                                 dataset_id=ids["l1_3"], direction=direction,
+                                home="level1",
                                 children={}
                             ),
                         ],
                         "atmos_corr": [
                             LineageTree(
                                 dataset_id=ids["atmos"], direction=direction,
+                                home="anciliary",
                                 children=None
                             )
                         ],
@@ -865,24 +869,29 @@ def src_lineage_tree(src_tree_ids):
                         "l1": [
                             LineageTree(
                                 dataset_id=ids["l1_4"], direction=direction,
+                                home="level1",
                                 children={}
                             ),
                             LineageTree(
                                 dataset_id=ids["l1_5"], direction=direction,
+                                home="level1",
                                 children={}
                             ),
                             LineageTree(
                                 dataset_id=ids["l1_6"], direction=direction,
+                                home="level1",
                                 children={}
                             ),
                         ],
                         "atmos_corr": [
                             LineageTree(
                                 dataset_id=ids["atmos"], direction=direction,
+                                home="anciliary",
                                 children={
                                     "preatmos": [
                                         LineageTree(
                                             dataset_id=ids["atmos_parent"], direction=direction,
+                                            home="anciliary",
                                             children={}
                                         )
                                     ]

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -902,4 +902,95 @@ def src_lineage_tree(src_tree_ids):
                 ),
             ]
         }
+    ), ids
+
+
+@pytest.fixture
+def compatible_derived_tree(src_tree_ids):
+    ids = src_tree_ids.copy()
+    ids.update({
+        "atmos_grandparent": uuid4(),
+        "ard3": uuid4(),
+        "ard4": uuid4(),
+        "leaf_1": uuid4(),
+        "leaf_2": uuid4(),
+        "leaf_3": uuid4()
+    })
+    tree = LineageTree(
+        dataset_id=ids["atmos_grandparent"],
+        direction=LineageDirection.DERIVED,
+        home="steves_basement",
+        children={
+            "spam": [
+                LineageTree(
+                    dataset_id=ids["atmos_parent"],
+                    direction=LineageDirection.DERIVED,
+                    home="anciliary",
+                    children={
+                        "preatmos": [
+                            LineageTree(
+                                dataset_id=ids["atmos"],
+                                direction=LineageDirection.DERIVED,
+                                home="anciliary",
+                                children={
+                                    "atmos_corr": [
+                                        LineageTree(
+                                            dataset_id=ids["ard1"],
+                                            direction=LineageDirection.DERIVED,
+                                            home="ard",
+                                            children={
+                                                "ard": [
+                                                    LineageTree(
+                                                        dataset_id=ids["root"],
+                                                        direction=LineageDirection.DERIVED,
+                                                        home="extensions", children={}
+                                                    ),
+                                                    LineageTree(
+                                                        dataset_id=ids["leaf_1"],
+                                                        direction=LineageDirection.DERIVED,
+                                                        home="extensions", children={}
+                                                    ),
+                                                ]
+                                            }
+                                        ),
+                                        LineageTree(
+                                            dataset_id=ids["ard2"],
+                                            direction=LineageDirection.DERIVED,
+                                            home="ard",
+                                            children={}
+                                        ),
+                                        LineageTree(
+                                            dataset_id=ids["ard3"],
+                                            direction=LineageDirection.DERIVED,
+                                            home="ard",
+                                            children={
+                                                "ard": [
+                                                    LineageTree(
+                                                        dataset_id=ids["leaf_2"],
+                                                        direction=LineageDirection.DERIVED,
+                                                        home="extensions", children={}
+                                                    ),
+                                                    LineageTree(
+                                                        dataset_id=ids["leaf_3"],
+                                                        direction=LineageDirection.DERIVED,
+                                                        home="extensions", children={}
+                                                    ),
+                                                ]
+                                            }
+                                        ),
+                                        LineageTree(
+                                            dataset_id=ids["ard4"],
+                                            direction=LineageDirection.DERIVED,
+                                            home="ard",
+                                            children={}
+                                        ),
+                                    ]
+                                }
+                            )
+                        ]
+                    }
+                )
+            ]
+        }
     )
+    return tree, ids

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -32,6 +32,7 @@ from integration_tests.utils import _make_geotiffs, _make_ls5_scene_datasets, lo
 from datacube.config import LocalConfig
 from datacube.drivers.postgres import PostgresDb
 from datacube.drivers.postgis import PostGisDb
+from datacube.model import LineageTree, LineageDirection
 
 _SINGLE_RUN_CONFIG_TEMPLATE = """
 
@@ -803,3 +804,93 @@ def dataset_add_configs():
                            datasets_eo3_updated=str(B / 'datasets_eo3_updated.yml'),
                            datasets=str(B / 'datasets.yml'),
                            empty_file=str(B / 'empty_file.yml'))
+
+
+@pytest.fixture
+def src_tree_ids():
+    return {
+        "root": uuid4(),
+        "ard1": uuid4(),
+        "ard2": uuid4(),
+
+        "l1_1": uuid4(),
+        "l1_2": uuid4(),
+        "l1_3": uuid4(),
+
+        "l1_4": uuid4(),
+        "l1_5": uuid4(),
+        "l1_6": uuid4(),
+
+        "atmos": uuid4(),
+        "atmos_parent": uuid4()
+    }
+
+
+@pytest.fixture
+def src_lineage_tree(src_tree_ids):
+    ids = src_tree_ids
+    direction = LineageDirection.SOURCES
+    return LineageTree(
+        dataset_id=ids["root"], direction=direction,
+        children={
+            "ard": [
+                LineageTree(
+                    dataset_id=ids["ard1"], direction=direction,
+                    children={
+                        "l1": [
+                            LineageTree(
+                                dataset_id=ids["l1_1"], direction=direction,
+                                children={}
+                            ),
+                            LineageTree(
+                                dataset_id=ids["l1_2"], direction=direction,
+                                children={}
+                            ),
+                            LineageTree(
+                                dataset_id=ids["l1_3"], direction=direction,
+                                children={}
+                            ),
+                        ],
+                        "atmos_corr": [
+                            LineageTree(
+                                dataset_id=ids["atmos"], direction=direction,
+                                children=None
+                            )
+                        ],
+                    }
+                ),
+                LineageTree(
+                    dataset_id=ids["ard2"], direction=direction,
+                    children={
+                        "l1": [
+                            LineageTree(
+                                dataset_id=ids["l1_4"], direction=direction,
+                                children={}
+                            ),
+                            LineageTree(
+                                dataset_id=ids["l1_5"], direction=direction,
+                                children={}
+                            ),
+                            LineageTree(
+                                dataset_id=ids["l1_6"], direction=direction,
+                                children={}
+                            ),
+                        ],
+                        "atmos_corr": [
+                            LineageTree(
+                                dataset_id=ids["atmos"], direction=direction,
+                                children={
+                                    "preatmos": [
+                                        LineageTree(
+                                            dataset_id=ids["atmos_parent"], direction=direction,
+                                            children={}
+                                        )
+                                    ]
+                                }
+                            )
+                        ],
+                    }
+                ),
+            ]
+        }
+    )

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -331,7 +331,7 @@ def test_get_missing_things(index: Index) -> None:
     missing_thing = index.datasets.get(uuid_, include_sources=False)
     assert missing_thing is None, "get() should return none when it doesn't exist"
 
-    if index.supports_lineage:
+    if index.supports_lineage and not index.supports_external_lineage:
         missing_thing = index.datasets.get(uuid_, include_sources=True)
         assert missing_thing is None, "get() should return none when it doesn't exist"
 

--- a/integration_tests/index/test_postgis_index.py
+++ b/integration_tests/index/test_postgis_index.py
@@ -5,7 +5,7 @@
 import pytest
 from uuid import uuid4 as random_uuid
 
-from datacube.model import Range
+from datacube.model import LineageDirection, Range
 from datacube.index import Index
 from datacube.utils.geometry import CRS
 
@@ -218,3 +218,18 @@ def test_lineage_home_api(index):
     # Test clear_home with actual work done.
     assert index.lineage.clear_home(*a_uuids) == 10
     assert index.lineage.clear_home(*b_uuids) == 10
+
+
+@pytest.mark.parametrize('datacube_env_name', ('experimental',))
+def test_lineage_tree_index_api(index, src_lineage_tree, src_tree_ids):
+    src_tree = index.lineage.get_source_tree(src_tree_ids["root"])
+    assert src_tree.dataset_id == src_tree_ids["root"]
+    assert src_tree.direction == LineageDirection.SOURCES
+    assert src_tree.children == {}
+    index.lineage.add(src_lineage_tree, max_depth=1)
+    src_tree = index.lineage.get_source_tree(src_tree_ids["root"])
+    assert src_tree.dataset_id == src_tree_ids["root"]
+    assert src_tree.direction == LineageDirection.SOURCES
+    for ard_subtree in src_tree.children["ard"]:
+        assert ard_subtree.dataset_id in (src_tree_ids["ard1"], src_tree_ids["ard2"])
+        assert not ard_subtree.children

--- a/integration_tests/index/test_postgis_index.py
+++ b/integration_tests/index/test_postgis_index.py
@@ -222,8 +222,6 @@ def test_lineage_home_api(index):
 
 @pytest.mark.parametrize('datacube_env_name', ('experimental',))
 def test_lineage_tree_index_api(index, src_lineage_tree, src_tree_ids):
-    import pydevd_pycharm
-    pydevd_pycharm.settrace('localhost', port=54321, stdoutToServer=True, stderrToServer=True)
     src_tree = index.lineage.get_source_tree(src_tree_ids["root"])
     assert src_tree.dataset_id == src_tree_ids["root"]
     assert src_tree.direction == LineageDirection.SOURCES

--- a/integration_tests/index/test_postgis_index.py
+++ b/integration_tests/index/test_postgis_index.py
@@ -199,13 +199,19 @@ def test_lineage_home_api(index):
     a_uuids = [random_uuid() for i in range(10)]
     b_uuids = [random_uuid() for i in range(10)]
     all_uuids = a_uuids + b_uuids
+    assert index.lineage.get_homes(*a_uuids) == {}
     # Test delete of non-existent entries
     assert index.lineage.clear_home(*a_uuids) == 0
     # Test insert a uuids
     assert index.lineage.set_home("spam", *a_uuids) == 10
+    for home in index.lineage.get_homes(*a_uuids).values():
+        assert home == "spam"
     # Test update with and without allow_update
     index.lineage.set_home("eggs", *a_uuids) == 0
     index.lineage.set_home("eggs", *a_uuids, allow_updates=True) == 10
+    for home in index.lineage.get_homes(*a_uuids).values():
+        assert home == "eggs"
+    assert index.lineage.get_homes(*b_uuids) == {}
     index.lineage.set_home("eggs", *a_uuids, allow_updates=True) == 0
     index.lineage.set_home("eggs", *b_uuids, allow_updates=True) == 10
 

--- a/integration_tests/index/test_postgis_index.py
+++ b/integration_tests/index/test_postgis_index.py
@@ -253,3 +253,5 @@ def test_lineage_tree_index_api(index, src_lineage_tree, src_tree_ids):
             assert "preatmos" in ard_subtree.children["atmos_corr"][0].children
             seen = True
     assert seen
+    der_tree = index.lineage.get_derived_tree(src_tree_ids["atmos_parent"])
+    assert der_tree.find_subtree(src_tree_ids["root"]).dataset_id == src_tree_ids["root"]

--- a/integration_tests/index/test_postgis_index.py
+++ b/integration_tests/index/test_postgis_index.py
@@ -257,6 +257,19 @@ def test_lineage_tree_index_api_simple(index, src_lineage_tree):
     # And test reversing the tree
     der_tree = index.lineage.get_derived_tree(ids["atmos_parent"])
     assert der_tree.find_subtree(ids["root"]).dataset_id == ids["root"]
+    # Test Lineage removal - sourcewards
+    index.lineage.remove(ids["root"], LineageDirection.SOURCES, max_depth=2)
+    src_tree = index.lineage.get_source_tree(ids["root"])
+    assert not src_tree.children
+    src_tree = index.lineage.get_source_tree(ids["atmos"])
+    assert src_tree.children
+    # Test Lineage removal - derivedwards
+    index.lineage.add(tree, max_depth=0)
+    index.lineage.remove(ids["atmos_parent"], LineageDirection.DERIVED, max_depth=2)
+    src_tree = index.lineage.get_source_tree(ids["root"])
+    assert src_tree.children
+    src_tree = index.lineage.get_source_tree(ids["atmos"])
+    assert not src_tree.children
 
 
 @pytest.mark.parametrize('datacube_env_name', ('experimental',))

--- a/integration_tests/test_dataset_add.py
+++ b/integration_tests/test_dataset_add.py
@@ -196,20 +196,21 @@ def check_bad_yaml(clirunner, index):
     assert 'ERROR Failed reading documents from ' in r.output
 
 
-# Current formulation of this test relies on non-EO3 test data
-@pytest.mark.parametrize('datacube_env_name', ('datacube', ))
-def test_dataset_add_no_id(dataset_add_configs, index_empty, clirunner):
-    p = dataset_add_configs
-    index = index_empty
-    ds_no_id = load_dataset_definition(p.datasets_no_id)
-
-    clirunner(['metadata', 'add', p.metadata])
-    clirunner(['product', 'add', p.products])
+def test_dataset_add_no_id(index, eo3_ls8_dataset3_doc, ls8_eo3_product):
+    doc, uri = eo3_ls8_dataset3_doc
+    del doc["id"]
 
     # Check .hl.Doc2Dataset
     doc2ds = Doc2Dataset(index)
-    _ds, _err = doc2ds(ds_no_id, 'file:///something')
+    _ds, _err = doc2ds(doc, uri)
     assert _err == 'No id defined in dataset doc'
+
+
+def test_dataset_add_not_eo3(index, ls8_eo3_product, eo3_wo_dataset_doc):
+    from datacube.model.utils import BadMatch
+    doc2ds = Doc2Dataset(index)
+    _ds, _err = doc2ds(*eo3_wo_dataset_doc)
+    assert isinstance(_err, BadMatch)
 
 
 # Current formulation of this test relies on non-EO3 test data

--- a/tests/index/test_hl_index.py
+++ b/tests/index/test_hl_index.py
@@ -15,12 +15,14 @@ def test_support_validation(non_geo_dataset_doc, eo_dataset_doc):
 
     idx.supports_legacy = True
     idx.supports_nongeo = False
+    idx.supports_external_lineage = False
     resolver = Doc2Dataset(idx, products=["product_a"], eo3=False)
     _, err = resolver(non_geo_dataset_doc, "//location/")
     assert "Non-geospatial metadata formats" in err
 
     idx.supports_legacy = False
     idx.supports_nongeo = True
+    idx.supports_external_lineage = False
     resolver = Doc2Dataset(idx, products=["product_a"], eo3=False)
     _, err = resolver(eo_dataset_doc, "//location/")
     assert "Legacy metadata formats" in err

--- a/tests/index/test_hl_index.py
+++ b/tests/index/test_hl_index.py
@@ -17,15 +17,8 @@ def test_support_validation(non_geo_dataset_doc, eo_dataset_doc):
         resolver = Doc2Dataset(idx, fail_on_missing_lineage=True)
 
     idx.supports_lineage = True
-    idx.supports_external_lineage = False
-    with pytest.raises(ValueError, match="source_tree is not supported for this index driver"):
-        resolver = Doc2Dataset(idx, source_tree=MagicMock())
-
     idx.supports_external_lineage = True
-    with pytest.raises(ValueError, match="Cannot provide both an explicit source_tree and a home_index"):
-        resolver = Doc2Dataset(idx, home_index="right_here", source_tree=MagicMock())
-
-    with pytest.raises(ValueError, match="Cannot provide an explicit source_tree or home_index when skip_lineage"):
+    with pytest.raises(ValueError, match="Cannot provide a default home_index when skip_lineage"):
         resolver = Doc2Dataset(idx, home_index="right_here", skip_lineage=True)
 
     idx.supports_legacy = True

--- a/tests/index/test_hl_index.py
+++ b/tests/index/test_hl_index.py
@@ -13,6 +13,21 @@ def test_support_validation(non_geo_dataset_doc, eo_dataset_doc):
     with pytest.raises(ValueError, match="EO3 cannot be set to False"):
         resolver = Doc2Dataset(idx, eo3=False)
 
+    with pytest.raises(ValueError, match="fail_on_missing_lineage is not supported for this index driver"):
+        resolver = Doc2Dataset(idx, fail_on_missing_lineage=True)
+
+    idx.supports_lineage = True
+    idx.supports_external_lineage = False
+    with pytest.raises(ValueError, match="source_tree is not supported for this index driver"):
+        resolver = Doc2Dataset(idx, source_tree=MagicMock())
+
+    idx.supports_external_lineage = True
+    with pytest.raises(ValueError, match="Cannot provide both an explicit source_tree and a home_index"):
+        resolver = Doc2Dataset(idx, home_index="right_here", source_tree=MagicMock())
+
+    with pytest.raises(ValueError, match="Cannot provide an explicit source_tree or home_index when skip_lineage"):
+        resolver = Doc2Dataset(idx, home_index="right_here", skip_lineage=True)
+
     idx.supports_legacy = True
     idx.supports_nongeo = False
     idx.supports_external_lineage = False

--- a/tests/test_ext_lineage.py
+++ b/tests/test_ext_lineage.py
@@ -6,7 +6,7 @@ import pytest
 from uuid import uuid4 as random_uuid
 
 from datacube.model import LineageDirection, LineageTree, InconsistentLineageException
-from datacube.model.lineage import LineageRelations
+from datacube.model.lineage import LineageRelations, LineageIDPair
 
 
 def test_directions():
@@ -492,13 +492,13 @@ def test_good_consistency_check(big_src_lineage_tree, src_lineage_tree, big_src_
     rels2 = LineageRelations(tree=big_src_lineage_tree)
     diff = rels1.relations_diff(rels2)
     assert diff[1] == {} and diff[3] == {}
-    assert (src_lineage_tree.dataset_id, big_src_tree_ids["ard1"]) in diff[0]
+    assert LineageIDPair(derived_id=src_lineage_tree.dataset_id, source_id=big_src_tree_ids["ard1"]) in diff[0]
     diff = rels1.relations_diff(rels2, allow_updates=True)
     assert diff[1] == {} and diff[3] == {}
-    assert (src_lineage_tree.dataset_id, big_src_tree_ids["ard1"]) in diff[0]
+    assert LineageIDPair(derived_id=src_lineage_tree.dataset_id, source_id=big_src_tree_ids["ard1"]) in diff[0]
     diff = rels1.relations_diff()
     assert diff[1] == {} and diff[3] == {}
-    assert (src_lineage_tree.dataset_id, big_src_tree_ids["ard1"]) in diff[0]
+    assert LineageIDPair(derived_id=src_lineage_tree.dataset_id, source_id=big_src_tree_ids["ard1"]) in diff[0]
 
 
 def test_bad_diamond(src_lineage_tree_with_bad_diamond, big_src_tree_ids):
@@ -517,7 +517,7 @@ def test_home_mismatch(big_src_lineage_tree):
 def test_classifier_mismatch(big_src_lineage_tree, classifier_mismatch):
     rels1 = LineageRelations(tree=big_src_lineage_tree)
     rels2 = LineageRelations(tree=classifier_mismatch)
-    with pytest.raises(InconsistentLineageException, match="Dataset .* depends on .* with inconsistent classifiers."):
+    with pytest.raises(InconsistentLineageException, match="Dataset .* is derived from .* with inconsistent classifiers."):
         rels1.merge(rels2)
 
 

--- a/tests/test_ext_lineage.py
+++ b/tests/test_ext_lineage.py
@@ -96,6 +96,7 @@ def src_lineage_tree(src_tree_ids):
         }
     )
 
+
 @pytest.fixture
 def big_src_tree_ids(shared_tree_ids):
     ids = shared_tree_ids

--- a/tests/test_ext_lineage.py
+++ b/tests/test_ext_lineage.py
@@ -10,17 +10,19 @@ from datacube.model.lineage import InconsistentLineageException, LineageRelation
 
 def test_ltree_clsmethods():
     root = random_uuid()
+    # Minimal tree - root node only
     minimal = LineageTree.from_eo3_doc(dsid=root)
     assert minimal.dataset_id == root
     assert minimal.direction == LineageDirection.SOURCES
     assert minimal.children is None
+    # Check optional args to from_eo3_doc are set correctly.
     optional_args = LineageTree.from_eo3_doc(dsid=root, sources={},
                                           direction=LineageDirection.DERIVED,
                                           home="notused")
     assert optional_args == LineageTree(direction=LineageDirection.DERIVED,
                                         dataset_id=root,
                                         children={},
-                                        home=None
+                                        home=None   # Note home is not written to the root node
                                         )
 
 @pytest.fixture
@@ -94,8 +96,25 @@ def big_src_lineage_tree(big_src_tree_ids):
     )
 
 
-def test_lin_rels_minimal(big_src_lineage_tree):
+def test_child_datasets(big_src_lineage_tree, big_src_tree_ids):
+    cds = big_src_lineage_tree.child_datasets()
+    for dsid in big_src_tree_ids.values():
+        assert dsid == big_src_lineage_tree.dataset_id or dsid in cds
+
+
+def test_lin_rels_lin_tree_conversions(big_src_lineage_tree):
+    # Create LRS from LT
     rels1 = LineageRelations(tree=big_src_lineage_tree)
+    # Extract LT from LRS
+    extracted_tree = rels1.extract_tree(big_src_lineage_tree.dataset_id, big_src_lineage_tree.direction)
+    # Confirm extract LT produces same LRS as original LT
+    rels2 = LineageRelations(tree=extracted_tree)
+    for rel in rels1.relations:
+        assert rel in rels2.relations
+
+
+def test_detect_cyclic_deps(big_src_lineage_tree, big_src_tree_ids):
+    # Confirm trivial cyclic dependencies are detected.
     repeated_uuid = random_uuid()
     looped_tree = LineageTree(
         dataset_id=repeated_uuid, direction=LineageDirection.SOURCES, children={
@@ -107,5 +126,20 @@ def test_lin_rels_minimal(big_src_lineage_tree):
         }
     )
     with pytest.raises(InconsistentLineageException) as e:
-        rels2 = LineageRelations(looped_tree)
-    assert "foobar" in str(e.value)
+        rels2 = LineageRelations(tree=looped_tree)
+    assert "LineageTrees must be acyclic" in str(e.value)
+    # Confirm more complex cyclic dependencies can be detected.
+    rels = LineageRelations(tree=big_src_lineage_tree)
+    breaking_tree = LineageTree(
+        dataset_id= big_src_tree_ids["l1_1"],
+        direction=LineageDirection.SOURCES,
+        children={
+            "cyclic_dep": [LineageTree(
+                dataset_id=big_src_tree_ids["root"],
+                direction=LineageDirection.SOURCES
+            )]
+        }
+    )
+    with pytest.raises(InconsistentLineageException) as e:
+        rels.merge_tree(breaking_tree)
+    assert "LineageTrees must be acyclic" in str(e.value)

--- a/tests/test_ext_lineage.py
+++ b/tests/test_ext_lineage.py
@@ -1,0 +1,111 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2023 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+from uuid import UUID, uuid4 as random_uuid
+
+from datacube.model import LineageDirection, LineageTree, InconsistentLineageException
+from datacube.model.lineage import InconsistentLineageException, LineageRelations, LineageRelation
+
+def test_ltree_clsmethods():
+    root = random_uuid()
+    minimal = LineageTree.from_eo3_doc(dsid=root)
+    assert minimal.dataset_id == root
+    assert minimal.direction == LineageDirection.SOURCES
+    assert minimal.children is None
+    optional_args = LineageTree.from_eo3_doc(dsid=root, sources={},
+                                          direction=LineageDirection.DERIVED,
+                                          home="notused")
+    assert optional_args == LineageTree(direction=LineageDirection.DERIVED,
+                                        dataset_id=root,
+                                        children={},
+                                        home=None
+                                        )
+
+@pytest.fixture
+def big_src_tree_ids():
+    return {
+        "root": random_uuid(),
+        "ard1": random_uuid(),
+        "ard2": random_uuid(),
+
+        "l1_1": random_uuid(),
+        "l1_2": random_uuid(),
+        "l1_3": random_uuid(),
+
+        "l1_4": random_uuid(),
+        "l1_5": random_uuid(),
+        "l1_6": random_uuid(),
+
+        "atmos": random_uuid(),
+    }
+
+
+@pytest.fixture
+def big_src_lineage_tree(big_src_tree_ids):
+    ids = big_src_tree_ids
+    direction = LineageDirection.SOURCES
+    return LineageTree(dataset_id=ids["root"], direction=direction,
+        children={
+            "ard": [
+                LineageTree(dataset_id=ids["ard1"], direction=direction,
+                    children={
+                        "l1": [
+                            LineageTree(dataset_id=ids["l1_1"], direction=direction,
+                                children={}
+                            ),
+                            LineageTree(dataset_id=ids["l1_2"], direction=direction,
+                                children={}
+                            ),
+                            LineageTree(dataset_id=ids["l1_3"], direction=direction,
+                                children={}
+                            ),
+                        ],
+                        "atmos_corr": [
+                            LineageTree(dataset_id=ids["atmos"], direction=direction,
+                                children={}
+                            )
+                        ],
+                    }
+                ),
+                LineageTree(dataset_id=ids["ard2"], direction=direction,
+                    children={
+                        "l1": [
+                            LineageTree(dataset_id=ids["l1_4"], direction=direction,
+                                children={}
+                            ),
+                            LineageTree(dataset_id=ids["l1_5"], direction=direction,
+                                children={}
+                            ),
+                            LineageTree(dataset_id=ids["l1_6"], direction=direction,
+                                children={}
+                            ),
+                        ],
+                        "atmos_corr": [
+                            LineageTree(dataset_id=ids["atmos"], direction=direction,
+                                children={}
+                            )
+                        ],
+                    }
+                ),
+            ]
+        }
+    )
+
+
+def test_lin_rels_minimal(big_src_lineage_tree):
+    rels1 = LineageRelations(tree=big_src_lineage_tree)
+    repeated_uuid = random_uuid()
+    looped_tree = LineageTree(
+        dataset_id=repeated_uuid, direction=LineageDirection.SOURCES, children={
+            "cyclic_self": [
+                LineageTree(
+                    dataset_id=repeated_uuid, direction=LineageDirection.SOURCES, children={}
+                )
+            ]
+        }
+    )
+    with pytest.raises(InconsistentLineageException) as e:
+        rels2 = LineageRelations(looped_tree)
+    assert "foobar" in str(e.value)

--- a/tests/test_ext_lineage.py
+++ b/tests/test_ext_lineage.py
@@ -3,10 +3,11 @@
 # Copyright (c) 2015-2023 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import pytest
-from uuid import UUID, uuid4 as random_uuid
+from uuid import uuid4 as random_uuid
 
 from datacube.model import LineageDirection, LineageTree, InconsistentLineageException
-from datacube.model.lineage import InconsistentLineageException, LineageRelations, LineageRelation
+from datacube.model.lineage import LineageRelations
+
 
 def test_ltree_clsmethods():
     root = random_uuid()
@@ -17,13 +18,13 @@ def test_ltree_clsmethods():
     assert minimal.children is None
     # Check optional args to from_eo3_doc are set correctly.
     optional_args = LineageTree.from_eo3_doc(dsid=root, sources={},
-                                          direction=LineageDirection.DERIVED,
-                                          home="notused")
+                                             direction=LineageDirection.DERIVED,
+                                             home="notused")
     assert optional_args == LineageTree(direction=LineageDirection.DERIVED,
                                         dataset_id=root,
                                         children={},
-                                        home=None   # Note home is not written to the root node
-                                        )
+                                        home=None)   # Note home is not written to the root node
+
 
 @pytest.fixture
 def big_src_tree_ids():

--- a/tests/test_ext_lineage.py
+++ b/tests/test_ext_lineage.py
@@ -32,9 +32,11 @@ def test_ltree_clsmethods(data_folder):
                                         dataset_id=root,
                                         children={},
                                         home=None)   # Note home is not written to the root node
-    doc = list(read_documents(
-       str(os.path.join(data_folder, "ds_eo3.yml"))
-    ))[0][1]
+    doc = list(
+        read_documents(
+            str(os.path.join(data_folder, "ds_eo3.yml"))
+        )
+    )[0][1]
     tree = LineageTree.from_eo3_doc(doc, home="src_home", home_derived="der_home")
     assert tree.home == "der_home"
     for child in tree.children["bc"]:

--- a/tests/test_ext_lineage.py
+++ b/tests/test_ext_lineage.py
@@ -49,44 +49,55 @@ def big_src_tree_ids():
 def big_src_lineage_tree(big_src_tree_ids):
     ids = big_src_tree_ids
     direction = LineageDirection.SOURCES
-    return LineageTree(dataset_id=ids["root"], direction=direction,
+    return LineageTree(
+        dataset_id=ids["root"], direction=direction,
         children={
             "ard": [
-                LineageTree(dataset_id=ids["ard1"], direction=direction,
+                LineageTree(
+                    dataset_id=ids["ard1"], direction=direction,
                     children={
                         "l1": [
-                            LineageTree(dataset_id=ids["l1_1"], direction=direction,
+                            LineageTree(
+                                dataset_id=ids["l1_1"], direction=direction,
                                 children={}
                             ),
-                            LineageTree(dataset_id=ids["l1_2"], direction=direction,
+                            LineageTree(
+                                dataset_id=ids["l1_2"], direction=direction,
                                 children={}
                             ),
-                            LineageTree(dataset_id=ids["l1_3"], direction=direction,
+                            LineageTree(
+                                dataset_id=ids["l1_3"], direction=direction,
                                 children={}
                             ),
                         ],
                         "atmos_corr": [
-                            LineageTree(dataset_id=ids["atmos"], direction=direction,
+                            LineageTree(
+                                dataset_id=ids["atmos"], direction=direction,
                                 children={}
                             )
                         ],
                     }
                 ),
-                LineageTree(dataset_id=ids["ard2"], direction=direction,
+                LineageTree(
+                    dataset_id=ids["ard2"], direction=direction,
                     children={
                         "l1": [
-                            LineageTree(dataset_id=ids["l1_4"], direction=direction,
+                            LineageTree(
+                                dataset_id=ids["l1_4"], direction=direction,
                                 children={}
                             ),
-                            LineageTree(dataset_id=ids["l1_5"], direction=direction,
+                            LineageTree(
+                                dataset_id=ids["l1_5"], direction=direction,
                                 children={}
                             ),
-                            LineageTree(dataset_id=ids["l1_6"], direction=direction,
+                            LineageTree(
+                                dataset_id=ids["l1_6"], direction=direction,
                                 children={}
                             ),
                         ],
                         "atmos_corr": [
-                            LineageTree(dataset_id=ids["atmos"], direction=direction,
+                            LineageTree(
+                                dataset_id=ids["atmos"], direction=direction,
                                 children={}
                             )
                         ],
@@ -118,11 +129,10 @@ def test_detect_cyclic_deps(big_src_lineage_tree, big_src_tree_ids):
     # Confirm trivial cyclic dependencies are detected.
     repeated_uuid = random_uuid()
     looped_tree = LineageTree(
-        dataset_id=repeated_uuid, direction=LineageDirection.SOURCES, children={
+        dataset_id=repeated_uuid, direction=LineageDirection.SOURCES,
+        children={
             "cyclic_self": [
-                LineageTree(
-                    dataset_id=repeated_uuid, direction=LineageDirection.SOURCES, children={}
-                )
+                LineageTree(dataset_id=repeated_uuid, direction=LineageDirection.SOURCES, children={})
             ]
         }
     )
@@ -132,7 +142,7 @@ def test_detect_cyclic_deps(big_src_lineage_tree, big_src_tree_ids):
     # Confirm more complex cyclic dependencies can be detected.
     rels = LineageRelations(tree=big_src_lineage_tree)
     breaking_tree = LineageTree(
-        dataset_id= big_src_tree_ids["l1_1"],
+        dataset_id=big_src_tree_ids["l1_1"],
         direction=LineageDirection.SOURCES,
         children={
             "cyclic_dep": [LineageTree(

--- a/tests/test_ext_lineage.py
+++ b/tests/test_ext_lineage.py
@@ -112,6 +112,45 @@ def src_lineage_tree(src_tree_ids):
     )
 
 
+def test_lineage_serialisation(src_lineage_tree, src_tree_ids):
+    ids = src_tree_ids
+    serialised = src_lineage_tree.serialise()
+    assert serialised == {
+        "id": str(ids["root"]),
+        "sources": {
+            "ard": [
+                {
+                    "id": str(ids["ard1"]),
+                    "sources": {
+                        "l1": [
+                            {
+                                "id": str(ids["l1_1"]),
+                                "home": "level1db"
+                            },
+                            {
+                                "id": str(ids["l1_2"]),
+                                "home": "level1db"
+                            },
+                            {
+                                "id": str(ids["l1_3"]),
+                                "home": "level1db"
+                            },
+                        ],
+                        "atmos_corr": [
+                            {
+                                "id": str(ids["atmos"]),
+                                "home": "level1db"
+                            }
+                        ]
+                    },
+                }
+            ]
+        }
+    }
+    tree_out = LineageTree.deserialise(serialised)
+    assert tree_out == src_lineage_tree
+
+
 @pytest.fixture
 def src_lineage_tree_diffhome(src_tree_ids):
     ids = src_tree_ids

--- a/tests/test_ext_lineage.py
+++ b/tests/test_ext_lineage.py
@@ -517,7 +517,9 @@ def test_home_mismatch(big_src_lineage_tree):
 def test_classifier_mismatch(big_src_lineage_tree, classifier_mismatch):
     rels1 = LineageRelations(tree=big_src_lineage_tree)
     rels2 = LineageRelations(tree=classifier_mismatch)
-    with pytest.raises(InconsistentLineageException, match="Dataset .* is derived from .* with inconsistent classifiers."):
+    with pytest.raises(
+            InconsistentLineageException,
+            match="Dataset .* is derived from .* with inconsistent classifiers."):
         rels1.merge(rels2)
 
 


### PR DESCRIPTION
### Reason for this pull request

Implementation of Remote Lineage API, as per [EP-008](https://github.com/opendatacube/datacube-core/wiki/ODC-EP-008)

Features needed but deliberately left for future PRs:

- CLI for lineage
- Include lineage in bulk-ops API.
- Extensions to EO3 format to allow nested lineage trees to be embedded in EO3 dataset docs (?)

### Proposed changes

- Schema definitions in `postgis` driver
- Abstract index driver method definitions
- Make lineage remapping optional in `prep_eo3`
- Changes to "high level" index API
- New "supports" flags on Index objects
- Changes to `Dataset` model
- New `LineageTree` and `LineageRelations` models.
- Tests for new models, and updates for existing tests.


 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
