### PR TITLE
Sqlalchemy deprecations fix

### DIFF
--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -8,7 +8,7 @@ Core SQL schema settings.
 
 import logging
 
-from sqlalchemy import MetaData
+from sqlalchemy import MetaData, inspect
 from sqlalchemy.engine import Engine
 from sqlalchemy.schema import CreateSchema
 
@@ -91,7 +91,7 @@ def ensure_db(engine, with_permissions=True):
         grant all on database {db} to odc_admin;
         """.format(db=quoted_db_name))
 
-    if not has_schema(engine, c):
+    if not has_schema(engine):
         is_new = True
         try:
             c.execute('begin')
@@ -144,7 +144,7 @@ def database_exists(engine):
     """
     Have they init'd this database?
     """
-    return has_schema(engine, engine)
+    return has_schema(engine)
 
 
 def schema_is_latest(engine: Engine) -> bool:
@@ -217,8 +217,9 @@ def has_role(conn, role_name):
     return bool(conn.execute('SELECT rolname FROM pg_roles WHERE rolname=%s', role_name).fetchall())
 
 
-def has_schema(engine, connection):
-    return engine.dialect.has_schema(connection, SCHEMA_NAME)
+def has_schema(engine):
+    inspector = inspect(engine)
+    return SCHEMA_NAME in inspector.get_schema_names()
 
 
 def drop_db(connection):

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -49,9 +49,9 @@ _DATASET_SELECT_FIELDS = (
     DATASET,
     # All active URIs, from newest to oldest
     func.array(
-        select([
+        select(
             _dataset_uri_field(SELECTED_DATASET_LOCATION)
-        ]).where(
+        ).where(
             and_(
                 SELECTED_DATASET_LOCATION.c.dataset_ref == DATASET.c.id,
                 SELECTED_DATASET_LOCATION.c.archived == None
@@ -67,9 +67,9 @@ _DATASET_BULK_SELECT_FIELDS = (
     DATASET.c.metadata,
     # All active URIs, from newest to oldest
     func.array(
-        select([
+        select(
             _dataset_uri_field(SELECTED_DATASET_LOCATION)
-        ]).where(
+        ).where(
             and_(
                 SELECTED_DATASET_LOCATION.c.dataset_ref == DATASET.c.id,
                 SELECTED_DATASET_LOCATION.c.archived == None

--- a/docker/constraints.txt
+++ b/docker/constraints.txt
@@ -28,11 +28,11 @@ babel==2.11.0
     # via sphinx
 bleach==6.0.0
     # via readme-renderer
-boto3==1.26.56
+boto3==1.26.70
     # via
     #   -r constraints.in
     #   moto
-botocore==1.29.56
+botocore==1.29.70
     # via
     #   boto3
     #   moto
@@ -91,21 +91,21 @@ contourpy==1.0.7
     # via matplotlib
 coverage==7.1.0
     # via pytest-cov
-cryptography==39.0.0
+cryptography==39.0.1
     # via
     #   moto
     #   secretstorage
 cycler==0.11.0
     # via matplotlib
-dask==2023.1.0
+dask==2023.2.0
     # via
     #   -r constraints.in
     #   distributed
 decorator==5.1.1
     # via validators
-distributed==2023.1.0
+distributed==2023.2.0
     # via -r constraints.in
-docutils==0.17.1
+docutils==0.18.1
     # via
     #   readme-renderer
     #   recommonmark
@@ -116,7 +116,7 @@ exceptiongroup==1.1.0
     # via
     #   hypothesis
     #   pytest
-fiona==1.8.22
+fiona==1.9.1
     # via -r constraints.in
 fonttools==4.38.0
     # via matplotlib
@@ -124,11 +124,11 @@ fsspec==2023.1.0
     # via dask
 geoalchemy2==0.13.1
     # via -r constraints.in
-greenlet==2.0.1
+greenlet==2.0.2
     # via sqlalchemy
 heapdict==1.0.1
     # via zict
-hypothesis==6.65.0
+hypothesis==6.68.1
     # via -r constraints.in
 idna==3.4
     # via requests
@@ -183,7 +183,7 @@ markupsafe==2.1.2
     # via
     #   jinja2
     #   werkzeug
-matplotlib==3.6.3
+matplotlib==3.7.0
     # via -r constraints.in
 mccabe==0.6.1
     # via pylint
@@ -191,7 +191,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==9.0.0
     # via jaraco-classes
-moto==4.1.1
+moto==4.1.2
     # via -r constraints.in
 msgpack==1.0.4
     # via distributed
@@ -201,7 +201,7 @@ netcdf4==1.6.2
     # via
     #   -r constraints.in
     #   compliance-checker
-numpy==1.24.1
+numpy==1.24.2
     # via
     #   -r constraints.in
     #   bottleneck
@@ -299,13 +299,13 @@ pyyaml==6.0
     #   dask
     #   distributed
     #   owslib
-rasterio==1.3.4
+rasterio==1.3.6
     # via -r constraints.in
 readme-renderer==37.3
     # via twine
 recommonmark==0.7.1
     # via -r constraints.in
-redis==4.4.2
+redis==4.5.1
     # via -r constraints.in
 regex==2022.10.31
     # via compliance-checker
@@ -324,7 +324,7 @@ responses==0.22.0
     # via moto
 rfc3986==2.0.0
     # via twine
-rich==13.2.0
+rich==13.3.1
     # via twine
 ruamel-yaml==0.17.21
     # via -r constraints.in
@@ -336,13 +336,12 @@ secretstorage==3.3.3
     # via keyring
 setuptools-scm==7.1.0
     # via -r constraints.in
-shapely==2.0.0
+shapely==2.0.1
     # via -r constraints.in
 six==1.16.0
     # via
     #   astroid
     #   bleach
-    #   fiona
     #   isodate
     #   munch
     #   python-dateutil
@@ -361,18 +360,20 @@ sphinx==5.3.0
     #   sphinx-autodoc-typehints
     #   sphinx-click
     #   sphinx-rtd-theme
-sphinx-autodoc-typehints==1.21.8
+sphinx-autodoc-typehints==1.22
     # via -r constraints.in
 sphinx-click==4.4.0
     # via -r constraints.in
-sphinx-rtd-theme==1.1.1
+sphinx-rtd-theme==1.2.0
     # via -r constraints.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-htmlhelp==2.0.1
     # via sphinx
+sphinxcontrib-jquery==2.0.0
+    # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
 sphinxcontrib-qthelp==1.0.3
@@ -404,7 +405,7 @@ tornado==6.2
     # via distributed
 twine==4.0.2
     # via -r constraints.in
-types-toml==0.10.8.1
+types-toml==0.10.8.3
     # via responses
 typing-extensions==4.4.0
     # via
@@ -429,13 +430,13 @@ wheel==0.38.4
     # via -r constraints.in
 wrapt==1.11.2
     # via astroid
-xarray==2023.1.0
+xarray==2023.2.0
     # via -r constraints.in
 xmltodict==0.13.0
     # via moto
 zict==2.2.0
     # via distributed
-zipp==3.11.0
+zipp==3.13.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -9,6 +9,7 @@ v1.8.next
 =========
 
 - Rename Geometry `type` attribute to `geom_type`, to align with Shapely 2.0 (:pull:`1402`)
+- Remove some deprecated SQLAlchemy usages (:pull:`1403`)
 
 
 v1.8.11 (6 February 2023)

--- a/integration_tests/test_config_tool.py
+++ b/integration_tests/test_config_tool.py
@@ -201,7 +201,7 @@ def test_db_init(clirunner, index):
     with index._db._connect() as connection:
         drop_db(connection._connection)
 
-        assert not has_schema(index._db._engine, connection._connection)
+        assert not has_schema(index._db._engine)
 
     # Run on an empty database.
     if index._db.driver_name == "postgis":
@@ -212,7 +212,7 @@ def test_db_init(clirunner, index):
     assert 'Created.' in result.output
 
     with index._db._connect() as connection:
-        assert has_schema(index._db._engine, connection._connection)
+        assert has_schema(index._db._engine)
 
 
 def test_add_no_such_product(clirunner, index):


### PR DESCRIPTION
### Reason for this pull request

The postgis and especially postgres index drivers have some deprecated SQLAlchemy usages that produce threatening warnings as reported [here](https://github.com/GeoscienceAustralia/dea-sandbox/issues/242)

### Proposed changes

- Use SQLAlchemy `Inspector` interface to detect existence of schema in both drivers.
- Refactor stock-expressions to use new `select` function calling conventions.
- Update constraints.txt to get latest SQLAlchemy 1.4.x release into test docker image.

 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1403.org.readthedocs.build/en/1403/

<!-- readthedocs-preview datacube-core end -->