### PR TITLE
Include port in database config example

### DIFF
--- a/docs/installation/database/setup.rst
+++ b/docs/installation/database/setup.rst
@@ -48,6 +48,9 @@ Datacube looks for a configuration file in ~/.datacube.conf or in the location s
 
     # A blank host will use a local socket. Specify a hostname (such as localhost) to use TCP.
     db_hostname:
+    
+    # Port is optional. The default port is 5432.
+    # db_hostname:
 
     # Credentials are optional: you might have other Postgres authentication configured.
     # The default username otherwise is the current user id.


### PR DESCRIPTION
### Reason for this pull request

The documentation lacks the option to change the database port


### Proposed changes

Add the variable that changes the database port in the .datacube.conf example


 - [ ] Closes #xxxx
 - [v] Tests added / passed
 - [v] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
