### PR TITLE
fix bug in virtual product and remove deprecation messages in test

### DIFF
--- a/datacube/testutils/geom.py
+++ b/datacube/testutils/geom.py
@@ -5,6 +5,7 @@
 import numpy as np
 from affine import Affine
 from typing import Callable, Union, Tuple
+import warnings
 
 from datacube.utils.geometry import (
     CRS,
@@ -108,7 +109,15 @@ def to_fixed_point(a, dtype='uint16'):
     ii = np.iinfo(dtype)
     a = a*ii.max + 0.5
     a = np.clip(a, 0, ii.max, out=a)
-    return a.astype(ii.dtype)
+    warnings.filterwarnings("error")
+    try:
+        b = a.astype(ii.dtype)
+    except RuntimeWarning as e:
+        raise TypeError(e)
+    warnings.resetwarnings()
+    if not (np.abs(a - b) < 1).all():
+        raise TypeError(f"Cannot safely cast float to {dtype}")
+    return b
 
 
 def from_fixed_point(a):

--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -383,7 +383,12 @@ def wrap_shapely(method):
             if first.crs != arg.crs:
                 raise CRSMismatchError((first.crs, arg.crs))
 
+        if method.__name__ in ["intersects", "intersection"]:
+            np_settings = numpy.seterr()
+            numpy.seterr(invalid="ignore")
         result = method(*[arg.geom for arg in args])
+        if method.__name__ in ["intersects", "intersection"]:
+            numpy.seterr(**np_settings)
         if isinstance(result, base.BaseGeometry):
             return Geometry(result, first.crs)
         return result
@@ -485,10 +490,7 @@ class Geometry:
 
     @wrap_shapely
     def intersects(self, other: 'Geometry') -> bool:
-        np_settings = numpy.seterr()
-        numpy.seterr(invalid="ignore")
         intersect = self.intersects(other)
-        numpy.seterr(**np_settings)
         return intersect
 
     @wrap_shapely
@@ -509,10 +511,7 @@ class Geometry:
 
     @wrap_shapely
     def intersection(self, other: 'Geometry') -> 'Geometry':
-        np_settings = numpy.seterr()
-        numpy.seterr(invalid="ignore")
         intersection = self.intersection(other)
-        numpy.seterr(**np_settings)
         return intersection
 
     @wrap_shapely

--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -485,7 +485,11 @@ class Geometry:
 
     @wrap_shapely
     def intersects(self, other: 'Geometry') -> bool:
-        return self.intersects(other)
+        np_settings = numpy.seterr()
+        numpy.seterr(invalid="ignore")
+        intersect = self.intersects(other)
+        numpy.seterr(**np_settings)
+        return intersect
 
     @wrap_shapely
     def touches(self, other: 'Geometry') -> bool:
@@ -505,7 +509,11 @@ class Geometry:
 
     @wrap_shapely
     def intersection(self, other: 'Geometry') -> 'Geometry':
-        return self.intersection(other)
+        np_settings = numpy.seterr()
+        numpy.seterr(invalid="ignore")
+        intersection = self.intersection(other)
+        numpy.seterr(**np_settings)
+        return intersection
 
     @wrap_shapely
     def symmetric_difference(self, other: 'Geometry') -> 'Geometry':

--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -370,29 +370,31 @@ def _norm_crs_or_error(crs: MaybeCRS) -> CRS:
     return CRS(crs)
 
 
-def wrap_shapely(method):
+def wrap_shapely(suppress_geos_warnings=False):
     """
     Takes a method that expects shapely geometry arguments
     and converts it to a method that operates on `Geometry`
     objects that carry their CRSs.
     """
-    @functools.wraps(method, assigned=('__doc__', ))
-    def wrapped(*args):
-        first = args[0]
-        for arg in args[1:]:
-            if first.crs != arg.crs:
-                raise CRSMismatchError((first.crs, arg.crs))
+    def wrap_func(method):
+        @functools.wraps(method, assigned=('__doc__', ))
+        def wrapped(*args):
+            first = args[0]
+            for arg in args[1:]:
+                if first.crs != arg.crs:
+                    raise CRSMismatchError((first.crs, arg.crs))
 
-        if method.__name__ in ["intersects", "intersection"]:
-            np_settings = numpy.seterr()
-            numpy.seterr(invalid="ignore")
-        result = method(*[arg.geom for arg in args])
-        if method.__name__ in ["intersects", "intersection"]:
-            numpy.seterr(**np_settings)
-        if isinstance(result, base.BaseGeometry):
-            return Geometry(result, first.crs)
-        return result
-    return wrapped
+            if suppress_geos_warnings:
+                np_settings = numpy.seterr()
+                numpy.seterr(invalid="ignore")
+            result = method(*[arg.geom for arg in args])
+            if suppress_geos_warnings:
+                numpy.seterr(**np_settings)
+            if isinstance(result, base.BaseGeometry):
+                return Geometry(result, first.crs)
+            return result
+        return wrapped
+    return wrap_func
 
 
 def force_2d(geojson: Dict[str, Any]) -> Dict[str, Any]:
@@ -476,65 +478,63 @@ class Geometry:
     def clone(self) -> 'Geometry':
         return Geometry(self)
 
-    @wrap_shapely
+    @wrap_shapely()
     def contains(self, other: 'Geometry') -> bool:
         return self.contains(other)
 
-    @wrap_shapely
+    @wrap_shapely()
     def crosses(self, other: 'Geometry') -> bool:
         return self.crosses(other)
 
-    @wrap_shapely
+    @wrap_shapely()
     def disjoint(self, other: 'Geometry') -> bool:
         return self.disjoint(other)
 
-    @wrap_shapely
+    @wrap_shapely(suppress_geos_warnings=True)
     def intersects(self, other: 'Geometry') -> bool:
-        intersect = self.intersects(other)
-        return intersect
+        return self.intersects(other)
 
-    @wrap_shapely
+    @wrap_shapely()
     def touches(self, other: 'Geometry') -> bool:
         return self.touches(other)
 
-    @wrap_shapely
+    @wrap_shapely()
     def within(self, other: 'Geometry') -> bool:
         return self.within(other)
 
-    @wrap_shapely
+    @wrap_shapely()
     def overlaps(self, other: 'Geometry') -> bool:
         return self.overlaps(other)
 
-    @wrap_shapely
+    @wrap_shapely()
     def difference(self, other: 'Geometry') -> 'Geometry':
         return self.difference(other)
 
-    @wrap_shapely
+    @wrap_shapely(suppress_geos_warnings=True)
     def intersection(self, other: 'Geometry') -> 'Geometry':
-        intersection = self.intersection(other)
-        return intersection
+        return self.intersection(other)
 
-    @wrap_shapely
+    @wrap_shapely()
     def symmetric_difference(self, other: 'Geometry') -> 'Geometry':
         return self.symmetric_difference(other)
 
-    @wrap_shapely
+    @wrap_shapely()
     def union(self, other: 'Geometry') -> 'Geometry':
         return self.union(other)
 
-    @wrap_shapely
+    @wrap_shapely()
     def __and__(self, other: 'Geometry') -> 'Geometry':
         return self.__and__(other)
 
-    @wrap_shapely
+    @wrap_shapely()
     def __or__(self, other: 'Geometry') -> 'Geometry':
         return self.__or__(other)
 
-    @wrap_shapely
+    @wrap_shapely()
     def __xor__(self, other: 'Geometry') -> 'Geometry':
         return self.__xor__(other)
 
-    @wrap_shapely
+    @wrap_shapely()
     def __sub__(self, other: 'Geometry') -> 'Geometry':
         return self.__sub__(other)
 

--- a/datacube/virtual/impl.py
+++ b/datacube/virtual/impl.py
@@ -610,7 +610,8 @@ class Collate(VirtualProduct):
                   in enumerate(zip(self._children, datasets.bag['collate']))]
 
         dim = self.get('dim', 'time')
-        return VirtualDatasetBox(xarray.concat([grouped.box for grouped in groups], dim=dim).sortby(dim),
+        return VirtualDatasetBox(xarray.concat([grouped.box for grouped in groups
+                                                if grouped.box.shape[0] > 0], dim=dim).sortby(dim),
                                  select_unique([grouped.geobox for grouped in groups]),
                                  select_unique([grouped.load_natively for grouped in groups]),
                                  merge_dicts([grouped.product_definitions for grouped in groups]),

--- a/tests/api/test_virtual.py
+++ b/tests/api/test_virtual.py
@@ -174,7 +174,11 @@ def catalog():
                     method: mean
                     group_by: month
                     input:
-                        transform: to_float
+                        transform: expressions
+                        output:
+                          blue:
+                            formula: blue
+                            dtype: float32
                         input:
                             collate:
                               - product: ls7_nbar_albers
@@ -342,62 +346,6 @@ def test_misspelled_product(dc, query):
 #####################################
 # Virtual Product Transform Tests
 #####################################
-
-
-def test_select_transform(dc, query):
-    select = construct_from_yaml("""
-        transform: select
-        measurement_names:
-            - green
-        input:
-            product: ls8_nbar_albers
-            measurements: [blue, green]
-    """)
-
-    with mock.patch('datacube.virtual.impl.Datacube') as mock_datacube:
-        mock_datacube.load_data = load_data
-        mock_datacube.group_datasets = group_datasets
-        data = select.load(dc, **query)
-
-    assert 'green' in data
-    assert 'blue' not in data
-
-
-def test_rename_transform(dc, query):
-    rename = construct_from_yaml("""
-        transform: rename
-        measurement_names:
-            green: verde
-        input:
-            product: ls8_nbar_albers
-            measurements: [blue, green]
-    """)
-
-    with mock.patch('datacube.virtual.impl.Datacube') as mock_datacube:
-        mock_datacube.load_data = load_data
-        mock_datacube.group_datasets = group_datasets
-        data = rename.load(dc, **query)
-
-    assert 'verde' in data
-    assert 'blue' in data
-    assert 'green' not in data
-
-
-def test_to_float_transform(dc, query):
-    to_float = construct_from_yaml("""
-        transform: to_float
-        input:
-            product: ls8_nbar_albers
-            measurements: [blue]
-    """)
-
-    with mock.patch('datacube.virtual.impl.Datacube') as mock_datacube:
-        mock_datacube.load_data = load_data
-        mock_datacube.group_datasets = group_datasets
-        data = to_float.load(dc, **query)
-
-    assert numpy.all(numpy.isnan(data.blue.values))
-    assert data.blue.dtype == 'float32'
 
 
 def test_vp_handles_product_aliases(dc, query):

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -599,9 +599,13 @@ def test_gen_test_image_xy():
     np.testing.assert_almost_equal(x, x_, 4)
     np.testing.assert_almost_equal(y, y_, 4)
 
-    for dt in ('int8', np.int16, np.dtype(np.uint64)):
+    for dt in ('int8', np.int16):
         xy, _ = gen_test_image_xy(gbox, dt)
         assert xy.dtype == dt
+
+    # can't safely cast np.float64.max to np.uint64
+    with pytest.raises(Exception):
+        xy, _ = gen_test_image_xy(gbox, np.uint64)
 
     # check no-data
     xy, denorm = gen_test_image_xy(gbox, 'float32')


### PR DESCRIPTION
### Reason for this pull request

fix #1408 

### Proposed changes

- only concat when the dataset is non-empty
- remove the tests on deprecated functions and add the new one
- suppress unnecessary warnings from geos
- make `np.dtype` cast safer
    - catch `RuntimeWarnings` from `numpy`, when it says `invalid`, it's incorrect, e.g., casting `np.float64.max` to `np.uint64` will result in `0`.  In our user case, scaling `1` to `np.uint64.max` produces `np.float64` then casting it back to `np.uint64` guarantees `0`, which is incorrect and shouldn't be allowed.
    - check the difference between results within `1` range to ensure the sanity.



 - [x] Closes #1408 
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1410.org.readthedocs.build/en/1410/

<!-- readthedocs-preview datacube-core end -->