### PR TITLE
Reduce transaction isolation level

### DIFF
--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -224,7 +224,7 @@ class PostgisDbAPI(object):
         return self._connection.in_transaction()
 
     def begin(self):
-        self._connection.execution_options(isolation_level="SERIALIZABLE")
+        self._connection.execution_options(isolation_level="REPEATABLE READ")
         self._sqla_txn = self._connection.begin()
 
     def _end_transaction(self):

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -189,7 +189,7 @@ class PostgresDbAPI(object):
         return self._connection.in_transaction()
 
     def begin(self):
-        self._connection.execution_options(isolation_level="SERIALIZABLE")
+        self._connection.execution_options(isolation_level="REPEATABLE READ")
         self._sqla_txn = self._connection.begin()
 
     def _end_transaction(self):

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -13,6 +13,7 @@ v1.8.next
 - Fix RTD docs build (:pull:`1399`)
 - Minor Documentation fixes (:pull:`1409`, :pull:`1413`)
 - Bugfix and code cleanup in virtual products (:pull:`1410`)
+- Reduce transaction isolation level to improve database write concurrency (:pull:`1414`)
 
 
 v1.8.11 (6 February 2023)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -12,7 +12,7 @@ v1.8.next
 - Remove some deprecated SQLAlchemy usages (:pull:`1403`, :pull:`1407`)
 - Fix RTD docs build (:pull:`1399`)
 - Minor Documentation fixes (:pull:`1409`, :pull:`1413`)
-- Bugfix and code cleanup in virtual products (:pull:`1410`)
+- Bug-fix and code cleanup in virtual products (:pull:`1410`)
 - Reduce transaction isolation level to improve database write concurrency (:pull:`1414`)
 
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -11,6 +11,8 @@ v1.8.next
 - Rename Geometry `type` attribute to `geom_type`, to align with Shapely 2.0 (:pull:`1402`)
 - Remove some deprecated SQLAlchemy usages (:pull:`1403`, :pull:`1407`)
 - Fix RTD docs build (:pull:`1399`)
+- Minor Documentation fixes (:pull:`1409`, :pull:`1413`)
+- Bugfix and code cleanup in virtual products (:pull:`1410`)
 
 
 v1.8.11 (6 February 2023)


### PR DESCRIPTION
### Reason for this pull request

The [transaction isolation level](https://www.postgresql.org/docs/current/transaction-iso.html) is set to Serializable, which is unreasonably high and causes failures when multiple processes (or threads) are indexing in parallel.  The next level down (Repeatable Read) is a much better compromise between transaction isolation and concurrency.


### Proposed changes

- Reduce transaction isolation level from `SERIALIZABLE` to `REPEATABLE READ`.


 - [x] Closes #1412 
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1414.org.readthedocs.build/en/1414/

<!-- readthedocs-preview datacube-core end -->