### PR TITLE
Fix docs footer links

### DIFF
--- a/docs/_templates/odc-footer.html
+++ b/docs/_templates/odc-footer.html
@@ -1,1 +1,1 @@
-<a href="/about/license.html">ODC License</a> | <a href="/about/whats_new.html">Change Log</a> 
+<a href="/{{ READTHEDOCS_LANGUAGE }}/{{ READTHEDOCS_VERSION }}/about/license.html">ODC License</a> | <a href="/about/whats_new.html">Change Log</a> 

--- a/docs/_templates/odc-footer.html
+++ b/docs/_templates/odc-footer.html
@@ -1,1 +1,1 @@
-<a href="/{{ READTHEDOCS_LANGUAGE }}/{{ READTHEDOCS_VERSION }}/about/license.html">ODC License</a> | <a href="/about/whats_new.html">Change Log</a> 
+<a href="/page/about/license.html">ODC License</a> | <a href="/page/about/whats_new.html">Change Log</a> 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,7 +70,7 @@ release = version
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['README.rst', '.condaenv', '.direnv']
+exclude_patterns = ['README.rst', '.condaenv', '.direnv', '_build']
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 add_function_parentheses = True


### PR DESCRIPTION
### Reason for this pull request

The links contained in the documentation footer only work when running locally; once actually deployed, they are broken.


### Proposed changes

- Use `/page/` redirect in link. This is broken locally but should work in the deployed docs.
- Add exclude pattern in conf to fix file name too long error from nbsphinx when building



 - [x] Closes #1343
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1417.org.readthedocs.build/en/1417/

<!-- readthedocs-preview datacube-core end -->