### PR TITLE
Bulk lineage ops

### DIFF
--- a/datacube/config.py
+++ b/datacube/config.py
@@ -6,11 +6,14 @@
 User configuration.
 """
 
+import logging
 import os
 from pathlib import Path
 import configparser
 from urllib.parse import unquote_plus, urlparse, parse_qsl
 from typing import Any, Dict, Iterable, MutableMapping, Optional, Tuple, Union
+
+_LOG = logging.getLogger("datacube_cfg")
 
 PathLike = Union[str, 'os.PathLike[Any]']
 
@@ -87,7 +90,6 @@ class LocalConfig(object):
         if env is None:
             env = os.environ.get('DATACUBE_ENVIRONMENT',
                                  config.get('user', 'default_environment', fallback=None))
-
         # If the user specifies a particular env, we either want to use it or Fail
         if env:
             if config.has_section(env):

--- a/datacube/config.py
+++ b/datacube/config.py
@@ -6,14 +6,11 @@
 User configuration.
 """
 
-import logging
 import os
 from pathlib import Path
 import configparser
 from urllib.parse import unquote_plus, urlparse, parse_qsl
 from typing import Any, Dict, Iterable, MutableMapping, Optional, Tuple, Union
-
-_LOG = logging.getLogger("datacube_cfg")
 
 PathLike = Union[str, 'os.PathLike[Any]']
 

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -680,6 +680,14 @@ class PostgisDbAPI(object):
         query = select(DatasetLineage.dataset_ref, DatasetLineage.classifier, DatasetLineage.dataset_source_ref)
         return self._connection.execution_options(stream_results=True, yield_per=batch_size).execute(query)
 
+
+    def insert_lineage_bulk(self, values):
+        requested = len(values)
+        res = self._connection.execute(
+            insert(DatasetLineage), values
+        ).on_conflict_do_nothing()
+        return res.rowcount, requested - res.rowcount
+
     @staticmethod
     def search_unique_datasets_query(expressions, select_fields, limit):
         """

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -674,6 +674,12 @@ class PostgisDbAPI(object):
             conn = self._connection
         return conn.execute(query)
 
+    def get_all_lineage(self, batch_size: int):
+        if batch_size > 0 and not self.in_transaction:
+            raise ValueError("Postgresql bulk reads must occur within a transaction.")
+        query = select(DatasetLineage.dataset_ref, DatasetLineage.classifier, DatasetLineage.dataset_source_ref)
+        return self._connection.execution_options(stream_results=True, yield_per=batch_size).execute(query)
+
     @staticmethod
     def search_unique_datasets_query(expressions, select_fields, limit):
         """

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -684,7 +684,6 @@ class PostgisDbAPI(object):
         )
         return self._connection.execution_options(stream_results=True, yield_per=batch_size).execute(query)
 
-
     def insert_lineage_bulk(self, values):
         requested = len(values)
         res = self._connection.execute(

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -671,7 +671,7 @@ class PostgresDbAPI(object):
             ['dataset_ref', 'classifier', 'source_dataset_ref'],
             sel_query
         ).on_conflict_do_nothing(
-            index_elements = ['classifier', 'dataset_ref']
+            index_elements=['classifier', 'dataset_ref']
         )
         res = self._connection.execute(query)
         return res.rowcount, requested - res.rowcount

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -648,14 +648,15 @@ class PostgresDbAPI(object):
     def get_all_lineage(self, batch_size: int):
         if batch_size > 0 and not self.in_transaction:
             raise ValueError("Postgresql bulk reads must occur within a transaction.")
-        query = select(DATASET_SOURCE.c.dataset_ref, DATASET_SOURCE.c.classifier, DATASET_SOURCE.c.dataset_source_ref)
+        query = select(DATASET_SOURCE.c.dataset_ref, DATASET_SOURCE.c.classifier, DATASET_SOURCE.c.source_dataset_ref)
         return self._connection.execution_options(stream_results=True, yield_per=batch_size).execute(query)
 
     def insert_lineage_bulk(self, values):
         requested = len(values)
         res = self._connection.execute(
-            insert(DATASET_SOURCE), values
-        ).on_conflict_do_nothing()
+            insert(DATASET_SOURCE).on_conflict_do_nothing(),
+            values
+        )
         return res.rowcount, requested - res.rowcount
 
     @staticmethod

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -645,6 +645,12 @@ class PostgresDbAPI(object):
             query = query.where(DATASET.c.dataset_type_ref.in_(products))
         return self._connection.execution_options(stream_results=True, yield_per=batch_size).execute(query)
 
+    def get_all_lineage(self, batch_size: int):
+        if batch_size > 0 and not self.in_transaction:
+            raise ValueError("Postgresql bulk reads must occur within a transaction.")
+        query = select(DATASET_SOURCE.c.dataset_ref, DATASET_SOURCE.c.classifier, DATASET_SOURCE.c.dataset_source_ref)
+        return self._connection.execution_options(stream_results=True, yield_per=batch_size).execute(query)
+
     @staticmethod
     def search_unique_datasets_query(expressions, select_fields, limit):
         """

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import datetime
 import logging
-import sys
 
 from pathlib import Path
 from threading import Lock
@@ -1865,7 +1864,11 @@ class AbstractIndex(ABC):
         :return: true if the database was created, false if already exists
         """
 
-    def clone(self, origin_index: "AbstractIndex", batch_size: int = 1000, skip_lineage=False, lineage_only=False) -> Mapping[str, BatchStatus]:
+    def clone(self,
+              origin_index: "AbstractIndex",
+              batch_size: int = 1000,
+              skip_lineage=False,
+              lineage_only=False) -> Mapping[str, BatchStatus]:
         """
         Clone an existing index into this one.
 
@@ -1902,7 +1905,8 @@ class AbstractIndex(ABC):
             results["metadata_types"] = self.metadata_types.bulk_add(origin_index.metadata_types.get_all_docs(),
                                                                      batch_size=batch_size)
             res = results["metadata_types"]
-            msg = f'{res.completed} metadata types loaded ({res.skipped} skipped) in {res.seconds_elapsed:.2f}seconds ' \
+            msg = f'{res.completed} metadata types loaded ({res.skipped} skipped) in ' \
+                  f'{res.seconds_elapsed:.2f}seconds ' \
                   f'({res.completed * 60 / res.seconds_elapsed:.2f} metadata_types/min)'
             report_to_user(msg, logger=_LOG)
             metadata_cache = {name: self.metadata_types.get_by_name(name) for name in res.safe}

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -1926,13 +1926,15 @@ class AbstractIndex(ABC):
         msg = f'{res.completed} datasets loaded ({res.skipped} skipped) in {res.seconds_elapsed:.2f}seconds ' \
               f'({res.completed * 60 / res.seconds_elapsed:.2f} datasets/min)'
         report_to_user(msg, logger=_LOG)
-        if not self.supports_lineage or not origin_index.supports_external_lineage or skip_lineage:
+        if not self.supports_lineage or not origin_index.supports_lineage or skip_lineage:
             report_to_user("Skipping lineage")
             return results
         report_to_user("Cloning Lineage:")
-        lineage_stream = origin_index.lineage.get_all_lineage()
-        results["lineage"] = {}
-
+        results["lineage"] = self.lineage.bulk_add(origin_index.lineage.get_all_lineage(batch_size), batch_size)
+        res = results["lineage"]
+        msg = f'{res.completed} lineage relations loaded ({res.skipped} skipped) in {res.seconds_elapsed:.2f}seconds ' \
+              f'({res.completed * 60 / res.seconds_elapsed:.2f} lineage relations/min)'
+        report_to_user(msg, logger=_LOG)
         return results
 
     @abstractmethod

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -21,8 +21,8 @@ from datacube.config import LocalConfig
 from datacube.index.exceptions import TransactionException
 from datacube.index.fields import Field
 from datacube.model import Product, Dataset, MetadataType, Range
-from datacube.model import LineageTree, LineageDirection
-from datacube.model.lineage import LineageRelations, LineageRelation
+from datacube.model import LineageTree, LineageDirection, LineageRelation
+from datacube.model.lineage import LineageRelations
 from datacube.utils import cached_property, jsonify_document, read_documents, InvalidDocException, report_to_user
 from datacube.utils.changes import AllowPolicy, Change, Offset, DocumentMismatchError, check_doc_unchanged
 from datacube.utils.generic import thread_local_cache

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -763,7 +763,7 @@ class DatasetResource(AbstractDatasetResource):
 
 class LineageResource(NoLineageResource):
     def get_all_lineage(self, batch_size: int = 1000) -> Iterable[LineageRelation]:
-        return self._index.datasets.get_all_lineage()
+        return self._index.datasets._get_all_lineage()
 
     def _add_batch(self, batch_rels: Iterable[LineageRelation]) -> BatchStatus:
         return self._index.datasets._add_lineage_batch(batch_rels)

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -17,7 +17,7 @@ from uuid import UUID
 from datacube.index import fields
 
 from datacube.index.abstract import (AbstractDatasetResource, DSID, dsid_to_uuid, BatchStatus,
-                                     QueryField,  DatasetSpatialMixin, NoLineageResource)
+                                     QueryField, DatasetSpatialMixin, NoLineageResource)
 from datacube.index.fields import Field
 from datacube.index.memory._fields import build_custom_fields, get_dataset_fields
 from datacube.index.memory._products import ProductResource

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -727,6 +727,8 @@ class DatasetResource(AbstractDatasetResource):
     def spatial_extent(self, ids, crs=None):
         return None
 
+    # Lineage methods need to be implemented on the dataset resource as that is where the relevant indexes
+    # currently live.
     def _get_all_lineage(self) -> Iterable[LineageRelation]:
         for derived_id, sources in self.derived_from.items():
             for classifier, source_id in sources.items():
@@ -762,6 +764,10 @@ class DatasetResource(AbstractDatasetResource):
 
 
 class LineageResource(NoLineageResource):
+    """
+    Minimal implementation as does not support external lineage.
+    Lineage indexes live in the Dataset resource, so thin wrapper around that.
+    """
     def get_all_lineage(self, batch_size: int = 1000) -> Iterable[LineageRelation]:
         return self._index.datasets._get_all_lineage()
 

--- a/datacube/index/memory/index.py
+++ b/datacube/index/memory/index.py
@@ -5,12 +5,12 @@
 import logging
 from threading import Lock
 
-from datacube.index.memory._datasets import DatasetResource  # type: ignore
+from datacube.index.memory._datasets import DatasetResource, LineageResource  # type: ignore
 from datacube.index.memory._fields import get_dataset_fields
 from datacube.index.memory._metadata_types import MetadataTypeResource
 from datacube.index.memory._products import ProductResource
 from datacube.index.memory._users import UserResource
-from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, UnhandledTransaction, LegacyLineageResource
+from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, UnhandledTransaction
 from datacube.model import MetadataType
 from datacube.utils.geometry import CRS
 
@@ -30,7 +30,7 @@ class Index(AbstractIndex):
         self._users = UserResource()
         self._metadata_types = MetadataTypeResource()
         self._products = ProductResource(self.metadata_types)
-        self._lineage = LegacyLineageResource(self)
+        self._lineage = LineageResource(self)
         self._datasets = DatasetResource(self.products)
         global counter
         with counter_lock:
@@ -50,7 +50,7 @@ class Index(AbstractIndex):
         return self._products
 
     @property
-    def lineage(self) -> LegacyLineageResource:
+    def lineage(self) -> LineageResource:
         return self._lineage
 
     @property

--- a/datacube/index/null/index.py
+++ b/datacube/index/null/index.py
@@ -8,7 +8,7 @@ from datacube.index.null._datasets import DatasetResource  # type: ignore
 from datacube.index.null._metadata_types import MetadataTypeResource
 from datacube.index.null._products import ProductResource
 from datacube.index.null._users import UserResource
-from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, UnhandledTransaction, LegacyLineageResource
+from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, UnhandledTransaction, NoLineageResource
 from datacube.model import MetadataType
 from datacube.model.fields import get_dataset_fields
 from datacube.utils.geometry import CRS
@@ -27,7 +27,7 @@ class Index(AbstractIndex):
         self._users = UserResource()
         self._metadata_types = MetadataTypeResource()
         self._products = ProductResource(self.metadata_types)
-        self._lineage = LegacyLineageResource(self)
+        self._lineage = NoLineageResource(self)
         self._datasets = DatasetResource(self.products)
 
     @property
@@ -43,7 +43,7 @@ class Index(AbstractIndex):
         return self._products
 
     @property
-    def lineage(self) -> LegacyLineageResource:
+    def lineage(self) -> NoLineageResource:
         return self._lineage
 
     @property

--- a/datacube/index/postgis/_lineage.py
+++ b/datacube/index/postgis/_lineage.py
@@ -140,9 +140,9 @@ class LineageResource(AbstractLineageResource, IndexResourceAddIn):
             b_added, b_skipped = connection.insert_lineage_bulk(
                 [
                     {
-                        "dataset_ref": rel.derived_id,
+                        "derived_dataset_ref": rel.derived_id,
                         "classifier": rel.classifier,
-                        "dataset_source_ref": rel.source_id,
+                        "source_dataset_ref": rel.source_id,
                     }
                     for rel in batch
                 ]

--- a/datacube/index/postgis/_lineage.py
+++ b/datacube/index/postgis/_lineage.py
@@ -129,9 +129,9 @@ class LineageResource(AbstractLineageResource, IndexResourceAddIn):
         with self._db_connection(transaction=True) as connection:
             for row in connection.get_all_lineage(batch_size=batch_size):
                 yield LineageRelation(
-                    derived_id=row.dataset_ref,
+                    derived_id=row.derived_dataset_ref,
                     classifier=row.classifier,
-                    source_id=row.dataset_source_ref
+                    source_id=row.source_dataset_ref
                 )
 
     def _add_batch(self, batch: Iterable[LineageRelation]) -> BatchStatus:

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -927,5 +927,3 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             for row in connection.bulk_simple_dataset_search(products=product_search_key, batch_size=batch_size):
                 prod_name, metadata_doc, uris = tuple(row)
                 yield DatasetTuple(product, metadata_doc, uris)
-
-

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -17,9 +17,10 @@ from sqlalchemy import select, func
 
 from datacube.drivers.postgres._fields import SimpleDocField, DateDocField
 from datacube.drivers.postgres._schema import DATASET
-from datacube.index.abstract import AbstractDatasetResource, DatasetSpatialMixin, DSID, DatasetTuple, BatchStatus
+from datacube.index.abstract import (AbstractDatasetResource, DatasetSpatialMixin, DSID,
+                                     DatasetTuple, BatchStatus, NoLineageResource)
 from datacube.index.postgres._transaction import IndexResourceAddIn
-from datacube.model import Dataset, Product
+from datacube.model import Dataset, Product, LineageRelation
 from datacube.model.fields import Field
 from datacube.model.utils import flatten_datasets
 from datacube.utils import jsonify_document, _readable_offset, changes
@@ -926,3 +927,22 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             for row in connection.bulk_simple_dataset_search(products=product_search_key, batch_size=batch_size):
                 prod_name, metadata_doc, uris = tuple(row)
                 yield DatasetTuple(product, metadata_doc, uris)
+
+
+class LineageResource(NoLineageResource, IndexResourceAddIn):
+    def __init__(self, db, index):
+        self._db = db
+        super().__init__(index)
+
+    def get_all_lineage(self, batch_size: int = 1000) -> Iterable[LineageRelation]:
+        with self._db_connection(transaction=True) as connection:
+            for row in connection.get_all_lineage(batch_size=batch_size):
+                yield LineageRelation(
+                    derived_id=row.dataset_ref,
+                    classifier=row.classifier,
+                    source_id=row.dataset_source_ref
+                )
+
+    def _add_batch(self, batch_rels: Iterable[LineageRelation]) -> BatchStatus:
+        b_started = monotonic()
+        return BatchStatus(0, 0, monotonic()-b_started)

--- a/datacube/index/postgres/_lineage.py
+++ b/datacube/index/postgres/_lineage.py
@@ -29,11 +29,7 @@ class LineageResource(NoLineageResource, IndexResourceAddIn):
         with self._db_connection(transaction=True) as connection:
             b_added, b_skipped = connection.insert_lineage_bulk(
                 [
-                    {
-                        "dataset_ref": rel.derived_id,
-                        "classifier": rel.classifier,
-                        "source_dataset_ref": rel.source_id,
-                    }
+                    (str(rel.derived_id), rel.classifier, str(rel.source_id))
                     for rel in batch
                 ]
             )

--- a/datacube/index/postgres/_lineage.py
+++ b/datacube/index/postgres/_lineage.py
@@ -21,7 +21,7 @@ class LineageResource(NoLineageResource, IndexResourceAddIn):
                 yield LineageRelation(
                     derived_id=row.dataset_ref,
                     classifier=row.classifier,
-                    source_id=row.dataset_source_ref
+                    source_id=row.source_dataset_ref
                 )
 
     def _add_batch(self, batch: Iterable[LineageRelation]) -> BatchStatus:
@@ -32,7 +32,7 @@ class LineageResource(NoLineageResource, IndexResourceAddIn):
                     {
                         "dataset_ref": rel.derived_id,
                         "classifier": rel.classifier,
-                        "dataset_source_ref": rel.source_id,
+                        "source_dataset_ref": rel.source_id,
                     }
                     for rel in batch
                 ]

--- a/datacube/index/postgres/_lineage.py
+++ b/datacube/index/postgres/_lineage.py
@@ -1,0 +1,29 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2022 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+from time import monotonic
+from typing import Iterable
+
+from datacube.index.abstract import NoLineageResource, BatchStatus
+from datacube.index.postgres._transaction import IndexResourceAddIn
+from datacube.model import LineageRelation
+
+
+class LineageResource(NoLineageResource, IndexResourceAddIn):
+    def __init__(self, db, index):
+        self._db = db
+        super().__init__(index)
+
+    def get_all_lineage(self, batch_size: int = 1000) -> Iterable[LineageRelation]:
+        with self._db_connection(transaction=True) as connection:
+            for row in connection.get_all_lineage(batch_size=batch_size):
+                yield LineageRelation(
+                    derived_id=row.dataset_ref,
+                    classifier=row.classifier,
+                    source_id=row.dataset_source_ref
+                )
+
+    def _add_batch(self, batch_rels: Iterable[LineageRelation]) -> BatchStatus:
+        b_started = monotonic()
+        return BatchStatus(0, 0, monotonic()-b_started)

--- a/datacube/index/postgres/_lineage.py
+++ b/datacube/index/postgres/_lineage.py
@@ -24,6 +24,17 @@ class LineageResource(NoLineageResource, IndexResourceAddIn):
                     source_id=row.dataset_source_ref
                 )
 
-    def _add_batch(self, batch_rels: Iterable[LineageRelation]) -> BatchStatus:
+    def _add_batch(self, batch: Iterable[LineageRelation]) -> BatchStatus:
         b_started = monotonic()
-        return BatchStatus(0, 0, monotonic()-b_started)
+        with self._db_connection(transaction=True) as connection:
+            b_added, b_skipped = connection.insert_lineage_bulk(
+                [
+                    {
+                        "dataset_ref": rel.derived_id,
+                        "classifier": rel.classifier,
+                        "dataset_source_ref": rel.source_id,
+                    }
+                    for rel in batch
+                ]
+            )
+        return BatchStatus(b_added, b_skipped, monotonic() - b_started)

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -7,12 +7,12 @@ from contextlib import contextmanager
 
 from datacube.drivers.postgres import PostgresDb, PostgresDbAPI
 from datacube.index.postgres._transaction import PostgresTransaction
-from datacube.index.postgres._datasets import DatasetResource  # type: ignore
+from datacube.index.postgres._datasets import DatasetResource, LineageResource  # type: ignore
 from datacube.index.postgres._metadata_types import MetadataTypeResource
 from datacube.index.postgres._products import ProductResource
 from datacube.index.postgres._users import UserResource
 from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, AbstractTransaction, \
-    default_metadata_type_docs, LegacyLineageResource
+    default_metadata_type_docs
 from datacube.model import MetadataType
 from datacube.utils.geometry import CRS
 
@@ -51,7 +51,7 @@ class Index(AbstractIndex):
         self._users = UserResource(db, self)
         self._metadata_types = MetadataTypeResource(db, self)
         self._products = ProductResource(db, self)
-        self._lineage = LegacyLineageResource(self)
+        self._lineage = LineageResource(db, self)
         self._datasets = DatasetResource(db, self)
 
     @property
@@ -67,7 +67,7 @@ class Index(AbstractIndex):
         return self._products
 
     @property
-    def lineage(self) -> LegacyLineageResource:
+    def lineage(self) -> LineageResource:
         return self._lineage
 
     @property

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -7,7 +7,8 @@ from contextlib import contextmanager
 
 from datacube.drivers.postgres import PostgresDb, PostgresDbAPI
 from datacube.index.postgres._transaction import PostgresTransaction
-from datacube.index.postgres._datasets import DatasetResource, LineageResource  # type: ignore
+from datacube.index.postgres._datasets import DatasetResource  # type: ignore
+from datacube.index.postgres._lineage import LineageResource
 from datacube.index.postgres._metadata_types import MetadataTypeResource
 from datacube.index.postgres._products import ProductResource
 from datacube.index.postgres._users import UserResource

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -23,12 +23,12 @@ from datacube.index.eo3 import is_doc_eo3
 from .fields import Field, get_dataset_fields
 from ._base import Range, ranges_overlap  # noqa: F401
 from .eo3 import validate_eo3_compatible_type
-from .lineage import LineageDirection, LineageTree, InconsistentLineageException  # noqa: F401
+from .lineage import LineageDirection, LineageTree, LineageRelation, InconsistentLineageException  # noqa: F401
 
 __all__ = [
     "Field", "get_dataset_fields",
     "Range", "ranges_overlap",
-    "LineageDirection", "LineageTree", "InconsistentLineageException",
+    "LineageDirection", "LineageTree", "LineageRelation", "InconsistentLineageException",
     "Dataset", "Product", "MetadataType", "Measurement", "GridSpec",
     "metadata_from_doc",
     "ExtraDimensions", "IngestorConfig"

--- a/datacube/scripts/system.py
+++ b/datacube/scripts/system.py
@@ -105,9 +105,20 @@ def check(local_config: LocalConfig):
               help='Size of batches for bulk-adding to the new index',
               type=int,
               default=1000)
+@click.option(
+    '--skip-lineage/--no-skip-lineage', is_flag=True, default=False,
+    help="Clone lineage data where possible. (default: true)"
+)
+@click.option(
+    '--lineage-only/--no-lineage-only', is_flag=True, default=False,
+    help="Clone lineage data only. (default: false)"
+)
 @click.argument('source-env', type=str, nargs=1)
 @ui.pass_index()
-def clone(index: Index, batch_size: int, source_env: str):
+def clone(index: Index, batch_size: int, skip_lineage: bool, lineage_only: bool, source_env: str):
+    if skip_lineage and lineage_only:
+        echo("Cannot set both lineage-only and skip-lineage")
+        exit(1)
     try:
         source_dc = Datacube(env=source_env)
     except OperationalError as e:
@@ -115,4 +126,4 @@ def clone(index: Index, batch_size: int, source_env: str):
     except IndexSetupError as e:
         handle_exception('Source database not initialised: %s', e)
 
-    index.clone(source_dc.index, batch_size=batch_size)
+    index.clone(source_dc.index, batch_size=batch_size, skip_lineage=skip_lineage, lineage_only=lineage_only)

--- a/datacube/scripts/system.py
+++ b/datacube/scripts/system.py
@@ -9,7 +9,6 @@ from click import echo, style
 from sqlalchemy.exc import OperationalError
 
 import datacube
-from datacube import Datacube
 from datacube.index import Index, index_connect
 from datacube.drivers.postgres._connections import IndexSetupError
 from datacube.ui import click as ui

--- a/datacube/utils/__init__.py
+++ b/datacube/utils/__init__.py
@@ -37,6 +37,7 @@ from .math import (
 from ._misc import (
     DatacubeException,
     gen_password,
+    report_to_user
 )
 
 
@@ -75,4 +76,5 @@ __all__ = (
     "check_write_path",
     "gen_password",
     "_readable_offset",
+    "report_to_user"
 )

--- a/datacube/utils/_misc.py
+++ b/datacube/utils/_misc.py
@@ -25,6 +25,16 @@ def gen_password(num_random_bytes=12):
 
 
 def report_to_user(msg: str, logger: Optional[logging.Logger] = None, progress_indicator=False):
+    """
+    Report a message or progress indicator to the user, either via stdout or via the log if stdout
+    is not a typewriter.
+
+    :param msg: The message to report to the user.
+    :param logger: The logger (optional - if not provided and stdout is not a typewriter, the message is not reported)
+    :param progress_indicator: If true, and writing to stdout, no eol character is written and the stream is flushed
+                               after writing.
+    :return: None
+    """
     if sys.stdout.isatty():
         if progress_indicator:
             print(msg, end="", flush=True)

--- a/datacube/utils/_misc.py
+++ b/datacube/utils/_misc.py
@@ -6,6 +6,9 @@
 Utility functions
 """
 import os
+import sys
+import logging
+from typing import Optional
 
 
 class DatacubeException(Exception):  # noqa: N818
@@ -19,3 +22,13 @@ def gen_password(num_random_bytes=12):
     """
     import base64
     return base64.urlsafe_b64encode(os.urandom(num_random_bytes)).decode('utf-8')
+
+
+def report_to_user(msg: str, logger: Optional[logging.Logger] = None, progress_indicator=False):
+    if sys.stdout.isatty():
+        if progress_indicator:
+            print(msg, end="", flush=True)
+        else:
+            print(msg)
+    elif logger:
+        logger.info(msg)

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -203,7 +203,12 @@ def doc_to_ds(index, product_name, ds_doc, ds_path):
     resolver = Doc2Dataset(index, products=[product_name], verify_lineage=False)
     ds, err = resolver(ds_doc, ds_path)
     assert err is None and ds is not None
-    index.datasets.add(ds, with_lineage=False)
+    if index.supports_external_lineage:
+        index.datasets.add(ds, with_lineage=False)
+        eo3_tree = LineageTree.from_eo3_doc(ds_doc)
+        index.lineage.add(eo3_tree)
+    else:
+        index.datasets.add(ds, with_lineage=index.supports_lineage)
     return index.datasets.get(ds.id)
 
 

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -314,15 +314,6 @@ def mem_eo3_data(mem_index_eo3, datasets_with_unembedded_lineage_doc):
     return mem_index_eo3, ds_ls8.id, ds_wo.id
 
 
-@pytest.fixture
-def global_integration_cli_args():
-    """
-    The first arguments to pass to a cli command for integration test configuration.
-    """
-    # List of a config files in order.
-    return list(itertools.chain(*(('--config', f) for f in CONFIG_FILE_PATHS)))
-
-
 @pytest.fixture(scope="module", params=["datacube", "experimental"])
 def datacube_env_name(request):
     return request.param
@@ -745,7 +736,7 @@ def example_ls5_nbar_metadata_doc():
 
 
 @pytest.fixture
-def clirunner(global_integration_cli_args, datacube_env_name):
+def clirunner(datacube_env_name):
     def _run_cli(opts, catch_exceptions=False,
                  expect_success=True, cli_method=datacube.scripts.cli_app.cli,
                  verbose_flag='-v'):

--- a/integration_tests/index/test_index_cloning.py
+++ b/integration_tests/index/test_index_cloning.py
@@ -24,20 +24,26 @@ def test_index_clone_small_batch(index_pair_populated_empty):
     assert results["datasets"].skipped == 0
 
 
-def test_index_clone_cli(local_config_pair, index_pair_populated_empty, clirunner_raw):
+def test_index_clone_cli(local_config_pair, index_pair_populated_empty, clirunner):
     source_cfg, target_cfg = local_config_pair
-    clirunner_raw([
+    clirunner([
+        '-E', target_cfg._env,
+        'system', 'clone',
+        '--lineage-only', '--skip-lineage',
+        source_cfg._env
+    ], expect_success=False)
+    clirunner([
         '-E', target_cfg._env,
         'system', 'clone',
         source_cfg._env
-    ], expect_success=False)
+    ], expect_success=True)
 
 
-def test_index_clone_cli_small_batch(local_config_pair, index_pair_populated_empty, clirunner_raw):
+def test_index_clone_cli_small_batch(local_config_pair, index_pair_populated_empty, clirunner):
     source_cfg, target_cfg = local_config_pair
-    clirunner_raw([
+    clirunner([
         '-E', target_cfg._env,
         'system', 'clone',
         '--batch-size', '2',
         source_cfg._env
-    ], expect_success=False)
+    ], expect_success=True)

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -70,7 +70,7 @@ _pseudo_telemetry_dataset_type = {
 }
 
 
-def test_archive_datasets(index, local_config, ls8_eo3_dataset):
+def test_archive_datasets(index, ls8_eo3_dataset):
     datasets = index.datasets.search_eager()
     assert len(datasets) == 1
     assert datasets[0].is_active


### PR DESCRIPTION
### Reason for this pull request

The index cloning feature did not include lineage data because:
a. no bulk read/write API methods had been implemented for lineage data
b. Semantic differences in interpretation of lineage data between external lineage index drivers and legacy lineage index drivers made API design challenging.  (Indeed, the external lineage API did not exist when the index cloning was implemented.)

### Proposed changes

- Options at API and CLI level to clone lineage only or skip lineage while cloning.
- If either the source or origin index does not support lineage (at all) `skip_lineage` automatically applies.
- If the source index supports non-eo3 metadata types and the target index does not, non-eo3 metadata types and the products and datasets associated with them are skipped in the cloning process.
- If the source index supports external lineage and target index does not, lineage records that reference external datasets are skipped.
- If the target index supports external lineage, ALL lineage records are cloned, including ones that reference datasets that are skipped for any of the above reasons.
- Improvements to EO3 test fixtures


 - [x] Closes #xxxx
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
