### PR TITLE
Migrate to SQLAlchemy 2.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,7 +95,7 @@ jobs:
       if: steps.changes.outputs.docker == 'true'
       uses: docker/build-push-action@v4
       with:
-        context: .
+        context: ./docker
         push: true
         tags: ${{env.DOCKER_IMAGE}}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,7 +92,10 @@ jobs:
         EOF
 
     - name: DockerHub Push
-      if: steps.changes.outputs.docker == 'true'
+      if: |
+        github.event_name == 'push'
+        && github.ref == 'refs/heads/develop'
+        && steps.changes.outputs.docker == 'true'
       uses: docker/build-push-action@v4
       with:
         file: docker/Dockerfile
@@ -136,7 +139,6 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PyPiToken }}
 
     - name: Upload coverage to Codecov
-      if: steps.cfg.outputs.primary == 'yes'
       uses: codecov/codecov-action@v3
       with:
         file: ./coverage.xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
         password: ${{ secrets.GADOCKERSVC_PASSWORD }}
 
     - name: Build Docker
-      # if: steps.changes.outputs.docker == 'true'
+      if: steps.changes.outputs.docker == 'true'
       uses: docker/build-push-action@v4
       with:
         file: docker/Dockerfile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,7 +95,8 @@ jobs:
       if: steps.changes.outputs.docker == 'true'
       uses: docker/build-push-action@v4
       with:
-        context: "{{defaultContext}}:docker"
+        file: docker/Dockerfile
+        context: .
         push: true
         tags: ${{env.DOCKER_IMAGE}}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,9 @@ on:
   
 env:
   DOCKER_USER: gadockersvc
-  DOCKER_IMAGE: opendatacube/datacube-tests:latest
+  DOCKER_IMAGE: opendatacube/datacube-tests:latest1.9
+  # NB Restore standard image name when merge into develop
+  # DOCKER_IMAGE: opendatacube/datacube-tests:latest
 
 
 jobs:
@@ -63,7 +65,6 @@ jobs:
         password: ${{ secrets.GADOCKERSVC_PASSWORD }}
 
     - name: Build Docker
-      if: steps.changes.outputs.docker == 'true'
       uses: docker/build-push-action@v4
       with:
         file: docker/Dockerfile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
         password: ${{ secrets.GADOCKERSVC_PASSWORD }}
 
     - name: Build Docker
-      if: steps.changes.outputs.docker == 'true'
+      # if: steps.changes.outputs.docker == 'true'
       uses: docker/build-push-action@v4
       with:
         file: docker/Dockerfile
@@ -95,7 +95,7 @@ jobs:
       if: steps.changes.outputs.docker == 'true'
       uses: docker/build-push-action@v4
       with:
-        context: ./docker
+        context: "{{defaultContext}}:docker"
         push: true
         tags: ${{env.DOCKER_IMAGE}}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,7 @@ jobs:
       with:
         context: .
         push: true
-        tags: ${DOCKER_IMAGE}
+        tags: ${{env.DOCKER_IMAGE}}
 
     - name: Build Packages
       run: |

--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -32,7 +32,7 @@ dependencies:
   - pyyaml
   - rasterio >=1.3.2
   - ruamel.yaml
-  - sqlalchemy <2.0
+  - sqlalchemy >=2.0
   - GeoAlchemy2
   - xarray >=0.9
   - toolz

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -391,9 +391,9 @@ class PostgisDbAPI(object):
         if SpatialIndex is None:
             return None
         result = self._connection.execute(
-            select([
+            select(
                 func.ST_AsGeoJSON(func.ST_Union(SpatialIndex.extent))
-            ]).select_from(
+            ).select_from(
                 SpatialIndex
             ).where(
                 SpatialIndex.dataset_ref.in_(ids)
@@ -619,7 +619,7 @@ class PostgisDbAPI(object):
         raw_expressions = PostgisDbAPI._alchemify_expressions(expressions)
         join_tables = PostgisDbAPI._join_tables(expressions, select_fields)
         where_expr = and_(Dataset.archived == None, *raw_expressions)
-        query = select(select_columns).select_from(Dataset)
+        query = select(*select_columns).select_from(Dataset)
         for joins in join_tables:
             query = query.join(*joins)
         if spatialquery is not None:
@@ -739,7 +739,8 @@ class PostgisDbAPI(object):
         join_tables = PostgisDbAPI._join_tables(expressions, match_fields)
 
         query = select(
-            (func.array_agg(Dataset.id),) + group_expressions
+            func.array_agg(Dataset.id),
+            *group_expressions
         ).select_from(Dataset)
         for joins in join_tables:
             query = query.join(*joins)
@@ -792,24 +793,24 @@ class PostgisDbAPI(object):
     def count_datasets_through_time_query(self, start, end, period, time_field, expressions):
         raw_expressions = self._alchemify_expressions(expressions)
 
-        start_times = select((
+        start_times = select(
             func.generate_series(start, end, cast(period, INTERVAL)).label('start_time'),
-        )).alias('start_times')
+        ).alias('start_times')
 
         time_range_select = (
-            select((
+            select(
                 func.tstzrange(
                     start_times.c.start_time,
                     func.lead(start_times.c.start_time).over()
                 ).label('time_period'),
-            ))
+            )
         ).alias('all_time_ranges')
 
         # Exclude the trailing (end time to infinite) row. Is there a simpler way?
         time_ranges = (
-            select((
+            select(
                 time_range_select,
-            )).where(
+            ).where(
                 ~func.upper_inf(time_range_select.c.time_period)
             )
         ).alias('time_ranges')
@@ -826,7 +827,7 @@ class PostgisDbAPI(object):
             )
         )
 
-        return select((time_ranges.c.time_period, count_query.label('dataset_count')))
+        return select(time_ranges.c.time_period, count_query.label('dataset_count'))
 
     def update_search_index(self, product_names: Sequence[str] = [], dsids: Sequence[DSID] = []):
         """
@@ -1287,9 +1288,9 @@ class PostgisDbAPI(object):
             ))
         )
         for rel in results:
-            yield LineageRelation(classifier=rel["classifier"],
-                                  source_id=rel["source_dataset_ref"],
-                                  derived_id=rel["derived_dataset_ref"])
+            yield LineageRelation(classifier=rel.classifier,
+                                  source_id=rel.source_dataset_ref,
+                                  derived_id=rel.derived_dataset_ref)
 
     def write_relations(self, relations: Iterable[LineageRelation], allow_updates: bool):
         """
@@ -1366,9 +1367,9 @@ class PostgisDbAPI(object):
         next_lvl_ids = set()
         results = self._connection.execute(qry)
         for row in results:
-            rel = LineageRelation(classifier=row["classifier"],
-                                  source_id=row["source_dataset_ref"],
-                                  derived_id=row["derived_dataset_ref"])
+            rel = LineageRelation(classifier=row.classifier,
+                                  source_id=row.source_dataset_ref,
+                                  derived_id=row.derived_dataset_ref)
             relations.append(rel)
             if direction == LineageDirection.SOURCES:
                 next_id = rel.source_id

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -442,7 +442,7 @@ class PostgisDbAPI(object):
 
         return self._connection.execute(
             select(
-                _dataset_select_fields()
+                *_dataset_select_fields()
             ).join(
                 Dataset.locations
             ).where(

--- a/datacube/drivers/postgis/sql.py
+++ b/datacube/drivers/postgis/sql.py
@@ -7,7 +7,8 @@ Custom types for postgres & sqlalchemy
 """
 
 from sqlalchemy import TIMESTAMP, text
-from sqlalchemy.dialects.postgresql.ranges import RangeOperators
+from sqlalchemy.types import Double
+from sqlalchemy.dialects.postgresql.ranges import AbstractRange, Range
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql import sqltypes
 from sqlalchemy.sql.expression import Executable, ClauseElement
@@ -74,7 +75,7 @@ create type {schema}.float8range as range (
 
 
 # pylint: disable=abstract-method
-class FLOAT8RANGE(RangeOperators, sqltypes.TypeEngine):
+class FLOAT8RANGE(AbstractRange[Range[Double]]):
     __visit_name__ = 'FLOAT8RANGE'
 
 

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -530,7 +530,7 @@ class PostgresDbAPI(object):
             # Include the IDs of source datasets
             select_columns += (
                 select(
-                    (func.array_agg(DATASET_SOURCE.c.source_dataset_ref),)
+                    func.array_agg(DATASET_SOURCE.c.source_dataset_ref)
                 ).select_from(
                     DATASET_SOURCE
                 ).where(

--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -99,6 +99,7 @@ def ensure_db(engine, with_permissions=True):
 
     if not has_schema(engine):
         is_new = True
+        sqla_txn = None
         try:
             sqla_txn = c.begin()
             if with_permissions:
@@ -115,7 +116,8 @@ def ensure_db(engine, with_permissions=True):
             install_added_column(c)
             sqla_txn.commit()
         except:  # noqa: E722
-            sqla_txn.rollback()
+            if sqla_txn is not None:
+                sqla_txn.rollback()
             raise
         finally:
             if with_permissions:

--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -81,68 +81,60 @@ def ensure_db(engine, with_permissions=True):
 
     Create the schema if it doesn't exist.
     """
-    is_new = False
-    c = engine.connect()
+    is_new = not has_schema(engine)
+    with engine.connect() as c:
+        #  NB. Using default SQLA2.0 auto-begin commit-as-you-go behaviour
+        quoted_db_name, quoted_user = _get_quoted_connection_info(c)
 
-    quoted_db_name, quoted_user = _get_quoted_connection_info(c)
+        if with_permissions:
+            _LOG.info('Ensuring user roles.')
+            _ensure_role(c, 'agdc_user')
+            _ensure_role(c, 'agdc_ingest', inherits_from='agdc_user')
+            _ensure_role(c, 'agdc_manage', inherits_from='agdc_ingest')
+            _ensure_role(c, 'agdc_admin', inherits_from='agdc_manage', add_user=True)
 
-    if with_permissions:
-        _LOG.info('Ensuring user roles.')
-        _ensure_role(c, 'agdc_user')
-        _ensure_role(c, 'agdc_ingest', inherits_from='agdc_user')
-        _ensure_role(c, 'agdc_manage', inherits_from='agdc_ingest')
-        _ensure_role(c, 'agdc_admin', inherits_from='agdc_manage', add_user=True)
+            c.execute(text("""
+            grant all on database {db} to agdc_admin;
+            """.format(db=quoted_db_name)))
+            c.commit()
 
-        c.execute(text("""
-        grant all on database {db} to agdc_admin;
-        """.format(db=quoted_db_name)))
-
-    if not has_schema(engine):
-        is_new = True
-        sqla_txn = None
-        try:
-            sqla_txn = c.begin()
+        if is_new:
             if with_permissions:
                 # Switch to 'agdc_admin', so that all items are owned by them.
                 c.execute(text('set role agdc_admin'))
             _LOG.info('Creating schema.')
             c.execute(CreateSchema(SCHEMA_NAME))
-            _LOG.info('Creating tables.')
+            _LOG.info('Creating types.')
             c.execute(text(TYPES_INIT_SQL))
+            _LOG.info('Creating tables.')
             METADATA.create_all(c)
             _LOG.info("Creating triggers.")
             install_timestamp_trigger(c)
             _LOG.info("Creating added column.")
             install_added_column(c)
-            sqla_txn.commit()
-        except:  # noqa: E722
-            if sqla_txn is not None:
-                sqla_txn.rollback()
-            raise
-        finally:
             if with_permissions:
                 c.execute(text('set role {}'.format(quoted_user)))
+            c.commit()
 
-    if with_permissions:
-        _LOG.info('Adding role grants.')
-        c.execute(text("""
-        grant usage on schema {schema} to agdc_user;
-        grant select on all tables in schema {schema} to agdc_user;
-        grant execute on function {schema}.common_timestamp(text) to agdc_user;
+        if with_permissions:
+            _LOG.info('Adding role grants.')
+            c.execute(text("""
+            grant usage on schema {schema} to agdc_user;
+            grant select on all tables in schema {schema} to agdc_user;
+            grant execute on function {schema}.common_timestamp(text) to agdc_user;
 
-        grant insert on {schema}.dataset,
-                        {schema}.dataset_location,
-                        {schema}.dataset_source to agdc_ingest;
-        grant usage, select on all sequences in schema {schema} to agdc_ingest;
+            grant insert on {schema}.dataset,
+                            {schema}.dataset_location,
+                            {schema}.dataset_source to agdc_ingest;
+            grant usage, select on all sequences in schema {schema} to agdc_ingest;
 
-        -- (We're only granting deletion of types that have nothing written yet: they can't delete the data itself)
-        grant insert, delete on {schema}.dataset_type,
-                                {schema}.metadata_type to agdc_manage;
-        -- Allow creation of indexes, views
-        grant create on schema {schema} to agdc_manage;
-        """.format(schema=SCHEMA_NAME)))
-
-    c.close()
+            -- (We're only granting deletion of types that have nothing written yet: they can't delete the data itself)
+            grant insert, delete on {schema}.dataset_type,
+                                    {schema}.metadata_type to agdc_manage;
+            -- Allow creation of indexes, views
+            grant create on schema {schema} to agdc_manage;
+            """.format(schema=SCHEMA_NAME)))
+            c.commit()
 
     return is_new
 

--- a/datacube/drivers/postgres/_fields.py
+++ b/datacube/drivers/postgres/_fields.py
@@ -397,7 +397,7 @@ class DoubleRangeDocField(RangeDocField):
         """
         :rtype: Expression
         """
-        return RangeBetweenExpression(self, low, high, _range_class=NumericRange)
+        return RangeBetweenExpression(self, low, high, _range_class=func.agdc.float8range)
 
 
 class DateRangeDocField(RangeDocField):

--- a/datacube/drivers/postgres/sql.py
+++ b/datacube/drivers/postgres/sql.py
@@ -7,7 +7,8 @@ Custom types for postgres & sqlalchemy
 """
 
 from sqlalchemy import TIMESTAMP, text
-from sqlalchemy.dialects.postgresql.ranges import RangeOperators
+from sqlalchemy.types import Double
+from sqlalchemy.dialects.postgresql.ranges import AbstractRange, Range
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql import sqltypes
 from sqlalchemy.sql.expression import Executable, ClauseElement
@@ -74,7 +75,7 @@ create type {schema}.float8range as range (
 
 
 # pylint: disable=abstract-method
-class FLOAT8RANGE(RangeOperators, sqltypes.TypeEngine):
+class FLOAT8RANGE(AbstractRange[Range[Double]]):
     __visit_name__ = 'FLOAT8RANGE'
 
 

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -760,7 +760,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         """
         for _, results in self._do_search_by_product(query, return_fields=True):
             for columns in results:
-                output = dict(columns)
+                output = columns._asdict()
                 _LOG.warning("search results: %s (%s)", output["id"], output["product"])
                 yield output
 

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -739,13 +739,13 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         """
         for _, results in self._do_search_by_product(query, return_fields=True):
             for columns in results:
-                yield dict(columns)
+                yield columns._asdict()
 
     def get_product_time_bounds(self, product: str):
         """
         Returns the minimum and maximum acquisition time of the product.
         """
-
+        # This implementation violates architecture - should not be SQLAlchemy code at this level.
         # Get the offsets from dataset doc
         product = self.types.get_by_name(product)
         dataset_section = product.metadata_type.definition['dataset']
@@ -769,7 +769,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         with self._db_connection() as connection:
             result = connection.execute(
                 select(
-                    [func.min(time_min.alchemy_expression), func.max(time_max.alchemy_expression)]
+                    func.min(time_min.alchemy_expression), func.max(time_max.alchemy_expression)
                 ).where(
                     DATASET.c.dataset_type_ref == product.id
                 )

--- a/docker/constraints.in
+++ b/docker/constraints.in
@@ -35,7 +35,7 @@ shapely>=2.0
 sphinx-click
 sphinx_autodoc_typehints
 sphinx_rtd_theme
-sqlalchemy<2.0
+sqlalchemy>=2.0
 toolz
 xarray>=0.9
 

--- a/docker/constraints.txt
+++ b/docker/constraints.txt
@@ -380,7 +380,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==1.4.46
+sqlalchemy==2.0.8
     # via
     #   -r constraints.in
     #   geoalchemy2
@@ -411,6 +411,7 @@ typing-extensions==4.4.0
     # via
     #   pygeoif
     #   setuptools-scm
+    #   sqlalchemy
 urllib3==1.26.14
     # via
     #   botocore

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -5,6 +5,14 @@
 What's New
 **********
 
+v1.9.next
+=========
+
+- External Lineage API (:pull:`#1401`)
+- Add lineage support to index clone operation (:pull:`#1429`)
+- Migrate to SQLAlchemy 2.0 (:pull:`#14??`)
+
+
 v1.8.next
 =========
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -10,7 +10,7 @@ v1.9.next
 
 - External Lineage API (:pull:`#1401`)
 - Add lineage support to index clone operation (:pull:`#1429`)
-- Migrate to SQLAlchemy 2.0 (:pull:`#14??`)
+- Migrate to SQLAlchemy 2.0 (:pull:`#1432`)
 
 
 v1.8.next

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -9,6 +9,7 @@ Module
 import copy
 import pytest
 import yaml
+from sqlalchemy import text
 
 from datacube.drivers.postgres._fields import NumericRangeDocField as PgrNumericRangeDocField, PgField as PgrPgField
 from datacube.drivers.postgis._fields import NumericRangeDocField as PgsNumericRangeDocField, PgField as PgsPgField
@@ -162,7 +163,7 @@ def _object_exists(index, index_name):
     else:
         schema_name = "agdc"
     with index._active_connection() as connection:
-        val = connection._connection.execute(f"SELECT to_regclass('{schema_name}.{index_name}')").scalar()
+        val = connection._connection.execute(text(f"SELECT to_regclass('{schema_name}.{index_name}')")).scalar()
     return val in (index_name, f'{schema_name}.{index_name}')
 
 

--- a/integration_tests/index/test_search_legacy.py
+++ b/integration_tests/index/test_search_legacy.py
@@ -16,6 +16,7 @@ import pytest
 import yaml
 from dateutil import tz
 from psycopg2._range import NumericRange
+from sqlalchemy.dialects.postgresql.ranges import Range as SQLARange
 
 from datacube.config import LocalConfig
 from datacube.drivers.postgres._connections import DEFAULT_DB_USER
@@ -489,7 +490,6 @@ def test_search_returning(index: Index,
                           pseudo_ls8_type: Product,
                           pseudo_ls8_dataset: Dataset,
                           ls5_dataset_w_children) -> None:
-
     assert index.datasets.count() == 4, "Expected four test datasets"
 
     # Expect one product with our one dataset.
@@ -500,10 +500,11 @@ def test_search_returning(index: Index,
     ))
     assert len(results) == 1
     id_, path_range, sat_range = results[0]
+    path_range_type = path_range.__class__
     assert id_ == pseudo_ls8_dataset.id
     # TODO: output nicer types?
-    assert path_range == NumericRange(Decimal('116'), Decimal('116'), '[]')
-    assert sat_range == NumericRange(Decimal('74'), Decimal('84'), '[]')
+    assert path_range == SQLARange(lower=Decimal('116'), upper=Decimal('116'), bounds='[]')
+    assert sat_range == SQLARange(lower=Decimal('74'), upper=Decimal('84'), bounds='[]')
 
     results = list(index.datasets.search_returning(
         ('id', 'metadata_doc',),
@@ -875,8 +876,6 @@ def test_cli_missing_info(clirunner, index):
 def test_find_duplicates(index, pseudo_ls8_type,
                          pseudo_ls8_dataset, pseudo_ls8_dataset2, pseudo_ls8_dataset3, pseudo_ls8_dataset4,
                          ls5_dataset_w_children):
-    # type: (Index, Product, Dataset, Dataset, Dataset, Dataset, Dataset) -> None
-
     # Our four ls8 datasets and three ls5.
     all_datasets = index.datasets.search_eager()
     assert len(all_datasets) == 7
@@ -885,15 +884,15 @@ def test_find_duplicates(index, pseudo_ls8_type,
     expected_ls8_path_row_duplicates = [
         (
             (
-                NumericRange(Decimal('116'), Decimal('116'), '[]'),
-                NumericRange(Decimal('74'), Decimal('84'), '[]')
+                SQLARange(lower=Decimal('116'), upper=Decimal('116'), bounds='[]'),
+                SQLARange(lower=Decimal('74'), upper=Decimal('84'), bounds='[]')
             ),
             {pseudo_ls8_dataset.id, pseudo_ls8_dataset2.id}
         ),
         (
             (
-                NumericRange(Decimal('116'), Decimal('116'), '[]'),
-                NumericRange(Decimal('85'), Decimal('87'), '[]')
+                SQLARange(lower=Decimal('116'), upper=Decimal('116'), bounds='[]'),
+                SQLARange(lower=Decimal('85'), upper=Decimal('87'), bounds='[]')
             ),
             {pseudo_ls8_dataset3.id, pseudo_ls8_dataset4.id}
         ),
@@ -902,28 +901,24 @@ def test_find_duplicates(index, pseudo_ls8_type,
 
     # Specifying groups as fields:
     f = pseudo_ls8_type.metadata_type.dataset_fields.get
-    field_res = sorted(index.datasets.search_product_duplicates(
-        pseudo_ls8_type,
-        f('sat_path'), f('sat_row')
-    ))
-    assert field_res == expected_ls8_path_row_duplicates
+    field_res = list(
+        index.datasets.search_product_duplicates(
+            pseudo_ls8_type,
+            f('sat_path'), f('sat_row')
+        )
+    )
+    assert len(field_res) == len(expected_ls8_path_row_duplicates)
+    for field_result in field_res:
+        assert field_result in expected_ls8_path_row_duplicates
     # Field names as strings
-    product_res = sorted(index.datasets.search_product_duplicates(
+    product_res = list(index.datasets.search_product_duplicates(
         pseudo_ls8_type,
         'sat_path', 'sat_row'
     ))
     assert product_res == expected_ls8_path_row_duplicates
 
     # Get duplicates that start on the same day
-    f = pseudo_ls8_type.metadata_type.dataset_fields.get
-    field_res = sorted(index.datasets.search_product_duplicates(
-        pseudo_ls8_type,
-        f('time').lower.day  # type: ignore
-    ))
-
-    # Datasets 1 & 3 are on the 26th.
-    # Datasets 2 & 4 are on the 27th.
-    assert field_res == [
+    expected_time_day_duplicates = [
         (
             (
                 datetime.datetime(2014, 7, 26, 0, 0),
@@ -938,9 +933,22 @@ def test_find_duplicates(index, pseudo_ls8_type,
         ),
 
     ]
+    f = pseudo_ls8_type.metadata_type.dataset_fields.get
+    field_res = list(
+            index.datasets.search_product_duplicates(
+                pseudo_ls8_type,
+                f('time').lower.day  # type: ignore
+            )
+        )
+
+    # Datasets 1 & 3 are on the 26th.
+    # Datasets 2 & 4 are on the 27th.
+    assert len(field_res) == len(expected_time_day_duplicates)
+    for field_result in field_res:
+        assert field_result in expected_time_day_duplicates
 
     # No LS5 duplicates: there's only one of each
-    sat_res = sorted(index.datasets.search_product_duplicates(
+    sat_res = list(index.datasets.search_product_duplicates(
         ls5_dataset_w_children.product,
         'sat_path', 'sat_row'
     ))

--- a/integration_tests/index/test_search_legacy.py
+++ b/integration_tests/index/test_search_legacy.py
@@ -15,7 +15,6 @@ from typing import List, Any
 import pytest
 import yaml
 from dateutil import tz
-from psycopg2._range import NumericRange
 from sqlalchemy.dialects.postgresql.ranges import Range as SQLARange
 
 from datacube.config import LocalConfig
@@ -935,11 +934,11 @@ def test_find_duplicates(index, pseudo_ls8_type,
     ]
     f = pseudo_ls8_type.metadata_type.dataset_fields.get
     field_res = list(
-            index.datasets.search_product_duplicates(
-                pseudo_ls8_type,
-                f('time').lower.day  # type: ignore
-            )
+        index.datasets.search_product_duplicates(
+            pseudo_ls8_type,
+            f('time').lower.day  # type: ignore
         )
+    )
 
     # Datasets 1 & 3 are on the 26th.
     # Datasets 2 & 4 are on the 27th.

--- a/integration_tests/index/test_update_columns.py
+++ b/integration_tests/index/test_update_columns.py
@@ -31,7 +31,8 @@ and tgrelid = '{schema}.{table}'::regclass;
 
 
 def check_column(conn, table_name: str, column_name: str) -> bool:
-    column_result = conn.execute(text(
+    column_result = conn.execute(
+        text(
             COLUMN_PRESENCE.format(
                 schema=SCHEMA_NAME, table=table_name, column=column_name
             )
@@ -41,7 +42,8 @@ def check_column(conn, table_name: str, column_name: str) -> bool:
 
 
 def check_trigger(conn, table_name: str) -> bool:
-    trigger_result = conn.execute(text(
+    trigger_result = conn.execute(
+        text(
             TRIGGER_PRESENCE.format(schema=SCHEMA_NAME, table=table_name)
         )
     ).fetchone()

--- a/integration_tests/index/test_update_columns.py
+++ b/integration_tests/index/test_update_columns.py
@@ -7,6 +7,7 @@ Test creation of added/updated columns during
 `datacube system init`
 """
 import pytest
+from sqlalchemy import text
 
 from datacube.drivers.postgres.sql import SCHEMA_NAME
 from datacube.drivers.postgres import _schema
@@ -30,17 +31,19 @@ and tgrelid = '{schema}.{table}'::regclass;
 
 
 def check_column(conn, table_name: str, column_name: str) -> bool:
-    column_result = conn.execute(
-        COLUMN_PRESENCE.format(
-            schema=SCHEMA_NAME, table=table_name, column=column_name
+    column_result = conn.execute(text(
+            COLUMN_PRESENCE.format(
+                schema=SCHEMA_NAME, table=table_name, column=column_name
+            )
         )
     ).fetchone()
     return column_result == (True,)
 
 
 def check_trigger(conn, table_name: str) -> bool:
-    trigger_result = conn.execute(
-        TRIGGER_PRESENCE.format(schema=SCHEMA_NAME, table=table_name)
+    trigger_result = conn.execute(text(
+            TRIGGER_PRESENCE.format(schema=SCHEMA_NAME, table=table_name)
+        )
     ).fetchone()
     if trigger_result is None:
         return False
@@ -48,8 +51,11 @@ def check_trigger(conn, table_name: str) -> bool:
 
 
 def drop_column(conn, table: str, column: str):
-    conn.execute(DROP_COLUMN.format(
-        schema=SCHEMA_NAME, table=table, column=column))
+    conn.execute(
+        text(
+            DROP_COLUMN.format(schema=SCHEMA_NAME, table=table, column=column)
+        )
+    )
 
 
 @pytest.mark.parametrize('datacube_env_name', ('datacube', ))

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ setup(
         'pyyaml',
         'rasterio>=1.3.2',  # Warping broken in 1.3.0 and 1.3.1
         'ruamel.yaml',
-        'sqlalchemy>=1.4,<2.0',  # GeoAlchemy2 requires >=1.4.  SqlAlchemy2 *may* work but has not been tested yet.
+        'sqlalchemy>=2.0',  # GeoAlchemy2 requires >=1.4.  SqlAlchemy2 *may* work but has not been tested yet.
         'GeoAlchemy2',
         'toolz',
         'xarray>=0.9',  # >0.9 fixes most problems with `crs` attributes being lost


### PR DESCRIPTION
### Reason for this pull request

SQLAlchemy2.0 has been released with a number of backwards incompatible API changes.  Datacube-1.9 is a convenient place to deal with this.

### Proposed changes

- Use the new postgresql dialect Range type hierarchy.
- Fix all remaining SQLA1.4 query and row access API incompatibilities.
- Update `ensure_db` implementations to work with SQLA2.0 transaction defaults.



 - [x] Closes #1431
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
