### PR TITLE
GitHub actions fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,12 +92,16 @@ jobs:
         EOF
 
     - name: DockerHub Push
-      if: steps.changes.outputs.docker == 'true'
+      if: |
+        github.event_name == 'push'
+        && github.ref == 'refs/heads/develop'
+        && steps.changes.outputs.docker == 'true'
       uses: docker/build-push-action@v4
       with:
+        file: docker/Dockerfile
         context: .
         push: true
-        tags: ${DOCKER_IMAGE}
+        tags: ${{ env.DOCKER_IMAGE }}
 
     - name: Build Packages
       run: |
@@ -135,7 +139,6 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PyPiToken }}
 
     - name: Upload coverage to Codecov
-      if: steps.cfg.outputs.primary == 'yes'
       uses: codecov/codecov-action@v3
       with:
         file: ./coverage.xml

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -9,7 +9,7 @@ v1.8.next
 =========
 
 - Fix broken Github action workflows (:pull:`1425`, :pull:`1433`)
-- Setup Dependabot, and dependabot-generated updates (:pull:`1416`, :pull:`1420`, :pull:`1423`,
+- Setup Dependabot, and Dependabot-generated updates (:pull:`1416`, :pull:`1420`, :pull:`1423`,
             :pull:`1428`)
 - Documentation fixes (:pull:`1417`, :pull:`1418`, :pull:`1430`)
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,7 +8,10 @@ What's New
 v1.8.next
 =========
 
-- Documentation fixes (:pull:`1417`, :pull:`1418`)
+- Fix broken Github action workflows (:pull:`1425`, :pull:`1433`)
+- Setup Dependabot, and dependabot-generated updates (:pull:`1416`, :pull:`1420`, :pull:`1423`,
+            :pull:`1428`)
+- Documentation fixes (:pull:`1417`, :pull:`1418`, :pull:`1430`)
 
 
 v1.8.12 (7th March 2023)


### PR DESCRIPTION
### Reason for this pull request

Github actions still getting stalled when Docker image updates


### Proposed changes

- Backport GHA fixes from PR #1432 to develop-1.9 branch.
- Update whats_new.rst

 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1433.org.readthedocs.build/en/1433/

<!-- readthedocs-preview datacube-core end -->