### PR TITLE
Allow open date range in dc load and find_datasets

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -232,12 +232,17 @@ class Datacube(object):
 
                 x=(1516200, 1541300), y=(-3867375, -3867350), crs='EPSG:3577'
 
-            The ``time`` dimension can be specified using a tuple of datetime objects or strings with
-            ``YYYY-MM-DD hh:mm:ss`` format. Data will be loaded inclusive of the start and finish times. E.g::
+            The ``time`` dimension can be specified using a single or tuple of datetime objects or strings with
+            ``YYYY-MM-DD hh:mm:ss`` format. Data will be loaded inclusive of the start and finish times.
+            A ``None`` value in the range indicates an open range, with the provided date serving as either the
+            upper or lower bound. E.g::
 
                 time=('2000-01-01', '2001-12-31')
                 time=('2000-01', '2001-12')
                 time=('2000', '2001')
+                time=('2000')
+                time=('2000', None)  # all data from 2000 onward
+                time=(None, '2000')  # all data before 2000
 
             For 3D datasets, where the product definition contains an ``extra_dimension`` specification,
             these dimensions can be queried using that dimension's name. E.g.::

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -242,7 +242,7 @@ class Datacube(object):
                 time=('2000', '2001')
                 time=('2000')
                 time=('2000', None)  # all data from 2000 onward
-                time=(None, '2000')  # all data before 2000
+                time=(None, '2000')  # all data up to and including 2000
 
             For 3D datasets, where the product definition contains an ``extra_dimension`` specification,
             these dimensions can be queried using that dimension's name. E.g.::

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -346,7 +346,7 @@ def _time_to_search_dims(time_range):
             tr_start = datetime.datetime.fromtimestamp(0)
         start = _to_datetime(tr_start)
         if tr_end is None:
-            tr_end = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+            tr_end = datetime.datetime.now().strftime("%Y-%m-%d")
         end = _to_datetime(pandas.Period(tr_end)
                            .end_time
                            .to_pydatetime())

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -126,11 +126,16 @@ class Query(object):
             if 'time' not in self.search:
                 time_coord = like.coords.get('time')
                 if time_coord is not None:
-                    self.search['time'] = _time_to_search_dims(
-                        (pandas_to_datetime(time_coord.values[0]).to_pydatetime(),
-                         pandas_to_datetime(time_coord.values[-1]).to_pydatetime()
-                         + datetime.timedelta(milliseconds=1))  # TODO: inclusive time searches
-                    )
+                    if time_coord.values[0] is None:
+                        self.search['time'] = _time_to_open_range(time_coord.values[1], lower_bound=False)
+                    elif time_coord.values[-1] is None:
+                        self.search['time'] = _time_to_open_range(time_coord.values[0], lower_bound=True)
+                    else:
+                        self.search['time'] = _time_to_search_dims(
+                            (pandas_to_datetime(time_coord.values[0]).to_pydatetime(),
+                                pandas_to_datetime(time_coord.values[-1]).to_pydatetime()
+                                + datetime.timedelta(milliseconds=1))  # TODO: inclusive time searches
+                        )
 
     @property
     def search_terms(self):

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -126,16 +126,11 @@ class Query(object):
             if 'time' not in self.search:
                 time_coord = like.coords.get('time')
                 if time_coord is not None:
-                    if time_coord.values[0] is None:
-                        self.search['time'] = _time_to_open_range(time_coord.values[1], lower_bound=False)
-                    elif time_coord.values[-1] is None:
-                        self.search['time'] = _time_to_open_range(time_coord.values[0], lower_bound=True)
-                    else:
-                        self.search['time'] = _time_to_search_dims(
-                            (pandas_to_datetime(time_coord.values[0]).to_pydatetime(),
-                                pandas_to_datetime(time_coord.values[-1]).to_pydatetime()
-                                + datetime.timedelta(milliseconds=1))  # TODO: inclusive time searches
-                        )
+                    self.search['time'] = _time_to_search_dims(
+                        (pandas_to_datetime(time_coord.values[0]).to_pydatetime(),
+                            pandas_to_datetime(time_coord.values[-1]).to_pydatetime()
+                            + datetime.timedelta(milliseconds=1))  # TODO: inclusive time searches
+                    )
 
     @property
     def search_terms(self):
@@ -347,7 +342,11 @@ def _time_to_search_dims(time_range):
         if hasattr(tr_end, 'isoformat'):
             tr_end = tr_end.isoformat()
 
+        if tr_start is None:
+            tr_start = datetime.datetime.fromtimestamp(0)
         start = _to_datetime(tr_start)
+        if tr_end is None:
+            tr_end = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
         end = _to_datetime(pandas.Period(tr_end)
                            .end_time
                            .to_pydatetime())
@@ -357,19 +356,6 @@ def _time_to_search_dims(time_range):
             return tr[0]
 
         return tr
-
-
-def _time_to_open_range(time, lower_bound: bool):
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", UserWarning)
-
-        if lower_bound:  # from date provided (not inclusive) to latest available
-            start = _to_datetime(pandas.Period(time).end_time.to_pydatetime())
-            end = _to_datetime(datetime.datetime.now())
-        else:  # from earliest available to date provided (not inclusive)
-            start = _to_datetime(datetime.datetime.fromtimestamp(0))
-            end = _to_datetime(pandas.Period(time).start_time.to_pydatetime())
-        return Range(start, end)
 
 
 def _convert_to_solar_time(utc, longitude):

--- a/datacube/ui/expression.py
+++ b/datacube/ui/expression.py
@@ -20,7 +20,7 @@ and START, END are either numbers or dates.
 
 from lark import Lark, v_args, Transformer
 
-from datacube.api.query import _time_to_search_dims, _time_to_open_range
+from datacube.api.query import _time_to_search_dims
 from datacube.model import Range
 
 
@@ -119,11 +119,10 @@ class TreeToSearchExprs(Transformer):
         return _time_to_search_dims((start, end))
     
     def range_lower_bound(self, date):
-        return _time_to_open_range(date, lower_bound=True)
+        return _time_to_search_dims((date, None))
 
     def range_upper_bound(self, date):
-        return _time_to_open_range(date, lower_bound=False)
-
+        return _time_to_search_dims((None, date))
 
     def date(self, y, m=None, d=None):
         return "-".join(x for x in [y, m, d] if x is not None)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -14,7 +14,7 @@ v1.8.next
 - Documentation fixes (:pull:`1417`, :pull:`1418`, :pull:`1430`)
 - ``datacube dataset`` cli commands print error message if missing argument (:pull:`1437`)
 - Add pre-commit hook to verify license headers (:pull:`1438`)
-- Support open-ended date ranges in `datacube dataset search` (:pull:`1439`)
+- Support open-ended date ranges in `datacube dataset search`, `dc.load`, and `dc.find_datasets` (:pull:`1439`, :pull:`1443`)
 
 
 v1.8.12 (7th March 2023)

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -142,7 +142,7 @@ testdata = [
     ((datetime.date(2008, 1, 1)),
      format_test('2008-01-01T00:00:00', '2008-01-01T23:59:59.999999')),
     ((datetime.date(2008, 1, 1), None),
-     format_test('2008-01-01T00:00:00', datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S.999999"))),
+     format_test('2008-01-01T00:00:00', datetime.datetime.now().strftime("%Y-%m-%dT23:59:59.999999"))),
     ((None, '2008'),
      format_test(datetime.datetime.fromtimestamp(0).strftime("%Y-%m-%dT%H:%M:%S"), '2008-12-31T23:59:59.999999'))
 ]

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -140,7 +140,11 @@ testdata = [
     ((datetime.datetime(2008, 1, 1), datetime.datetime(2008, 1, 10, 23, 59, 40)),
      format_test('2008-01-01T00:00:00', '2008-01-10T23:59:40.999999')),
     ((datetime.date(2008, 1, 1)),
-     format_test('2008-01-01T00:00:00', '2008-01-01T23:59:59.999999'))
+     format_test('2008-01-01T00:00:00', '2008-01-01T23:59:59.999999')),
+    ((datetime.date(2008, 1, 1), None),
+     format_test('2008-01-01T00:00:00', datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S.999999"))),
+    ((None, '2008'),
+     format_test(datetime.datetime.fromtimestamp(0).strftime("%Y-%m-%dT%H:%M:%S"), '2008-12-31T23:59:59.999999'))
 ]
 
 


### PR DESCRIPTION
### Reason for this pull request

As raised by @robbibt, #183 was closed without having been resolved. The logic introduced in #1439 to support open-ended date ranges in `datacube dataset search`, can be used to allow them in `dc.load()` and `dc.find_datasets()` as well.


### Proposed changes

- Handle None dates in `_time_to_search_dims` rather than in a separate function



 - [x] Closes #183
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1443.org.readthedocs.build/en/1443/

<!-- readthedocs-preview datacube-core end -->