### PR TITLE
Pass X and Y Scale factors through to rasterio.warp.project.

### DIFF
--- a/datacube/storage/_read.py
+++ b/datacube/storage/_read.py
@@ -129,6 +129,7 @@ def read_time_slice(rdr,
 
     is_nn = is_resampling_nn(resampling)
     scale = pick_read_scale(rr.scale, rdr)
+    scale_xy = [pick_read_scale(s, rdr) for s in rr.scale2]
 
     paste_ok, _ = can_paste(rr, ttol=0.9 if is_nn else 0.01)
 
@@ -188,7 +189,8 @@ def read_time_slice(rdr,
                         src_nodata=rdr.nodata, dst_nodata=dst_nodata)
         else:
             rio_reproject(pix, dst, src_gbox, dst_gbox, resampling,
-                          src_nodata=rdr.nodata, dst_nodata=dst_nodata)
+                          src_nodata=rdr.nodata, dst_nodata=dst_nodata,
+                          XSCALE=scale_xy[0], YSCALE=scale_xy[1])
 
     return rr.roi_dst
 

--- a/datacube/storage/_read.py
+++ b/datacube/storage/_read.py
@@ -129,7 +129,7 @@ def read_time_slice(rdr,
 
     is_nn = is_resampling_nn(resampling)
     scale = pick_read_scale(rr.scale, rdr)
-    scale_xy = [pick_read_scale(s, rdr) for s in rr.scale2]
+    scale_x, scale_y = [pick_read_scale(s) for s in rr.scale2]
 
     paste_ok, _ = can_paste(rr, ttol=0.9 if is_nn else 0.01)
 
@@ -190,7 +190,7 @@ def read_time_slice(rdr,
         else:
             rio_reproject(pix, dst, src_gbox, dst_gbox, resampling,
                           src_nodata=rdr.nodata, dst_nodata=dst_nodata,
-                          XSCALE=scale_xy[0], YSCALE=scale_xy[1])
+                          XSCALE=scale_x, YSCALE=scale_y)
 
     return rr.roi_dst
 

--- a/datacube/utils/geometry/_warp.py
+++ b/datacube/utils/geometry/_warp.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2015-2023 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from typing import Union, Optional
+from typing import Union, Optional, Tuple
 import rasterio.warp  # type: ignore[import]
 import rasterio.crs   # type: ignore[import]
 import numpy as np
@@ -132,6 +132,7 @@ def rio_reproject(src: np.ndarray,
     :param     s_gbox: GeoBox of source image
     :param     d_gbox: GeoBox of destination image
     :param resampling: str|rasterio.warp.Resampling resampling strategy
+    :param   scale_xy: Integer scale factors in x and y directions, default to (1,1)
     :param src_nodata: Value representing "no data" in the source image
     :param dst_nodata: Value to represent "no data" in the destination image
 

--- a/datacube/utils/geometry/_warp.py
+++ b/datacube/utils/geometry/_warp.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2015-2023 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from typing import Union, Optional, Tuple
+from typing import Union, Optional
 import rasterio.warp  # type: ignore[import]
 import rasterio.crs   # type: ignore[import]
 import numpy as np

--- a/datacube/utils/geometry/_warp.py
+++ b/datacube/utils/geometry/_warp.py
@@ -132,7 +132,6 @@ def rio_reproject(src: np.ndarray,
     :param     s_gbox: GeoBox of source image
     :param     d_gbox: GeoBox of destination image
     :param resampling: str|rasterio.warp.Resampling resampling strategy
-    :param   scale_xy: Integer scale factors in x and y directions, default to (1,1)
     :param src_nodata: Value representing "no data" in the source image
     :param dst_nodata: Value to represent "no data" in the destination image
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -15,8 +15,9 @@ v1.8.next
 - ``datacube dataset`` cli commands print error message if missing argument (:pull:`1437`)
 - Add pre-commit hook to verify license headers (:pull:`1438`)
 - Support open-ended date ranges in `datacube dataset search`, `dc.load`, and `dc.find_datasets` (:pull:`1439`, :pull:`1443`)
-- Pass Y and Y Scale factors through to rasterio.warp.reproject, to eliminate projection bug affecting non-square AOIs
-  (See `Issue #1448 <https://github.com/opendatacube/datacube-core/issues/1448>`_) (:pull:`1450`)
+- Pass Y and Y Scale factors through to rasterio.warp.reproject, to eliminate projection bug affecting
+  non-square Areas Of Interest (See `Issue #1448`_) (:pull:`1450`)
+.. _`Issue #1448`: https://github.com/opendatacube/datacube-core/issues/1448
 
 
 v1.8.12 (7th March 2023)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -16,7 +16,7 @@ v1.8.next
 - Add pre-commit hook to verify license headers (:pull:`1438`)
 - Support open-ended date ranges in `datacube dataset search`, `dc.load`, and `dc.find_datasets` (:pull:`1439`, :pull:`1443`)
 - Pass Y and Y Scale factors through to rasterio.warp.reproject, to eliminate projection bug affecting non-square AOIs
-  (See https://github.com/opendatacube/datacube-core/issues/1448) (:pull:`1450`)
+  (See `Issue #1448 <https://github.com/opendatacube/datacube-core/issues/1448>`_) (:pull:`1450`)
 
 
 v1.8.12 (7th March 2023)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -16,7 +16,7 @@ v1.8.next
 - Add pre-commit hook to verify license headers (:pull:`1438`)
 - Support open-ended date ranges in `datacube dataset search`, `dc.load`, and `dc.find_datasets` (:pull:`1439`, :pull:`1443`)
 - Pass Y and Y Scale factors through to rasterio.warp.reproject, to eliminate projection bug affecting non-square AOIs
-  (See https://github.com/opendatacube/datacube-core/issues/1448) (:pull:`XXXX`)
+  (See https://github.com/opendatacube/datacube-core/issues/1448) (:pull:`1450`)
 
 
 v1.8.12 (7th March 2023)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -15,6 +15,8 @@ v1.8.next
 - ``datacube dataset`` cli commands print error message if missing argument (:pull:`1437`)
 - Add pre-commit hook to verify license headers (:pull:`1438`)
 - Support open-ended date ranges in `datacube dataset search`, `dc.load`, and `dc.find_datasets` (:pull:`1439`, :pull:`1443`)
+- Pass Y and Y Scale factors through to rasterio.warp.reproject, to eliminate projection bug affecting non-square AOIs
+  (See https://github.com/opendatacube/datacube-core/issues/1448) (:pull:`XXXX`)
 
 
 v1.8.12 (7th March 2023)


### PR DESCRIPTION
### Reason for this pull request

Attempted fix for issue #1448


### Proposed changes

- Pass integer scale factors through to rasterio.warp.project (as XSCALE and YSCALE parameters).



 - [x] Closes #1448
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes



<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1450.org.readthedocs.build/en/1450/

<!-- readthedocs-preview datacube-core end -->