### PR TITLE
add archive_less_mature option to add and update

### DIFF
--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -898,6 +898,37 @@ class AbstractDatasetResource(ABC):
         :param Iterable[Union[str,UUID]] ids: list of dataset ids to archive
         """
 
+    def archive_less_mature(self, ds: Dataset) -> None:
+        """
+        Archive less mature versions of a dataset
+
+        :param Dataset ds: dataset to search
+        """
+        less_mature = []
+        dupes = self.search(product=ds.product.name,
+                            region_code=ds.metadata.region_code,
+                            time=ds.metadata.time)
+        for dupe in dupes:
+            if dupe.id == ds.id:
+                continue
+            if dupe.metadata.dataset_maturity == ds.metadata.dataset_maturity:
+                # Duplicate has the same maturity, which one should be archived is unclear
+                raise ValueError(
+                    f"A dataset with the same maturity as dataset {ds.id} already exists, "
+                    f"with id: {dupe.id}"
+                )
+            if dupe.metadata.dataset_maturity < ds.metadata.dataset_maturity:
+                # Duplicate is more mature than dataset
+                # Note that "final" < "nrt"
+                raise ValueError(
+                    f"A more mature version of dataset {ds.id} already exists, with id: "
+                    f"{dupe.id} and maturity: {dupe.metadata.dataset_maturity}"
+                )
+            less_mature.append(dupe.id)
+        self.archive(less_mature)
+        for lm_ds in less_mature:
+            _LOG.info(f"Archived less mature dataset: {lm_ds}")
+
     @abstractmethod
     def restore(self, ids: Iterable[DSID]) -> None:
         """

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -825,7 +825,8 @@ class AbstractDatasetResource(ABC):
 
     @abstractmethod
     def add(self, dataset: Dataset,
-            with_lineage: bool = True
+            with_lineage: bool = True,
+            archive_less_mature: bool = False,
            ) -> Dataset:
         """
         Add ``dataset`` to the index. No-op if it is already present.
@@ -836,6 +837,10 @@ class AbstractDatasetResource(ABC):
            - ``True (default)`` attempt adding lineage datasets if missing
            - ``False`` record lineage relations, but do not attempt
              adding lineage datasets to the db
+
+        :param archive_less_mature:
+            - ``True`` search for less mature versions of the dataset
+            and archive them
 
         :return: Persisted Dataset model
         """
@@ -874,12 +879,14 @@ class AbstractDatasetResource(ABC):
     @abstractmethod
     def update(self,
                dataset: Dataset,
-               updates_allowed: Optional[Mapping[Offset, AllowPolicy]] = None
+               updates_allowed: Optional[Mapping[Offset, AllowPolicy]] = None,
+               archive_less_mature: bool = False,
               ) -> Dataset:
         """
         Update dataset metadata and location
         :param Dataset dataset: Dataset model with unpersisted updates
         :param updates_allowed: Allowed updates
+        :param archive_less_mature: Find and archive less mature datasets
         :return: Persisted dataset model
         """
 

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -101,6 +101,8 @@ class DatasetResource(AbstractDatasetResource):
                 self.by_product[dataset.product.name].append(dataset.id)
             else:
                 self.by_product[dataset.product.name] = [dataset.id]
+        if archive_less_mature:
+            _LOG.warning("archive-less-mature functionality is not implemented for memory driver")
         return cast(Dataset, self.get(dataset.id))
 
     def persist_source_relationship(self, ds: Dataset, src: Dataset, classifier: str) -> None:

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -72,7 +72,8 @@ class DatasetResource(AbstractDatasetResource):
         return (self.has(id_) for id_ in ids_)
 
     def add(self, dataset: Dataset,
-            with_lineage: bool = True) -> Dataset:
+            with_lineage: bool = True,
+            archive_less_mature: bool = False) -> Dataset:
         if with_lineage is None:
             with_lineage = True
         _LOG.info('indexing %s', dataset.id)
@@ -186,7 +187,8 @@ class DatasetResource(AbstractDatasetResource):
 
     def update(self,
                dataset: Dataset,
-               updates_allowed: Optional[Mapping[Offset, AllowPolicy]] = None
+               updates_allowed: Optional[Mapping[Offset, AllowPolicy]] = None,
+               archive_less_mature: bool = False
               ) -> Dataset:
         existing = self.get(dataset.id)
         if not existing:

--- a/datacube/index/null/_datasets.py
+++ b/datacube/index/null/_datasets.py
@@ -28,7 +28,8 @@ class DatasetResource(AbstractDatasetResource):
         return [False for id_ in ids_]
 
     def add(self, dataset: Dataset,
-            with_lineage: bool = True) -> Dataset:
+            with_lineage: bool = True,
+            archive_less_mature: bool = False) -> Dataset:
         raise NotImplementedError()
 
     def search_product_duplicates(self, product: DatasetType, *args):
@@ -37,7 +38,7 @@ class DatasetResource(AbstractDatasetResource):
     def can_update(self, dataset, updates_allowed=None):
         raise NotImplementedError()
 
-    def update(self, dataset: Dataset, updates_allowed=None):
+    def update(self, dataset: Dataset, updates_allowed=None, archive_less_mature=False):
         raise NotImplementedError()
 
     def archive(self, ids):

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -137,7 +137,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                 map((lambda x: UUID(x) if isinstance(x, str) else x), ids_)]
 
     def add(self, dataset: Dataset,
-            with_lineage: bool = True) -> Dataset:
+            with_lineage: bool = True, archive_less_mature: bool = False) -> Dataset:
         """
         Add ``dataset`` to the index. No-op if it is already present.
 
@@ -147,6 +147,10 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
            - ``True (default)`` attempt adding lineage datasets if missing
            - ``False`` record lineage relations, but do not attempt
              adding lineage datasets to the db
+
+        :param archive_less_mature:
+            - ``True`` search for less mature versions of the dataset
+            and archive them
 
         :rtype: Dataset
         """
@@ -170,7 +174,36 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                 if dataset.uris is not None:
                     self._ensure_new_locations(dataset, transaction=transaction)
 
+            if archive_less_mature:
+                self._archive_less_mature(dataset)
+
         return dataset
+
+    def _archive_less_mature(self, ds: Dataset):
+        less_mature = []
+        dupes = self.search(product=ds.product.name,
+                            region_code=ds.metadata.region_code,
+                            time=ds.metadata.time)
+        for dupe in dupes:
+            if dupe.id == ds.id:
+                continue
+            if dupe.metadata.dataset_maturity == ds.metadata.dataset_maturity:
+                # Duplicate has the same maturity, which one should be archived is unclear
+                raise ValueError(
+                    f"A dataset with the same maturity as dataset {ds.id} already exists, "
+                    f"with id: {dupe.id}"
+                )
+            if dupe.metadata.dataset_maturity < ds.metadata.dataset_maturity:
+                # Duplicate is more mature than dataset
+                # Note that "final" < "nrt"
+                raise ValueError(
+                    f"A more mature version of dataset {ds.id} already exists, with id: "
+                    f"{dupe.id} and maturity: {dupe.metadata.dataset_maturity}"
+                )
+            less_mature.append(dupe.id)
+        self.archive(less_mature)
+        for lm_ds in less_mature:
+            _LOG.info(f"Archived less mature dataset: {lm_ds}")
 
     def _init_bulk_add_cache(self):
         return {}
@@ -305,11 +338,12 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
         return not bad_changes, good_changes, bad_changes
 
-    def update(self, dataset: Dataset, updates_allowed=None):
+    def update(self, dataset: Dataset, updates_allowed=None, archive_less_mature=False):
         """
         Update dataset metadata and location
         :param Dataset dataset: Dataset to update
         :param updates_allowed: Allowed updates
+        :param archive_less_mature: Find and archive less mature datasets
         :rtype: Dataset
         """
         existing = self.get(dataset.id)
@@ -342,6 +376,8 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                 raise ValueError("Failed to update dataset %s..." % dataset.id)
             transaction.update_spindex(dsids=[dataset.id])
             transaction.update_search_index(dsids=[dataset.id])
+            if archive_less_mature:
+                self._archive_less_mature(dataset)
 
         self._ensure_new_locations(dataset, existing)
 

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -173,37 +173,10 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                 # 1c. Store locations
                 if dataset.uris is not None:
                     self._ensure_new_locations(dataset, transaction=transaction)
-
             if archive_less_mature:
-                self._archive_less_mature(dataset)
+                self.archive_less_mature(dataset)
 
         return dataset
-
-    def _archive_less_mature(self, ds: Dataset):
-        less_mature = []
-        dupes = self.search(product=ds.product.name,
-                            region_code=ds.metadata.region_code,
-                            time=ds.metadata.time)
-        for dupe in dupes:
-            if dupe.id == ds.id:
-                continue
-            if dupe.metadata.dataset_maturity == ds.metadata.dataset_maturity:
-                # Duplicate has the same maturity, which one should be archived is unclear
-                raise ValueError(
-                    f"A dataset with the same maturity as dataset {ds.id} already exists, "
-                    f"with id: {dupe.id}"
-                )
-            if dupe.metadata.dataset_maturity < ds.metadata.dataset_maturity:
-                # Duplicate is more mature than dataset
-                # Note that "final" < "nrt"
-                raise ValueError(
-                    f"A more mature version of dataset {ds.id} already exists, with id: "
-                    f"{dupe.id} and maturity: {dupe.metadata.dataset_maturity}"
-                )
-            less_mature.append(dupe.id)
-        self.archive(less_mature)
-        for lm_ds in less_mature:
-            _LOG.info(f"Archived less mature dataset: {lm_ds}")
 
     def _init_bulk_add_cache(self):
         return {}

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -191,9 +191,8 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
         with self._db_connection(transaction=True) as transaction:
             process_bunch(dss, dataset, transaction)
-
-        if archive_less_mature:
-            _LOG.warning("archive-less-mature functionality is not implemented for postgres driver")
+            if archive_less_mature:
+                self.archive_less_mature(dataset)
 
         return dataset
 

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -132,7 +132,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                 map((lambda x: UUID(x) if isinstance(x, str) else x), ids_)]
 
     def add(self, dataset: Dataset,
-            with_lineage: bool = True) -> Dataset:
+            with_lineage: bool = True, archive_less_mature: bool = False) -> Dataset:
         """
         Add ``dataset`` to the index. No-op if it is already present.
 
@@ -142,6 +142,10 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
            - ``True (default)`` attempt adding lineage datasets if missing
            - ``False`` record lineage relations, but do not attempt
              adding lineage datasets to the db
+
+        :param archive_less_mature:
+            - ``True`` search for less mature versions of the dataset
+            and archive them
 
         :rtype: Dataset
         """
@@ -187,6 +191,9 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
         with self._db_connection(transaction=True) as transaction:
             process_bunch(dss, dataset, transaction)
+
+        if archive_less_mature:
+            _LOG.warning("archive-less-mature functionality is not implemented for postgres driver")
 
         return dataset
 
@@ -278,11 +285,12 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
         return not bad_changes, good_changes, bad_changes
 
-    def update(self, dataset: Dataset, updates_allowed=None):
+    def update(self, dataset: Dataset, updates_allowed=None, archive_less_mature=False):
         """
         Update dataset metadata and location
         :param Dataset dataset: Dataset to update
         :param updates_allowed: Allowed updates
+        :param archive_less_mature: Find and archive less mature datasets
         :rtype: Dataset
         """
         existing = self.get(dataset.id)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -15,6 +15,7 @@ v1.8.next
 - ``datacube dataset`` cli commands print error message if missing argument (:pull:`1437`)
 - Add pre-commit hook to verify license headers (:pull:`1438`)
 - Support open-ended date ranges in `datacube dataset search`, `dc.load`, and `dc.find_datasets` (:pull:`1439`, :pull:`1443`)
+- Add `archive_less_mature` option to `datacube dataset add` and `datacube dataset update` (:pull:`1451`)
 
 
 v1.8.12 (7th March 2023)

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -197,6 +197,24 @@ def africa_s2_product_doc():
     return get_eo3_test_data_doc("s2_africa_product.yaml")
 
 
+@pytest.fixture
+def final_dataset_doc():
+    return (
+        get_eo3_test_data_doc("final_dataset.yaml"),
+        's3://dea-public-data/baseline/ga_ls8c_ard_3/090/086/2023/04/30'
+        'ga_ls8c_ard_3-2-1_090086_2023-04-30_final.stac-item.json'
+    )
+
+
+@pytest.fixture
+def nrt_dataset_doc():
+    return (
+        get_eo3_test_data_doc("nrt_dataset.yaml"),
+        's3://dea-public-data/baseline/ga_ls8c_ard_3/090/086/2023/04/30_nrt'
+        'ga_ls8c_ard_3-2-1_090086_2023-04-30_nrt.stac-item.json'
+    )
+
+
 def doc_to_ds(index, product_name, ds_doc, ds_path):
     from datacube.index.hl import Doc2Dataset
     resolver = Doc2Dataset(index, products=[product_name], verify_lineage=False)
@@ -279,6 +297,28 @@ def africa_eo3_dataset(index, africa_s2_eo3_product, eo3_africa_dataset_doc):
     return doc_to_ds(index,
                      africa_s2_eo3_product.name,
                      *eo3_africa_dataset_doc)
+
+
+@pytest.fixture
+def nrt_dataset(index, extended_eo3_metadata_type, ls8_eo3_product, nrt_dataset_doc):
+    ds_doc = nrt_dataset_doc[0]
+    ds_path = nrt_dataset_doc[1]
+    from datacube.index.hl import Doc2Dataset
+    resolver = Doc2Dataset(index, products=[ls8_eo3_product.name], verify_lineage=False)
+    ds, err = resolver(ds_doc, ds_path)
+    assert err is None and ds is not None
+    return ds
+
+
+@pytest.fixture
+def final_dataset(index, extended_eo3_metadata_type, ls8_eo3_product, final_dataset_doc):
+    ds_doc = final_dataset_doc[0]
+    ds_path = final_dataset_doc[1]
+    from datacube.index.hl import Doc2Dataset
+    resolver = Doc2Dataset(index, products=[ls8_eo3_product.name], verify_lineage=False)
+    ds, err = resolver(ds_doc, ds_path)
+    assert err is None and ds is not None
+    return ds
 
 
 @pytest.fixture

--- a/integration_tests/data/eo3/final_dataset.yaml
+++ b/integration_tests/data/eo3/final_dataset.yaml
@@ -135,7 +135,5 @@ accessories:
   checksum:sha1:
     path: ga_ls8c_ard_3-2-1_090086_2023-04-30_final.sha1
 
-lineage:
-  level1:
-  - 1362eb23-4bbc-5686-a803-cdf7cd6158d8
+lineage: {}
 ...

--- a/integration_tests/data/eo3/final_dataset.yaml
+++ b/integration_tests/data/eo3/final_dataset.yaml
@@ -1,0 +1,141 @@
+---
+# Dataset
+$schema: https://schemas.opendatacube.org/dataset
+id: 6241395f-f341-41b0-96b7-60f486c577d0
+
+label: ga_ls8c_ard_3-2-1_090086_2023-04-30_final
+product:
+  name: ga_ls8c_ard_3
+  href: https://collections.dea.ga.gov.au/product/ga_ls8c_ard_3
+
+crs: epsg:32655
+geometry:
+  type: Polygon
+  coordinates: [[[559816.0052888468, -4219857.620084257], [559721.8933982822, -4219833.106601718],
+      [559732.9800465275, -4219728.735567618], [560962.9813034026, -4214988.730722999],
+      [571612.9871046449, -4174023.7084477567], [604522.9880076076, -4048158.7049931744],
+      [608708.0157636222, -4032408.6003978983], [608918.1498917936, -4031628.1325757634],
+      [609157.5, -4030897.5], [609243.8473913191, -4030914.6899256567], [609255.0,
+        -4030905.0], [609449.0888722979, -4030955.549131081], [609461.1380343755,
+        -4030957.947862498], [611246.2821331235, -4031422.984647127], [614491.7279428138,
+        -4032268.87029345], [795172.5726569144, -4079325.971481828], [796033.5623962873,
+        -4079585.522912585], [796173.1066017178, -4079621.893398282], [747082.5, -4268617.5],
+      [746957.9666764413, -4268587.428373786], [746857.7239312489, -4268594.104275004],
+      [746137.4401493662, -4268414.031855924], [560077.4396544178, -4219964.0317270355],
+      [559816.0052888468, -4219857.620084257]]]
+grids:
+  default:
+    shape: [7931, 7901]
+    transform: [30.0, 0.0, 559485.0, 0.0, -30.0, -4030785.0, 0.0, 0.0, 1.0]
+  panchromatic:
+    shape: [15861, 15801]
+    transform: [15.0, 0.0, 559492.5, 0.0, -15.0, -4030792.5, 0.0, 0.0, 1.0]
+
+properties:
+  datetime: 2023-04-30 23:50:34.384549Z
+  dea:dataset_maturity: final
+  dea:product_maturity: stable
+  dtr:end_datetime: 2023-04-30 23:50:48.771747Z
+  dtr:start_datetime: 2023-04-30 23:50:19.818416Z
+  eo:cloud_cover: 93.24450316290117
+  eo:gsd: 15.0  # Ground sample distance (m)
+  eo:instrument: OLI_TIRS
+  eo:platform: landsat-8
+  eo:sun_azimuth: 36.68926293
+  eo:sun_elevation: 29.26893394
+  fmask:clear: 6.177487638246016
+  fmask:cloud: 93.24450316290117
+  fmask:cloud_shadow: 0.14004371437490343
+  fmask:snow: 0.006964025007482182
+  fmask:water: 0.43100145947042295
+  gqa:abs_iterative_mean_x: 0.19
+  gqa:abs_iterative_mean_xy: 0.26
+  gqa:abs_iterative_mean_y: 0.18
+  gqa:abs_x: 0.65
+  gqa:abs_xy: 0.73
+  gqa:abs_y: 0.33
+  gqa:cep90: 0.4
+  gqa:iterative_mean_x: -0.15
+  gqa:iterative_mean_xy: 0.18
+  gqa:iterative_mean_y: 0.1
+  gqa:iterative_stddev_x: 0.16
+  gqa:iterative_stddev_xy: 0.24
+  gqa:iterative_stddev_y: 0.18
+  gqa:mean_x: 0.23
+  gqa:mean_xy: 0.23
+  gqa:mean_y: -0.02
+  gqa:stddev_x: 1.42
+  gqa:stddev_xy: 1.48
+  gqa:stddev_y: 0.42
+  landsat:collection_category: T1
+  landsat:collection_number: 2
+  landsat:landsat_product_id: LC08_L1TP_090086_20230430_20230509_02_T1
+  landsat:landsat_scene_id: LC80900862023120LGN00
+  landsat:wrs_path: 90
+  landsat:wrs_row: 86
+  odc:dataset_version: 3.2.1
+  odc:file_format: GeoTIFF
+  odc:processing_datetime: 2023-05-10 10:57:11.431704Z
+  odc:producer: ga.gov.au
+  odc:product_family: ard
+  odc:region_code: '090086'
+
+measurements:
+  nbart_blue:
+    path: ga_ls8c_nbart_3-2-1_090086_2023-04-30_final_band02.tif
+  nbart_coastal_aerosol:
+    path: ga_ls8c_nbart_3-2-1_090086_2023-04-30_final_band01.tif
+  nbart_green:
+    path: ga_ls8c_nbart_3-2-1_090086_2023-04-30_final_band03.tif
+  nbart_nir:
+    path: ga_ls8c_nbart_3-2-1_090086_2023-04-30_final_band05.tif
+  nbart_panchromatic:
+    path: ga_ls8c_nbart_3-2-1_090086_2023-04-30_final_band08.tif
+    grid: panchromatic
+  nbart_red:
+    path: ga_ls8c_nbart_3-2-1_090086_2023-04-30_final_band04.tif
+  nbart_swir_1:
+    path: ga_ls8c_nbart_3-2-1_090086_2023-04-30_final_band06.tif
+  nbart_swir_2:
+    path: ga_ls8c_nbart_3-2-1_090086_2023-04-30_final_band07.tif
+  oa_azimuthal_exiting:
+    path: ga_ls8c_oa_3-2-1_090086_2023-04-30_final_azimuthal-exiting.tif
+  oa_azimuthal_incident:
+    path: ga_ls8c_oa_3-2-1_090086_2023-04-30_final_azimuthal-incident.tif
+  oa_combined_terrain_shadow:
+    path: ga_ls8c_oa_3-2-1_090086_2023-04-30_final_combined-terrain-shadow.tif
+  oa_exiting_angle:
+    path: ga_ls8c_oa_3-2-1_090086_2023-04-30_final_exiting-angle.tif
+  oa_fmask:
+    path: ga_ls8c_oa_3-2-1_090086_2023-04-30_final_fmask.tif
+  oa_incident_angle:
+    path: ga_ls8c_oa_3-2-1_090086_2023-04-30_final_incident-angle.tif
+  oa_nbart_contiguity:
+    path: ga_ls8c_oa_3-2-1_090086_2023-04-30_final_nbart-contiguity.tif
+  oa_relative_azimuth:
+    path: ga_ls8c_oa_3-2-1_090086_2023-04-30_final_relative-azimuth.tif
+  oa_relative_slope:
+    path: ga_ls8c_oa_3-2-1_090086_2023-04-30_final_relative-slope.tif
+  oa_satellite_azimuth:
+    path: ga_ls8c_oa_3-2-1_090086_2023-04-30_final_satellite-azimuth.tif
+  oa_satellite_view:
+    path: ga_ls8c_oa_3-2-1_090086_2023-04-30_final_satellite-view.tif
+  oa_solar_azimuth:
+    path: ga_ls8c_oa_3-2-1_090086_2023-04-30_final_solar-azimuth.tif
+  oa_solar_zenith:
+    path: ga_ls8c_oa_3-2-1_090086_2023-04-30_final_solar-zenith.tif
+  oa_time_delta:
+    path: ga_ls8c_oa_3-2-1_090086_2023-04-30_final_time-delta.tif
+
+accessories:
+  thumbnail:nbart:
+    path: ga_ls8c_nbart_3-2-1_090086_2023-04-30_final_thumbnail.jpg
+  metadata:processor:
+    path: ga_ls8c_ard_3-2-1_090086_2023-04-30_final.proc-info.yaml
+  checksum:sha1:
+    path: ga_ls8c_ard_3-2-1_090086_2023-04-30_final.sha1
+
+lineage:
+  level1:
+  - 1362eb23-4bbc-5686-a803-cdf7cd6158d8
+...

--- a/integration_tests/data/eo3/nrt_dataset.yaml
+++ b/integration_tests/data/eo3/nrt_dataset.yaml
@@ -1,0 +1,138 @@
+---
+# Dataset
+$schema: https://schemas.opendatacube.org/dataset
+id: 94db51ab-4279-4402-8bcf-ec2f4ec494e3
+
+label: ga_ls8c_ard_3-2-1_090086_2023-04-30_nrt
+product:
+  name: ga_ls8c_ard_3
+  href: https://collections.dea.ga.gov.au/product/ga_ls8c_ard_3
+
+crs: epsg:32655
+geometry:
+  type: Polygon
+  coordinates: [[[559721.8933982822, -4219833.106601718], [559732.9800465275, -4219728.735567618],
+      [560962.9813034026, -4214988.730722999], [571612.9871046449, -4174023.7084477567],
+      [604522.9880076076, -4048158.7049931744], [608903.006475906, -4031688.6350602414],
+      [609157.5, -4030897.5], [609243.8827279789, -4030914.696960433], [609255.0,
+        -4030905.0], [609449.0888722979, -4030955.549131081], [609461.1380343755,
+        -4030957.947862498], [611246.2821331235, -4031422.984647127], [614491.7279428138,
+        -4032268.87029345], [795172.5726569144, -4079325.971481828], [796033.5623962873,
+        -4079585.522912585], [796173.1066017178, -4079621.893398282], [747082.5, -4268617.5],
+      [746957.9666764413, -4268587.428373786], [746857.7239312489, -4268594.104275004],
+      [746137.4401493662, -4268414.031855924], [560077.4396544178, -4219964.0317270355],
+      [559816.0052888468, -4219857.620084257], [559721.8933982822, -4219833.106601718]]]
+grids:
+  default:
+    shape: [7931, 7901]
+    transform: [30.0, 0.0, 559485.0, 0.0, -30.0, -4030785.0, 0.0, 0.0, 1.0]
+  nbart:panchromatic:
+    shape: [15861, 15801]
+    transform: [15.0, 0.0, 559492.5, 0.0, -15.0, -4030792.5, 0.0, 0.0, 1.0]
+
+properties:
+  datetime: 2023-04-30 23:50:34.384549Z
+  dea:dataset_maturity: nrt
+  dea:product_maturity: stable
+  eo:cloud_cover: 93.23672818080765
+  eo:gsd: 15.0  # Ground sample distance (m)
+  eo:instrument: OLI_TIRS
+  eo:platform: landsat-8
+  eo:sun_azimuth: 36.68926293
+  eo:sun_elevation: 29.26893394
+  fmask:clear: 6.182802588011784
+  fmask:cloud: 93.23672818080765
+  fmask:cloud_shadow: 0.14184073083015938
+  fmask:snow: 0.006917692167185185
+  fmask:water: 0.4317108081832226
+  gqa:abs_iterative_mean_x: 0.19
+  gqa:abs_iterative_mean_xy: 0.26
+  gqa:abs_iterative_mean_y: 0.18
+  gqa:abs_x: 0.65
+  gqa:abs_xy: 0.73
+  gqa:abs_y: 0.33
+  gqa:cep90: 0.4
+  gqa:iterative_mean_x: -0.15
+  gqa:iterative_mean_xy: 0.18
+  gqa:iterative_mean_y: 0.1
+  gqa:iterative_stddev_x: 0.16
+  gqa:iterative_stddev_xy: 0.24
+  gqa:iterative_stddev_y: 0.18
+  gqa:mean_x: 0.23
+  gqa:mean_xy: 0.23
+  gqa:mean_y: -0.02
+  gqa:stddev_x: 1.42
+  gqa:stddev_xy: 1.48
+  gqa:stddev_y: 0.42
+  landsat:collection_category: RT
+  landsat:collection_number: 2
+  landsat:landsat_product_id: LC08_L1TP_090086_20230430_20230501_02_RT
+  landsat:landsat_scene_id: LC80900862023120LGN00
+  landsat:wrs_path: 90
+  landsat:wrs_row: 86
+  odc:dataset_version: 3.2.1
+  odc:file_format: GeoTIFF
+  odc:processing_datetime: 2023-05-01 08:53:27.948360Z
+  odc:producer: ga.gov.au
+  odc:product_family: ard
+  odc:region_code: '090086'
+
+measurements:
+  nbart_blue:
+    path: ga_ls8c_nbart_3-2-1_090086_2023-04-30_nrt_band02.tif
+  nbart_coastal_aerosol:
+    path: ga_ls8c_nbart_3-2-1_090086_2023-04-30_nrt_band01.tif
+  nbart_green:
+    path: ga_ls8c_nbart_3-2-1_090086_2023-04-30_nrt_band03.tif
+  nbart_nir:
+    path: ga_ls8c_nbart_3-2-1_090086_2023-04-30_nrt_band05.tif
+  nbart_panchromatic:
+    path: ga_ls8c_nbart_3-2-1_090086_2023-04-30_nrt_band08.tif
+    grid: nbart:panchromatic
+  nbart_red:
+    path: ga_ls8c_nbart_3-2-1_090086_2023-04-30_nrt_band04.tif
+  nbart_swir_1:
+    path: ga_ls8c_nbart_3-2-1_090086_2023-04-30_nrt_band06.tif
+  nbart_swir_2:
+    path: ga_ls8c_nbart_3-2-1_090086_2023-04-30_nrt_band07.tif
+  oa_azimuthal_exiting:
+    path: ga_ls8c_oa_3-2-1_090086_2023-04-30_nrt_azimuthal-exiting.tif
+  oa_azimuthal_incident:
+    path: ga_ls8c_oa_3-2-1_090086_2023-04-30_nrt_azimuthal-incident.tif
+  oa_combined_terrain_shadow:
+    path: ga_ls8c_oa_3-2-1_090086_2023-04-30_nrt_combined-terrain-shadow.tif
+  oa_exiting_angle:
+    path: ga_ls8c_oa_3-2-1_090086_2023-04-30_nrt_exiting-angle.tif
+  oa_fmask:
+    path: ga_ls8c_oa_3-2-1_090086_2023-04-30_nrt_fmask.tif
+  oa_incident_angle:
+    path: ga_ls8c_oa_3-2-1_090086_2023-04-30_nrt_incident-angle.tif
+  oa_nbart_contiguity:
+    path: ga_ls8c_oa_3-2-1_090086_2023-04-30_nrt_nbart-contiguity.tif
+  oa_relative_azimuth:
+    path: ga_ls8c_oa_3-2-1_090086_2023-04-30_nrt_relative-azimuth.tif
+  oa_relative_slope:
+    path: ga_ls8c_oa_3-2-1_090086_2023-04-30_nrt_relative-slope.tif
+  oa_satellite_azimuth:
+    path: ga_ls8c_oa_3-2-1_090086_2023-04-30_nrt_satellite-azimuth.tif
+  oa_satellite_view:
+    path: ga_ls8c_oa_3-2-1_090086_2023-04-30_nrt_satellite-view.tif
+  oa_solar_azimuth:
+    path: ga_ls8c_oa_3-2-1_090086_2023-04-30_nrt_solar-azimuth.tif
+  oa_solar_zenith:
+    path: ga_ls8c_oa_3-2-1_090086_2023-04-30_nrt_solar-zenith.tif
+  oa_time_delta:
+    path: ga_ls8c_oa_3-2-1_090086_2023-04-30_nrt_time-delta.tif
+
+accessories:
+  thumbnail:nbart:
+    path: ga_ls8c_nbart_3-2-1_090086_2023-04-30_nrt_thumbnail.jpg
+  metadata:processor:
+    path: ga_ls8c_ard_3-2-1_090086_2023-04-30_nrt.proc-info.yaml
+  checksum:sha1:
+    path: ga_ls8c_ard_3-2-1_090086_2023-04-30_nrt.sha1
+
+lineage:
+  level1:
+  - 1090d7f4-2db2-58aa-bc09-cf8c446afdbd
+...

--- a/integration_tests/data/eo3/nrt_dataset.yaml
+++ b/integration_tests/data/eo3/nrt_dataset.yaml
@@ -132,7 +132,5 @@ accessories:
   checksum:sha1:
     path: ga_ls8c_ard_3-2-1_090086_2023-04-30_nrt.sha1
 
-lineage:
-  level1:
-  - 1090d7f4-2db2-58aa-bc09-cf8c446afdbd
+lineage: {}
 ...


### PR DESCRIPTION
### Reason for this pull request

The maturity model is currently only accessible via `odc-tools`, which is not currently available on NCI and requires many additional dependencies to install.


### Proposed changes

- Add archive_less_mature as an optional flag to datacube dataset add and datacube dataset update



 - [x] Closes #1444
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1451.org.readthedocs.build/en/1451/

<!-- readthedocs-preview datacube-core end -->