### PR TITLE
Improve archive_less_mature compatibility with odc-tools

### DIFF
--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -904,6 +904,20 @@ class AbstractDatasetResource(ABC):
 
         :param Dataset ds: dataset to search
         """
+        less_mature = self.find_less_mature(ds)
+        less_mature_ids = map(lambda x: x.id, less_mature)
+
+        self.archive(less_mature_ids)
+        for lm_ds in less_mature_ids:
+            _LOG.info(f"Archived less mature dataset: {lm_ds}")
+
+    def find_less_mature(self, ds: Dataset) -> Iterable[Dataset]:
+        """
+        Find less mature versions of a dataset
+
+        :param Dataset ds: Dataset to search
+        :return: Iterable of less mature datasets
+        """
         less_mature = []
         dupes = self.search(product=ds.product.name,
                             region_code=ds.metadata.region_code,
@@ -924,10 +938,8 @@ class AbstractDatasetResource(ABC):
                     f"A more mature version of dataset {ds.id} already exists, with id: "
                     f"{dupe.id} and maturity: {dupe.metadata.dataset_maturity}"
                 )
-            less_mature.append(dupe.id)
-        self.archive(less_mature)
-        for lm_ds in less_mature:
-            _LOG.info(f"Archived less mature dataset: {lm_ds}")
+            less_mature.append(dupe)
+        return less_mature
 
     @abstractmethod
     def restore(self, ids: Iterable[DSID]) -> None:

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -16,6 +16,7 @@ from typing import (Any, Iterable, Iterator,
                     NamedTuple, Optional,
                     Tuple, Union, Sequence)
 from uuid import UUID
+from datetime import timedelta
 
 from datacube.config import LocalConfig
 from datacube.index.exceptions import TransactionException
@@ -919,9 +920,12 @@ class AbstractDatasetResource(ABC):
         :return: Iterable of less mature datasets
         """
         less_mature = []
+        # 'expand' the date range by a millisecond to give a bit more leniency in datetime comparison
+        expanded_time_range = Range(ds.metadata.time.begin - timedelta(milliseconds=1),
+                                    ds.metadata.time.end + timedelta(milliseconds=1))
         dupes = self.search(product=ds.product.name,
                             region_code=ds.metadata.region_code,
-                            time=ds.metadata.time)
+                            time=expanded_time_range)
         for dupe in dupes:
             if dupe.id == ds.id:
                 continue

--- a/datacube/index/fields.py
+++ b/datacube/index/fields.py
@@ -38,7 +38,7 @@ class OrExpression(Expression):
 
 def as_expression(field: Field, value) -> Expression:
     """
-    Convert a single field/value to expression, following the "simple" convensions.
+    Convert a single field/value to expression, following the "simple" conventions.
     """
     if isinstance(value, Range):
         return field.between(value.begin, value.end)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -19,6 +19,7 @@ v1.8.next
   non-square Areas Of Interest (See `Issue #1448`_) (:pull:`1450`)
 .. _`Issue #1448`: https://github.com/opendatacube/datacube-core/issues/1448
 - Add `archive_less_mature` option to `datacube dataset add` and `datacube dataset update` (:pull:`1451`, :pull:`1452`)
+- Allow for +-1ms leniency in finding other maturity versions of a dataset (:pull:`1452`)
 
 
 v1.8.12 (7th March 2023)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -18,7 +18,7 @@ v1.8.next
 - Pass Y and Y Scale factors through to rasterio.warp.reproject, to eliminate projection bug affecting
   non-square Areas Of Interest (See `Issue #1448`_) (:pull:`1450`)
 .. _`Issue #1448`: https://github.com/opendatacube/datacube-core/issues/1448
-- Add `archive_less_mature` option to `datacube dataset add` and `datacube dataset update` (:pull:`1451`)
+- Add `archive_less_mature` option to `datacube dataset add` and `datacube dataset update` (:pull:`1451`, :pull:`1452`)
 
 
 v1.8.12 (7th March 2023)

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -78,7 +78,6 @@ def eo3_product_paths():
         str(EO3_TESTDIR / "ard_ls8.odc-product.yaml"),
         str(EO3_TESTDIR / "ga_ls_wo_3.odc-product.yaml"),
         str(EO3_TESTDIR / "s2_africa_product.yaml"),
-        str(EO3_TESTDIR / "ga_s2am_ard_3.odc-product.yaml"),
     ]
 
 

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -252,6 +252,14 @@ def doc_to_ds(index, product_name, ds_doc, ds_path):
     return index.datasets.get(ds.id)
 
 
+def doc_to_ds_no_add(index, product_name, ds_doc, ds_path):
+    from datacube.index.hl import Doc2Dataset
+    resolver = Doc2Dataset(index, products=[product_name], verify_lineage=False)
+    ds, err = resolver(ds_doc, ds_path)
+    assert err is None and ds is not None
+    return ds
+
+
 @pytest.fixture
 def extended_eo3_metadata_type(index, extended_eo3_metadata_type_doc):
     return index.metadata_types.add(
@@ -341,46 +349,34 @@ def africa_eo3_dataset(index, africa_s2_eo3_product, eo3_africa_dataset_doc):
 
 @pytest.fixture
 def nrt_dataset(index, extended_eo3_metadata_type, ls8_eo3_product, nrt_dataset_doc):
-    ds_doc = nrt_dataset_doc[0]
-    ds_path = nrt_dataset_doc[1]
-    from datacube.index.hl import Doc2Dataset
-    resolver = Doc2Dataset(index, products=[ls8_eo3_product.name], verify_lineage=False)
-    ds, err = resolver(ds_doc, ds_path)
-    assert err is None and ds is not None
-    return ds
+    return doc_to_ds_no_add(
+        index,
+        ls8_eo3_product.name,
+        *nrt_dataset_doc)
 
 
 @pytest.fixture
 def final_dataset(index, extended_eo3_metadata_type, ls8_eo3_product, final_dataset_doc):
-    ds_doc = final_dataset_doc[0]
-    ds_path = final_dataset_doc[1]
-    from datacube.index.hl import Doc2Dataset
-    resolver = Doc2Dataset(index, products=[ls8_eo3_product.name], verify_lineage=False)
-    ds, err = resolver(ds_doc, ds_path)
-    assert err is None and ds is not None
-    return ds
+    return doc_to_ds_no_add(
+        index,
+        ls8_eo3_product.name,
+        *final_dataset_doc)
 
 
 @pytest.fixture
 def ga_s2am_ard3_final(index, eo3_sentinel_metadata_type, ga_s2am_ard_3_product, ga_s2am_ard_3_final_doc):
-    ds_doc = ga_s2am_ard_3_final_doc[0]
-    ds_path = ga_s2am_ard_3_final_doc[1]
-    from datacube.index.hl import Doc2Dataset
-    resolver = Doc2Dataset(index, products=[ga_s2am_ard_3_product.name], verify_lineage=False)
-    ds, err = resolver(ds_doc, ds_path)
-    assert err is None and ds is not None
-    return ds
+    return doc_to_ds_no_add(
+        index,
+        ga_s2am_ard_3_product.name,
+        *ga_s2am_ard_3_final_doc)
 
 
 @pytest.fixture
 def ga_s2am_ard3_interim(index, eo3_sentinel_metadata_type, ga_s2am_ard_3_product, ga_s2am_ard_3_interim_doc):
-    ds_doc = ga_s2am_ard_3_interim_doc[0]
-    ds_path = ga_s2am_ard_3_interim_doc[1]
-    from datacube.index.hl import Doc2Dataset
-    resolver = Doc2Dataset(index, products=[ga_s2am_ard_3_product.name], verify_lineage=False)
-    ds, err = resolver(ds_doc, ds_path)
-    assert err is None and ds is not None
-    return ds
+    return doc_to_ds_no_add(
+        index,
+        ga_s2am_ard_3_product.name,
+        *ga_s2am_ard_3_interim_doc)
 
 
 @pytest.fixture

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -78,6 +78,7 @@ def eo3_product_paths():
         str(EO3_TESTDIR / "ard_ls8.odc-product.yaml"),
         str(EO3_TESTDIR / "ga_ls_wo_3.odc-product.yaml"),
         str(EO3_TESTDIR / "s2_africa_product.yaml"),
+        str(EO3_TESTDIR / "ga_s2am_ard_3.odc-product.yaml"),
     ]
 
 
@@ -183,6 +184,11 @@ def extended_eo3_metadata_type_doc():
 
 
 @pytest.fixture
+def eo3_sentinel_metadata_type_doc():
+    return get_eo3_test_data_doc("eo3_sentinel_ard.odc-type.yaml")
+
+
+@pytest.fixture
 def extended_eo3_product_doc():
     return get_eo3_test_data_doc("ard_ls8.odc-product.yaml")
 
@@ -195,6 +201,11 @@ def base_eo3_product_doc():
 @pytest.fixture
 def africa_s2_product_doc():
     return get_eo3_test_data_doc("s2_africa_product.yaml")
+
+
+@pytest.fixture
+def s2_ard_product_doc():
+    return get_eo3_test_data_doc("ga_s2am_ard_3.odc-product.yaml")
 
 
 @pytest.fixture
@@ -215,6 +226,24 @@ def nrt_dataset_doc():
     )
 
 
+@pytest.fixture
+def ga_s2am_ard_3_interim_doc():
+    return (
+        get_eo3_test_data_doc("ga_s2am_ard_3_interim.yaml"),
+        's3://dea-public-data/baseline/ga_s2am_ard_3/53/JNN/2021/07/24_interim'
+        '20230222T235626/ga_s2am_ard_3-2-1_53JNN_2021-07-24_interim.odc-metadata.yaml'
+    )
+
+
+@pytest.fixture
+def ga_s2am_ard_3_final_doc():
+    return (
+        get_eo3_test_data_doc("ga_s2am_ard_3_final.yaml"),
+        's3://dea-public-data/baseline/ga_s2am_ard_3/53/JNN/2021/07/24'
+        '20210724T023436/ga_s2am_ard_3-2-1_53JNN_2021-07-24_final.odc-metadata.yaml'
+    )
+
+
 def doc_to_ds(index, product_name, ds_doc, ds_path):
     from datacube.index.hl import Doc2Dataset
     resolver = Doc2Dataset(index, products=[product_name], verify_lineage=False)
@@ -232,6 +261,13 @@ def extended_eo3_metadata_type(index, extended_eo3_metadata_type_doc):
 
 
 @pytest.fixture
+def eo3_sentinel_metadata_type(index, eo3_sentinel_metadata_type_doc):
+    return index.metadata_types.add(
+        index.metadata_types.from_doc(eo3_sentinel_metadata_type_doc)
+    )
+
+
+@pytest.fixture
 def ls8_eo3_product(index, extended_eo3_metadata_type, extended_eo3_product_doc):
     return index.products.add_document(extended_eo3_product_doc)
 
@@ -244,6 +280,11 @@ def wo_eo3_product(index, base_eo3_product_doc):
 @pytest.fixture
 def africa_s2_eo3_product(index, africa_s2_product_doc):
     return index.products.add_document(africa_s2_product_doc)
+
+
+@pytest.fixture
+def ga_s2am_ard_3_product(index, eo3_sentinel_metadata_type, s2_ard_product_doc):
+    return index.products.add_document(s2_ard_product_doc)
 
 
 @pytest.fixture
@@ -316,6 +357,28 @@ def final_dataset(index, extended_eo3_metadata_type, ls8_eo3_product, final_data
     ds_path = final_dataset_doc[1]
     from datacube.index.hl import Doc2Dataset
     resolver = Doc2Dataset(index, products=[ls8_eo3_product.name], verify_lineage=False)
+    ds, err = resolver(ds_doc, ds_path)
+    assert err is None and ds is not None
+    return ds
+
+
+@pytest.fixture
+def ga_s2am_ard3_final(index, eo3_sentinel_metadata_type, ga_s2am_ard_3_product, ga_s2am_ard_3_final_doc):
+    ds_doc = ga_s2am_ard_3_final_doc[0]
+    ds_path = ga_s2am_ard_3_final_doc[1]
+    from datacube.index.hl import Doc2Dataset
+    resolver = Doc2Dataset(index, products=[ga_s2am_ard_3_product.name], verify_lineage=False)
+    ds, err = resolver(ds_doc, ds_path)
+    assert err is None and ds is not None
+    return ds
+
+
+@pytest.fixture
+def ga_s2am_ard3_interim(index, eo3_sentinel_metadata_type, ga_s2am_ard_3_product, ga_s2am_ard_3_interim_doc):
+    ds_doc = ga_s2am_ard_3_interim_doc[0]
+    ds_path = ga_s2am_ard_3_interim_doc[1]
+    from datacube.index.hl import Doc2Dataset
+    resolver = Doc2Dataset(index, products=[ga_s2am_ard_3_product.name], verify_lineage=False)
     ds, err = resolver(ds_doc, ds_path)
     assert err is None and ds is not None
     return ds

--- a/integration_tests/data/eo3/eo3_sentinel_ard.odc-type.yaml
+++ b/integration_tests/data/eo3/eo3_sentinel_ard.odc-type.yaml
@@ -1,0 +1,361 @@
+---
+# Metadata Type
+# url: https://explorer-aws.dea.ga.gov.au/metadata-types/eo3_sentinel_ard.odc-type.yaml
+name: eo3_sentinel_ard
+description: EO3 for Sentinel 2 ARD
+dataset:
+  id:
+  - id
+  label:
+  - label
+  format:
+  - properties
+  - odc:file_format
+  sources:
+  - lineage
+  - source_datasets
+  creation_dt:
+  - properties
+  - odc:processing_datetime
+  grid_spatial:
+  - grid_spatial
+  - projection
+  measurements:
+  - measurements
+  search_fields:
+    lat:
+      type: double-range
+      max_offset:
+      - - extent
+        - lat
+        - end
+      min_offset:
+      - - extent
+        - lat
+        - begin
+      description: Latitude range
+    lon:
+      type: double-range
+      max_offset:
+      - - extent
+        - lon
+        - end
+      min_offset:
+      - - extent
+        - lon
+        - begin
+      description: Longitude range
+    time:
+      type: datetime-range
+      max_offset:
+      - - properties
+        - dtr:end_datetime
+      - - properties
+        - datetime
+      min_offset:
+      - - properties
+        - dtr:start_datetime
+      - - properties
+        - datetime
+      description: Acquisition time range
+    eo_gsd:
+      type: double
+      offset:
+      - properties
+      - eo:gsd
+      indexed: false
+      description: "Ground sampling distance of the sensor’s best resolution band\n\
+        in metres; represents the size (or spatial resolution) of one pixel.\n"
+    crs_raw:
+      offset:
+      - crs
+      indexed: false
+      description: "The raw CRS string as it appears in metadata\n\n(e.g. ‘epsg:32654’)\n"
+    platform:
+      offset:
+      - properties
+      - eo:platform
+      indexed: false
+      description: Platform code
+    gqa_abs_x:
+      type: double
+      offset:
+      - properties
+      - gqa:abs_x
+      indexed: false
+      description: "Absolute value of the x-axis (east-to-west) GCP residuals, in\
+        \ pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5\
+        \ metres)\n"
+    gqa_abs_y:
+      type: double
+      offset:
+      - properties
+      - gqa:abs_y
+      indexed: false
+      description: "Absolute value of the y-axis (north-to-south) GCP residuals, in\
+        \ pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5\
+        \ metres)\n"
+    gqa_cep90:
+      type: double
+      offset:
+      - properties
+      - gqa:cep90
+      indexed: false
+      description: "Circular error probable (90%) of the values of the GCP residuals,\
+        \ in pixel units based on a 25 metre resolution reference image (i.e. 0.2\
+        \ = 5 metres)\n"
+    fmask_snow:
+      type: double
+      offset:
+      - properties
+      - fmask:snow
+      indexed: false
+      description: "The proportion (from 0 to 100) of the dataset's valid data area\
+        \ that contains clear snow pixels according to the Fmask algorithm\n"
+    gqa_abs_xy:
+      type: double
+      offset:
+      - properties
+      - gqa:abs_xy
+      indexed: false
+      description: "Absolute value of the total GCP residuals, in pixel units based\
+        \ on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)\n"
+    gqa_mean_x:
+      type: double
+      offset:
+      - properties
+      - gqa:mean_x
+      indexed: false
+      description: "Mean of the values of the x-axis (east-to-west) GCP residuals,\
+        \ in pixel units based on a 25 metre resolution reference image (i.e. 0.2\
+        \ = 5 metres)\n"
+    gqa_mean_y:
+      type: double
+      offset:
+      - properties
+      - gqa:mean_y
+      indexed: false
+      description: "Mean of the values of the y-axis (north-to-south) GCP residuals,\
+        \ in pixel units based on a 25 metre resolution reference image (i.e. 0.2\
+        \ = 5 metres)\n"
+    instrument:
+      offset:
+      - properties
+      - eo:instrument
+      indexed: false
+      description: Instrument name
+    cloud_cover:
+      type: double
+      offset:
+      - properties
+      - eo:cloud_cover
+      description: "The proportion (from 0 to 100) of the dataset's valid data area\
+        \ that contains cloud pixels.\n\nFor these ARD products, this value comes\
+        \ from the Fmask algorithm.\n"
+    fmask_clear:
+      type: double
+      offset:
+      - properties
+      - fmask:clear
+      indexed: false
+      description: "The proportion (from 0 to 100) of the dataset's valid data area\
+        \ that contains clear land pixels according to the Fmask algorithm\n"
+    fmask_water:
+      type: double
+      offset:
+      - properties
+      - fmask:water
+      indexed: false
+      description: "The proportion (from 0 to 100) of the dataset's valid data area\
+        \ that contains clear water pixels according to the Fmask algorithm\n"
+    gqa_mean_xy:
+      type: double
+      offset:
+      - properties
+      - gqa:mean_xy
+      indexed: false
+      description: "Mean of the values of the GCP residuals, in pixel units based\
+        \ on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)\n"
+    region_code:
+      offset:
+      - properties
+      - odc:region_code
+      description: "Spatial reference code from the provider.\nFor Sentinel it is\
+        \ MGRS code.\n"
+    gqa_stddev_x:
+      type: double
+      offset:
+      - properties
+      - gqa:stddev_x
+      indexed: false
+      description: "Standard Deviation of the values of the x-axis (east-to-west)\
+        \ GCP residuals, in pixel units based on a 25 metre resolution reference image\
+        \ (i.e. 0.2 = 5 metres)\n"
+    gqa_stddev_y:
+      type: double
+      offset:
+      - properties
+      - gqa:stddev_y
+      indexed: false
+      description: "Standard Deviation of the values of the y-axis (north-to-south)\
+        \ GCP residuals, in pixel units based on a 25 metre resolution reference image\
+        \ (i.e. 0.2 = 5 metres)\n"
+    gqa_stddev_xy:
+      type: double
+      offset:
+      - properties
+      - gqa:stddev_xy
+      indexed: false
+      description: "Standard Deviation of the values of the GCP residuals, in pixel\
+        \ units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)\n"
+    eo_sun_azimuth:
+      type: double
+      offset:
+      - properties
+      - eo:sun_azimuth
+      indexed: false
+      description: "The azimuth angle of the sun at the moment of acquisition, in\
+        \ degree units measured clockwise from due north\n"
+    product_family:
+      offset:
+      - properties
+      - odc:product_family
+      indexed: false
+      description: Product family code
+    dataset_maturity:
+      offset:
+      - properties
+      - dea:dataset_maturity
+      indexed: false
+      description: One of - final|interim|nrt  (near real time)
+    eo_sun_elevation:
+      type: double
+      offset:
+      - properties
+      - eo:sun_elevation
+      indexed: false
+      description: "The elevation angle of the sun at the moment of acquisition, in\
+        \ degree units relative to the horizon.\n"
+    sentinel_tile_id:
+      offset:
+      - properties
+      - sentinel:sentinel_tile_id
+      indexed: false
+      description: "Granule ID according to the ESA naming convention\n\n(e.g. ‘S2A_OPER_MSI_L1C_TL_SGS__20161214T040601_A007721_T53KRB_N02.04’)\n"
+    s2cloudless_clear:
+      type: double
+      offset:
+      - properties
+      - s2cloudless:clear
+      description: "The proportion (from 0 to 100) of the dataset's valid data area\
+        \ that contains clear land pixels according to s3cloudless\n"
+    s2cloudless_cloud:
+      type: double
+      offset:
+      - properties
+      - s2cloudless:cloud
+      description: "The proportion (from 0 to 100) of the dataset's valid data area\
+        \ that contains cloud land pixels according to s3cloudless\n"
+    fmask_cloud_shadow:
+      type: double
+      offset:
+      - properties
+      - fmask:cloud_shadow
+      indexed: false
+      description: "The proportion (from 0 to 100) of the dataset's valid data area\
+        \ that contains cloud shadow pixels according to the Fmask algorithm\n"
+    gqa_iterative_mean_x:
+      type: double
+      offset:
+      - properties
+      - gqa:iterative_mean_x
+      indexed: false
+      description: "Mean of the values of the x-axis (east-to-west) GCP residuals\
+        \ after removal of outliers, in pixel units based on a 25 metre resolution\
+        \ reference image (i.e. 0.2 = 5 metres)\n"
+    gqa_iterative_mean_y:
+      type: double
+      offset:
+      - properties
+      - gqa:iterative_mean_y
+      indexed: false
+      description: "Mean of the values of the y-axis (north-to-south) GCP residuals\
+        \ after removal of outliers, in pixel units based on a 25 metre resolution\
+        \ reference image (i.e. 0.2 = 5 metres)\n"
+    gqa_iterative_mean_xy:
+      type: double
+      offset:
+      - properties
+      - gqa:iterative_mean_xy
+      indexed: false
+      description: "Mean of the values of the GCP residuals after removal of outliers,\
+        \ in pixel units based on a 25 metre resolution reference image (i.e. 0.2\
+        \ = 5 metres)\n"
+    sentinel_datastrip_id:
+      offset:
+      - properties
+      - sentinel:datastrip_id
+      indexed: false
+      description: "Unique identifier for a datastrip relative to a given Datatake.\n\
+        \n(e.g. ‘S2A_OPER_MSI_L1C_DS_SGS__20161214T040601_S20161214T005840_N02.04’)\n"
+    sentinel_product_name:
+      offset:
+      - properties
+      - sentinel:product_name
+      indexed: false
+      description: "ESA product URI, with the '.SAFE' ending removed.\n\n(e.g. 'S2A_MSIL1C_20220303T000731_N0400_R073_T56LNM_20220303T012845')\n"
+    gqa_iterative_stddev_x:
+      type: double
+      offset:
+      - properties
+      - gqa:iterative_stddev_x
+      indexed: false
+      description: "Standard Deviation of the values of the x-axis (east-to-west)\
+        \ GCP residuals after removal of outliers, in pixel units based on a 25 metre\
+        \ resolution reference image (i.e. 0.2 = 5 metres)\n"
+    gqa_iterative_stddev_y:
+      type: double
+      offset:
+      - properties
+      - gqa:iterative_stddev_y
+      indexed: false
+      description: "Standard Deviation of the values of the y-axis (north-to-south)\
+        \ GCP residuals after removal of outliers, in pixel units based on a 25 metre\
+        \ resolution reference image (i.e. 0.2 = 5 metres)\n"
+    gqa_iterative_stddev_xy:
+      type: double
+      offset:
+      - properties
+      - gqa:iterative_stddev_xy
+      indexed: false
+      description: "Standard Deviation of the values of the GCP residuals after removal\
+        \ of outliers, in pixel units based on a 25 metre resolution reference image\
+        \ (i.e. 0.2 = 5 metres)\n"
+    gqa_abs_iterative_mean_x:
+      type: double
+      offset:
+      - properties
+      - gqa:abs_iterative_mean_x
+      indexed: false
+      description: "Mean of the absolute values of the x-axis (east-to-west) GCP residuals\
+        \ after removal of outliers, in pixel units based on a 25 metre resolution\
+        \ reference image (i.e. 0.2 = 5 metres)\n"
+    gqa_abs_iterative_mean_y:
+      type: double
+      offset:
+      - properties
+      - gqa:abs_iterative_mean_y
+      indexed: false
+      description: "Mean of the absolute values of the y-axis (north-to-south) GCP\
+        \ residuals after removal of outliers, in pixel units based on a 25 metre\
+        \ resolution reference image (i.e. 0.2 = 5 metres)\n"
+    gqa_abs_iterative_mean_xy:
+      type: double
+      offset:
+      - properties
+      - gqa:abs_iterative_mean_xy
+      indexed: false
+      description: "Mean of the absolute values of the GCP residuals after removal\
+        \ of outliers, in pixel units based on a 25 metre resolution reference image\
+        \ (i.e. 0.2 = 5 metres)\n"
+...

--- a/integration_tests/data/eo3/ga_s2am_ard_3.odc-product.yaml
+++ b/integration_tests/data/eo3/ga_s2am_ard_3.odc-product.yaml
@@ -1,0 +1,240 @@
+---
+name: ga_s2am_ard_3
+license: CC-BY-4.0
+metadata_type: eo3_sentinel_ard
+description: Geoscience Australia Sentinel 2A MSI Analysis Ready Data Collection 3
+metadata:
+  product:
+    name: ga_s2am_ard_3
+  properties:
+    eo:platform: sentinel-2a
+    odc:producer: ga.gov.au
+    eo:instrument: MSI
+    odc:product_family: ard
+    dea:product_maturity: stable
+measurements:
+- name: nbart_coastal_aerosol
+  dtype: int16
+  units: '1'
+  nodata: -999
+  aliases:
+  - nbart_band01
+  - coastal_aerosol
+- name: nbart_blue
+  dtype: int16
+  units: '1'
+  nodata: -999
+  aliases:
+  - nbart_band02
+  - blue
+- name: nbart_green
+  dtype: int16
+  units: '1'
+  nodata: -999
+  aliases:
+  - nbart_band03
+  - green
+- name: nbart_red
+  dtype: int16
+  units: '1'
+  nodata: -999
+  aliases:
+  - nbart_band04
+  - red
+- name: nbart_red_edge_1
+  dtype: int16
+  units: '1'
+  nodata: -999
+  aliases:
+  - nbart_band05
+  - red_edge_1
+- name: nbart_red_edge_2
+  dtype: int16
+  units: '1'
+  nodata: -999
+  aliases:
+  - nbart_band06
+  - red_edge_2
+- name: nbart_red_edge_3
+  dtype: int16
+  units: '1'
+  nodata: -999
+  aliases:
+  - nbart_band07
+  - red_edge_3
+- name: nbart_nir_1
+  dtype: int16
+  units: '1'
+  nodata: -999
+  aliases:
+  - nbart_band08
+  - nir_1
+  - nbart_common_nir
+- name: nbart_nir_2
+  dtype: int16
+  units: '1'
+  nodata: -999
+  aliases:
+  - nbart_band8a
+  - nir_2
+- name: nbart_swir_2
+  dtype: int16
+  units: '1'
+  nodata: -999
+  aliases:
+  - nbart_band11
+  - swir_2
+  - nbart_common_swir_1
+  - swir2
+- name: nbart_swir_3
+  dtype: int16
+  units: '1'
+  nodata: -999
+  aliases:
+  - nbart_band12
+  - swir_3
+  - nbart_common_swir_2
+- name: oa_fmask
+  dtype: uint8
+  units: '1'
+  nodata: 0
+  aliases:
+  - fmask
+  flags_definition:
+    fmask:
+      bits:
+      - 0
+      - 1
+      - 2
+      - 3
+      - 4
+      - 5
+      - 6
+      - 7
+      values:
+        '0': nodata
+        '1': valid
+        '2': cloud
+        '3': shadow
+        '4': snow
+        '5': water
+      description: Fmask
+- name: oa_nbart_contiguity
+  dtype: uint8
+  units: '1'
+  nodata: 255
+  aliases:
+  - nbart_contiguity
+  flags_definition:
+    contiguous:
+      bits:
+      - 0
+      values:
+        '0': false
+        '1': true
+- name: oa_azimuthal_exiting
+  dtype: float32
+  units: '1'
+  nodata: NaN
+  aliases:
+  - azimuthal_exiting
+- name: oa_azimuthal_incident
+  dtype: float32
+  units: '1'
+  nodata: NaN
+  aliases:
+  - azimuthal_incident
+- name: oa_combined_terrain_shadow
+  dtype: uint8
+  units: '1'
+  nodata: 255
+  aliases:
+  - combined_terrain_shadow
+- name: oa_exiting_angle
+  dtype: float32
+  units: '1'
+  nodata: NaN
+  aliases:
+  - exiting_angle
+- name: oa_incident_angle
+  dtype: float32
+  units: '1'
+  nodata: NaN
+  aliases:
+  - incident_angle
+- name: oa_relative_azimuth
+  dtype: float32
+  units: '1'
+  nodata: NaN
+  aliases:
+  - relative_azimuth
+- name: oa_relative_slope
+  dtype: float32
+  units: '1'
+  nodata: NaN
+  aliases:
+  - relative_slope
+- name: oa_satellite_azimuth
+  dtype: float32
+  units: '1'
+  nodata: NaN
+  aliases:
+  - satellite_azimuth
+- name: oa_satellite_view
+  dtype: float32
+  units: '1'
+  nodata: NaN
+  aliases:
+  - satellite_view
+- name: oa_solar_azimuth
+  dtype: float32
+  units: '1'
+  nodata: NaN
+  aliases:
+  - solar_azimuth
+- name: oa_solar_zenith
+  dtype: float32
+  units: '1'
+  nodata: NaN
+  aliases:
+  - solar_zenith
+- name: oa_time_delta
+  dtype: float32
+  units: '1'
+  nodata: NaN
+  aliases:
+  - time_delta
+- name: oa_s2cloudless_mask
+  dtype: uint8
+  units: '1'
+  nodata: 0
+  aliases:
+  - s2cloudless_mask
+  flags_definition:
+    s2cloudless_mask:
+      bits:
+      - 0
+      - 1
+      - 2
+      values:
+        '0': nodata
+        '1': valid
+        '2': cloud
+      description: s2cloudless mask
+- name: oa_s2cloudless_prob
+  dtype: float64
+  units: '1'
+  nodata: NaN
+  aliases:
+  - s2cloudless_prob
+# Product
+# url: https://explorer-aws.dea.ga.gov.au/products/ga_s2am_ard_3.odc-product.yaml
+load:
+  crs: EPSG:3577
+  align:
+    x: 0
+    y: 0
+  resolution:
+    x: 10
+    y: -10
+...

--- a/integration_tests/data/eo3/ga_s2am_ard_3_final.yaml
+++ b/integration_tests/data/eo3/ga_s2am_ard_3_final.yaml
@@ -1,0 +1,150 @@
+---
+# Dataset
+$schema: https://schemas.opendatacube.org/dataset
+id: 4123766b-5779-4f96-b71f-28e28a326434
+
+label: ga_s2am_ard_3-2-1_53JNN_2021-07-24_final
+product:
+  name: ga_s2am_ard_3
+  href: https://collections.dea.ga.gov.au/product/ga_s2am_ard_3
+
+crs: epsg:32753
+geometry:
+  type: Polygon
+  coordinates: [[[499980.0, 7300000.0], [609780.0, 7300000.0], [609780.0, 7190200.0],
+      [499980.0, 7190200.0], [499980.0, 7300000.0]]]
+grids:
+  default:
+    shape: [5490, 5490]
+    transform: [20.0, 0.0, 499980.0, 0.0, -20.0, 7300000.0, 0.0, 0.0, 1.0]
+  '10':
+    shape: [10980, 10980]
+    transform: [10.0, 0.0, 499980.0, 0.0, -10.0, 7300000.0, 0.0, 0.0, 1.0]
+  '60':
+    shape: [1830, 1830]
+    transform: [60.0, 0.0, 499980.0, 0.0, -60.0, 7300000.0, 0.0, 0.0, 1.0]
+
+properties:
+  datetime: 2021-07-24 01:14:10.195987Z
+  dea:dataset_maturity: final
+  dea:product_maturity: stable
+  eo:cloud_cover: 0.0
+  eo:constellation: sentinel-2
+  eo:gsd: 10.0  # Ground sample distance (m)
+  eo:instrument: MSI
+  eo:platform: sentinel-2a
+  eo:sun_azimuth: 33.4140301515032
+  eo:sun_elevation: 52.1651784839186
+  fmask:clear: 99.9999469145756
+  fmask:cloud: 0.0
+  fmask:cloud_shadow: 0.0
+  fmask:snow: 0.0
+  fmask:water: 5.30854244013789e-05
+  gqa:abs_iterative_mean_x: 0.88
+  gqa:abs_iterative_mean_xy: 2.17
+  gqa:abs_iterative_mean_y: 1.98
+  gqa:abs_x: 1.48
+  gqa:abs_xy: 4.03
+  gqa:abs_y: 3.74
+  gqa:cep90: 4.78
+  gqa:iterative_mean_x: 0.52
+  gqa:iterative_mean_xy: 0.55
+  gqa:iterative_mean_y: 0.18
+  gqa:iterative_stddev_x: 1.41
+  gqa:iterative_stddev_xy: 4.21
+  gqa:iterative_stddev_y: 3.97
+  gqa:mean_x: 0.69
+  gqa:mean_xy: 0.74
+  gqa:mean_y: -0.25
+  gqa:stddev_x: 14.77
+  gqa:stddev_xy: 39.88
+  gqa:stddev_y: 37.04
+  odc:dataset_version: 3.2.1
+  odc:file_format: GeoTIFF
+  odc:processing_datetime: 2022-07-12 17:54:39.369087Z
+  odc:producer: ga.gov.au
+  odc:product_family: ard
+  odc:region_code: 53JNN
+  s2cloudless:clear: 100.0
+  s2cloudless:cloud: 0.0
+  sat:orbit_state: descending
+  sat:relative_orbit: 45
+  sentinel:datastrip_id: S2A_OPER_MSI_L1C_DS_VGS4_20210724T023436_S20210724T010731_N03.01
+  sentinel:datatake_start_datetime: 2021-07-24 02:34:36Z
+  sentinel:product_name: S2A_MSIL1C_20210724T010731_N0301_R045_T53JNN_20210724T023436
+  sentinel:sentinel_tile_id: S2A_OPER_MSI_L1C_TL_VGS4_20210724T023436_A031788_T53JNN_N03.01
+
+measurements:
+  nbart_blue:
+    path: ga_s2am_nbart_3-2-1_53JNN_2021-07-24_final_band02.tif
+    grid: '10'
+  nbart_coastal_aerosol:
+    path: ga_s2am_nbart_3-2-1_53JNN_2021-07-24_final_band01.tif
+    grid: '60'
+  nbart_green:
+    path: ga_s2am_nbart_3-2-1_53JNN_2021-07-24_final_band03.tif
+    grid: '10'
+  nbart_nir_1:
+    path: ga_s2am_nbart_3-2-1_53JNN_2021-07-24_final_band08.tif
+    grid: '10'
+  nbart_nir_2:
+    path: ga_s2am_nbart_3-2-1_53JNN_2021-07-24_final_band08a.tif
+  nbart_red:
+    path: ga_s2am_nbart_3-2-1_53JNN_2021-07-24_final_band04.tif
+    grid: '10'
+  nbart_red_edge_1:
+    path: ga_s2am_nbart_3-2-1_53JNN_2021-07-24_final_band05.tif
+  nbart_red_edge_2:
+    path: ga_s2am_nbart_3-2-1_53JNN_2021-07-24_final_band06.tif
+  nbart_red_edge_3:
+    path: ga_s2am_nbart_3-2-1_53JNN_2021-07-24_final_band07.tif
+  nbart_swir_2:
+    path: ga_s2am_nbart_3-2-1_53JNN_2021-07-24_final_band11.tif
+  nbart_swir_3:
+    path: ga_s2am_nbart_3-2-1_53JNN_2021-07-24_final_band12.tif
+  oa_azimuthal_exiting:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_final_azimuthal-exiting.tif
+  oa_azimuthal_incident:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_final_azimuthal-incident.tif
+  oa_combined_terrain_shadow:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_final_combined-terrain-shadow.tif
+  oa_exiting_angle:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_final_exiting-angle.tif
+  oa_fmask:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_final_fmask.tif
+  oa_incident_angle:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_final_incident-angle.tif
+  oa_nbart_contiguity:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_final_nbart-contiguity.tif
+    grid: '10'
+  oa_relative_azimuth:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_final_relative-azimuth.tif
+  oa_relative_slope:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_final_relative-slope.tif
+  oa_s2cloudless_mask:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_final_s2cloudless-mask.tif
+    grid: '60'
+  oa_s2cloudless_prob:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_final_s2cloudless-prob.tif
+    grid: '60'
+  oa_satellite_azimuth:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_final_satellite-azimuth.tif
+  oa_satellite_view:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_final_satellite-view.tif
+  oa_solar_azimuth:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_final_solar-azimuth.tif
+  oa_solar_zenith:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_final_solar-zenith.tif
+  oa_time_delta:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_final_time-delta.tif
+
+accessories:
+  thumbnail:nbart:
+    path: ga_s2am_nbart_3-2-1_53JNN_2021-07-24_final_thumbnail.jpg
+  metadata:processor:
+    path: ga_s2am_ard_3-2-1_53JNN_2021-07-24_final.proc-info.yaml
+  checksum:sha1:
+    path: ga_s2am_ard_3-2-1_53JNN_2021-07-24_final.sha1
+
+lineage: {}
+...

--- a/integration_tests/data/eo3/ga_s2am_ard_3_interim.yaml
+++ b/integration_tests/data/eo3/ga_s2am_ard_3_interim.yaml
@@ -1,0 +1,151 @@
+---
+# Dataset
+$schema: https://schemas.opendatacube.org/dataset
+id: c0324cbb-f499-4e8d-8001-a38206ff6904
+
+label: ga_s2am_ard_3-2-1_53JNN_2021-07-24_interim
+product:
+  name: ga_s2am_ard_3
+  href: https://collections.dea.ga.gov.au/product/ga_s2am_ard_3
+
+crs: epsg:32753
+geometry:
+  type: Polygon
+  coordinates: [[[499980.0, 7300000.0], [609780.0, 7300000.0], [609780.0, 7190200.0],
+      [499980.0, 7190200.0], [499980.0, 7300000.0]]]
+grids:
+  default:
+    shape: [5490, 5490]
+    transform: [20.0, 0.0, 499980.0, 0.0, -20.0, 7300000.0, 0.0, 0.0, 1.0]
+  '10':
+    shape: [10980, 10980]
+    transform: [10.0, 0.0, 499980.0, 0.0, -10.0, 7300000.0, 0.0, 0.0, 1.0]
+  '60':
+    shape: [1830, 1830]
+    transform: [60.0, 0.0, 499980.0, 0.0, -60.0, 7300000.0, 0.0, 0.0, 1.0]
+
+properties:
+  datetime: 2021-07-24 01:14:10.195809Z
+  dea:dataset_maturity: interim
+  dea:product_maturity: stable
+  eo:cloud_cover: 0.0
+  eo:constellation: sentinel-2
+  eo:gsd: 10.0  # Ground sample distance (m)
+  eo:instrument: MSI
+  eo:platform: sentinel-2a
+  eo:sun_azimuth: 33.4134402697606
+  eo:sun_elevation: 52.1647723037447
+  fmask:clear: 99.99995355025365
+  fmask:cloud: 0.0
+  fmask:cloud_shadow: 0.0
+  fmask:snow: 0.0
+  fmask:water: 4.6449746351206534e-05
+  gqa:abs_iterative_mean_x: 0.48
+  gqa:abs_iterative_mean_xy: 1.02
+  gqa:abs_iterative_mean_y: 0.91
+  gqa:abs_x: 0.81
+  gqa:abs_xy: 2.04
+  gqa:abs_y: 1.87
+  gqa:cep90: 2.56
+  gqa:iterative_mean_x: 0.33
+  gqa:iterative_mean_xy: 0.41
+  gqa:iterative_mean_y: 0.24
+  gqa:iterative_stddev_x: 0.6
+  gqa:iterative_stddev_xy: 1.7
+  gqa:iterative_stddev_y: 1.6
+  gqa:mean_x: 0.41
+  gqa:mean_xy: 0.41
+  gqa:mean_y: 0.03
+  gqa:stddev_x: 3.58
+  gqa:stddev_xy: 10.73
+  gqa:stddev_y: 10.12
+  odc:dataset_version: 3.2.1
+  odc:file_format: GeoTIFF
+  odc:processing_datetime: 2023-05-31 21:12:25.979068Z
+  odc:producer: ga.gov.au
+  odc:product_family: ard
+  odc:region_code: 53JNN
+  s2cloudless:clear: 100.0
+  s2cloudless:cloud: 0.0
+  sentinel:datastrip_id: S2A_OPER_MSI_L1C_DS_S2RP_20230222T235626_S20210724T010731_N05.00
+  sentinel:datatake_start_datetime: 2023-02-22 23:56:26Z
+  sentinel:grid_square: NN
+  sentinel:latitude_band: J
+  sentinel:product_name: S2A_MSIL1C_20210724T010731_N0500_R045_T53JNN_20230222T235626.SAFE
+  sentinel:sentinel_tile_id: S2A_OPER_MSI_L1C_TL_S2RP_20230222T235626_A031788_T53JNN_N05.00
+  sentinel:utm_zone: 53
+
+measurements:
+  nbart_blue:
+    path: ga_s2am_nbart_3-2-1_53JNN_2021-07-24_interim_band02.tif
+    grid: '10'
+  nbart_coastal_aerosol:
+    path: ga_s2am_nbart_3-2-1_53JNN_2021-07-24_interim_band01.tif
+    grid: '60'
+  nbart_green:
+    path: ga_s2am_nbart_3-2-1_53JNN_2021-07-24_interim_band03.tif
+    grid: '10'
+  nbart_nir_1:
+    path: ga_s2am_nbart_3-2-1_53JNN_2021-07-24_interim_band08.tif
+    grid: '10'
+  nbart_nir_2:
+    path: ga_s2am_nbart_3-2-1_53JNN_2021-07-24_interim_band08a.tif
+  nbart_red:
+    path: ga_s2am_nbart_3-2-1_53JNN_2021-07-24_interim_band04.tif
+    grid: '10'
+  nbart_red_edge_1:
+    path: ga_s2am_nbart_3-2-1_53JNN_2021-07-24_interim_band05.tif
+  nbart_red_edge_2:
+    path: ga_s2am_nbart_3-2-1_53JNN_2021-07-24_interim_band06.tif
+  nbart_red_edge_3:
+    path: ga_s2am_nbart_3-2-1_53JNN_2021-07-24_interim_band07.tif
+  nbart_swir_2:
+    path: ga_s2am_nbart_3-2-1_53JNN_2021-07-24_interim_band11.tif
+  nbart_swir_3:
+    path: ga_s2am_nbart_3-2-1_53JNN_2021-07-24_interim_band12.tif
+  oa_azimuthal_exiting:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_interim_azimuthal-exiting.tif
+  oa_azimuthal_incident:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_interim_azimuthal-incident.tif
+  oa_combined_terrain_shadow:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_interim_combined-terrain-shadow.tif
+  oa_exiting_angle:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_interim_exiting-angle.tif
+  oa_fmask:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_interim_fmask.tif
+  oa_incident_angle:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_interim_incident-angle.tif
+  oa_nbart_contiguity:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_interim_nbart-contiguity.tif
+    grid: '10'
+  oa_relative_azimuth:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_interim_relative-azimuth.tif
+  oa_relative_slope:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_interim_relative-slope.tif
+  oa_s2cloudless_mask:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_interim_s2cloudless-mask.tif
+    grid: '60'
+  oa_s2cloudless_prob:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_interim_s2cloudless-prob.tif
+    grid: '60'
+  oa_satellite_azimuth:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_interim_satellite-azimuth.tif
+  oa_satellite_view:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_interim_satellite-view.tif
+  oa_solar_azimuth:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_interim_solar-azimuth.tif
+  oa_solar_zenith:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_interim_solar-zenith.tif
+  oa_time_delta:
+    path: ga_s2am_oa_3-2-1_53JNN_2021-07-24_interim_time-delta.tif
+
+accessories:
+  thumbnail:nbart:
+    path: ga_s2am_nbart_3-2-1_53JNN_2021-07-24_interim_thumbnail.jpg
+  metadata:processor:
+    path: ga_s2am_ard_3-2-1_53JNN_2021-07-24_interim.proc-info.yaml
+  checksum:sha1:
+    path: ga_s2am_ard_3-2-1_53JNN_2021-07-24_interim.sha1
+
+lineage: {}
+...

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -110,6 +110,15 @@ def test_archive_less_mature(index, final_dataset, nrt_dataset):
         index.datasets.add(nrt_dataset, with_lineage=False, archive_less_mature=True)
 
 
+def test_archive_less_mature_approx_timestamp(index, ga_s2am_ard3_final, ga_s2am_ard3_interim):
+    # test archive_less_mature where there's a slight difference in timestamps
+    index.datasets.add(ga_s2am_ard3_interim, with_lineage=False)
+    index.datasets.get(ga_s2am_ard3_interim.id).is_active
+    index.datasets.add(ga_s2am_ard3_final, with_lineage=False, archive_less_mature=True)
+    assert index.datasets.get(ga_s2am_ard3_interim.id).is_archived
+    assert index.datasets.get(ga_s2am_ard3_final.id).is_active
+
+
 def test_purge_datasets(index, ls8_eo3_dataset):
     assert index.datasets.has(ls8_eo3_dataset.id)
     datasets = index.datasets.search_eager()

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -94,7 +94,6 @@ def test_archive_datasets(index, local_config, ls8_eo3_dataset):
     assert not indexed_dataset.is_archived
 
 
-@pytest.mark.parametrize('datacube_env_name', ('experimental',))
 def test_archive_less_mature(index, final_dataset, nrt_dataset):
     # case 1: add nrt then final; nrt should get archived
     index.datasets.add(nrt_dataset, with_lineage=False, archive_less_mature=True)


### PR DESCRIPTION
### Reason for this pull request

`odc-tools` also uses the `archive_less_mature` functionality, but additionally needs to be able to access the less mature datasets to public the STAC document to an SNS topic. With the current implementation of `archive_less_mature`, this requires a lot of duplicate code.


### Proposed changes

- Split the search logic in `archive_less_mature` into a new function, `find_less_mature`, that simply returns a list of the less mature Datasets
- Allow a leniency of 1ms in searching for other maturity versions of a dataset



 - [ ] Closes #xxxx
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1452.org.readthedocs.build/en/1452/

<!-- readthedocs-preview datacube-core end -->