### PR TITLE
Fix gha pypi publishing condition

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,13 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Config
+      id: cfg
+      run: |
+        if "${GITHUB_REF}" in "refs/tags/"*; then
+          echo "push_pypi=yes" >> $GITHUB_OUTPUT
+        fi
+
     - uses: dorny/paths-filter@v2
       id: changes
       if: |
@@ -117,7 +124,7 @@ jobs:
     - name: Publish to PyPi
       if: |
         github.event_name == 'push'
-        && github.ref == 'refs/heads/pypi/publish'
+        && steps.cfg.outputs.push_pypi == 'yes'
       run: |
         if [ -n "${TWINE_PASSWORD}" ]; then
           docker run --rm  \

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,9 @@ What's New
 v1.8.next
 =========
 
+- Fix broken pypi publishing Github action (:pull:`1454`)
+
+
 v1.8.13 (6th June 2023)
 =======================
 


### PR DESCRIPTION
### Reason for this pull request

The latest release revealed that I incorrectly added a condition in the github workflow, requiring a push to `pypi/publish` to publish to pypi.


### Proposed changes

- Simplify and reinstate previous `Config` step with `push_pypi` output 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1454.org.readthedocs.build/en/1454/

<!-- readthedocs-preview datacube-core end -->