### PR TITLE
Always use XSCALE=1,YSCALE=1 in warp.

### DIFF
--- a/datacube/storage/_read.py
+++ b/datacube/storage/_read.py
@@ -182,26 +182,32 @@ def read_time_slice(rdr,
 
         pix = rdr.read(*norm_read_args(rr.roi_src, src_gbox.shape, extra_dim_index))
 
+        # XSCALE and YSCALE are (currently) undocumented arguments that rasterio passed through to
+        # GDAL.  Not using them results in very inaccurate warping in images with highly
+        # non-square (i.e. long and thin) aspect ratios.
+        #
+        # See https://github.com/OSGeo/gdal/issues/7750 as well as
+        # https://github.com/opendatacube/datacube-core/pull/1450 and
+        # https://github.com/opendatacube/datacube-core/issues/1456
+        #
+        # In theory we might be able to get better results for queries with significantly
+        # different vertical and horizontal scales, but explicitly using XSCALE=1, YSCALE=1
+        # appears to be most appropriate for most requests, and is demonstrably better
+        # than not setting them at all.
+        gdal_scale_params = {
+            "XSCALE": 1,
+            "YSCALE": 1,
+        }
         if rr.transform.linear is not None:
             A = (~src_gbox.transform)*dst_gbox.transform
             warp_affine(pix, dst, A, resampling,
-                        src_nodata=rdr.nodata, dst_nodata=dst_nodata)
+                        src_nodata=rdr.nodata, dst_nodata=dst_nodata,
+                        **gdal_scale_params)
         else:
-            # XSCALE and YSCALE are (currently) undocumented arguments that rasterio passed through to
-            # GDAL.  Not using them results in very inaccurate warping in images with highly
-            # non-square (i.e. long and thin) aspect ratios.
-            #
-            # See https://github.com/OSGeo/gdal/issues/7750 as well as
-            # https://github.com/opendatacube/datacube-core/pull/1450 and
-            # https://github.com/opendatacube/datacube-core/issues/1456
-            #
-            # In theory we might be able to get better results for queries with significantly
-            # different vertical and horizontal scales, but explicitly using XSCALE=1, YSCALE=1
-            # appears to be most appropriate for most requests, and is demonstrably better
-            # than not setting them at all.
+
             rio_reproject(pix, dst, src_gbox, dst_gbox, resampling,
                           src_nodata=rdr.nodata, dst_nodata=dst_nodata,
-                          XSCALE=1, YSCALE=1)
+                          **gdal_scale_params)
 
     return rr.roi_dst
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,8 @@ What's New
 v1.8.next
 =========
 
+- Second attempt to address unexpected handling of image aspect ratios in rasterio and
+  GDAL. (:pull:`XXX`)
 - Fix broken pypi publishing Github action (:pull:`1454`)
 
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -9,7 +9,7 @@ v1.8.next
 =========
 
 - Second attempt to address unexpected handling of image aspect ratios in rasterio and
-  GDAL. (:pull:`XXX`)
+  GDAL. (:pull:`1457`)
 - Fix broken pypi publishing Github action (:pull:`1454`)
 
 

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -233,7 +233,8 @@ def assert_same_read_results(source, dst_shape, dst_dtype, dst_transform, dst_no
                                 dst_transform=dst_transform,
                                 dst_crs=str(dst_projection),
                                 dst_nodata=dst_nodata,
-                                resampling=resampling)
+                                resampling=resampling,
+                                XSCALE=1, YSCALE=1)
 
     result = np.full(dst_shape, dst_nodata, dtype=dst_dtype)
     H, W = dst_shape


### PR DESCRIPTION
### Reason for this pull request

#1450 was an attempt to fix a reprojection bug reported in #1448 which affects target geoboxes with highly non-square (i.e. long, thin) aspect ratios.  The root cause is upstream (GDAL, via Rasterio), and #1450 attempts to use the undocumented GDAL arguments `XSCALE` and `YSCALE` to force GDAL to behave appropriately, but does this badly - the obvious long narrow cases were obviously better to the naked eye, but it introduced more subtle systemic issues with more square aspect ratios.

This second attempt hopes to be an incremental improvement on both the pre-#1450 and post-#1450 behaviour.

I suspect there will still be some issues after this PR, but they should be restricted to rarely-encountered corner cases where the vertical scaling is significantly different to the horizontal scaling.

I am reluctant to attempt a more complete solution until the XSCALE and YSCALE parameters are better documented by GDAL.

### Proposed changes

- Always use `XSCALE=1, YSCALE=1` in rasterio warping.


 - [x] Closes #1456
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes



<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1457.org.readthedocs.build/en/1457/

<!-- readthedocs-preview datacube-core end -->