### PR TITLE
Increase maturity search buffer to 500ms

### DIFF
--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -921,8 +921,8 @@ class AbstractDatasetResource(ABC):
         """
         less_mature = []
         # 'expand' the date range by a millisecond to give a bit more leniency in datetime comparison
-        expanded_time_range = Range(ds.metadata.time.begin - timedelta(milliseconds=1),
-                                    ds.metadata.time.end + timedelta(milliseconds=1))
+        expanded_time_range = Range(ds.metadata.time.begin - timedelta(milliseconds=500),
+                                    ds.metadata.time.end + timedelta(milliseconds=500))
         dupes = self.search(product=ds.product.name,
                             region_code=ds.metadata.region_code,
                             time=expanded_time_range)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -11,6 +11,8 @@ v1.8.next
 - Second attempt to address unexpected handling of image aspect ratios in rasterio and
   GDAL. (:pull:`1457`)
 - Fix broken pypi publishing Github action (:pull:`1454`)
+- Documentation improvements (:pull:`1455`)
+- Increase maturity leniency to +-500ms (:pull:`1458`)
 
 
 v1.8.13 (6th June 2023)


### PR DESCRIPTION
### Reason for this pull request

When finding a less mature version of a dataset, we previously introduced a 1ms buffer to account for slight timestamp discrepancies. For Landsat 9, this buffer is not sufficient.


### Proposed changes

- Increase buffer to +-500ms, giving 1s of wiggle room in finding less mature versions of a dataset



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1458.org.readthedocs.build/en/1458/

<!-- readthedocs-preview datacube-core end -->