### PR TITLE
mark ingestion as deprecated

### DIFF
--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -439,6 +439,7 @@ class Product:
     def license(self) -> str:
         return self.definition.get("license", None)
 
+    @deprecat(reason="Ingestion has been deprecated and will be removed in a future version.", version="1.8.14")
     @property
     def managed(self) -> bool:
         return self.definition.get('managed', False)

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -24,6 +24,8 @@ from .fields import Field, get_dataset_fields
 from ._base import Range, ranges_overlap  # noqa: F401
 from .eo3 import validate_eo3_compatible_type
 
+from deprecat import deprecat
+
 _LOG = logging.getLogger(__name__)
 
 DEFAULT_SPATIAL_DIMS = ('y', 'x')  # Used when product lacks grid_spec
@@ -713,6 +715,7 @@ class Product:
 DatasetType = Product
 
 
+@deprecat(reason="Ingestion has been deprecated and will be removed in a future version.", version="1.8.14")
 @schema_validated(SCHEMA_PATH / 'ingestor-config-type-schema.yaml')
 class IngestorConfig:
     """

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -439,8 +439,8 @@ class Product:
     def license(self) -> str:
         return self.definition.get("license", None)
 
-    @deprecat(reason="Ingestion has been deprecated and will be removed in a future version.", version="1.8.14")
     @property
+    @deprecat(reason="Ingestion has been deprecated and will be removed in a future version.", version="1.8.14")
     def managed(self) -> bool:
         return self.definition.get('managed', False)
 

--- a/datacube/model/schema/dataset-type-schema.yaml
+++ b/datacube/model/schema/dataset-type-schema.yaml
@@ -36,6 +36,7 @@ properties:
         items:
             "$ref": "#/definitions/measurement"
     managed:
+        # Indicates ingested product - deprecated
         type: boolean
 
 required:

--- a/datacube/scripts/ingest.py
+++ b/datacube/scripts/ingest.py
@@ -391,7 +391,8 @@ def get_driver_from_config(config):
     return driver
 
 
-@cli.command('ingest', help="Ingest datasets")
+@cli.command('ingest', help="WARNING: Ingestion has been deprecated in v1.8.14 and will be removed in v1.9\n"
+                            "Ingest datasets")
 @click.option('--config-file', '-c',
               type=click.Path(exists=True, readable=True, writable=False, dir_okay=False),
               help='Ingest configuration file')

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -15,6 +15,7 @@ v1.8.next
 - Increase default maturity leniency to +-500ms (:pull:`1458`)
 - Add option to specify maturity timedelta when using ``--archive-less-mature`` option (:pull:`1460`)
 - Mark executors as deprecated (:pull:`1461`)
+- Mark ingestion as deprecated (:pull:`1463`)
 
 
 v1.8.13 (6th June 2023)


### PR DESCRIPTION
### Reason for this pull request

Ingestion has already been informally deprecated in the documentation; it should be properly marked as deprecated in the code in preparation for being removed in v1.9


### Proposed changes

- Mark ingestion cmd as deprecated



 - [ ] Closes #xxxx
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1463.org.readthedocs.build/en/1463/

<!-- readthedocs-preview datacube-core end -->