### PR TITLE
Replace deprecated pkg_resources

### DIFF
--- a/datacube/drivers/driver_cache.py
+++ b/datacube/drivers/driver_cache.py
@@ -26,14 +26,9 @@ def load_drivers(group: str) -> Dict[str, Any]:
     """
 
     def safe_load(ep):
-        from importlib.metadata import PackageNotFoundError
         # pylint: disable=broad-except,bare-except
         try:
             driver_init = ep.load()
-        except PackageNotFoundError:
-            # This happens when entry points were marked with extra features,
-            # but extra feature were not requested for installation
-            return None
         except Exception as e:
             _LOG.warning('Failed to resolve driver %s::%s', group, ep.name)
             _LOG.warning('Error was: %s', repr(e))
@@ -52,7 +47,7 @@ def load_drivers(group: str) -> Dict[str, Any]:
 
     def resolve_all(group: str) -> Iterable[Tuple[str, Any]]:
         from importlib.metadata import entry_points
-        for ep in entry_points(group=group, name=None):
+        for ep in entry_points(group=group):
             driver = safe_load(ep)
             if driver is not None:
                 yield (ep.name, driver)

--- a/datacube/drivers/driver_cache.py
+++ b/datacube/drivers/driver_cache.py
@@ -26,11 +26,11 @@ def load_drivers(group: str) -> Dict[str, Any]:
     """
 
     def safe_load(ep):
-        from pkg_resources import DistributionNotFound
+        from importlib.metadata import PackageNotFoundError
         # pylint: disable=broad-except,bare-except
         try:
             driver_init = ep.load()
-        except DistributionNotFound:
+        except PackageNotFoundError:
             # This happens when entry points were marked with extra features,
             # but extra feature were not requested for installation
             return None
@@ -51,8 +51,8 @@ def load_drivers(group: str) -> Dict[str, Any]:
         return driver
 
     def resolve_all(group: str) -> Iterable[Tuple[str, Any]]:
-        from pkg_resources import iter_entry_points
-        for ep in iter_entry_points(group=group, name=None):
+        from importlib.metadata import entry_points
+        for ep in entry_points(group=group, name=None):
             driver = safe_load(ep)
             if driver is not None:
                 yield (ep.name, driver)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -15,7 +15,7 @@ v1.8.next
 - Increase default maturity leniency to +-500ms (:pull:`1458`)
 - Add option to specify maturity timedelta when using ``--archive-less-mature`` option (:pull:`1460`)
 - Mark executors as deprecated (:pull:`1461`)
-- Replace deprecated ``pgk_resources`` with ``importlib.resources`` and ``importlib.metadata`` (:pull:`1466`)
+- Replace deprecated ``pkg_resources`` with ``importlib.resources`` and ``importlib.metadata`` (:pull:`1466`)
 
 
 v1.8.13 (6th June 2023)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -15,6 +15,7 @@ v1.8.next
 - Increase default maturity leniency to +-500ms (:pull:`1458`)
 - Add option to specify maturity timedelta when using ``--archive-less-mature`` option (:pull:`1460`)
 - Mark executors as deprecated (:pull:`1461`)
+- Replace deprecated ``pgk_resources`` with ``importlib.resources`` and ``importlib.metadata`` (:pull:`1466`)
 
 
 v1.8.13 (6th June 2023)

--- a/docs/click_utils.py
+++ b/docs/click_utils.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2015-2023 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-import pkg_resources
+from importlib.metadata import entry_points
 from docutils.nodes import literal_block, section, title, make_id
 from sphinx.domains import Domain
 from docutils.parsers.rst import Directive
@@ -34,8 +34,8 @@ def find_script_callable_from_env(name, env):
 
 
 def find_script_callable(name):
-    return list(pkg_resources.iter_entry_points(
-        'console_scripts', name))[0].load()
+    return list(entry_points(
+        group='console_scripts', name=name))[0].load()
 
 
 def generate_help_text(command, prefix):

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -206,6 +206,7 @@ IAM
 ident
 identifer
 img
+importlib
 INEGI
 inegi
 ing
@@ -338,6 +339,7 @@ pgadmin
 pgintegration
 pgisintegration
 pixelquality
+pkg
 pkgs
 Pluggable
 pmap


### PR DESCRIPTION
### Reason for this pull request

See #1464 


### Proposed changes

- Replace `pkg_resources` with `importlib.resources` and `importlib.metadata`



 - [x] Closes #1464 
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1466.org.readthedocs.build/en/1466/

<!-- readthedocs-preview datacube-core end -->