### PR TITLE
Update whats_new.rst for 1.8.15 release.

### DIFF
--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -10,7 +10,7 @@ v1.8.next
 
 v1.8.15 (11th July 2023)
 ========================
-- Replace `entry_points(group=group)` with `entry_points().select(group=group)` for python <3.10 compatibility
+- Replace `importlib_metadata` for python <3.10 compatibility
   (:pull:`1469`)
 - Update whats_new.rst for release (:pull:`1470`)
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,12 @@ What's New
 v1.8.next
 =========
 
+v1.8.15 (11th July 2023)
+========================
+- Replace `entry_points(group=group)` with `entry_points().select(group=group)` for python <3.10 compatibility
+  (:pull:`1469`)
+- Update whats_new.rst for release (:pull:`1470`)
+
 v1.8.14 (28th June 2023)
 ========================
 
@@ -21,7 +27,6 @@ v1.8.14 (28th June 2023)
 - Mark ingestion as deprecated (:pull:`1463`)
 - Replace deprecated ``pkg_resources`` with ``importlib.resources`` and ``importlib.metadata`` (:pull:`1466`)
 - Update whats_new.rst for release (:pull:`1467`)
-
 
 v1.8.13 (6th June 2023)
 =======================


### PR DESCRIPTION
### Reason for this pull request

Update whats_new.rst for 1.8.15 release

### Proposed changes

- Update whats_new.rst for 1.8.15 release

 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1470.org.readthedocs.build/en/1470/

<!-- readthedocs-preview datacube-core end -->