### PR TITLE
Upgrade jsonschema

### DIFF
--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - dask
   - pyproj >=2.5
   - shapely >=2.0
-  - jsonschema <4.18
+  - jsonschema >=4.18
   - lark
   - netcdf4
   - numpy

--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -17,7 +17,7 @@ from datacube.drivers.postgres.sql import (INSTALL_TRIGGER_SQL_TEMPLATE,
                                            pg_column_exists)
 from sqlalchemy import MetaData, inspect, text
 from sqlalchemy.engine import Engine
-from sqlalchemy.schema import CreateSchema, DropSchema
+from sqlalchemy.schema import CreateSchema
 
 
 USER_ROLES = ('agdc_user', 'agdc_ingest', 'agdc_manage', 'agdc_admin')

--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -17,7 +17,7 @@ from datacube.drivers.postgres.sql import (INSTALL_TRIGGER_SQL_TEMPLATE,
                                            pg_column_exists)
 from sqlalchemy import MetaData, inspect, text
 from sqlalchemy.engine import Engine
-from sqlalchemy.schema import CreateSchema
+from sqlalchemy.schema import CreateSchema, DropSchema
 
 
 USER_ROLES = ('agdc_user', 'agdc_ingest', 'agdc_manage', 'agdc_admin')

--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -211,7 +211,7 @@ def validate_document(document, schema, schema_folder=None):
             if not path.exists():
                 raise ValueError("Reference not found: %s" % path)
             referenced_schema = next(iter(read_documents(path)))[1]
-            return referenced_schema
+            return referencing.Resource(referenced_schema, referencing.jsonschema.DRAFT4)
 
         if schema_folder:
             registry = referencing.Registry(retrieve=doc_reference)

--- a/docker/constraints.in
+++ b/docker/constraints.in
@@ -14,8 +14,8 @@ dask>=2021.10.1
 distributed>=2021.10.0
 fiona
 geoalchemy2
-jsonschema<4.18
-# Was lark-parser>=0.6.7
+# New reference resolution API
+jsonschema>=4.18
 lark
 matplotlib
 moto

--- a/docker/constraints.txt
+++ b/docker/constraints.txt
@@ -24,6 +24,7 @@ attrs==22.2.0
     #   jsonschema
     #   pytest
     #   rasterio
+    #   referencing
 babel==2.11.0
     # via sphinx
 bleach==6.0.0
@@ -163,8 +164,10 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.17.3
+jsonschema==4.18.4
     # via -r constraints.in
+jsonschema-specifications==2023.7.1
+    # via jsonschema
 keyring==23.13.1
     # via twine
 kiwisolver==1.4.4
@@ -266,8 +269,6 @@ pyproj==3.4.1
     # via
     #   -r constraints.in
     #   compliance-checker
-pyrsistent==0.19.3
-    # via jsonschema
 pytest==7.2.1
     # via
     #   -r constraints.in
@@ -309,6 +310,10 @@ recommonmark==0.7.1
     # via -r constraints.in
 redis==4.5.1
     # via -r constraints.in
+referencing==0.30.0
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
 regex==2022.10.31
     # via compliance-checker
 requests==2.28.2
@@ -328,6 +333,10 @@ rfc3986==2.0.0
     # via twine
 rich==13.3.1
     # via twine
+rpds-py==0.9.2
+    # via
+    #   jsonschema
+    #   referencing
 ruamel-yaml==0.17.21
     # via -r constraints.in
 ruamel-yaml-clib==0.2.7

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,7 @@ What's New
 v1.8.next
 =========
 - Fix schema creation with postgres driver when initialising system with ``--no-init-users`` (:pull:`1504`)
+- Switch to new jsonschema 'referencing' API and repin jsonschema to >=4.18 (:pull:`1477`)
 
 v1.8.16 (17th October 2023)
 ===========================

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
         'cloudpickle>=0.4',
         'dask[array]',
         'distributed',
-        'jsonschema<4.18',
+        'jsonschema>=4.18',  # New reference resolution API
         'netcdf4',
         'numpy',
         'psycopg2',

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -391,6 +391,7 @@ reampling
 redis
 Reflectance
 reflectance
+repin
 Reproject
 reproject
 reprojected


### PR DESCRIPTION
### Reason for this pull request

A `jsonschema` deprecation warning was raised in #1474.

This turned out to be due to the new "referencing" library released in jsonschema 4.18.0 replacing the old `RefResolver` API, which was deprecated from 4.18.0.

I pinned `jsonschema<4.18` in #1476 as an immediate fix.  This PR is a longer term fix - pinning to `jsonschema>=4.18` switching to the new API.

4.18.0 was released barely 2 weeks ago at the time of writing and there have been 4 minor releases since, hence merging of this was postponed until the rest of the ecosystem calmed down.


### Proposed changes

- Migrate the `validate_document` decorator to use the new `referencing` API.
- Pin `jsonschema>=4.18`

 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1477.org.readthedocs.build/en/1477/

<!-- readthedocs-preview datacube-core end -->