### PR TITLE
support "like=<geobox>" in virtual products

### DIFF
--- a/datacube/virtual/impl.py
+++ b/datacube/virtual/impl.py
@@ -356,9 +356,12 @@ class Product(VirtualProduct):
         merged = merge_search_terms(self, group_settings)
 
         try:
-            geobox = output_geobox(datasets=selected,
-                                   grid_spec=datasets.product_definitions[self._product].grid_spec,
-                                   geopolygon=geopolygon, **select_keys(merged, self._GEOBOX_KEYS))
+            if isinstance(merged.get("like"), GeoBox):
+                geobox = merged["like"]
+            else:
+                geobox = output_geobox(datasets=selected,
+                                       grid_spec=datasets.product_definitions[self._product].grid_spec,
+                                       geopolygon=geopolygon, **select_keys(merged, self._GEOBOX_KEYS))
             load_natively = False
 
         except ValueError:

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -13,6 +13,7 @@ v1.8.next
 - Fix SQLAlchemy calls and pin jsonschema version to suppress deprecation warnings (:pull:`1476`)
 - Throw a better error if a dataset is not compatible with ``archive_less_mature`` logic (:pull:`1491`)
 - Fix broken Github action workflow (:pull:`1496`)
+- Support ``like=<GeoBox>`` in virtual product ``load`` (:pull:`1497`)
 
 v1.8.15 (11th July 2023)
 ========================


### PR DESCRIPTION
### Reason for this pull request
This is to address Issue #1276. Sincere apologies for not doing this earlier.

### Proposed changes
- Recognize the possibility that the user may have already provide a preferred geobox in the `like` setting

 - [X] Closes #1276 
 - [X] Tests added / passed
 - [X] Fully documented, including `docs/about/whats_new.rst` for all changes


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1497.org.readthedocs.build/en/1497/

<!-- readthedocs-preview datacube-core end -->