### PR TITLE
Account for bools in archive_less_mature

### DIFF
--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -925,15 +925,15 @@ class AbstractDatasetResource(ABC):
         Bool value accepted only for improving backwards compatibility, int preferred.
         :return: Iterable of less mature datasets
         """
-        if isinstance(delta, int):
-            if delta < 0:
-                raise ValueError("timedelta must be a positive integer")
         if isinstance(delta, bool):
             _LOG.warning("received delta as a boolean value. Int is prefered")
             if delta is True:  # treat True as default
                 delta = 500
             else:  # treat False the same as None
                 return []
+        elif isinstance(delta, int):
+            if delta < 0:
+                raise ValueError("timedelta must be a positive integer")
         elif delta is None:
             return []
         else:

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -928,7 +928,7 @@ class AbstractDatasetResource(ABC):
         if isinstance(delta, int):
             if delta < 0:
                 raise ValueError("timedelta must be a positive integer")
-        elif isinstance(delta, bool):
+        if isinstance(delta, bool):
             _LOG.warning("received delta as a boolean value. Int is prefered")
             if delta is True:  # treat True as default
                 delta = 500

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -925,8 +925,9 @@ class AbstractDatasetResource(ABC):
         Bool value accepted only for improving backwards compatibility, int preferred.
         :return: Iterable of less mature datasets
         """
-        if isinstance(delta, int) and delta < 0:
-            raise ValueError("timedelta must be a positive integer")
+        if isinstance(delta, int):
+            if delta < 0:
+                raise ValueError("timedelta must be a positive integer")
         elif isinstance(delta, bool):
             _LOG.warning("received delta as a boolean value. Int is prefered")
             if delta is True:  # treat True as default

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -923,6 +923,12 @@ class AbstractDatasetResource(ABC):
         less_mature = []
         assert delta >= 0
 
+        # in case value winds up getting passed in as a bool
+        if delta is True:
+            delta = 500
+        if delta is False:
+            return []
+
         def check_maturity_information(dataset, props):
             # check that the dataset metadata includes all maturity-related properties
             # passing in the required props to enable greater extensibility should it be needed

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -899,11 +899,14 @@ class AbstractDatasetResource(ABC):
         :param Iterable[Union[str,UUID]] ids: list of dataset ids to archive
         """
 
-    def archive_less_mature(self, ds: Dataset, delta: int = 500) -> None:
+    def archive_less_mature(self, ds: Dataset, delta: Union[int, bool] = 500) -> None:
         """
         Archive less mature versions of a dataset
 
         :param Dataset ds: dataset to search
+        :param Union[int,bool] delta: millisecond delta for time range.
+        If True, default to 500ms. If False, do not find or archive less mature datasets.
+        Bool value accepted only for improving backwards compatibility, int preferred.
         """
         less_mature = self.find_less_mature(ds, delta)
         less_mature_ids = map(lambda x: x.id, less_mature)
@@ -912,22 +915,24 @@ class AbstractDatasetResource(ABC):
         for lm_ds in less_mature_ids:
             _LOG.info(f"Archived less mature dataset: {lm_ds}")
 
-    def find_less_mature(self, ds: Dataset, delta: int = 500) -> Iterable[Dataset]:
+    def find_less_mature(self, ds: Dataset, delta: Union[int, bool] = 500) -> Iterable[Dataset]:
         """
         Find less mature versions of a dataset
 
         :param Dataset ds: Dataset to search
-        :param int delta: millisecond delta for time range
+        :param Union[int,bool] delta: millisecond delta for time range.
+        If True, default to 500ms. If None or False, do not find or archive less mature datasets.
+        Bool value accepted only for improving backwards compatibility, int preferred.
         :return: Iterable of less mature datasets
         """
-        less_mature = []
-        assert delta >= 0
-
-        # in case value winds up getting passed in as a bool
-        if delta is True:
+        if isinstance(delta, int) and delta < 0:
+            raise ValueError("timedelta must be a positive integer")
+        elif delta is True:
             delta = 500
-        if delta is False:
+        elif delta is False or delta is None:
             return []
+        else:
+            raise TypeError("timedelta must be None, a positive integer, or a boolean")
 
         def check_maturity_information(dataset, props):
             # check that the dataset metadata includes all maturity-related properties
@@ -948,6 +953,7 @@ class AbstractDatasetResource(ABC):
                             region_code=ds.metadata.region_code,
                             time=expanded_time_range)
 
+        less_mature = []
         for dupe in dupes:
             if dupe.id == ds.id:
                 continue

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -927,9 +927,13 @@ class AbstractDatasetResource(ABC):
         """
         if isinstance(delta, int) and delta < 0:
             raise ValueError("timedelta must be a positive integer")
-        elif delta is True:
-            delta = 500
-        elif delta is False or delta is None:
+        elif isinstance(delta, bool):
+            _LOG.warning("received delta as a boolean value. Int is prefered")
+            if delta is True:  # treat True as default
+                delta = 500
+            else:  # treat False the same as None
+                return []
+        elif delta is None:
             return []
         else:
             raise TypeError("timedelta must be None, a positive integer, or a boolean")

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -14,6 +14,7 @@ v1.8.next
 - Throw a better error if a dataset is not compatible with ``archive_less_mature`` logic (:pull:`1491`)
 - Fix broken Github action workflow (:pull:`1496`)
 - Support ``like=<GeoBox>`` in virtual product ``load`` (:pull:`1497`)
+- Don't archive less mature if archive_less_mature is provided as `False` instead of `None` (:pull:`1498`)
 
 v1.8.15 (11th July 2023)
 ========================

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -129,6 +129,15 @@ def test_archive_less_mature_approx_timestamp(index, ga_s2am_ard3_final, ga_s2am
     assert index.datasets.get(ga_s2am_ard3_final.id).is_active
 
 
+def test_dont_archive_less_mature(index, final_dataset, nrt_dataset):
+    # ensure datasets aren't archive if no archive_less_mature value is provided
+    index.datasets.add(nrt_dataset, with_lineage=False)
+    index.datasets.get(nrt_dataset.id).is_active
+    index.datasets.add(final_dataset, with_lineage=False, archive_less_mature=None)
+    assert index.datasets.get(nrt_dataset.id).is_active
+    assert index.datasets.get(final_dataset.id).is_active
+
+
 def test_archive_less_mature_bool(index, final_dataset, nrt_dataset):
     # if archive_less_mature value gets passed as a bool via an outdated script
     index.datasets.add(nrt_dataset, with_lineage=False)

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -129,6 +129,15 @@ def test_archive_less_mature_approx_timestamp(index, ga_s2am_ard3_final, ga_s2am
     assert index.datasets.get(ga_s2am_ard3_final.id).is_active
 
 
+def test_archive_less_mature_bool(index, final_dataset, nrt_dataset):
+    # if archive_less_mature value gets passed as a bool via an outdated script
+    index.datasets.add(nrt_dataset, with_lineage=False)
+    index.datasets.get(nrt_dataset.id).is_active
+    index.datasets.add(final_dataset, with_lineage=False, archive_less_mature=False)
+    assert index.datasets.get(nrt_dataset.id).is_active
+    assert index.datasets.get(final_dataset.id).is_active
+
+
 def test_purge_datasets(index, ls8_eo3_dataset):
     assert index.datasets.has(ls8_eo3_dataset.id)
     datasets = index.datasets.search_eager()


### PR DESCRIPTION
### Reason for this pull request

Datacube-core has updated to have archive_less_mature provided as an optional integer, with archive_less_mature logic skipped if the value is None. But some other scripts have not yet been updated, such as the odc-tools `*-to-dc` commands, causing errors such as this one: https://app.slack.com/client/T0L4V0TFT/C0L4WHVME/thread/C0L4WHVME-1696543022.226709


### Proposed changes

-  Account for archive_less_mature being provided as a bool by setting it to 500ms (default) if True and returning if False so that it doesn't search for or archive less mature datasets



 - [ ] Closes #xxxx
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1498.org.readthedocs.build/en/1498/

<!-- readthedocs-preview datacube-core end -->