### PR TITLE
Require Python 3.9 at minimum.

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
     name: Pylint
     steps:
       - name: checkout git
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test-conda-build.yml
+++ b/.github/workflows/test-conda-build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
           os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-          python-version: ["3.8", "3.9"]
+          python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -13,7 +13,7 @@ v1.8.next
 - Fix SQLAlchemy calls and pin jsonschema version to suppress deprecation warnings (:pull:`1476`)
 - Throw a better error if a dataset is not compatible with ``archive_less_mature`` logic (:pull:`1491`)
 - Fix broken Github action workflow (:pull:`1496`)
-- Raise minimum supported Python version to 3.9 (:pull:`???`)
+- Raise minimum supported Python version to 3.9 (:pull:`1500`)
 
 v1.8.15 (11th July 2023)
 ========================

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -15,6 +15,7 @@ v1.8.next
 - Fix broken Github action workflow (:pull:`1496`)
 - Support ``like=<GeoBox>`` in virtual product ``load`` (:pull:`1497`)
 - Don't archive less mature if archive_less_mature is provided as `False` instead of `None` (:pull:`1498`)
+- Raise minimum supported Python version to 3.9 (:pull:`???`)
 
 v1.8.15 (11th July 2023)
 ========================

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -13,6 +13,7 @@ v1.8.next
 - Fix SQLAlchemy calls and pin jsonschema version to suppress deprecation warnings (:pull:`1476`)
 - Throw a better error if a dataset is not compatible with ``archive_less_mature`` logic (:pull:`1491`)
 - Fix broken Github action workflow (:pull:`1496`)
+- Raise minimum supported Python version to 3.9 (:pull:`???`)
 
 v1.8.15 (11th July 2023)
 ========================

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -15,7 +15,7 @@ v1.8.next
 - Fix broken Github action workflow (:pull:`1496`)
 - Support ``like=<GeoBox>`` in virtual product ``load`` (:pull:`1497`)
 - Don't archive less mature if archive_less_mature is provided as `False` instead of `None` (:pull:`1498`)
-- Raise minimum supported Python version to 3.9 (:pull:`???`)
+- Raise minimum supported Python version to 3.9 (:pull:`1500`)
 
 v1.8.15 (11th July 2023)
 ========================

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ extra_plugins = dict(read=[], write=[], index=[])
 
 setup(
     name='datacube',
-    python_requires='>=3.8.0',
+    python_requires='>=3.9.0',
 
     url='https://github.com/opendatacube/datacube-core',
     author='Open Data Cube',
@@ -70,9 +70,10 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Scientific/Engineering :: GIS",
         "Topic :: Scientific/Engineering :: Information Analysis",
     ],


### PR DESCRIPTION
### Reason for this pull request

Python 3.8 is now end of life, with the final security update released earlier this month.  The latest versions of xarray and PyProj already require 3.9+.

### Proposed changes

- Drop support for Python 3.8
- Add PyPI tags and conda smoke tests for Python 3.10 and 3.11.

 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes




<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1500.org.readthedocs.build/en/1500/

<!-- readthedocs-preview datacube-core end -->