### PR TITLE
Fix schema creation logic requiring permissions

### DIFF
--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -7,6 +7,7 @@ What's New
 
 v1.8.next
 =========
+- Fix schema creation with postgres driver when initialising system with ``--no-init-users`` (:pull:`1504`)
 
 v1.8.16 (17th October 2023)
 ===========================


### PR DESCRIPTION
### Reason for this pull request

Logic to create schema if doesn't exist requires permissions in postgres driver - judging by the logic in the postgis driver and previous functionality, this seems to be in error


### Proposed changes

- Move `if not has_schema` back out of `if with_permissions`



 - [x] Closes #1502 
 - [ ] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1504.org.readthedocs.build/en/1504/

<!-- readthedocs-preview datacube-core end -->