### PR TITLE
Increase minimum Python version for to 3.10 (for develop-1.9 branch)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10]
+        python-version: ["3.10"]
     name: Pylint
     steps:
       - name: checkout git
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10]
+        python-version: ["3.10"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.10]
     name: Pylint
     steps:
       - name: checkout git
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.10]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test-conda-build.yml
+++ b/.github/workflows/test-conda-build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
           os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-          python-version: ["3.9", "3.10", "3.11"]
+          python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - pip
-  - python >=3.9
+  - python >=3.10
   - setuptools
   - setuptools_scm >=3.4
   - toml

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -22,6 +22,7 @@ v1.9.next
 - Document best practice for pulling in changes from develop and update constraints.txt (:pull:`1478`)
 - Postgis index driver performance tuning (:pull:`1480`)
 - Cleanup and formalise spatial index API and expose in CLI (:pull:`1481`)
+- Increase minimum Python version to 3.10 (:pull:`1509`)
 
 
 v1.8.next

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ extra_plugins = dict(read=[], write=[], index=[])
 
 setup(
     name='datacube',
-    python_requires='>=3.9.0',
+    python_requires='>=3.10.0',
 
     url='https://github.com/opendatacube/datacube-core',
     author='Open Data Cube',
@@ -72,7 +72,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
### Reason for this pull request

Python 3.10 is cool.  Especially the | operator for type hints.

### Proposed changes

- Increase minimum Python version to 3.10
- Drop 3.9 smoke tests, add 3.12 smoke tests 

 - [ ] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
