### PR TITLE
Gridspec in virtual product tests

### DIFF
--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -745,7 +745,7 @@ DatasetType = Product
 
 
 @deprecat(
-    reason='This version of GridSpec has been deprecated. Please use the GridSpec class definted in odc-geo.',
+    reason='This version of GridSpec has been deprecated. Please use the GridSpec class defined in odc-geo.',
     version='1.9.0'
 )
 class GridSpec:

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -23,6 +23,7 @@ v1.9.next
 - Postgis index driver performance tuning (:pull:`1480`)
 - Cleanup and formalise spatial index API and expose in CLI (:pull:`1481`)
 - Increase minimum Python version to 3.10 (:pull:`1509`)
+- Virtual product tests using odc-geo GridSpec (:pull:`1512`)
 
 
 v1.8.next

--- a/tests/api/test_virtual.py
+++ b/tests/api/test_virtual.py
@@ -81,7 +81,7 @@ def example_product(name):
     result = Product(example_metadata_type(),
                      dict(name=name, description="", metadata_type='eo', metadata={}))
     result.grid_spec = GridSpec(crs=CRS('EPSG:3577'),
-                                tile_shape=(100000, 100000),
+                                tile_shape=(4000, 4000),
                                 resolution=25)
     if '_pq_' in name:
         result.definition = {'name': name, 'measurements': [pixelquality]}

--- a/tests/api/test_virtual.py
+++ b/tests/api/test_virtual.py
@@ -79,7 +79,7 @@ def example_product(name):
                         flags_definition=flags)
 
     result = Product(example_metadata_type(),
-                         dict(name=name, description="", metadata_type='eo', metadata={}))
+                     dict(name=name, description="", metadata_type='eo', metadata={}))
     result.grid_spec = GridSpec(crs=CRS('EPSG:3577'),
                                 tile_shape=(100000, 100000),
                                 resolution=25)

--- a/tests/api/test_virtual.py
+++ b/tests/api/test_virtual.py
@@ -12,8 +12,9 @@ from unittest import mock
 import numpy
 import xarray as xr
 
-from datacube.model import DatasetType, MetadataType, Dataset, GridSpec
+from datacube.model import Product, MetadataType, Dataset
 from odc.geo import CRS
+from odc.geo.gridspec import GridSpec
 from datacube.virtual import construct_from_yaml, catalog_from_yaml, VirtualProductException
 from datacube.virtual import DEFAULT_RESOLVER, Transformation
 from datacube.virtual.impl import Datacube
@@ -77,11 +78,11 @@ def example_product(name):
     pixelquality = dict(name='pixelquality', dtype='int16', nodata=0, units='1',
                         flags_definition=flags)
 
-    result = DatasetType(example_metadata_type(),
+    result = Product(example_metadata_type(),
                          dict(name=name, description="", metadata_type='eo', metadata={}))
     result.grid_spec = GridSpec(crs=CRS('EPSG:3577'),
-                                tile_size=(100000., 100000.),
-                                resolution=(-25, 25))
+                                tile_shape=(100000, 100000),
+                                resolution=25)
     if '_pq_' in name:
         result.definition = {'name': name, 'measurements': [pixelquality]}
     else:


### PR DESCRIPTION
### Reason for this pull request

Virtual Product tests were throwing a deprecation warning because they use the old datacube GridSpec.  Also that deprecation warning had a spelling mistake,


### Proposed changes

- Correct the spelling of the GridSpec deprecation warning.
- Get virtual products tests using the odc-geo GridSpec class.


 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
