### PR TITLE
Dataset CLI tool to find duplicates

### DIFF
--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -768,7 +768,7 @@ class PostgisDbAPI(object):
         query = select(
             func.array_agg(func.distinct(time_overlap.c.id)).label("ids"),
             *fields,
-            text("(lower(time_intersect)::timestamp, upper(time_intersect)::timestamp) as time")
+            text("(lower(time_intersect) at time zone 'UTC', upper(time_intersect) at time zone 'UTC') as time")
         ).select_from(
             time_overlap
         ).group_by(

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -706,10 +706,13 @@ class PostgisDbAPI(object):
 
     def get_duplicates(self, match_fields: Sequence[PgField], expressions: Sequence[PgExpression]) -> Iterable[tuple]:
         # TODO
+        if "time" in [f.name for f in match_fields]:
+            return self.get_duplicates_with_time(match_fields, expressions)
+
         group_expressions = tuple(f.alchemy_expression for f in match_fields)
         join_tables = PostgisDbAPI._join_tables(expressions, match_fields)
 
-        cols = (func.array_agg(Dataset.id),) + group_expressions
+        cols = (func.array_agg(Dataset.id).label('ids'),) + group_expressions
         query = select(
             *cols
         ).select_from(Dataset)
@@ -722,6 +725,56 @@ class PostgisDbAPI(object):
             *group_expressions
         ).having(
             func.count(Dataset.id) > 1
+        )
+        return self._connection.execute(query)
+
+    def get_duplicates_with_time(
+            self, match_fields: Sequence[PgField], expressions: Sequence[PgExpression]
+    ) -> Iterable[tuple]:
+        fields = []
+        for f in match_fields:
+            if f.name == "time":
+                time_field = f.expression_with_leniency
+            else:
+                fields.append(f.alchemy_expression)
+
+        join_tables = PostgisDbAPI._join_tables(expressions, match_fields)
+
+        cols = [Dataset.id, time_field.label('time'), *fields]
+        query = select(
+            *cols
+        ).select_from(Dataset)
+        for joins in join_tables:
+            query = query.join(*joins)
+
+        query = query.where(
+            and_(Dataset.archived == None, *(PostgisDbAPI._alchemify_expressions(expressions)))
+        )
+
+        t1 = query.alias("t1")
+        t2 = query.alias("t2")
+
+        time_overlap = select(
+            t1.c.id,
+            text("t1.time * t2.time as time_intersect"),
+            *fields
+        ).select_from(
+            t1.join(
+                t2,
+                and_(t1.c.time.overlaps(t2.c.time), t1.c.id != t2.c.id)
+            )
+        )
+
+        query = select(
+            func.array_agg(func.distinct(time_overlap.c.id)).label("ids"),
+            *fields,
+            text("(lower(time_intersect)::timestamp, upper(time_intersect)::timestamp) as time")
+        ).select_from(
+            time_overlap
+        ).group_by(
+            *fields, text("time_intersect")
+        ).having(
+            func.count(time_overlap.c.id) > 1
         )
         return self._connection.execute(query)
 

--- a/datacube/drivers/postgis/_fields.py
+++ b/datacube/drivers/postgis/_fields.py
@@ -16,6 +16,7 @@ from psycopg2.extras import NumericRange, DateTimeTZRange
 from sqlalchemy import cast, func, and_
 from sqlalchemy.dialects import postgresql as postgres
 from sqlalchemy.dialects.postgresql import NUMRANGE, TSTZRANGE
+from sqlalchemy.dialects.postgresql import INTERVAL
 from sqlalchemy.sql import ColumnElement
 from sqlalchemy.orm import aliased
 
@@ -223,7 +224,7 @@ class SimpleDocField(PgDocField):
 
     @property
     def alchemy_expression(self):
-        return self._alchemy_offset_value(self.offset, self.aggregation.pg_calc)
+        return self._alchemy_offset_value(self.offset, self.aggregation.pg_calc).label(self.name)
 
     def __eq__(self, value):
         """
@@ -360,7 +361,7 @@ class RangeDocField(PgDocField):
 
     @property
     def alchemy_expression(self):
-        return self.value_to_alchemy((self.lower.alchemy_expression, self.greater.alchemy_expression))
+        return self.value_to_alchemy((self.lower.alchemy_expression, self.greater.alchemy_expression)).label(self.name)
 
     def __eq__(self, value):
         """
@@ -438,6 +439,16 @@ class DateRangeDocField(RangeDocField):
         else:
             raise ValueError("Unknown comparison type for date range: "
                              "expecting datetimes, got: (%r, %r)" % (low, high))
+
+    @property
+    def expression_with_leniency(self):
+        return func.tstzrange(
+            self.lower.alchemy_expression - cast('500 milliseconds', INTERVAL),
+            self.greater.alchemy_expression + cast('500 milliseconds', INTERVAL),
+            # Inclusive on both sides.
+            '[]',
+            type_=TSTZRANGE,
+        )
 
 
 def _number_implies_year(v: Union[int, datetime]) -> datetime:

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -725,10 +725,13 @@ class PostgresDbAPI(object):
         return self._connection.execute(select_query)
 
     def get_duplicates(self, match_fields: Iterable[PgField], expressions: Iterable[PgExpression]) -> Iterable[Tuple]:
+        if "time" in [f.name for f in match_fields]:
+            return self.get_duplicates_with_time(match_fields, expressions)
+
         group_expressions = tuple(f.alchemy_expression for f in match_fields)
 
         select_query = select(
-            (func.array_agg(DATASET.c.id),) + group_expressions
+            (func.array_agg(DATASET.c.id).label('ids'),) + group_expressions
         ).select_from(
             PostgresDbAPI._from_expression(DATASET, expressions, match_fields)
         ).where(
@@ -739,6 +742,61 @@ class PostgresDbAPI(object):
             func.count(DATASET.c.id) > 1
         )
         return self._connection.execute(select_query)
+
+    def get_duplicates_with_time(
+            self, match_fields: Iterable[PgField], expressions: Iterable[PgExpression]
+    ) -> Iterable[Tuple]:
+        """
+        If considering time when searching for duplicates, we need to grant some amount of leniency
+        in case timestamps are not exactly the same.
+        From the set of datasets that are active and have the correct product (candidates),
+        find all those whose extended timestamp range overlap (overlapping),
+        then group them by the other fields.
+        """
+        fields = []
+        for f in match_fields:
+            if f.name == "time":
+                time_field = f.expression_with_leniency
+            else:
+                fields.append(f.alchemy_expression)
+
+        candidates_table = select(
+            DATASET.c.id,
+            time_field.label('time'),
+            *fields
+        ).select_from(
+            PostgresDbAPI._from_expression(DATASET, expressions, match_fields)
+        ).where(
+            and_(DATASET.c.archived == None, *(PostgresDbAPI._alchemify_expressions(expressions)))
+        )
+
+        t1 = candidates_table.alias("t1")
+        t2 = candidates_table.alias("t2")
+
+        overlapping = select(
+            t1.c.id,
+            text("t1.time * t2.time as time_intersect"),
+            *fields
+        ).select_from(
+            t1.join(
+                t2,
+                and_(t1.c.time.overlaps(t2.c.time), t1.c.id != t2.c.id)
+            )
+        )
+
+        final_query = select(
+            func.array_agg(func.distinct(overlapping.c.id)).label("ids"),
+            *fields,
+            text("(lower(time_intersect)::timestamp, upper(time_intersect)::timestamp) as time")
+        ).select_from(
+            overlapping
+        ).group_by(
+            *fields, text("time_intersect")
+        ).having(
+            func.count(overlapping.c.id) > 1
+        )
+
+        return self._connection.execute(final_query)
 
     def count_datasets(self, expressions):
         """

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -787,7 +787,7 @@ class PostgresDbAPI(object):
         final_query = select(
             func.array_agg(func.distinct(overlapping.c.id)).label("ids"),
             *fields,
-            text("(lower(time_intersect)::timestamp, upper(time_intersect)::timestamp) as time")
+            text("(lower(time_intersect) at time zone 'UTC', upper(time_intersect) at time zone 'UTC') as time")
         ).select_from(
             overlapping
         ).group_by(

--- a/datacube/drivers/postgres/_fields.py
+++ b/datacube/drivers/postgres/_fields.py
@@ -15,6 +15,7 @@ from sqlalchemy import cast, func, and_
 from sqlalchemy.dialects import postgresql as postgres
 from sqlalchemy.dialects.postgresql import INT4RANGE
 from sqlalchemy.dialects.postgresql import NUMRANGE, TSTZRANGE
+from sqlalchemy.dialects.postgresql import INTERVAL
 from sqlalchemy.sql import ColumnElement
 
 from datacube import utils
@@ -193,7 +194,7 @@ class SimpleDocField(PgDocField):
 
     @property
     def alchemy_expression(self):
-        return self._alchemy_offset_value(self.offset, self.aggregation.pg_calc)
+        return self._alchemy_offset_value(self.offset, self.aggregation.pg_calc).label(self.name)
 
     def __eq__(self, value):
         """
@@ -322,7 +323,7 @@ class RangeDocField(PgDocField):
 
     @property
     def alchemy_expression(self):
-        return self.value_to_alchemy((self.lower.alchemy_expression, self.greater.alchemy_expression))
+        return self.value_to_alchemy((self.lower.alchemy_expression, self.greater.alchemy_expression)).label(self.name)
 
     def __eq__(self, value):
         """
@@ -430,6 +431,16 @@ class DateRangeDocField(RangeDocField):
         else:
             raise ValueError("Unknown comparison type for date range: "
                              "expecting datetimes, got: (%r, %r)" % (low, high))
+
+    @property
+    def expression_with_leniency(self):
+        return func.tstzrange(
+            self.lower.alchemy_expression - cast('500 milliseconds', INTERVAL),
+            self.greater.alchemy_expression + cast('500 milliseconds', INTERVAL),
+            # Inclusive on both sides.
+            '[]',
+            type_=TSTZRANGE,
+        )
 
 
 def _number_implies_year(v: Union[int, datetime]) -> datetime:

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -269,15 +269,14 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             return f
 
         group_fields: List[fields.Field] = [load_field(f) for f in args]
-        result_type = namedtuple('search_result', list(f.name for f in group_fields))  # type: ignore
-
         expressions = [product.metadata_type.dataset_fields.get('product') == product.name]
 
         with self._db_connection() as connection:
             for record in connection.get_duplicates(group_fields, expressions):
-                dataset_ids = set(record[0])
-                grouped_fields = tuple(record[1:])
-                yield result_type(*grouped_fields), dataset_ids
+                as_dict = dict(record)
+                if 'ids' in as_dict.keys():
+                    ids = as_dict.pop('ids')
+                    yield namedtuple('search_result', as_dict.keys())(**as_dict), set(ids)
 
     def can_update(self, dataset, updates_allowed=None):
         """

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -244,15 +244,14 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             return f
 
         group_fields: List[fields.Field] = [load_field(f) for f in args]
-        result_type = namedtuple('search_result', list(f.name for f in group_fields))  # type: ignore
-
         expressions = [product.metadata_type.dataset_fields.get('product') == product.name]
 
         with self._db_connection() as connection:
             for record in connection.get_duplicates(group_fields, expressions):
-                dataset_ids = set(record[0])
-                grouped_fields = tuple(record[1:])
-                yield result_type(*grouped_fields), dataset_ids
+                as_dict = dict(record)
+                if "ids" in as_dict.keys():
+                    ids = as_dict.pop('ids')
+                    yield namedtuple('search_result', as_dict.keys())(**as_dict), set(ids)
 
     def can_update(self, dataset, updates_allowed=None):
         """

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -7,7 +7,13 @@ What's New
 
 v1.8.next
 =========
+- Add dataset cli tool ``find-duplicates`` to identify duplicate indexed datasets (:pull:`1517`)
+
+v1.8.17 (8th November 2023)
+===========================
 - Fix schema creation with postgres driver when initialising system with ``--no-init-users`` (:pull:`1504`)
+- Switch to new jsonschema 'referencing' API and repin jsonschema to >=4.18 (:pull:`1477`)
+- Update whats_new.rst for release (:pull:`1510`)
 
 v1.8.16 (17th October 2023)
 ===========================

--- a/integration_tests/index/test_memory_index.py
+++ b/integration_tests/index/test_memory_index.py
@@ -201,9 +201,7 @@ def test_mem_ds_search_dups(mem_eo3_data):
     dc, ls8_id, wo_id = mem_eo3_data
     ls8_ds = dc.index.datasets.get(ls8_id)
     dup_results = dc.index.datasets.search_product_duplicates(ls8_ds.product, "cloud_cover", "dataset_maturity")
-    assert len(dup_results) == 1
-    assert dup_results[0][0].cloud_cover == ls8_ds.metadata.cloud_cover
-    assert ls8_id in dup_results[0][1]
+    assert len(dup_results) == 0
 
 
 def test_mem_ds_locations(mem_eo3_data):

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -7,6 +7,7 @@ Module
 """
 import datetime
 from typing import Any
+from collections import namedtuple
 
 import pytest
 import yaml
@@ -738,13 +739,14 @@ def test_find_duplicates_eo3(index,
     assert len(all_datasets) == 5
 
     # First two ls8 datasets have the same path/row, last two have a different row.
+    dupe_fields = namedtuple('search_result', ['region_code', 'dataset_maturity'])
     expected_ls8_path_row_duplicates = [
         (
-            ('090086', 'final'),
+            dupe_fields('090086', 'final'),
             {ls8_eo3_dataset.id, ls8_eo3_dataset2.id}
         ),
         (
-            ('101077', 'final'),
+            dupe_fields('101077', 'final'),
             {ls8_eo3_dataset3.id, ls8_eo3_dataset4.id}
         ),
 
@@ -770,6 +772,30 @@ def test_find_duplicates_eo3(index,
         'region_code', 'dataset_maturity'
     ))
     assert sat_res == []
+
+
+def test_find_duplicates_with_time(index, nrt_dataset, final_dataset, ls8_eo3_dataset):
+    index.datasets.add(nrt_dataset, with_lineage=False)
+    index.datasets.add(final_dataset, with_lineage=False)
+    index.datasets.get(nrt_dataset.id).is_active
+    index.datasets.get(final_dataset.id).is_active
+
+    all_datasets = index.datasets.search_eager()
+    assert len(all_datasets) == 3
+
+    dupe_fields = namedtuple('search_result', ['region_code', 'time'])
+    expected_result = [
+        (
+            dupe_fields('090086', '("2023-04-30 23:50:33.884549","2023-04-30 23:50:34.884549")'),
+            {nrt_dataset.id, final_dataset.id}
+        )
+    ]
+    res = sorted(index.datasets.search_product_duplicates(
+        nrt_dataset.product,
+        'region_code', 'time',
+    ))
+
+    assert res == expected_result
 
 
 def test_csv_search_via_cli_eo3(clirunner: Any,

--- a/integration_tests/test_cli_output.py
+++ b/integration_tests/test_cli_output.py
@@ -83,6 +83,32 @@ def test_cli_dataset_subcommand(index, clirunner,
     for path in eo3_dataset_paths:
         result = clirunner(['dataset', 'add', "--ignore-lineage", path])
 
+    runner = clirunner(['dataset', 'find-duplicates'], verbose_flag=False, expect_success=False)
+    assert "Error: must provide field names to match on" in runner.output
+    assert runner.exit_code == 1
+
+    runner = clirunner(['dataset', 'find-duplicates', 'region_code', 'fake_field'],
+                       verbose_flag=False, expect_success=False)
+    assert "Error: no products found with fields region_code, fake_field" in runner.output
+    assert runner.exit_code == 1
+
+    runner = clirunner(['dataset', 'find-duplicates', 'region_code', 'landsat_scene_id',
+                        '-p', 'ga_ls8c_ard_3', '-p', 'ga_ls_wo_3'],
+                       verbose_flag=False,
+                       expect_success=False)
+    assert "Error: specified products ga_ls_wo_3 do not contain all required fields"
+    assert runner.exit_code == 1
+
+    runner = clirunner(['dataset', 'find-duplicates', 'region_code', 'uri'], verbose_flag=False)
+    assert "No potential duplicates found." in runner.output
+    assert runner.exit_code == 0
+
+    runner = clirunner(['dataset', 'find-duplicates', 'region_code', 'dataset_maturity'], verbose_flag=False)
+    assert "No potential duplicates found." not in runner.output
+    assert "(region_code='090086', dataset_maturity='final')" in runner.output
+    assert "(region_code='101077', dataset_maturity='final')" in runner.output
+    assert runner.exit_code == 0
+
     runner = clirunner(['dataset', 'archive'], verbose_flag=False, expect_success=False)
     assert "Completed dataset archival." not in runner.output
     assert "Usage:  [OPTIONS] [IDS]" in runner.output


### PR DESCRIPTION
### Reason for this pull request

Easily scan the database for duplicate indexed datasets, identifying duplicates by a set of specified field values, and produce a report on any datasets found.


### Proposed changes

- New dataset CLI tool, `find-duplicates` that takes in fields by which to search for duplicates and optional products in which to search
- Add `expression_with_leniency` property to `DateRangeDocField` to extend date range by +-500ms



 - [ ] Closes #xxxx
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1517.org.readthedocs.build/en/1517/

<!-- readthedocs-preview datacube-core end -->