### PR TITLE
Make solar_date() timezone aware.

### DIFF
--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -381,7 +381,7 @@ def solar_day(dataset: Dataset, longitude: Optional[float] = None) -> np.datetim
     :param longitude: If supplied correct timestamp for this longitude,
                       rather than mid-point of the Dataset's footprint
     """
-    utc = dataset.center_time
+    utc = dataset.center_time.astimezone(datetime.timezone.utc)
 
     if longitude is None:
         _lon = _ds_mid_longitude(dataset)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,7 @@ What's New
 v1.8.next
 =========
 - Add dataset cli tool ``find-duplicates`` to identify duplicate indexed datasets (:pull:`1517`)
+- Make solar_day() timezone aware (:pull:`1521`)
 
 v1.8.17 (8th November 2023)
 ===========================

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -171,6 +171,13 @@ def test_solar_day():
 
     assert 'Cannot compute solar_day: dataset is missing spatial info' in str(e.value)
 
+    # Test with Non-UTC timestamp in index.
+    ds = _s(center_time=parse_time('1997-05-22 22:07:44.2270250-7:00'),
+            metadata=_s(lon=Range(begin=-136.615,
+                                  end=-134.325)))
+    assert solar_day(ds) == np.datetime64('1997-05-22', 'D')
+    assert solar_day(ds, longitude=0) == np.datetime64('1997-05-23', 'D')
+
 
 def test_solar_offset():
     from datacube.utils.geometry import point


### PR DESCRIPTION
### Reason for this pull request

The `datacube.api.query.solar_date()` function takes a dataset object and calculates it's local solar date, based on center time and central longitude.  However, it assumes that the dataset center_time is in UTC timezone.  If the the center_time is in some other timezone, an incorrect date may be returned.

See also: https://github.com/opendatacube/datacube-ows/issues/979

### Proposed changes

- Call `.astimezone(utc)` on the center time before doing solar date calculations.


 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.
-->


<!-- readthedocs-preview datacube-core start -->
----
:books: Documentation preview :books:: https://datacube-core--1521.org.readthedocs.build/en/1521/

<!-- readthedocs-preview datacube-core end -->