### PR TITLE
Warn if non-eo3 dataset has eo3 metadata type

### DIFF
--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -5,6 +5,8 @@
 """
 High level indexing operations/utilities
 """
+import logging
+
 import json
 import toolz
 from uuid import UUID
@@ -16,6 +18,8 @@ from datacube.utils import changes, InvalidDocException, SimpleDocNav, jsonify_d
 from datacube.model.utils import BadMatch, dedup_lineage, remap_lineage_doc, flatten_datasets
 from datacube.utils.changes import get_doc_changes
 from .eo3 import prep_eo3, is_doc_eo3, is_doc_geo  # type: ignore[attr-defined]
+
+_LOG = logging.getLogger(__name__)
 
 
 class ProductRule:
@@ -148,6 +152,13 @@ def dataset_resolver(index: AbstractIndex,
                      skip_lineage: bool = False) -> Callable[[SimpleDocNav, str], DatasetOrError]:
     match_product = product_matcher(product_matching_rules)
 
+    def check_intended_eo3(ds: SimpleDocNav, product: Product) -> None:
+        # warn if it looks like dataset was meant to be eo3 but is not
+        if not is_doc_eo3(ds.doc) and product.metadata_type.name.contains("eo3"):
+            _LOG.warning(f"Dataset {ds.id} has a product with an eo3 metadata type, "
+                         "but the dataset definitiondoes not include the $schema field "
+                         "and so will not be recognised as an eo3 dataset.")
+
     def resolve_no_lineage(ds: SimpleDocNav, uri: str) -> DatasetOrError:
         doc = ds.doc_without_lineage_sources
         try:
@@ -155,6 +166,7 @@ def dataset_resolver(index: AbstractIndex,
         except BadMatch as e:
             return None, e
 
+        check_intended_eo3(ds, product)
         return Dataset(product, doc, uris=[uri], sources={}), None
 
     def resolve(main_ds_doc: SimpleDocNav, uri: str) -> DatasetOrError:
@@ -222,6 +234,7 @@ def dataset_resolver(index: AbstractIndex,
             else:
                 product = match_product(doc)
 
+            check_intended_eo3(ds, product)
             return with_cache(Dataset(product, doc, uris=uris, sources=sources), ds.id, cache)
         try:
             return remap_lineage_doc(main_ds, resolve_ds, cache={}), None

--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -154,9 +154,9 @@ def dataset_resolver(index: AbstractIndex,
 
     def check_intended_eo3(ds: SimpleDocNav, product: Product) -> None:
         # warn if it looks like dataset was meant to be eo3 but is not
-        if not is_doc_eo3(ds.doc) and product.metadata_type.name.contains("eo3"):
+        if not is_doc_eo3(ds.doc) and ("eo3" in product.metadata_type.name):
             _LOG.warning(f"Dataset {ds.id} has a product with an eo3 metadata type, "
-                         "but the dataset definitiondoes not include the $schema field "
+                         "but the dataset definition does not include the $schema field "
                          "and so will not be recognised as an eo3 dataset.")
 
     def resolve_no_lineage(ds: SimpleDocNav, uri: str) -> DatasetOrError:

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -9,6 +9,7 @@ v1.8.next
 =========
 - Add dataset cli tool ``find-duplicates`` to identify duplicate indexed datasets (:pull:`1517`)
 - Make solar_day() timezone aware (:pull:`1521`)
+- Warn if non-eo3 dataset has eo3 metadata type (:pull:`1523`)
 
 v1.8.17 (8th November 2023)
 ===========================


### PR DESCRIPTION
### Reason for this pull request

The sole criteria for a dataset being recognised as an eo3 dataset is the inclusion of the eo3 schema in the definition. If the dataset is not considered eo3 due to a missing schema but is otherwise treated as eo3 due to the product metadata type, it can cause seemingly mysterious errors down the line, as seen [on slack](https://opendatacube.slack.com/archives/C0L4W42KU/p1702502177617989).


### Proposed changes

- When resolving a dataset in `Doc2Dataset`, alert users if there is a mismatch between `is_doc_eo3` and the product metadata type


 - [ ] Closes #xxxx
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1523.org.readthedocs.build/en/1523/

<!-- readthedocs-preview datacube-core end -->