### PR TITLE
GHA: Update dockerhub credential passing mechanism.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,8 +72,8 @@ jobs:
         && github.ref == 'refs/heads/develop'
       uses: docker/login-action@v3
       with:
-        username: ${{ env.DOCKER_USER }}
-        password: ${{ secrets.GADOCKERSVC_PASSWORD }}
+        username: ${{ secrets.DOCKERHUBUSER }}
+        password: ${{ secrets.DOCKERHUBPASSWD }}
 
     - name: Build Docker
       uses: docker/build-push-action@v5

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -12,7 +12,7 @@ v1.8.next
 - Warn if non-eo3 dataset has eo3 metadata type (:pull:`1523`)
 - Update pandas version in docker image to be consistent with conda environment and default to stdlib
   timezone instead of pytz when converting timestamps; automatically update copyright years (:pull:`1527`)
-- Update github-dockerhub credential-passing mechanism. (:pull:`1528`)
+- Update github-Dockerhub credential-passing mechanism. (:pull:`1528`)
 
 v1.8.17 (8th November 2023)
 ===========================

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -12,6 +12,7 @@ v1.8.next
 - Warn if non-eo3 dataset has eo3 metadata type (:pull:`1523`)
 - Update pandas version in docker image to be consistent with conda environment and default to stdlib
   timezone instead of pytz when converting timestamps; automatically update copyright years (:pull:`1527`)
+- Update github-dockerhub credential-passing mechanism. (:pull:`1528`)
 
 v1.8.17 (8th November 2023)
 ===========================

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -120,6 +120,7 @@ digitalearthafrica
 Dingley
 distutils
 Dockerfile
+Dockerhub
 dropdb
 ds
 dsm


### PR DESCRIPTION
The dockerhub GHA is failing because the secret was deleted?  We probably shouldn't be using the gadockersvc account anyway.

I've made the dockerhub username a repo secret too so can switch more easily in future.


 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes



<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1528.org.readthedocs.build/en/1528/

<!-- readthedocs-preview datacube-core end -->