### PR TITLE
Index level ep13

### DIFF
--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -1917,24 +1917,42 @@ class AbstractIndex(ABC):
     override other methods and contract flags as required.
     """
 
-    # Interface contracts
-    #   supports add() update() remove() etc methods.
-    supports_persistance = True
+    # Interface contracts - implementations should set to True where appropriate.
+
+    ### Metadata type support flags
     #   supports legacy ODCv1 EO style metadata types.
-    supports_legacy = True
+    supports_legacy = False
+    #   supports eo3 compatible metadata types.
+    supports_eo3 = False
     #   supports non-geospatial (e.g. telemetry) metadata types
-    supports_nongeo = True
-    #   supports lineage
-    supports_lineage = True
-    #   supports external lineage API (as described in EP-08)
+    supports_nongeo = False
+    #   supports geospatial vector (i.e. non-raster) metadata types (reserved for future use)
+    supports_vector = False
+
+
+    ### Database/storage feature support flags
+    #   supports add() update() remove() etc methods.
+    supports_write = False
+    #   supports persistent storage. Writes from previous instantiations will persist into future ones.
+    #   (Requires supports_write)
+    supports_persistance = False
+    #    Supports ACID transactions (Requires supports_write)
+    supports_transactions = False
+    #    Supports per-CRS spatial indexes (Requires supports_write)
+    supports_spatial_indexes = False
+
+    ### User managment support flags
+    #   support the index.users API
+    supports_users = False
+
+    ### Lineage support flags
+    #   supports lineage (either legacy or new API)
+    supports_lineage = False
+    #   supports external lineage API (as described in EP-08).  Requires supports_lineage
     #   IF support_lineage is True and supports_external_lineage is False THEN legacy lineage API.
     supports_external_lineage = False
-    #   supports an external lineage home field.  Only valid if also supports_external_lineage
+    #   supports an external lineage home field.  Requires supports_external_lineage
     supports_external_home = False
-    # Supports ACID transactions
-    supports_transactions = False
-    # Supports per-CRS spatial indexes
-    supports_spatial_indexes = False
 
     @property
     @abstractmethod

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -1919,7 +1919,7 @@ class AbstractIndex(ABC):
 
     # Interface contracts - implementations should set to True where appropriate.
 
-    ### Metadata type support flags
+    # Metadata type support flags
     #   supports legacy ODCv1 EO style metadata types.
     supports_legacy = False
     #   supports eo3 compatible metadata types.
@@ -1930,7 +1930,7 @@ class AbstractIndex(ABC):
     supports_vector = False
 
 
-    ### Database/storage feature support flags
+    # Database/storage feature support flags
     #   supports add() update() remove() etc methods.
     supports_write = False
     #   supports persistent storage. Writes from previous instantiations will persist into future ones.
@@ -1941,11 +1941,11 @@ class AbstractIndex(ABC):
     #    Supports per-CRS spatial indexes (Requires supports_write)
     supports_spatial_indexes = False
 
-    ### User managment support flags
+    # User managment support flags
     #   support the index.users API
     supports_users = False
 
-    ### Lineage support flags
+    # Lineage support flags
     #   supports lineage (either legacy or new API)
     supports_lineage = False
     #   supports external lineage API (as described in EP-08).  Requires supports_lineage

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -18,6 +18,7 @@ from urllib.parse import urlparse, ParseResult
 from uuid import UUID
 from datetime import timedelta
 
+from deprecat import deprecat
 from datacube.cfg.api import ODCEnvironment, ODCOptionHandler
 from datacube.index.exceptions import TransactionException
 from datacube.index.fields import Field
@@ -27,6 +28,7 @@ from datacube.model.lineage import LineageRelations
 from datacube.utils import cached_property, jsonify_document, read_documents, InvalidDocException, report_to_user
 from datacube.utils.changes import AllowPolicy, Change, Offset, DocumentMismatchError, check_doc_unchanged
 from datacube.utils.generic import thread_local_cache
+from datacube.migration import ODC2DeprecationWarning
 from odc.geo import CRS, Geometry
 from odc.geo.geom import box
 from datacube.utils.documents import UnknownMetadataType
@@ -2220,6 +2222,11 @@ class AbstractIndexDriver(ABC):
 
     @staticmethod
     @abstractmethod
+    @deprecat(
+        reason="The 'metadata_type_from_doc' static method has been deprecated. "
+                 "Please use the 'index.metadata_type_from_doc()' instead.",
+        version='1.9.0',
+        category=ODC2DeprecationWarning)
     def metadata_type_from_doc(definition: dict
                               ) -> MetadataType:
         ...

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -1929,7 +1929,6 @@ class AbstractIndex(ABC):
     #   supports geospatial vector (i.e. non-raster) metadata types (reserved for future use)
     supports_vector = False
 
-
     # Database/storage feature support flags
     #   supports add() update() remove() etc methods.
     supports_write = False
@@ -2242,7 +2241,7 @@ class AbstractIndexDriver(ABC):
     @abstractmethod
     @deprecat(
         reason="The 'metadata_type_from_doc' static method has been deprecated. "
-                 "Please use the 'index.metadata_type.from_doc()' instead.",
+               "Please use the 'index.metadata_type.from_doc()' instead.",
         version='1.9.0',
         category=ODC2DeprecationWarning)
     def metadata_type_from_doc(definition: dict

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -13,7 +13,7 @@ from abc import ABC, abstractmethod
 from typing import (Any, Iterable, Iterator,
                     List, Mapping, MutableMapping,
                     NamedTuple, Optional,
-                    Tuple, Union, Sequence)
+                    Tuple, Union, Sequence, Type)
 from urllib.parse import urlparse, ParseResult
 from uuid import UUID
 from datetime import timedelta
@@ -2205,13 +2205,18 @@ class AbstractIndexDriver(ABC):
     Abstract base class for an IndexDriver.  All IndexDrivers should inherit from this base class
     and implement all abstract methods.
     """
-    @staticmethod
+    @classmethod
     @abstractmethod
-    def connect_to_index(config_env: ODCEnvironment,
+    def index_class(cls) -> Type[AbstractIndex]:
+        ...
+
+    @classmethod
+    def connect_to_index(cls,
+                         config_env: ODCEnvironment,
                          application_name: Optional[str] = None,
                          validate_connection: bool = True
                         ) -> "AbstractIndex":
-        ...
+        return cls.index_class().from_config(config_env, application_name, validate_connection)
 
     @staticmethod
     @abstractmethod

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -2242,7 +2242,7 @@ class AbstractIndexDriver(ABC):
     @abstractmethod
     @deprecat(
         reason="The 'metadata_type_from_doc' static method has been deprecated. "
-                 "Please use the 'index.metadata_type_from_doc()' instead.",
+                 "Please use the 'index.metadata_type.from_doc()' instead.",
         version='1.9.0',
         category=ODC2DeprecationWarning)
     def metadata_type_from_doc(definition: dict

--- a/datacube/index/memory/index.py
+++ b/datacube/index/memory/index.py
@@ -29,6 +29,19 @@ class Index(AbstractIndex):
     """
     Lightweight in-memory index driver
     """
+    ### Metadata type support flags
+    supports_legacy = True
+    supports_eo3 = True
+    supports_nongeo = True
+
+    ### Database/storage feature support flags
+    supports_write = True
+
+    ### User managment support flags
+    supports_users = True
+
+    ### Lineage support flags
+    supports_lineage = True
 
     def __init__(self, env: ODCEnvironment) -> None:
         self._env = env

--- a/datacube/index/memory/index.py
+++ b/datacube/index/memory/index.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 from threading import Lock
+from typing import Type
 
 from datacube.cfg import ODCEnvironment
 from datacube.index.memory._datasets import DatasetResource, LineageResource  # type: ignore
@@ -97,9 +98,9 @@ class Index(AbstractIndex):
 
 
 class MemoryIndexDriver(AbstractIndexDriver):
-    @staticmethod
-    def connect_to_index(config_env: ODCEnvironment, application_name=None, validate_connection=True):
-        return Index.from_config(config_env, application_name, validate_connection)
+    @classmethod
+    def index_class(cls) -> Type[AbstractIndex]:
+        return Index
 
     @staticmethod
     def metadata_type_from_doc(definition: dict) -> MetadataType:

--- a/datacube/index/memory/index.py
+++ b/datacube/index/memory/index.py
@@ -120,7 +120,7 @@ class MemoryIndexDriver(AbstractIndexDriver):
     @staticmethod
     @deprecat(
         reason="The 'metadata_type_from_doc' static method has been deprecated. "
-               "Please use the 'index.metadata_type_from_doc()' instead.",
+               "Please use the 'index.metadata_type.from_doc()' instead.",
         version='1.9.0',
         category=ODC2DeprecationWarning)
     def metadata_type_from_doc(definition: dict) -> MetadataType:

--- a/datacube/index/memory/index.py
+++ b/datacube/index/memory/index.py
@@ -29,18 +29,18 @@ class Index(AbstractIndex):
     """
     Lightweight in-memory index driver
     """
-    ### Metadata type support flags
+    #   Metadata type support flags
     supports_legacy = True
     supports_eo3 = True
     supports_nongeo = True
 
-    ### Database/storage feature support flags
+    #   Database/storage feature support flags
     supports_write = True
 
-    ### User managment support flags
+    #   User managment support flags
     supports_users = True
 
-    ### Lineage support flags
+    #   Lineage support flags
     supports_lineage = True
 
     def __init__(self, env: ODCEnvironment) -> None:

--- a/datacube/index/memory/index.py
+++ b/datacube/index/memory/index.py
@@ -6,6 +6,7 @@ import logging
 from threading import Lock
 from typing import Type
 
+from deprecat import deprecat
 from datacube.cfg import ODCEnvironment
 from datacube.index.memory._datasets import DatasetResource, LineageResource  # type: ignore
 from datacube.index.memory._fields import get_dataset_fields
@@ -14,6 +15,7 @@ from datacube.index.memory._products import ProductResource
 from datacube.index.memory._users import UserResource
 from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, UnhandledTransaction
 from datacube.model import MetadataType
+from datacube.migration import ODC2DeprecationWarning
 from odc.geo import CRS
 
 _LOG = logging.getLogger(__name__)
@@ -103,6 +105,11 @@ class MemoryIndexDriver(AbstractIndexDriver):
         return Index
 
     @staticmethod
+    @deprecat(
+        reason="The 'metadata_type_from_doc' static method has been deprecated. "
+               "Please use the 'index.metadata_type_from_doc()' instead.",
+        version='1.9.0',
+        category=ODC2DeprecationWarning)
     def metadata_type_from_doc(definition: dict) -> MetadataType:
         """
         :param definition:

--- a/datacube/index/null/index.py
+++ b/datacube/index/null/index.py
@@ -24,12 +24,12 @@ class Index(AbstractIndex):
     """
     (Sub-)Minimal (non-)implementation of the Index API.
     """
-    ### Metadata type support flags
+    #   Metadata type support flags
     supports_legacy = True
     supports_eo3 = True
     supports_nongeo = True
 
-    ### User managment support flags
+    #   User managment support flags
     supports_users = True
 
     def __init__(self, env: ODCEnvironment) -> None:

--- a/datacube/index/null/index.py
+++ b/datacube/index/null/index.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2015-2024 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import logging
+from typing import Type
 
 from datacube.cfg import ODCEnvironment
 from datacube.index.null._datasets import DatasetResource  # type: ignore
@@ -90,9 +91,9 @@ class Index(AbstractIndex):
 
 
 class NullIndexDriver(AbstractIndexDriver):
-    @staticmethod
-    def connect_to_index(config_env, application_name=None, validate_connection=True):
-        return Index.from_config(config_env, application_name, validate_connection)
+    @classmethod
+    def index_class(cls) -> Type[AbstractIndex]:
+        return Index
 
     @staticmethod
     def metadata_type_from_doc(definition: dict) -> MetadataType:

--- a/datacube/index/null/index.py
+++ b/datacube/index/null/index.py
@@ -5,6 +5,7 @@
 import logging
 from typing import Type
 
+from deprecat import deprecat
 from datacube.cfg import ODCEnvironment
 from datacube.index.null._datasets import DatasetResource  # type: ignore
 from datacube.index.null._metadata_types import MetadataTypeResource
@@ -13,6 +14,7 @@ from datacube.index.null._users import UserResource
 from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, UnhandledTransaction, NoLineageResource
 from datacube.model import MetadataType
 from datacube.model.fields import get_dataset_fields
+from datacube.migration import ODC2DeprecationWarning
 from odc.geo import CRS
 
 _LOG = logging.getLogger(__name__)
@@ -96,6 +98,11 @@ class NullIndexDriver(AbstractIndexDriver):
         return Index
 
     @staticmethod
+    @deprecat(
+        reason="The 'metadata_type_from_doc' static method has been deprecated. "
+               "Please use the 'index.metadata_type_from_doc()' instead.",
+        version='1.9.0',
+        category=ODC2DeprecationWarning)
     def metadata_type_from_doc(definition: dict) -> MetadataType:
         """
         :param definition:

--- a/datacube/index/null/index.py
+++ b/datacube/index/null/index.py
@@ -24,8 +24,13 @@ class Index(AbstractIndex):
     """
     (Sub-)Minimal (non-)implementation of the Index API.
     """
-    # Supports everything but persistance
-    supports_persistance = False
+    ### Metadata type support flags
+    supports_legacy = True
+    supports_eo3 = True
+    supports_nongeo = True
+
+    ### User managment support flags
+    supports_users = True
 
     def __init__(self, env: ODCEnvironment) -> None:
         self._env = env

--- a/datacube/index/null/index.py
+++ b/datacube/index/null/index.py
@@ -105,7 +105,7 @@ class NullIndexDriver(AbstractIndexDriver):
     @staticmethod
     @deprecat(
         reason="The 'metadata_type_from_doc' static method has been deprecated. "
-               "Please use the 'index.metadata_type_from_doc()' instead.",
+               "Please use the 'index.metadata_type.from_doc()' instead.",
         version='1.9.0',
         category=ODC2DeprecationWarning)
     def metadata_type_from_doc(definition: dict) -> MetadataType:

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -5,7 +5,7 @@
 import logging
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterable, Sequence
+from typing import Iterable, Sequence, Type
 
 from datacube.cfg.api import ODCEnvironment, ODCOptionHandler
 from datacube.cfg.opt import config_options_for_psql_driver
@@ -213,12 +213,10 @@ WARNING: Database schema and internal APIs may change significantly between rele
                 yield conn
 
 
-class DefaultIndexDriver(AbstractIndexDriver):
-    @staticmethod
-    def connect_to_index(config_env: ODCEnvironment,
-                         application_name: str | None = None,
-                         validate_connection: bool = True):
-        return Index.from_config(config_env, application_name, validate_connection)
+class PostgisIndexDriver(AbstractIndexDriver):
+    @classmethod
+    def index_class(cls) -> Type[AbstractIndex]:
+        return Index
 
     @staticmethod
     def metadata_type_from_doc(definition: dict) -> MetadataType:
@@ -236,4 +234,4 @@ class DefaultIndexDriver(AbstractIndexDriver):
 
 
 def index_driver_init():
-    return DefaultIndexDriver()
+    return PostgisIndexDriver()

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -51,19 +51,22 @@ class Index(AbstractIndex):
     :type products: datacube.index._products.ProductResource
     :type metadata_types: datacube.index._metadata_types.MetadataTypeResource
     """
+    ### Metadata type support flags
+    supports_eo3 = True
 
-    # Postgis driver does not need to support pre-EO3 metadata formats
-    supports_legacy = False
-    # Hopefully can reinstate non-geo support, but dropping for now will make progress easier.
-    supports_nongeo = False
-    # Postgis driver supports the new lineage data model and API, as per EP-08.
+    ### Database/storage feature support flags
+    supports_write = True
+    supports_persistance = True
+    supports_transactions = True
+    supports_spatial_indexes = True
+
+    ### User managment support flags
+    supports_users = True
+
+    ### Lineage support flags
     supports_lineage = True
     supports_external_lineage = True
     supports_external_home = True
-    # Postgis driver supports ACID database transactions
-    supports_transactions = True
-    # Postgis supports per-CRS spatial indexes
-    supports_spatial_indexes = True
 
     def __init__(self, db: PostGisDb, env: ODCEnvironment) -> None:
         # POSTGIS driver is not stable with respect to database schema or internal APIs.

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -51,19 +51,19 @@ class Index(AbstractIndex):
     :type products: datacube.index._products.ProductResource
     :type metadata_types: datacube.index._metadata_types.MetadataTypeResource
     """
-    ### Metadata type support flags
+    #   Metadata type support flags
     supports_eo3 = True
 
-    ### Database/storage feature support flags
+    #   Database/storage feature support flags
     supports_write = True
     supports_persistance = True
     supports_transactions = True
     supports_spatial_indexes = True
 
-    ### User managment support flags
+    #   User managment support flags
     supports_users = True
 
-    ### Lineage support flags
+    #   Lineage support flags
     supports_lineage = True
     supports_external_lineage = True
     supports_external_home = True

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterable, Sequence, Type
 
+from deprecat import deprecat
 from datacube.cfg.api import ODCEnvironment, ODCOptionHandler
 from datacube.cfg.opt import config_options_for_psql_driver
 from datacube.drivers.postgis import PostGisDb, PostgisDbAPI
@@ -18,6 +19,7 @@ from datacube.index.postgis._products import ProductResource
 from datacube.index.postgis._users import UserResource
 from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, AbstractTransaction, default_metadata_type_docs
 from datacube.model import MetadataType
+from datacube.migration import ODC2DeprecationWarning
 from odc.geo import CRS
 
 _LOG = logging.getLogger(__name__)
@@ -219,6 +221,11 @@ class PostgisIndexDriver(AbstractIndexDriver):
         return Index
 
     @staticmethod
+    @deprecat(
+        reason="The 'metadata_type_from_doc' static method has been deprecated. "
+               "Please use the 'index.metadata_type_from_doc()' instead.",
+        version='1.9.0',
+        category=ODC2DeprecationWarning)
     def metadata_type_from_doc(definition: dict) -> MetadataType:
         """
         :param definition:

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -226,7 +226,7 @@ class PostgisIndexDriver(AbstractIndexDriver):
     @staticmethod
     @deprecat(
         reason="The 'metadata_type_from_doc' static method has been deprecated. "
-               "Please use the 'index.metadata_type_from_doc()' instead.",
+               "Please use the 'index.metadata_type.from_doc()' instead.",
         version='1.9.0',
         category=ODC2DeprecationWarning)
     def metadata_type_from_doc(definition: dict) -> MetadataType:

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -188,6 +188,7 @@ class Index(AbstractIndex):
 
 class DefaultIndexDriver(AbstractIndexDriver):
     aliases = ['postgres', 'legacy']
+
     @classmethod
     def index_class(cls) -> Type[AbstractIndex]:
         return Index

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -47,8 +47,21 @@ class Index(AbstractIndex):
     :type products: datacube.index._products.ProductResource
     :type metadata_types: datacube.index._metadata_types.MetadataTypeResource
     """
+    ### Metadata type support flags
+    supports_legacy = True
+    supports_eo3 = True
+    supports_nongeo = True
 
+    ### Database/storage feature support flags
+    supports_write = True
+    supports_persistance = True
     supports_transactions = True
+
+    ### User managment support flags
+    supports_users = True
+
+    ### Lineage support flags
+    supports_lineage = True
 
     def __init__(self, db: PostgresDb, env: ODCEnvironment) -> None:
         self._db = db

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 from contextlib import contextmanager
-from typing import Iterable
+from typing import Iterable, Type
 
 from datacube.cfg.opt import ODCOptionHandler, config_options_for_psql_driver
 from datacube.cfg.api import ODCEnvironment
@@ -173,12 +173,9 @@ class Index(AbstractIndex):
 
 class DefaultIndexDriver(AbstractIndexDriver):
     aliases = ['postgres', 'legacy']
-
-    @staticmethod
-    def connect_to_index(config_env: ODCEnvironment,
-                         application_name: str | None = None,
-                         validate_connection: bool = True):
-        return Index.from_config(config_env, application_name, validate_connection)
+    @classmethod
+    def index_class(cls) -> Type[AbstractIndex]:
+        return Index
 
     @staticmethod
     def metadata_type_from_doc(definition: dict) -> MetadataType:

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -47,20 +47,20 @@ class Index(AbstractIndex):
     :type products: datacube.index._products.ProductResource
     :type metadata_types: datacube.index._metadata_types.MetadataTypeResource
     """
-    ### Metadata type support flags
+    #   Metadata type support flags
     supports_legacy = True
     supports_eo3 = True
     supports_nongeo = True
 
-    ### Database/storage feature support flags
+    #   Database/storage feature support flags
     supports_write = True
     supports_persistance = True
     supports_transactions = True
 
-    ### User managment support flags
+    #   User managment support flags
     supports_users = True
 
-    ### Lineage support flags
+    #   Lineage support flags
     supports_lineage = True
 
     def __init__(self, db: PostgresDb, env: ODCEnvironment) -> None:

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -195,7 +195,7 @@ class DefaultIndexDriver(AbstractIndexDriver):
     @staticmethod
     @deprecat(
         reason="The 'metadata_type_from_doc' static method has been deprecated. "
-               "Please use the 'index.metadata_type_from_doc()' instead.",
+               "Please use the 'index.metadata_type.from_doc()' instead.",
         version='1.9.0',
         category=ODC2DeprecationWarning)
     def metadata_type_from_doc(definition: dict) -> MetadataType:

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -6,6 +6,7 @@ import logging
 from contextlib import contextmanager
 from typing import Iterable, Type
 
+from deprecat import deprecat
 from datacube.cfg.opt import ODCOptionHandler, config_options_for_psql_driver
 from datacube.cfg.api import ODCEnvironment
 from datacube.drivers.postgres import PostgresDb, PostgresDbAPI
@@ -18,6 +19,7 @@ from datacube.index.postgres._users import UserResource
 from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, AbstractTransaction, \
     default_metadata_type_docs
 from datacube.model import MetadataType
+from datacube.migration import ODC2DeprecationWarning
 
 _LOG = logging.getLogger(__name__)
 
@@ -178,6 +180,11 @@ class DefaultIndexDriver(AbstractIndexDriver):
         return Index
 
     @staticmethod
+    @deprecat(
+        reason="The 'metadata_type_from_doc' static method has been deprecated. "
+               "Please use the 'index.metadata_type_from_doc()' instead.",
+        version='1.9.0',
+        category=ODC2DeprecationWarning)
     def metadata_type_from_doc(definition: dict) -> MetadataType:
         """
         :param definition:

--- a/datacube/migration.py
+++ b/datacube/migration.py
@@ -1,0 +1,13 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2024 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+class ODC2DeprecationWarning(DeprecationWarning):
+    """
+    Subclasss of Deprecation Warning for API elements that are deprecated in 1.9 and will be removed in 2.0.
+
+    Provided to support suppression of 1.9 deprecation warnings in e.g. sandbox-like environments to prevent
+    end-users from freaking out.
+    """
+    pass

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -37,6 +37,7 @@ __all__ = [
 from odc.geo import CRS, BoundingBox, Geometry, wh_
 from odc.geo.geobox import GeoBox
 from odc.geo.geom import intersects, polygon
+from datacube.migration import ODC2DeprecationWarning
 from deprecat import deprecat
 
 _LOG = logging.getLogger(__name__)
@@ -100,7 +101,8 @@ class Dataset:
     @property
     @deprecat(
         reason="The 'type' attribute has been deprecated. Please use the 'product' attribute instead.",
-        version='1.9.0')
+        version='1.9.0',
+        category=ODC2DeprecationWarning)
     def type(self) -> "Product":
         # For compatibility
         return self.product
@@ -242,7 +244,9 @@ class Dataset:
     @property
     @deprecat(
         reason="The 'is_active' attribute has been deprecated. Please use 'is_archived' instead.",
-        version="1.9.0")
+        version="1.9.0",
+        category=ODC2DeprecationWarning
+    )
     def is_active(self) -> bool:
         """
         Is this dataset active?
@@ -746,7 +750,8 @@ DatasetType = Product
 
 @deprecat(
     reason='This version of GridSpec has been deprecated. Please use the GridSpec class defined in odc-geo.',
-    version='1.9.0'
+    version='1.9.0',
+    category=ODC2DeprecationWarning
 )
 class GridSpec:
     """

--- a/datacube/utils/cog.py
+++ b/datacube/utils/cog.py
@@ -13,6 +13,8 @@ from dask.delayed import Delayed
 from pathlib import Path
 from typing import Union, Optional, List, Any, Dict
 
+from datacube.migration import ODC2DeprecationWarning
+
 from .io import check_write_path
 from .geometry import GeoBox
 from .geometry.tools import align_up
@@ -209,7 +211,7 @@ _delayed_write_cog_to_file = dask.delayed(  # pylint: disable=invalid-name
 )
 
 
-@deprecat(reason='This method has been moved to odc-geo.', version='1.9.0')
+@deprecat(reason='This method has been moved to odc-geo.', version='1.9.0', category=ODC2DeprecationWarning)
 def write_cog(
     geo_im: xr.DataArray,
     fname: Union[str, Path],
@@ -307,7 +309,7 @@ def write_cog(
     )
 
 
-@deprecat(reason='This method has been moved to odc-geo.', version='1.9.0')
+@deprecat(reason='This method has been moved to odc-geo.', version='1.9.0', category=ODC2DeprecationWarning)
 def to_cog(
     geo_im: xr.DataArray,
     blocksize: Optional[int] = None,

--- a/datacube/utils/math.py
+++ b/datacube/utils/math.py
@@ -10,6 +10,7 @@ import xarray as xr
 import odc.geo.math as geomath
 from odc.geo.xr import spatial_dims as xr_spatial_dims
 
+from datacube.migration import ODC2DeprecationWarning
 from deprecat import deprecat
 
 
@@ -42,33 +43,33 @@ def unsqueeze_dataset(ds: xr.Dataset, dim: str, coord: int = 0, pos: int = 0) ->
     return ds
 
 
-@deprecat(reason='This method has been moved to odc-geo.', version='1.9.0')
+@deprecat(reason='This method has been moved to odc-geo.', version='1.9.0', category=ODC2DeprecationWarning)
 def spatial_dims(xx: Union[xr.DataArray, xr.Dataset],
                  relaxed: bool = False) -> Optional[Tuple[str, str]]:
     return xr_spatial_dims(xx, relaxed)
 
 
-@deprecat(reason='This method has been moved to odc-geo.', version='1.9.0')
+@deprecat(reason='This method has been moved to odc-geo.', version='1.9.0', category=ODC2DeprecationWarning)
 def maybe_zero(x: float, tol: float) -> float:
     return geomath.maybe_zero(x, tol)
 
 
-@deprecat(reason='This method has been moved to odc-geo.', version='1.9.0')
+@deprecat(reason='This method has been moved to odc-geo.', version='1.9.0', category=ODC2DeprecationWarning)
 def maybe_int(x: float, tol: float) -> Union[int, float]:
     return geomath.maybe_int(x, tol)
 
 
-@deprecat(reason='This method has been moved to odc-geo.', version='1.9.0')
+@deprecat(reason='This method has been moved to odc-geo.', version='1.9.0', category=ODC2DeprecationWarning)
 def snap_scale(s, tol=1e-6):
     return geomath.snap_scale(s, tol)
 
 
-@deprecat(reason='This method has been moved to odc-geo.', version='1.9.0')
+@deprecat(reason='This method has been moved to odc-geo.', version='1.9.0', category=ODC2DeprecationWarning)
 def clamp(x, lo, up):
     return geomath.clamp(x, lo, up)
 
 
-@deprecat(reason='This method has been moved to odc-geo.', version='1.9.0')
+@deprecat(reason='This method has been moved to odc-geo.', version='1.9.0', category=ODC2DeprecationWarning)
 def is_almost_int(x: float, tol: float):
     return geomath.is_almost_int(x, tol)
 
@@ -136,12 +137,12 @@ def num2numpy(x, dtype, ignore_range=None):
     return None
 
 
-@deprecat(reason='This method has been moved to odc-geo.', version='1.9.0')
+@deprecat(reason='This method has been moved to odc-geo.', version='1.9.0', category=ODC2DeprecationWarning)
 def data_resolution_and_offset(data, fallback_resolution=None):
     return geomath.data_resolution_and_offset(data, fallback_resolution)
 
 
-@deprecat(reason='This method has been moved to odc-geo.', version='1.9.0')
+@deprecat(reason='This method has been moved to odc-geo.', version='1.9.0', category=ODC2DeprecationWarning)
 def affine_from_axis(xx, yy, fallback_resolution=None):
     return geomath.affine_from_axis(xx, yy, fallback_resolution)
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,7 +8,7 @@ What's New
 v1.9.next
 =========
 
-- Merge in 1.8.x branch changes. (:pull:`1459`, :pull:`1473`)
+- Merge in 1.8.x branch changes. (:pull:`1459`, :pull:`1473`, :pull:`1532`)
 - External Lineage API (:pull:`1401`)
 - Add lineage support to index clone operation (:pull:`1429`)
 - Migrate to SQLAlchemy 2.0 (:pull:`1432`)
@@ -27,6 +27,7 @@ v1.9.next
 - New Configuration API, as per ODC-EP10 (:pull:`1505`)
 - Alembic migrations for postgis driver (:pull:`1520`)
 - EP08 lineage extensions/changes to datasets.get(). (:pull:`1530`)
+- EP13 API changes to Index and IndexDriver. (:pull:`1533`)
 
 
 v1.8.next

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -27,7 +27,7 @@ v1.9.next
 - New Configuration API, as per ODC-EP10 (:pull:`1505`)
 - Alembic migrations for postgis driver (:pull:`1520`)
 - EP08 lineage extensions/changes to datasets.get(). (:pull:`1530`)
-- EP13 API changes to Index and IndexDriver. (:pull:`1533`)
+- EP13 API changes to Index and IndexDriver. (:pull:`1534`)
 
 
 v1.8.next


### PR DESCRIPTION
### Reason for this pull request

Changes to the `Index` and `IndexDriver` APIs, as proposed in EP13.

### Proposed changes

- New `index_class` method on `IndexDriver`
- `connect_to_index()` function is now implemented in the base class (calls `from_config` on the class returned by `index_class`)
- `metadata_type_from_doc()` method on `IndexDriver` deprecated in favour of `index.metadata_type.from_doc()`
- "supports" flags on `Index`:  New flags, as per EP13, and make all flags default to False, so drivers have to explicitly declare all the flags they DO support.

 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->