### PR TITLE
tweak list_products to consider load_hints

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@
 ## Copyright (c) 2015-2020 ODC Contributors
 ## SPDX-License-Identifier: Apache-2.0
 ##
-FROM osgeo/gdal:ubuntu-small-latest
+FROM ghcr.io/osgeo/gdal:ubuntu-small-latest
 ARG V_PG=14
 ARG V_PGIS=14-postgis-3
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -13,6 +13,7 @@ v1.8.next
 - Update pandas version in docker image to be consistent with conda environment and default to stdlib
   timezone instead of pytz when converting timestamps; automatically update copyright years (:pull:`1527`)
 - Update github-Dockerhub credential-passing mechanism. (:pull:`1528`)
+- Tweak ``list_products`` logic for getting crs and resolution values (:pull:`1535`)
 
 v1.8.17 (8th November 2023)
 ===========================


### PR DESCRIPTION
### Reason for this pull request

`list_products` would always get `crs` and `resolution` from `grid_spec` even if `default_crs` or `default_resolution` is not None or if `crs` and `resolution` were defined via `load_hints`.


### Proposed changes

- Return default values if present
- Don't ignore `load_hints` if not



 - [x] Closes #1531
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1535.org.readthedocs.build/en/1535/

<!-- readthedocs-preview datacube-core end -->