### PR TITLE
EP13 product/metadata type resource updates

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -143,6 +143,14 @@ class Datacube(object):
         :return: A table or list of every product in the datacube.
         :rtype: pandas.DataFrame or list(dict)
         """
+        def _get_non_default(product, col):
+            load_hints = product.load_hints()
+            if load_hints:
+                if col == 'crs':
+                    return load_hints.get('output_crs', None)
+                return load_hints.get(col, None)
+            return getattr(product.grid_spec, col, None)
+
         # Read properties from each datacube product
         cols = [
             'name',
@@ -155,10 +163,10 @@ class Datacube(object):
             getattr(pr, col, None)
             # if 'default_crs' and 'default_resolution' are not None
             # return 'default_crs' and 'default_resolution'
-            if getattr(pr, col, None) and 'default' not in col
-            # else try 'grid_spec.crs' and 'grid_spec.resolution'
+            if getattr(pr, col, None) or 'default' not in col
+            # else get crs and resolution from load_hints or grid_spec
             # as per output_geobox() handling logic
-            else getattr(pr.grid_spec, col.replace('default_', ''), None)
+            else _get_non_default(pr, col.replace('default_', ''))
             for col in cols]
             for pr in self.index.products.get_all()]
 

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -118,7 +118,7 @@ class Query(object):
 
             remaining_keys -= known_dim_keys
 
-            unknown_keys = remaining_keys - set(index.datasets.get_field_names())
+            unknown_keys = remaining_keys - set(index.products.get_field_names())
             # TODO: What about keys source filters, and what if the keys don't match up with this product...
             if unknown_keys:
                 raise LookupError('Unknown arguments: ', unknown_keys)

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -295,6 +295,22 @@ class AbstractMetadataTypeResource(ABC):
         """
         return self.update(self.from_doc(definition), allow_unsafe_updates=allow_unsafe_updates)
 
+    def get_with_fields(self, field_names: Iterable[str]) -> Iterable[MetadataType]:
+        """
+        Return all metadata types that have all of the named search fields.
+
+        :param field_names: Iterable of search field names
+        :return: Iterable of matching metadata types.
+        """
+        for mdt in self.get_all():
+            all_fields_found: bool = True
+            for field in field_names:
+                if field not in mdt.dataset_fields:
+                    all_fields_found = False
+                    break
+            if all_fields_found:
+                yield self.clone(mdt)
+
     def get(self, id_: int) -> Optional[MetadataType]:
         """
         Fetch metadata type by id.

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -19,11 +19,9 @@ from uuid import UUID
 from datetime import timedelta
 from deprecat import deprecat
 
-from deprecat import deprecat
 from datacube.cfg.api import ODCEnvironment, ODCOptionHandler
 from datacube.index.exceptions import TransactionException
 from datacube.index.fields import Field
-from datacube.migration import ODC2DeprecationWarning
 from datacube.model import Product, Dataset, MetadataType, Range
 from datacube.model import LineageTree, LineageDirection, LineageRelation
 from datacube.model.lineage import LineageRelations

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -303,12 +303,7 @@ class AbstractMetadataTypeResource(ABC):
         :return: Iterable of matching metadata types.
         """
         for mdt in self.get_all():
-            all_fields_found: bool = True
-            for field in field_names:
-                if field not in mdt.dataset_fields:
-                    all_fields_found = False
-                    break
-            if all_fields_found:
+            if all(field in mdt.dataset_fields for field in field_names):
                 yield mdt
 
     def get(self, id_: int) -> Optional[MetadataType]:

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -689,12 +689,6 @@ class AbstractProductResource(ABC):
         :raises KeyError: if not found
         """
 
-    @deprecat(
-        reason="This method is deprecated and will be removed in v2.0. Please migrate to "
-               "`dc.index.metadata_types.get_with_fields()` and `dc.index.products.get_with_type()`",
-        version="1.9.0",
-        category=ODC2DeprecationWarning
-    )
     def get_with_fields(self, field_names: Iterable[str]) -> Iterable[Product]:
         """
         Return products that have all of the given fields.

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -311,7 +311,7 @@ class AbstractMetadataTypeResource(ABC):
                     all_fields_found = False
                     break
             if all_fields_found:
-                yield self.clone(mdt)
+                yield mdt
 
     def get(self, id_: int) -> Optional[MetadataType]:
         """
@@ -702,7 +702,7 @@ class AbstractProductResource(ABC):
         :param field_names: names of fields that returned products must have
         :returns: Matching product models
         """
-        return self.get_with_types(self._index.metadata_types.get_with_fields(field_names))
+        return self.get_with_types(self.metadata_type_resource.get_with_fields(field_names))
 
     def get_with_types(self, types: Iterable[MetadataType]) -> Iterable[Product]:
         """

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -296,20 +296,6 @@ class DatasetResource(AbstractDatasetResource):
         else:
             return (id_ for id_ in self.active_by_id.keys())
 
-    def get_field_names(self, product_name=None) -> Iterable[str]:
-        if product_name is None:
-            prods = self._index.products.get_all()
-        else:
-            prod = self._index.products.get_by_name(product_name)
-            if prod:
-                prods = [prod]
-            else:
-                prods = []
-        out: Set[str] = set()
-        for prod in prods:
-            out.update(prod.metadata_type.dataset_fields)
-        return out
-
     def get_locations(self, id_: DSID) -> Iterable[str]:
         uuid = dsid_to_uuid(id_)
         return (s for s in self.locations[uuid])

--- a/datacube/index/memory/_products.py
+++ b/datacube/index/memory/_products.py
@@ -119,14 +119,6 @@ class ProductResource(AbstractProductResource):
     def get_by_name_unsafe(self, name: str) -> Product:
         return self.clone(self.by_name[name])
 
-    def get_with_fields(self, field_names: Iterable[str]) -> Iterable[Product]:
-        for prod in self.get_all():
-            for name in field_names:
-                if name not in prod.metadata_type.dataset_fields:
-                    break
-            else:
-                yield prod
-
     def search_robust(self, **query: QueryField) -> Iterator[Tuple[Product, Mapping[str, QueryField]]]:
         def listify(v):
             if isinstance(v, tuple):

--- a/datacube/index/null/_datasets.py
+++ b/datacube/index/null/_datasets.py
@@ -9,8 +9,8 @@ from typing import Iterable, Optional
 
 
 class DatasetResource(AbstractDatasetResource):
-    def __init__(self, product_resource):
-        self.types = product_resource
+    def __init__(self, index):
+        super().__init__(index)
 
     def get(self, id_: DSID, include_sources: bool = False, include_deriveds: bool = False, max_depth: int = 0):
         return None

--- a/datacube/index/null/_datasets.py
+++ b/datacube/index/null/_datasets.py
@@ -53,9 +53,6 @@ class DatasetResource(AbstractDatasetResource):
     def get_all_dataset_ids(self, archived: bool):
         return []
 
-    def get_field_names(self, product_name=None):
-        return []
-
     def get_locations(self, id_):
         return []
 

--- a/datacube/index/null/_metadata_types.py
+++ b/datacube/index/null/_metadata_types.py
@@ -8,9 +8,6 @@ from datacube.model import MetadataType
 
 
 class MetadataTypeResource(AbstractMetadataTypeResource):
-    def __init__(self):
-        pass
-
     def from_doc(self, definition):
         raise NotImplementedError
 

--- a/datacube/index/null/_products.py
+++ b/datacube/index/null/_products.py
@@ -13,8 +13,8 @@ _LOG = logging.getLogger(__name__)
 
 
 class ProductResource(AbstractProductResource):
-    def __init__(self, metadata_type_resource):
-        self.metadata_type_resource = metadata_type_resource
+    def __init__(self, mdtr):
+        self.metadata_type_resource = mdtr
 
     def add(self, product, allow_table_lock=False):
         raise NotImplementedError()

--- a/datacube/index/null/_products.py
+++ b/datacube/index/null/_products.py
@@ -31,9 +31,6 @@ class ProductResource(AbstractProductResource):
     def get_by_name_unsafe(self, name):
         raise KeyError(name)
 
-    def get_with_fields(self, field_names):
-        return []
-
     def search_robust(self, **query):
         return []
 

--- a/datacube/index/null/index.py
+++ b/datacube/index/null/index.py
@@ -36,9 +36,9 @@ class Index(AbstractIndex):
         self._env = env
         self._users = UserResource()
         self._metadata_types = MetadataTypeResource()
-        self._products = ProductResource(self.metadata_types)
+        self._products = ProductResource(self._metadata_types)
         self._lineage = NoLineageResource(self)
-        self._datasets = DatasetResource(self.products)
+        self._datasets = DatasetResource(self)
 
     @property
     def environment(self) -> ODCEnvironment:

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -409,23 +409,6 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         with self._db_connection(transaction=True) as transaction:
             return [dsid[0] for dsid in transaction.all_dataset_ids(archived)]
 
-    def get_field_names(self, product_name=None):
-        """
-        Get the list of possible search fields for a Product
-
-        :param str product_name:
-        :rtype: set[str]
-        """
-        if product_name is None:
-            products = self.products.get_all()
-        else:
-            products = [self.products.get_by_name(product_name)]
-
-        out = set()
-        for prod_ in products:
-            out.update(prod_.metadata_type.dataset_fields)
-        return out
-
     def get_locations(self, id_):
         """
         Get the list of storage locations for the given dataset id

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -642,18 +642,6 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         """
         return next(self._do_time_count(period, query, ensure_single=True))[1]
 
-    def _get_products(self, q):
-        products = set()
-        if 'product' in q.keys():
-            products.add(self.products.get_by_name(q['product']))
-        else:
-            # Otherwise search any metadata type that has all the given search fields.
-            products = self.products.get_with_fields(tuple(q.keys()))
-            if not products:
-                raise ValueError('No type of dataset has fields: {}'.format(q.keys()))
-
-        return products
-
     def _get_product_queries(self, query):
         for product, q in self.products.search_robust(**query):
             q['product_id'] = product.id

--- a/datacube/index/postgis/_products.py
+++ b/datacube/index/postgis/_products.py
@@ -253,20 +253,6 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
             raise KeyError('"%s" is not a valid Product name' % name)
         return self._make(result)
 
-    def get_with_fields(self, field_names):
-        """
-        Return dataset types that have all the given fields.
-
-        :param tuple[str] field_names:
-        :rtype: __generator[Product]
-        """
-        for type_ in self.get_all():
-            for name in field_names:
-                if name not in type_.metadata_type.dataset_fields:
-                    break
-            else:
-                yield type_
-
     def search_robust(self, **query):
         """
         Return dataset types that match match-able fields and dict of remaining un-matchable fields.

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -391,23 +391,6 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         with self._db_connection(transaction=True) as transaction:
             return [dsid[0] for dsid in transaction.all_dataset_ids(archived)]
 
-    def get_field_names(self, product_name=None):
-        """
-        Get the list of possible search fields for a Product
-
-        :param str product_name:
-        :rtype: set[str]
-        """
-        if product_name is None:
-            types = self.types.get_all()
-        else:
-            types = [self.types.get_by_name(product_name)]
-
-        out = set()
-        for type_ in types:
-            out.update(type_.metadata_type.dataset_fields)
-        return out
-
     def get_locations(self, id_):
         """
         Get the list of storage locations for the given dataset id

--- a/datacube/index/postgres/_products.py
+++ b/datacube/index/postgres/_products.py
@@ -244,20 +244,6 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
             raise KeyError('"%s" is not a valid Product name' % name)
         return self._make(result)
 
-    def get_with_fields(self, field_names):
-        """
-        Return dataset types that have all the given fields.
-
-        :param tuple[str] field_names:
-        :rtype: __generator[Product]
-        """
-        for type_ in self.get_all():
-            for name in field_names:
-                if name not in type_.metadata_type.dataset_fields:
-                    break
-            else:
-                yield type_
-
     def search_robust(self, **query):
         """
         Return dataset types that match match-able fields and dict of remaining un-matchable fields.

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -411,6 +411,15 @@ class MetadataType:
         cls.validate(doc)
         validate_eo3_compatible_type(doc)
 
+    def __eq__(self, other: Any) -> bool:
+        if self is other:
+            return True
+
+        if self.__class__ != other.__class__:
+            return False
+
+        return self.name == other.name
+
     def __str__(self) -> str:
         return "MetadataType(name={name!r}, id_={id!r})".format(id=self.id, name=self.name)
 

--- a/datacube/scripts/search_tool.py
+++ b/datacube/scripts/search_tool.py
@@ -94,7 +94,7 @@ def datasets(ctx, index, expressions):
     Search available Datasets
     """
     ctx.obj['write_results'](
-        sorted(index.datasets.get_field_names()),
+        sorted(index.products.get_field_names()),
         index.datasets.search_summaries(**expressions)
     )
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@
 ## Copyright (c) 2015-2020 ODC Contributors
 ## SPDX-License-Identifier: Apache-2.0
 ##
-FROM osgeo/gdal:ubuntu-small-latest
+FROM ghcr.io/osgeo/gdal:ubuntu-small-latest
 ARG V_PG=14
 ARG V_PGIS=14-postgis-3
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -38,6 +38,8 @@ v1.8.next
 - Warn if non-eo3 dataset has eo3 metadata type (:pull:`1523`)
 - Update pandas version in docker image to be consistent with conda environment and default to stdlib
   timezone instead of pytz when converting timestamps; automatically update copyright years (:pull:`1527`)
+- Update github-Dockerhub credential-passing mechanism. (:pull:`1528`)
+- Tweak ``list_products`` logic for getting crs and resolution values (:pull:`1535`)
 
 v1.8.17 (8th November 2023)
 ===========================

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -28,6 +28,7 @@ v1.9.next
 - Alembic migrations for postgis driver (:pull:`1520`)
 - EP08 lineage extensions/changes to datasets.get(). (:pull:`1530`)
 - EP13 API changes to Index and IndexDriver. (:pull:`1534`)
+- EP13 API changes to Metadata and Product Resources. (:pull:`1535`)
 
 
 v1.8.next

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -28,7 +28,7 @@ v1.9.next
 - Alembic migrations for postgis driver (:pull:`1520`)
 - EP08 lineage extensions/changes to datasets.get(). (:pull:`1530`)
 - EP13 API changes to Index and IndexDriver. (:pull:`1534`)
-- EP13 API changes to Metadata and Product Resources. (:pull:`1535`)
+- EP13 API changes to Metadata and Product Resources. (:pull:`1536`)
 
 
 v1.8.next

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -28,7 +28,7 @@ v1.9.next
 - Alembic migrations for postgis driver (:pull:`1520`)
 - EP08 lineage extensions/changes to datasets.get(). (:pull:`1530`)
 - EP13 API changes to Index and IndexDriver. (:pull:`1534`)
-- EP13 API changes to Metadata and Product Resources. (:pull:`1536`)
+- EP13 API changes to metadata and product resources. (:pull:`1536`)
 
 
 v1.8.next

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -440,12 +440,26 @@ def test_filter_types_by_fields(index, wo_eo3_product):
     :type ls5_telem_type: datacube.model.DatasetType
     :type index: datacube.index.Index
     """
-    assert index.products
+    res = list(index.metadata_types.get_with_fields(['platform', 'instrument', 'region_code']))
+    assert res == [wo_eo3_product.metadata_type]
+
+    res = list(index.metadata_types.get_with_fields(['platform', 'instrument', 'region_code', 'favorite_icecream']))
+    assert len(res) == 0
+
     res = list(index.products.get_with_fields(['platform', 'instrument', 'region_code']))
     assert res == [wo_eo3_product]
 
     res = list(index.products.get_with_fields(['platform', 'instrument', 'region_code', 'favorite_icecream']))
     assert len(res) == 0
+
+
+def test_filter_products_by_types(index, wo_eo3_product):
+    """
+    :type ls5_telem_type: datacube.model.DatasetType
+    :type index: datacube.index.Index
+    """
+    res = list(index.products.get_with_types([wo_eo3_product.metadata_type]))
+    assert res == [wo_eo3_product]
 
 
 def test_filter_types_by_search(index, wo_eo3_product):

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -112,7 +112,7 @@ def test_cannot_search_for_less_mature(index, nrt_dataset, ds_no_region):
     # if a dataset is missing a property required for finding less mature datasets,
     # it should error
     index.datasets.add(nrt_dataset, with_lineage=False, archive_less_mature=0)
-    index.datasets.get(nrt_dataset.id).is_active
+    assert not index.datasets.get(nrt_dataset.id).is_archived
     assert ds_no_region.metadata.region_code is None
     with pytest.raises(ValueError, match="region_code"):
         index.datasets.add(ds_no_region, with_lineage=False, archive_less_mature=0)
@@ -130,19 +130,19 @@ def test_archive_less_mature_approx_timestamp(index, ga_s2am_ard3_final, ga_s2am
 def test_dont_archive_less_mature(index, final_dataset, nrt_dataset):
     # ensure datasets aren't archive if no archive_less_mature value is provided
     index.datasets.add(nrt_dataset, with_lineage=False)
-    index.datasets.get(nrt_dataset.id).is_active
+    assert not index.datasets.get(nrt_dataset.id).is_archived
     index.datasets.add(final_dataset, with_lineage=False, archive_less_mature=None)
-    assert index.datasets.get(nrt_dataset.id).is_active
-    assert index.datasets.get(final_dataset.id).is_active
+    assert not index.datasets.get(nrt_dataset.id).is_archived
+    assert not index.datasets.get(final_dataset.id).is_archived
 
 
 def test_archive_less_mature_bool(index, final_dataset, nrt_dataset):
     # if archive_less_mature value gets passed as a bool via an outdated script
     index.datasets.add(nrt_dataset, with_lineage=False)
-    index.datasets.get(nrt_dataset.id).is_active
+    assert not index.datasets.get(nrt_dataset.id).is_archived
     index.datasets.add(final_dataset, with_lineage=False, archive_less_mature=False)
-    assert index.datasets.get(nrt_dataset.id).is_active
-    assert index.datasets.get(final_dataset.id).is_active
+    assert not index.datasets.get(nrt_dataset.id).is_archived
+    assert not index.datasets.get(final_dataset.id).is_archived
 
 
 def test_purge_datasets(index, ls8_eo3_dataset):

--- a/integration_tests/index/test_null_index.py
+++ b/integration_tests/index/test_null_index.py
@@ -11,10 +11,12 @@ from datacube.cfg import ODCEnvironment
 
 test_uuid = UUID('4ec8fe97-e8b9-11e4-87ff-1040f381a756')
 
+
 def empty(iterable):
     for x in iterable:
         return False
     return True
+
 
 def test_init_null(null_config: ODCEnvironment):
     from datacube.drivers.indexes import index_cache

--- a/integration_tests/index/test_null_index.py
+++ b/integration_tests/index/test_null_index.py
@@ -11,6 +11,10 @@ from datacube.cfg import ODCEnvironment
 
 test_uuid = UUID('4ec8fe97-e8b9-11e4-87ff-1040f381a756')
 
+def empty(iterable):
+    for x in iterable:
+        return False
+    return True
 
 def test_init_null(null_config: ODCEnvironment):
     from datacube.drivers.indexes import index_cache
@@ -24,7 +28,7 @@ def test_init_null(null_config: ODCEnvironment):
 
 def test_null_user_resource(null_config: ODCEnvironment):
     with Datacube(env=null_config, validate_connection=True) as dc:
-        assert dc.index.users.list_users() == []
+        assert empty(dc.index.users.list_users())
         with pytest.raises(NotImplementedError) as e:
             dc.index.users.create_user("user1", "password2", "role1")
         with pytest.raises(NotImplementedError) as e:
@@ -58,7 +62,7 @@ def test_null_product_resource(null_config: ODCEnvironment):
     with Datacube(env=null_config, validate_connection=True) as dc:
         assert dc.index.products.get_all() == []
         assert dc.index.products.search_robust(foo="bar", baz=12) == []
-        assert dc.index.products.get_with_fields(["foo", "bar"]) == []
+        assert empty(dc.index.products.get_with_fields(["foo", "bar"]))
         with pytest.raises(KeyError) as e:
             dc.index.products.get_unsafe(1)
         with pytest.raises(KeyError) as e:
@@ -91,8 +95,8 @@ def test_null_dataset_resource(null_config: ODCEnvironment):
         with pytest.raises(NotImplementedError) as e:
             dc.index.datasets.purge([test_uuid, "foo"])
 
-        assert dc.index.datasets.get_all_dataset_ids(True) == []
-        assert dc.index.datasets.get_field_names() == []
+        assert empty(dc.index.datasets.get_all_dataset_ids(True))
+        assert empty(dc.index.datasets.get_field_names())
         assert dc.index.datasets.get_locations(test_uuid) == []
         assert dc.index.datasets.get_archived_locations(test_uuid) == []
         assert dc.index.datasets.get_archived_location_times(test_uuid) == []

--- a/integration_tests/index/test_null_index.py
+++ b/integration_tests/index/test_null_index.py
@@ -63,6 +63,7 @@ def test_null_product_resource(null_config: ODCEnvironment):
         assert dc.index.products.get_all() == []
         assert dc.index.products.search_robust(foo="bar", baz=12) == []
         assert empty(dc.index.products.get_with_fields(["foo", "bar"]))
+        assert empty(dc.index.products.get_field_names())
         with pytest.raises(KeyError) as e:
             dc.index.products.get_unsafe(1)
         with pytest.raises(KeyError) as e:
@@ -96,7 +97,7 @@ def test_null_dataset_resource(null_config: ODCEnvironment):
             dc.index.datasets.purge([test_uuid, "foo"])
 
         assert empty(dc.index.datasets.get_all_dataset_ids(True))
-        assert empty(dc.index.datasets.get_field_names())
+        assert empty(dc.index.datasets.get_field_names())  # DEPRECATED WRAPPER METHOD
         assert dc.index.datasets.get_locations(test_uuid) == []
         assert dc.index.datasets.get_archived_locations(test_uuid) == []
         assert dc.index.datasets.get_archived_location_times(test_uuid) == []

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -250,7 +250,7 @@ def test_search_by_product_eo3(index: Index,
     [dataset] = products[base_eo3_product_doc["name"]]
     assert dataset.id == wo_eo3_dataset.id
     assert dataset.is_eo3
-    assert dataset.type == dataset.product
+    assert dataset.type == dataset.product  # DEPRECATED MEMBER
 
 
 def test_search_limit_eo3(index, ls8_eo3_dataset, ls8_eo3_dataset2, wo_eo3_dataset):
@@ -816,8 +816,8 @@ def test_find_duplicates_eo3(index,
 def test_find_duplicates_with_time(index, nrt_dataset, final_dataset, ls8_eo3_dataset):
     index.datasets.add(nrt_dataset, with_lineage=False)
     index.datasets.add(final_dataset, with_lineage=False)
-    index.datasets.get(nrt_dataset.id).is_active
-    index.datasets.get(final_dataset.id).is_active
+    assert not index.datasets.get(nrt_dataset.id).is_archived
+    assert not index.datasets.get(final_dataset.id).is_archived
 
     all_datasets = index.datasets.search_eager()
     assert len(all_datasets) == 3

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -22,7 +22,7 @@ def mock_index():
 
 
 def test_query_kwargs(mock_index):
-    mock_index.datasets.get_field_names = lambda: {u'product', u'lat', u'sat_path', 'type_id', u'time', u'lon',
+    mock_index.products.get_field_names = lambda: {u'product', u'lat', u'sat_path', 'type_id', u'time', u'lon',
                                                    u'orbit', u'instrument', u'sat_row', u'platform', 'metadata_type',
                                                    u'gsi', 'type', 'id'}
 

--- a/tests/api/test_virtual.py
+++ b/tests/api/test_virtual.py
@@ -222,7 +222,7 @@ def group_datasets(*args, **kwargs):
 @pytest.fixture
 def dc():
     result = mock.MagicMock()
-    result.index.datasets.get_field_names.return_value = {'id', 'product', 'time'}
+    result.index.products.get_field_names.return_value = {'id', 'product', 'time'}
 
     ids = ['87a68652-b76a-450f-b44f-e5192243218e',
            'af9deddf-daf3-4e93-8f36-21437b52817c',


### PR DESCRIPTION
### Reason for this pull request

Changes to the `MetadataTypeResource` and `ProductResource` APIs, as proposed in EP13.


### Proposed changes

- New `products.get_with_types()` method
- New `metadata.get_with_fields()` method
- Existing `products.get_with_fields()` method implemented in the base class using the above new methods.
- `get_field_names()` moved from DatasetResource to ProductResource.  `datasets.get_field_names()` is now implemented in the base class as a deprecated wrapper method to `products.get_field_names()`.
- Changes to tests and test fixtures for API changes.
-  Cherry pick #1535, mostly for the GHA container repository fix.

 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
