### PR TITLE
Ep13 Dataset API - Phase 1

### DIFF
--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -1499,5 +1499,5 @@ class PostgisDbAPI:
                                 ],
                                 selection='greatest')
         return select(
-            [func.min(time_min.alchemy_expression), func.max(time_max.alchemy_expression)]
+            func.min(time_min.alchemy_expression), func.max(time_max.alchemy_expression)
         )

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -1062,14 +1062,14 @@ class AbstractDatasetResource(ABC):
         self.types = self.products  # types is compatibility alias for products
 
     @abstractmethod
-    def get(self,
-            id_: DSID,
-            include_sources: bool = False,
-            include_deriveds: bool = False,
-            max_depth: int = 0
-            ) -> Optional[Dataset]:
+    def get_unsafe(self,
+                    id_: DSID,
+                    include_sources: bool = False,
+                    include_deriveds: bool = False,
+                    max_depth: int = 0
+                    ) -> Dataset:
         """
-        Get dataset by id
+        Get dataset by id (Raises KeyError if id_ does not exist)
 
         - Index drivers supporting the legacy lineage API:
 
@@ -1085,6 +1085,34 @@ class AbstractDatasetResource(ABC):
         :param max_depth: The maximum depth of the source and/or derived tree.  Defaults to 0, meaning no limit.
         :rtype: Dataset model (None if not found)
         """
+
+    def get(self,
+            id_: DSID,
+            include_sources: bool = False,
+            include_deriveds: bool = False,
+            max_depth: int = 0
+            ) -> Optional[Dataset]:
+        """
+        Get dataset by id (Return None if id_ does not exist.
+
+        - Index drivers supporting the legacy lineage API:
+
+        :param id_: id of the dataset to retrieve
+        :param include_sources: include the full provenance tree of the dataset.
+
+
+        - Index drivers supporting the external lineage API:
+
+        :param id_: id of the dataset to retrieve
+        :param include_sources: include the full provenance tree for the dataset.
+        :param include_deriveds: include the full derivative tree for the dataset.
+        :param max_depth: The maximum depth of the source and/or derived tree.  Defaults to 0, meaning no limit.
+        :rtype: Dataset model (None if not found)
+        """
+        try:
+            return self.get_unsafe(id_, include_sources, include_deriveds, max_depth)
+        except KeyError:
+            return None
 
     def _check_get_legacy(self,
                           include_deriveds: bool = False,

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -1140,6 +1140,10 @@ class AbstractDatasetResource(ABC):
         :return: Iterable of Dataset models
         """
 
+    @deprecat(
+        reason="The 'get_derived' static method is deprecated in favour of the new lineage API.",
+        version='1.9.0',
+        category=ODC2DeprecationWarning)
     @abstractmethod
     def get_derived(self, id_: DSID) -> Iterable[Dataset]:
         """

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -1696,15 +1696,37 @@ class AbstractDatasetResource(ABC):
         return list(self.search(**query))  # type: ignore[arg-type]   # mypy isn't being very smart here :(
 
     @abstractmethod
+    def temporal_extent(self,
+                        product: str | Product | None,
+                        ids: Iterable[DSID] | None
+                        ) -> tuple[datetime.datetime, datetime.datetime]:
+        """
+        Returns the minimum and maximum acquisition time of a product or an iterable of dataset ids.
+
+        Only one ids or products can be passed - the other should be None.  Raises ValueError if
+        both or neither of ids and products is passed.  Raises KeyError if no datasets in the index
+        match the input argument.
+
+        :param product: Product or name of product
+        :param ids: Iterable of dataset ids.
+        :return: minimum and maximum acquisition times
+        """
+
+    @deprecat(
+        reason="This method has been renamed 'temporal_extent'",
+        version="1.9.0",
+        category=ODC2DeprecationWarning
+    )
     def get_product_time_bounds(self,
-                                product: str
-                               ) -> Tuple[datetime.datetime, datetime.datetime]:
+                                product: str | Product
+                               ) -> tuple[datetime.datetime, datetime.datetime]:
         """
         Returns the minimum and maximum acquisition time of the product.
 
-        :param product: Name of product
+        :param product: Product of name of product
         :return: minimum and maximum acquisition times
         """
+        return self.temporal_extent(product=product)
 
     @abstractmethod
     def search_returning_datasets_light(self,

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -1063,11 +1063,11 @@ class AbstractDatasetResource(ABC):
 
     @abstractmethod
     def get_unsafe(self,
-                    id_: DSID,
-                    include_sources: bool = False,
-                    include_deriveds: bool = False,
-                    max_depth: int = 0
-                    ) -> Dataset:
+                   id_: DSID,
+                   include_sources: bool = False,
+                   include_deriveds: bool = False,
+                   max_depth: int = 0
+                   ) -> Dataset:
         """
         Get dataset by id (Raises KeyError if id_ does not exist)
 

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -48,9 +48,9 @@ class DatasetResource(AbstractDatasetResource):
         self.by_product: MutableMapping[str, List[UUID]] = {}
 
     def get_unsafe(self, id_: DSID, include_sources: bool = False,
-            include_deriveds: bool = False, max_depth: int = 0) -> Dataset:
+                   include_deriveds: bool = False, max_depth: int = 0) -> Dataset:
         self._check_get_legacy(include_deriveds, max_depth)
-        ds = self.clone(self.by_id[dsid_to_uuid(id_)])  #  N.B. raises KeyError if id not in index.
+        ds = self.clone(self.by_id[dsid_to_uuid(id_)])  # N.B. raises KeyError if id not in index.
         if include_sources:
             ds.sources = {
                 classifier: cast(Dataset, self.get(dsid, include_sources=True))

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -654,7 +654,7 @@ class DatasetResource(AbstractDatasetResource):
         elif product is not None:
             if isinstance(product, str):
                 product = self._index.products.get_by_name_unsafe(product)
-            ids = self.by_product.get(product, [])
+            ids = self.by_product.get(product.name, [])
 
         min_time: Optional[datetime.datetime] = None
         max_time: Optional[datetime.datetime] = None

--- a/datacube/index/null/_datasets.py
+++ b/datacube/index/null/_datasets.py
@@ -12,8 +12,8 @@ class DatasetResource(AbstractDatasetResource):
     def __init__(self, index):
         super().__init__(index)
 
-    def get(self, id_: DSID, include_sources: bool = False, include_deriveds: bool = False, max_depth: int = 0):
-        return None
+    def get_unsafe(self, id_: DSID, include_sources: bool = False, include_deriveds: bool = False, max_depth: int = 0):
+        raise KeyError(id_)
 
     def bulk_get(self, ids):
         return []

--- a/datacube/index/null/_datasets.py
+++ b/datacube/index/null/_datasets.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2015-2024 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import datetime
+
 from datacube.index.abstract import AbstractDatasetResource, DSID
 from datacube.model import Dataset, Product
 from typing import Iterable, Optional
@@ -104,8 +106,19 @@ class DatasetResource(AbstractDatasetResource):
     def search_summaries(self, **query):
         return []
 
-    def get_product_time_bounds(self, product: str):
-        raise NotImplementedError()
+    def temporal_extent(
+            self,
+            product: str | Product = None,
+            ids: Iterable[DSID] | None = None
+    ) -> tuple[datetime.datetime, datetime.datetime]:
+        if product is None and ids is None:
+            raise ValueError("Must specify product or ids")
+        elif ids is not None and product is not None:
+            raise ValueError("Cannot specify both product and ids")
+        elif ids is not None:
+            raise KeyError(str(ids))
+        else:
+            raise KeyError(str(product))
 
     # pylint: disable=redefined-outer-name
     def search_returning_datasets_light(self, field_names: tuple, custom_offsets=None, limit=None, **query):

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -762,10 +762,10 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         elif product is not None:
             if isinstance(product, str):
                 product = self._index.products.get_by_name_unsafe(product)
-            with self._db_connnection() as connection:
+            with self._db_connection() as connection:
                 result = connection.temporal_extent_by_prod(product.id)
         else:
-            with self._db_connnection() as connection:
+            with self._db_connection() as connection:
                 result = connection.temporal_extent_by_ids(ids)
 
         return result

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -51,10 +51,10 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         self._db = db
         super().__init__(index)
 
-    def get(self, id_: DSID,
-            include_sources: bool = False, include_deriveds: bool = False, max_depth: int = 0) -> Optional[Dataset]:
+    def get_unsafe(self, id_: DSID,
+            include_sources: bool = False, include_deriveds: bool = False, max_depth: int = 0) -> Dataset:
         """
-        Get dataset by id
+        Get dataset by id (raise KeyError if not found)
 
         :param id_: id of the dataset to retrieve
         :param include_sources: include the full provenance tree for the dataset.
@@ -74,7 +74,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         with self._db_connection() as connection:
             dataset = connection.get_dataset(id_)
             if not dataset:
-                return None
+                raise KeyError(id_)
             return self._make(dataset, full_info=True, source_tree=source_tree, derived_tree=derived_tree)
 
     def bulk_get(self, ids):

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -87,6 +87,10 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             rows = connection.get_datasets(ids)
             return [self._make(r, full_info=True) for r in rows]
 
+    @deprecat(
+        reason="The 'get_derived' static method is deprecated in favour of the new lineage API.",
+        version='1.9.0',
+        category=ODC2DeprecationWarning)
     def get_derived(self, id_):
         """
         Get all derived datasets

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -53,7 +53,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         super().__init__(index)
 
     def get_unsafe(self, id_: DSID,
-            include_sources: bool = False, include_deriveds: bool = False, max_depth: int = 0) -> Dataset:
+                   include_sources: bool = False, include_deriveds: bool = False, max_depth: int = 0) -> Dataset:
         """
         Get dataset by id (raise KeyError if not found)
 

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -754,11 +754,10 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             if isinstance(product, str):
                 product = self._index.products.get_by_name_unsafe(product)
         else:
-            raise NotImplementedError("Sorry ids not supported yet.")
+            raise NotImplementedError("Sorry ids not supported in postgres driver.")
 
         # This implementation violates architecture - should not be SQLAlchemy code at this level.
         # Get the offsets from dataset doc
-        product = self.types.get_by_name(product)
         dataset_section = product.metadata_type.definition['dataset']
         min_offset = dataset_section['search_fields']['time']['min_offset']
         max_offset = dataset_section['search_fields']['time']['max_offset']

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -49,7 +49,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         super().__init__(index)
 
     def get_unsafe(self, id_: DSID, include_sources: bool = False,
-            include_deriveds: bool = False, max_depth: int = 0) -> Dataset:
+                   include_deriveds: bool = False, max_depth: int = 0) -> Dataset:
         """
         Get dataset by id (raise KeyError if not in index)
 

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -5,6 +5,7 @@
 """
 API for dataset indexing, access and search.
 """
+import datetime
 import json
 import logging
 import warnings
@@ -737,10 +738,24 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             for columns in results:
                 yield columns._asdict()
 
-    def get_product_time_bounds(self, product: str):
+    def temporal_extent(
+            self,
+            product: str | Product | None = None,
+            ids: Iterable[DSID] | None = None
+    ) -> tuple[datetime.datetime, datetime.datetime]:
         """
         Returns the minimum and maximum acquisition time of the product.
         """
+        if product is None and ids is None:
+            raise ValueError("Must supply product or ids")
+        elif product is not None and ids is not None:
+            raise ValueError("Cannot supply both product and ids")
+        elif product is not None:
+            if isinstance(product, str):
+                product = self._index.products.get_by_name_unsafe(product)
+        else:
+            raise NotImplementedError("Sorry ids not supported yet.")
+
         # This implementation violates architecture - should not be SQLAlchemy code at this level.
         # Get the offsets from dataset doc
         product = self.types.get_by_name(product)

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -47,10 +47,10 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         self._db = db
         super().__init__(index)
 
-    def get(self, id_: DSID, include_sources: bool = False,
-            include_deriveds: bool = False, max_depth: int = 0) -> Optional[Dataset]:
+    def get_unsafe(self, id_: DSID, include_sources: bool = False,
+            include_deriveds: bool = False, max_depth: int = 0) -> Dataset:
         """
-        Get dataset by id
+        Get dataset by id (raise KeyError if not in index)
 
         :param UUID id_: id of the dataset to retrieve
         :param bool include_sources: get the full provenance graph?
@@ -71,7 +71,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
         if not datasets:
             # No dataset found
-            return None
+            raise KeyError(id_)
 
         for dataset, result in datasets.values():
             dataset.metadata.sources = {

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -29,6 +29,7 @@ v1.9.next
 - EP08 lineage extensions/changes to datasets.get(). (:pull:`1530`)
 - EP13 API changes to Index and IndexDriver. (:pull:`1534`)
 - EP13 API changes to metadata and product resources. (:pull:`1536`)
+- Phase 1 of EP13 API changes to dataset resource - get_unsafe, get_derived, temporal_extent. (:pull:`1538`)
 
 
 v1.8.next

--- a/integration_tests/index/test_memory_index.py
+++ b/integration_tests/index/test_memory_index.py
@@ -400,7 +400,8 @@ def test_temporal_extent(mem_eo3_data: ODCEnvironment):
         assert (tmin is None and tmax is None) or tmin < tmax
         tmin2, tmax2 = dc.index.datasets.temporal_extent(product=ds.product)
         assert tmin2 == tmin and tmax2 == tmax
-        tmin2, tmax2 = dc.index.datasets.temporal_extent(ids=[ds.id])
+        ids = [doc["id"] for prod, doc, uris in dc.index.datasets.get_all_docs_for_product(product=ds.product)]
+        tmin2, tmax2 = dc.index.datasets.temporal_extent(ids=ids)
         assert tmin2 == tmin and tmax2 == tmax
 
 

--- a/integration_tests/index/test_null_index.py
+++ b/integration_tests/index/test_null_index.py
@@ -113,6 +113,12 @@ def test_null_dataset_resource(null_config: ODCEnvironment):
             dc.index.datasets.archive_location(test_uuid, "http://a.uri/test")
         with pytest.raises(NotImplementedError) as e:
             dc.index.datasets.restore_location(test_uuid, "http://a.uri/test")
+        with pytest.raises(ValueError) as e:
+            dc.index.datasets.temporal_extent()
+        with pytest.raises(ValueError) as e:
+            dc.index.datasets.temporal_extent(product="product1", ids=[test_uuid])
+        with pytest.raises(KeyError) as e:
+            dc.index.datasets.temporal_extent(ids=[test_uuid])
         with pytest.raises(KeyError) as e:
             dc.index.datasets.get_product_time_bounds("product1")
 

--- a/integration_tests/index/test_null_index.py
+++ b/integration_tests/index/test_null_index.py
@@ -113,7 +113,7 @@ def test_null_dataset_resource(null_config: ODCEnvironment):
             dc.index.datasets.archive_location(test_uuid, "http://a.uri/test")
         with pytest.raises(NotImplementedError) as e:
             dc.index.datasets.restore_location(test_uuid, "http://a.uri/test")
-        with pytest.raises(NotImplementedError) as e:
+        with pytest.raises(KeyError) as e:
             dc.index.datasets.get_product_time_bounds("product1")
 
         assert dc.index.datasets.search_product_duplicates(MagicMock()) == []

--- a/integration_tests/index/test_postgis_index.py
+++ b/integration_tests/index/test_postgis_index.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2015-2024 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+import datetime
 import pytest
 
 from datacube.model import Range
@@ -200,3 +201,23 @@ def test_spatial_search(index,
     assert len(dssids) == 2
     assert ls8_eo3_dataset3.id in dssids
     assert ls8_eo3_dataset3.id in dssids
+
+
+@pytest.mark.parametrize('datacube_env_name', ('experimental',))
+def test_temporal_extents(index,
+        ls8_eo3_dataset, ls8_eo3_dataset2,
+        ls8_eo3_dataset3, ls8_eo3_dataset4):
+    start, end = index.datasets.temporal_extent(product=ls8_eo3_dataset.product)
+    assert start == datetime.datetime(
+        2013, 4, 4, 0, 58, 34, 682275,
+        tzinfo=datetime.timezone.utc)
+    assert end == datetime.datetime(
+        2016, 5, 28, 23, 50, 59, 149573,
+        tzinfo=datetime.timezone.utc)
+    start2, end2 = index.datasets.temporal_extent(product=ls8_eo3_dataset.product.name)
+    assert start == start2 and end == end2
+    start2, end2 = index.datasets.temporal_extent(ids=[
+        ls8_eo3_dataset.id, ls8_eo3_dataset2.id,
+        ls8_eo3_dataset3.id, ls8_eo3_dataset4.id,
+    ])
+    assert start == start2 and end == end2

--- a/integration_tests/index/test_postgis_index.py
+++ b/integration_tests/index/test_postgis_index.py
@@ -205,8 +205,8 @@ def test_spatial_search(index,
 
 @pytest.mark.parametrize('datacube_env_name', ('experimental',))
 def test_temporal_extents(index,
-        ls8_eo3_dataset, ls8_eo3_dataset2,
-        ls8_eo3_dataset3, ls8_eo3_dataset4):
+                          ls8_eo3_dataset, ls8_eo3_dataset2,
+                          ls8_eo3_dataset3, ls8_eo3_dataset4):
     start, end = index.datasets.temporal_extent(product=ls8_eo3_dataset.product)
     assert start == datetime.datetime(
         2013, 4, 4, 0, 58, 34, 682275,

--- a/integration_tests/test_index_datasets_search.py
+++ b/integration_tests/test_index_datasets_search.py
@@ -2,6 +2,8 @@
 #
 # Copyright (c) 2015-2024 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+import datetime
+
 import pytest
 from pathlib import PurePosixPath
 
@@ -132,3 +134,36 @@ def test_index_get_product_time_bounds(index, clirunner, example_ls5_dataset_pat
 
     assert left == time_bounds[0]
     assert right == time_bounds[1]
+
+
+def test_temporal_extent(
+    index, ls8_eo3_dataset, ls8_eo3_dataset2, ls8_eo3_dataset3, ls8_eo3_dataset4
+):
+    with pytest.raises(ValueError):
+        start, end = index.datasets.temporal_extent()
+    with pytest.raises(ValueError):
+        start, end = index.datasets.temporal_extent(
+            product=ls8_eo3_dataset.product,
+            ids=[ls8_eo3_dataset.id, ls8_eo3_dataset2.id, ls8_eo3_dataset3.id, ls8_eo3_dataset4.id]
+        )
+    with pytest.raises(KeyError):
+        start, end = index.datasets.temporal_extent(product="orthentick_produckt")
+
+    start, end = index.datasets.temporal_extent(product=ls8_eo3_dataset.product)
+    assert start == datetime.datetime(
+        2013, 4, 4, 0, 58, 34, 682275,
+        tzinfo=datetime.timezone.utc)
+    assert end == datetime.datetime(
+        2016, 5, 28, 23, 50, 59, 149573,
+        tzinfo=datetime.timezone.utc)
+    start2, end2 = index.datasets.temporal_extent(product=ls8_eo3_dataset.product.name)
+    assert start == start2 and end == end2
+    try:
+        start2, end2 = index.datasets.temporal_extent(ids=[
+            ls8_eo3_dataset.id, ls8_eo3_dataset2.id,
+            ls8_eo3_dataset3.id, ls8_eo3_dataset4.id,
+        ])
+        assert start == start2 and end == end2
+    except NotImplementedError:
+        # Not implemented by postgres driver
+        pass


### PR DESCRIPTION
### Reason for this pull request

First batch of dataset resource API changes from [EP13 - Index Driver API cleanup](https://github.com/opendatacube/datacube-core/wiki/ODC-EP-013-Index-Driver-API-cleanup)


### Proposed changes

- Add new `get_unsafe()` method for consistency with other resources.  Implement `get` with `get_unsafe`
- Add new arguments to `get` and `get_unsafe` for EP8 lineage handling - implement in postgis driver
- Deprecate `get_derived()` method
- Implement `get_product_time_bounds()` with new `temporal_extent` method.  Not fully implemented in postgres driver for "boring technical reasons", as per EP13.


 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
