### PR TITLE
Deprecate search_eager and search_summaries and add archived arg to search/count methods

### DIFF
--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -725,7 +725,7 @@ class PostgisDbAPI:
         return res.rowcount, requested - res.rowcount
 
     @staticmethod
-    def search_unique_datasets_query(expressions, select_fields, limit):
+    def search_unique_datasets_query(expressions, select_fields, limit, archived: bool | None = False):
         """
         'unique' here refer to that the query results do not contain datasets
         having the same 'id' more than once.
@@ -738,7 +738,7 @@ class PostgisDbAPI:
         # TODO
         raise NotImplementedError()
 
-    def search_unique_datasets(self, expressions, select_fields=None, limit=None):
+    def search_unique_datasets(self, expressions, select_fields=None, limit=None, archived: bool | None = False):
         """
         Processes a search query without duplicating datasets.
 
@@ -747,7 +747,7 @@ class PostgisDbAPI:
         dataset_location or dataset_source tables. Joining with other tables would not
         result in multiple records per dataset due to the direction of cardinality.
         """
-        select_query = self.search_unique_datasets_query(expressions, select_fields, limit)
+        select_query = self.search_unique_datasets_query(expressions, select_fields, limit, archived=archived)
 
         return self._connection.execute(select_query)
 

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -719,7 +719,7 @@ class PostgresDbAPI(object):
         return res.rowcount, requested - res.rowcount
 
     @staticmethod
-    def search_unique_datasets_query(expressions, select_fields, limit, archived: bool | None  = False):
+    def search_unique_datasets_query(expressions, select_fields, limit, archived: bool | None = False):
         """
         'unique' here refer to that the query results do not contain datasets
         having the same 'id' more than once.

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -526,6 +526,8 @@ class PostgresDbAPI(object):
         """
 
         if select_fields:
+            # Expand select fields, inserting placeholder columns selections for fields that aren't defined for
+            # this product query.
             select_columns = tuple(
                 f.alchemy_expression.label(f.name) if f is not None else None
                 for f in select_fields
@@ -967,6 +969,7 @@ class PostgresDbAPI(object):
         if expressions:
             join_tables.update(expression.field.required_alchemy_table for expression in expressions)
         if fields:
+            # Ignore placeholder columns
             join_tables.update(field.required_alchemy_table for field in fields if field)
         join_tables.discard(source_table)
 

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -798,7 +798,7 @@ class PostgresDbAPI(object):
         result in multiple records per dataset due to the direction of cardinality.
         """
 
-        select_query = self.search_unique_datasets_query(expressions, select_fields, limit, archivedd=archived)
+        select_query = self.search_unique_datasets_query(expressions, select_fields, limit, archived=archived)
 
         return self._connection.execute(select_query)
 

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -521,7 +521,7 @@ class PostgresDbAPI(object):
 
         if select_fields:
             select_columns = tuple(
-                f.alchemy_expression.label(f.name)
+                f.alchemy_expression.label(f.name) if f is not None else None
                 for f in select_fields
             )
         else:
@@ -934,7 +934,7 @@ class PostgresDbAPI(object):
         if expressions:
             join_tables.update(expression.field.required_alchemy_table for expression in expressions)
         if fields:
-            join_tables.update(field.required_alchemy_table for field in fields)
+            join_tables.update(field.required_alchemy_table for field in fields if field)
         join_tables.discard(source_table)
 
         table_order_hack = [DATASET_SOURCE, DATASET_LOCATION, DATASET, PRODUCT, METADATA_TYPE]

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -1728,7 +1728,7 @@ class AbstractDatasetResource(ABC):
 
     @abstractmethod
     def search_returning(self,
-                         field_names: Iterable[str],
+                         field_names: Iterable[str] | None = None,
                          limit: int | None = None,
                          **query: QueryField
                         ) -> Iterable[tuple]:
@@ -1739,7 +1739,7 @@ class AbstractDatasetResource(ABC):
 
         It also allows for returning rows other than datasets, such as a row per uri when requesting field 'uri'.
 
-        :param field_names: Names of desired fields
+        :param field_names: Names of desired fields (default = all known search fields)
         :param limit: Limit number of dataset (None/default = unlimited)
         :param query: search query parameters
         :return: Namedtuple of requested fields, for each matching dataset.
@@ -1793,6 +1793,12 @@ class AbstractDatasetResource(ABC):
         :returns: The product, a list of time ranges and the count of matching datasets.
         """
 
+    @deprecat(
+        reason="This method is deprecated and will be removed in 2.0.  "
+               "Consider migrating to search_returning()",
+        version="1.9.0",
+        category=ODC2DeprecationWarning
+    )
     @abstractmethod
     def search_summaries(self, **query: QueryField) -> Iterable[Mapping[str, Any]]:
         """
@@ -1802,6 +1808,12 @@ class AbstractDatasetResource(ABC):
         :return: Mappings of search fields for matching datasets
         """
 
+    @deprecat(
+        reason="This method is deprecated and will be removed in 2.0.  "
+               "Please use list(dc.index.datasets.search(...)) instead",
+        version="1.9.0",
+        category=ODC2DeprecationWarning
+    )
     def search_eager(self, **query: QueryField) -> Iterable[Dataset]:
         """
         Perform a search, returning results as Dataset objects.

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -37,28 +37,28 @@ class DatasetResource(AbstractDatasetResource):
     def __init__(self, index: AbstractIndex) -> None:
         super().__init__(index)
         # Main dataset index
-        self.by_id: MutableMapping[UUID, Dataset] = {}
+        self._by_id: MutableMapping[UUID, Dataset] = {}
         # Indexes for active and archived datasets
-        self.active_by_id: MutableMapping[UUID, Dataset] = {}
-        self.archived_by_id: MutableMapping[UUID, Dataset] = {}
+        self._active_by_id: MutableMapping[UUID, Dataset] = {}
+        self._archived_by_id: MutableMapping[UUID, Dataset] = {}
         # Lineage indexes:
-        self.derived_from: MutableMapping[UUID, MutableMapping[str, UUID]] = {}
-        self.derivations: MutableMapping[UUID, MutableMapping[str, UUID]] = {}
+        self._derived_from: MutableMapping[UUID, MutableMapping[str, UUID]] = {}
+        self._derivations: MutableMapping[UUID, MutableMapping[str, UUID]] = {}
         # Location registers
-        self.locations: MutableMapping[UUID, List[str]] = {}
-        self.archived_locations: MutableMapping[UUID, List[Tuple[str, datetime.datetime]]] = {}
+        self._locations: MutableMapping[UUID, List[str]] = {}
+        self._archived_locations: MutableMapping[UUID, List[Tuple[str, datetime.datetime]]] = {}
         # Active Index By Product
-        self.by_product: MutableMapping[str, set[UUID]] = {}
-        self.archived_by_product: MutableMapping[str, set[UUID]] = {}
+        self._by_product: MutableMapping[str, set[UUID]] = {}
+        self._archived_by_product: MutableMapping[str, set[UUID]] = {}
 
     def get_unsafe(self, id_: DSID, include_sources: bool = False,
                    include_deriveds: bool = False, max_depth: int = 0) -> Dataset:
         self._check_get_legacy(include_deriveds, max_depth)
-        ds = self.clone(self.by_id[dsid_to_uuid(id_)])  # N.B. raises KeyError if id not in index.
+        ds = self.clone(self._by_id[dsid_to_uuid(id_)])  # N.B. raises KeyError if id not in index.
         if include_sources:
             ds.sources = {
                 classifier: cast(Dataset, self.get(dsid, include_sources=True))
-                for classifier, dsid in self.derived_from.get(ds.id, {}).items()
+                for classifier, dsid in self._derived_from.get(ds.id, {}).items()
             }
         return ds
 
@@ -66,10 +66,10 @@ class DatasetResource(AbstractDatasetResource):
         return (ds for ds in (self.get(dsid) for dsid in ids) if ds is not None)
 
     def get_derived(self, id_: DSID) -> Iterable[Dataset]:
-        return (cast(Dataset, self.get(dsid)) for dsid in self.derivations.get(dsid_to_uuid(id_), {}).values())
+        return (cast(Dataset, self.get(dsid)) for dsid in self._derivations.get(dsid_to_uuid(id_), {}).values())
 
     def has(self, id_: DSID) -> bool:
-        return dsid_to_uuid(id_) in self.by_id
+        return dsid_to_uuid(id_) in self._by_id
 
     def bulk_has(self, ids_: Iterable[DSID]) -> Iterable[bool]:
         return (self.has(id_) for id_ in ids_)
@@ -93,42 +93,42 @@ class DatasetResource(AbstractDatasetResource):
                 _LOG.warning("Dataset %s is already in the database", dataset.id)
                 return dataset
             persistable = self.clone(dataset, for_save=True)
-            self.by_id[persistable.id] = persistable
-            self.active_by_id[persistable.id] = persistable
+            self._by_id[persistable.id] = persistable
+            self._active_by_id[persistable.id] = persistable
             if dataset._uris:
-                self.locations[persistable.id] = dataset._uris.copy()
+                self._locations[persistable.id] = dataset._uris.copy()
             else:
-                self.locations[persistable.id] = []
-            self.archived_locations[persistable.id] = []
-            if dataset.product.name in self.by_product:
-                self.by_product[dataset.product.name].add(dataset.id)
+                self._locations[persistable.id] = []
+            self._archived_locations[persistable.id] = []
+            if dataset.product.name in self._by_product:
+                self._by_product[dataset.product.name].add(dataset.id)
             else:
-                self.by_product[dataset.product.name] = set([dataset.id])
+                self._by_product[dataset.product.name] = set([dataset.id])
         if archive_less_mature is not None:
             _LOG.warning("archive-less-mature functionality is not implemented for memory driver")
         return cast(Dataset, self.get(dataset.id))
 
     def persist_source_relationship(self, ds: Dataset, src: Dataset, classifier: str) -> None:
         # Add source lineage link
-        if ds.id not in self.derived_from:
-            self.derived_from[ds.id] = {}
-        if self.derived_from[ds.id].get(classifier, src.id) != src.id:
+        if ds.id not in self._derived_from:
+            self._derived_from[ds.id] = {}
+        if self._derived_from[ds.id].get(classifier, src.id) != src.id:
             _LOG.warning("Dataset %s: Old %s dataset source %s getting overwritten by %s",
                          ds.id,
                          classifier,
-                         self.derived_from[ds.id][classifier],
+                         self._derived_from[ds.id][classifier],
                          src.id)
-        self.derived_from[ds.id][classifier] = src.id
+        self._derived_from[ds.id][classifier] = src.id
         # Add source back-link
-        if src.id not in self.derivations:
-            self.derivations[src.id] = {}
-        if self.derivations[src.id].get(classifier, ds.id) != ds.id:
+        if src.id not in self._derivations:
+            self._derivations[src.id] = {}
+        if self._derivations[src.id].get(classifier, ds.id) != ds.id:
             _LOG.warning("Dataset %s: Old %s dataset derivation %s getting overwritten by %s",
                          src.id,
                          classifier,
-                         self.derivations[src.id][classifier],
+                         self._derivations[src.id][classifier],
                          ds.id)
-        self.derivations[src.id][classifier] = ds.id
+        self._derivations[src.id][classifier] = ds.id
 
     def search_product_duplicates(self,
                                   product: Product,
@@ -156,7 +156,7 @@ class DatasetResource(AbstractDatasetResource):
             return GroupedVals(*vals)
 
         dups: Dict[Tuple, set[UUID]] = {}
-        for ds in self.active_by_id.values():
+        for ds in self._active_by_id.values():
             if ds.product.name != product.name:
                 continue
             vals = values(ds)
@@ -235,8 +235,8 @@ class DatasetResource(AbstractDatasetResource):
         _LOG.info("Updating dataset %s", dataset.id)
         self._update_locations(dataset, existing)
         persistable = self.clone(dataset, for_save=True)
-        self.by_id[dataset.id] = persistable
-        self.active_by_id[dataset.id] = persistable
+        self._by_id[dataset.id] = persistable
+        self._active_by_id[dataset.id] = persistable
         if archive_less_mature is not None:
             _LOG.warning("archive-less-mature functionality is not implemented for memory driver")
         return cast(Dataset, self.get(dataset.id))
@@ -261,47 +261,47 @@ class DatasetResource(AbstractDatasetResource):
     def archive(self, ids: Iterable[DSID]) -> None:
         for id_ in ids:
             id_ = dsid_to_uuid(id_)
-            if id_ in self.active_by_id:
-                ds = self.active_by_id.pop(id_)
-                self.by_product[ds.product.name].remove(ds.id)
-                if ds.product.name not in self.archived_by_product:
-                    self.archived_by_product[ds.product.name] = set([ds.id])
+            if id_ in self._active_by_id:
+                ds = self._active_by_id.pop(id_)
+                self._by_product[ds.product.name].remove(ds.id)
+                if ds.product.name not in self._archived_by_product:
+                    self._archived_by_product[ds.product.name] = set([ds.id])
                 else:
-                    self.archived_by_product[ds.product.name].add(ds.id)
+                    self._archived_by_product[ds.product.name].add(ds.id)
                 ds.archived_time = datetime.datetime.now()
-                self.archived_by_id[id_] = ds
+                self._archived_by_id[id_] = ds
 
     def restore(self, ids: Iterable[DSID]) -> None:
         for id_ in ids:
             id_ = dsid_to_uuid(id_)
-            if id_ in self.archived_by_id:
-                ds = self.archived_by_id.pop(id_)
+            if id_ in self._archived_by_id:
+                ds = self._archived_by_id.pop(id_)
                 ds.archived_time = None
-                self.active_by_id[id_] = ds
-                self.archived_by_product[ds.product.name].remove(ds.id)
-                self.by_product[ds.product.name].add(ds.id)
+                self._active_by_id[id_] = ds
+                self._archived_by_product[ds.product.name].remove(ds.id)
+                self._by_product[ds.product.name].add(ds.id)
 
     def purge(self, ids: Iterable[DSID]) -> None:
         for id_ in ids:
             id_ = dsid_to_uuid(id_)
-            if id_ in self.archived_by_id:
-                ds = self.archived_by_id.pop(id_)
-                del self.by_id[id_]
-                if id_ in self.derived_from:
-                    for classifier, src_id in self.derived_from[id_].items():
-                        del self.derivations[src_id][classifier]
-                    del self.derived_from[id_]
-                if id_ in self.derivations:
-                    for classifier, child_id in self.derivations[id_].items():
-                        del self.derived_from[child_id][classifier]
-                    del self.derivations[id_]
-                self.archived_by_product[ds.product.name].remove(id_)
+            if id_ in self._archived_by_id:
+                ds = self._archived_by_id.pop(id_)
+                del self._by_id[id_]
+                if id_ in self._derived_from:
+                    for classifier, src_id in self._derived_from[id_].items():
+                        del self._derivations[src_id][classifier]
+                    del self._derived_from[id_]
+                if id_ in self._derivations:
+                    for classifier, child_id in self._derivations[id_].items():
+                        del self._derived_from[child_id][classifier]
+                    del self._derivations[id_]
+                self._archived_by_product[ds.product.name].remove(id_)
 
     def get_all_dataset_ids(self, archived: bool) -> Iterable[UUID]:
         if archived:
-            return (id_ for id_ in self.archived_by_id.keys())
+            return (id_ for id_ in self._archived_by_id.keys())
         else:
-            return (id_ for id_ in self.active_by_id.keys())
+            return (id_ for id_ in self._active_by_id.keys())
 
     @deprecat(
         reason="Multiple locations per dataset are now deprecated.  Please use the 'get_location' method.",
@@ -310,11 +310,11 @@ class DatasetResource(AbstractDatasetResource):
     )
     def get_locations(self, id_: DSID) -> Iterable[str]:
         uuid = dsid_to_uuid(id_)
-        return (s for s in self.locations[uuid])
+        return (s for s in self._locations[uuid])
 
     def get_location(self, id_: DSID) -> str:
         uuid = dsid_to_uuid(id_)
-        locations = [s for s in self.locations.get(uuid, [])]
+        locations = [s for s in self._locations.get(uuid, [])]
         if not locations:
             return None
         return locations[0]
@@ -327,7 +327,7 @@ class DatasetResource(AbstractDatasetResource):
     )
     def get_archived_locations(self, id_: DSID) -> Iterable[str]:
         uuid = dsid_to_uuid(id_)
-        return (s for s, dt in self.archived_locations[uuid])
+        return (s for s, dt in self._archived_locations[uuid])
 
     @deprecat(
         reason="Multiple locations per dataset are now deprecated. "
@@ -337,7 +337,7 @@ class DatasetResource(AbstractDatasetResource):
     )
     def get_archived_location_times(self, id_: DSID) -> Iterable[Tuple[str, datetime.datetime]]:
         uuid = dsid_to_uuid(id_)
-        return ((s, dt) for s, dt in self.archived_locations[uuid])
+        return ((s, dt) for s, dt in self._archived_locations[uuid])
 
     @deprecat(
         reason="Multiple locations per dataset are now deprecated. "
@@ -347,15 +347,15 @@ class DatasetResource(AbstractDatasetResource):
     )
     def add_location(self, id_: DSID, uri: str) -> bool:
         uuid = dsid_to_uuid(id_)
-        if uuid not in self.by_id:
+        if uuid not in self._by_id:
             warnings.warn(f"dataset {id_} is not an active dataset")
             return False
         if not uri:
             warnings.warn(f"Cannot add empty uri. (dataset {id_})")
             return False
-        if uri in self.locations[uuid]:
+        if uri in self._locations[uuid]:
             return False
-        self.locations[uuid].append(uri)
+        self._locations[uuid].append(uri)
         return True
 
     def get_datasets_for_location(self, uri: str, mode: Optional[str] = None) -> Iterable[Dataset]:
@@ -368,7 +368,7 @@ class DatasetResource(AbstractDatasetResource):
             test: Callable[[str], bool] = lambda l: l == uri  # noqa: E741
         else:
             test = lambda l: l.startswith(uri)  # noqa: E741,E731
-        for id_, locs in self.locations.items():
+        for id_, locs in self._locations.items():
             for loc in locs:
                 if test(loc):
                     ids.add(id_)
@@ -384,17 +384,17 @@ class DatasetResource(AbstractDatasetResource):
     def remove_location(self, id_: DSID, uri: str) -> bool:
         uuid = dsid_to_uuid(id_)
         removed = False
-        if uuid in self.locations:
-            old_locations = self.locations[uuid]
+        if uuid in self._locations:
+            old_locations = self._locations[uuid]
             new_locations = [loc for loc in old_locations if loc != uri]
             if len(new_locations) != len(old_locations):
-                self.locations[uuid] = new_locations
+                self._locations[uuid] = new_locations
                 removed = True
-        if not removed and uuid in self.archived_locations:
-            archived_locations = self.archived_locations[uuid]
+        if not removed and uuid in self._archived_locations:
+            archived_locations = self._archived_locations[uuid]
             new_archived_locations = [(loc, dt) for loc, dt in archived_locations if loc != uri]
             if len(new_archived_locations) != len(archived_locations):
-                self.archived_locations[uuid] = new_archived_locations
+                self._archived_locations[uuid] = new_archived_locations
                 removed = True
         return removed
 
@@ -407,14 +407,14 @@ class DatasetResource(AbstractDatasetResource):
     )
     def archive_location(self, id_: DSID, uri: str) -> bool:
         uuid = dsid_to_uuid(id_)
-        if uuid not in self.locations:
+        if uuid not in self._locations:
             return False
-        old_locations = self.locations[uuid]
+        old_locations = self._locations[uuid]
         new_locations = [loc for loc in old_locations if loc != uri]
         if len(new_locations) == len(old_locations):
             return False
-        self.locations[uuid] = new_locations
-        self.archived_locations[uuid].append((uri, datetime.datetime.now()))
+        self._locations[uuid] = new_locations
+        self._archived_locations[uuid].append((uri, datetime.datetime.now()))
         return True
 
     @deprecat(
@@ -426,18 +426,18 @@ class DatasetResource(AbstractDatasetResource):
     )
     def restore_location(self, id_: DSID, uri: str) -> bool:
         uuid = dsid_to_uuid(id_)
-        if uuid not in self.archived_locations:
+        if uuid not in self._archived_locations:
             return False
-        old_locations = self.archived_locations[uuid]
+        old_locations = self._archived_locations[uuid]
         new_locations = [(loc, dt) for loc, dt in old_locations if loc != uri]
         if len(new_locations) == len(old_locations):
             return False
-        self.archived_locations[uuid] = new_locations
-        self.locations[uuid].append(uri)
+        self._archived_locations[uuid] = new_locations
+        self._locations[uuid].append(uri)
         return True
 
     def search_by_metadata(self, metadata: Mapping[str, QueryField], archived: bool | None = False):
-        for ds in self.active_by_id.values():
+        for ds in self._active_by_id.values():
             if metadata_subset(metadata, ds.metadata_doc):
                 if archived is None:
                     yield ds
@@ -484,13 +484,13 @@ class DatasetResource(AbstractDatasetResource):
 
             if archived is None:
                 dsids = chain(
-                    self.archived_by_product.get(product.name, set()),
-                    self.by_product.get(product.name, set())
+                    self._archived_by_product.get(product.name, set()),
+                    self._by_product.get(product.name, set())
                 )
             elif archived:
-                dsids = self.archived_by_product.get(product.name, set())
+                dsids = self._archived_by_product.get(product.name, set())
             else:
-                dsids = self.by_product.get(product.name, set())
+                dsids = self._by_product.get(product.name, set())
 
             for dsid in dsids:
                 if limit is not None and matches >= limit:
@@ -812,7 +812,7 @@ class DatasetResource(AbstractDatasetResource):
         if for_save:
             uris = []
         elif lookup_locations:
-            uris = self.locations[orig.id].copy()
+            uris = self._locations[orig.id].copy()
         elif orig.uris:
             uris = orig.uris.copy()
         else:
@@ -835,7 +835,7 @@ class DatasetResource(AbstractDatasetResource):
     # Lineage methods need to be implemented on the dataset resource as that is where the relevant indexes
     # currently live.
     def _get_all_lineage(self) -> Iterable[LineageRelation]:
-        for derived_id, sources in self.derived_from.items():
+        for derived_id, sources in self._derived_from.items():
             for classifier, source_id in sources.items():
                 yield LineageRelation(
                     derived_id=derived_id,
@@ -848,22 +848,22 @@ class DatasetResource(AbstractDatasetResource):
         b_skipped = 0
         b_started = monotonic()
         for rel in batch_rels:
-            if rel.derived_id in self.derived_from:
-                if (rel.classifier in self.derived_from[rel.derived_id]
-                        and self.derived_from[rel.derived_id][rel.classifier] != rel.source_id):
+            if rel.derived_id in self._derived_from:
+                if (rel.classifier in self._derived_from[rel.derived_id]
+                        and self._derived_from[rel.derived_id][rel.classifier] != rel.source_id):
                     b_skipped += 1
                     continue
                 else:
-                    self.derived_from[rel.derived_id][rel.classifier] = rel.source_id
+                    self._derived_from[rel.derived_id][rel.classifier] = rel.source_id
                     b_added += 1
             else:
-                self.derived_from[rel.derived_id] = {rel.classifier: rel.source_id}
+                self._derived_from[rel.derived_id] = {rel.classifier: rel.source_id}
                 b_added += 1
 
-            if rel.source_id in self.derivations:
-                self.derivations[rel.source_id][rel.classifier] = rel.derived_id
+            if rel.source_id in self._derivations:
+                self._derivations[rel.source_id][rel.classifier] = rel.derived_id
             else:
-                self.derivations[rel.source_id] = {rel.classifier: rel.derived_id}
+                self._derivations[rel.source_id] = {rel.classifier: rel.derived_id}
 
         return BatchStatus(b_added, b_skipped, monotonic()-b_started)
 

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -569,7 +569,9 @@ class DatasetResource(AbstractDatasetResource):
             self._search_flat(limit=limit, source_filter=source_filter, archived=archived, **query)
         )
 
-    def search_by_product(self, archived: bool | None = False, **query: QueryField) -> Iterable[Tuple[Iterable[Dataset], Product]]:
+    def search_by_product(self,
+                          archived: bool | None = False,
+                          **query: QueryField) -> Iterable[Tuple[Iterable[Dataset], Product]]:
         return self._search_grouped(archived=archived, **query)  # type: ignore[arg-type]
 
     def search_returning(self,

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -349,6 +349,12 @@ class DatasetResource(AbstractDatasetResource):
         self.locations[uuid].append(uri)
         return True
 
+    @deprecat(
+        reason="Multiple locations per dataset are now deprecated. "
+               "Dataset location can be set or updated with the update() method.",
+        version="1.9.0",
+        category=ODC2DeprecationWarning
+    )
     def get_datasets_for_location(self, uri: str, mode: Optional[str] = None) -> Iterable[Dataset]:
         if mode is None:
             mode = 'exact' if uri.count('#') > 0 else 'prefix'

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -437,12 +437,18 @@ class DatasetResource(AbstractDatasetResource):
         return True
 
     def search_by_metadata(self, metadata: Mapping[str, QueryField], archived: bool | None = False):
-        for ds in self._active_by_id.values():
+        if archived:
+            # True: Return archived datasets only
+            dss = self._archived_by_id.values()
+        elif archived is not None:
+            # False: Return active datasets only
+            dss = self._active_by_id.values()
+        else:
+            # True: Return archived datasets only
+            dss = chain(self._active_by_id.values(), self._archived_by_id.values())
+        for ds in dss:
             if metadata_subset(metadata, ds.metadata_doc):
-                if archived is None:
-                    yield ds
-                elif archived and ds.is_archived or not (archived or ds.is_archived):
-                    yield ds
+                yield ds
 
     RET_FORMAT_DATASETS = 0
     RET_FORMAT_PRODUCT_GROUPED = 1

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -559,6 +559,16 @@ class DatasetResource(AbstractDatasetResource):
     def _get_prod_queries(self, **query: QueryField) -> Iterable[Tuple[Mapping[str, QueryField], Product]]:
         return ((q, product) for product, q in self._index.products.search_robust(**query))
 
+    @deprecat(
+        deprecated_args={
+            "source_filter": {
+                "reason": "Filtering by source metadata is deprecated and will be removed in future.",
+                "version": "1.9.0",
+                "category": ODC2DeprecationWarning
+
+            }
+        }
+    )
     def search(self,
                limit: Optional[int] = None,
                source_filter: Optional[Mapping[str, QueryField]] = None,

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -349,12 +349,6 @@ class DatasetResource(AbstractDatasetResource):
         self.locations[uuid].append(uri)
         return True
 
-    @deprecat(
-        reason="Multiple locations per dataset are now deprecated. "
-               "Dataset location can be set or updated with the update() method.",
-        version="1.9.0",
-        category=ODC2DeprecationWarning
-    )
     def get_datasets_for_location(self, uri: str, mode: Optional[str] = None) -> Iterable[Dataset]:
         if mode is None:
             mode = 'exact' if uri.count('#') > 0 else 'prefix'

--- a/datacube/index/memory/_products.py
+++ b/datacube/index/memory/_products.py
@@ -36,7 +36,7 @@ class ProductResource(AbstractProductResource):
                 f'Metadata Type {product.name}'
             )
         else:
-            mdt = self.metadata_type_resource.get_by_name(product.metadata_type.name)
+            mdt = self._index.metadata_types.get_by_name(product.metadata_type.name)
             if mdt is None:
                 _LOG.warning(f'Adding metadata_type "{product.metadata_type.name}" as it doesn\'t exist')
                 product.metadata_type = self._index.metadata_types.add(product.metadata_type,

--- a/datacube/index/memory/_products.py
+++ b/datacube/index/memory/_products.py
@@ -36,7 +36,7 @@ class ProductResource(AbstractProductResource):
                 f'Metadata Type {product.name}'
             )
         else:
-            mdt = self._index.metadata_types.get_by_name(product.metadata_type.name)
+            mdt = self.metadata_type_resource.get_by_name(product.metadata_type.name)
             if mdt is None:
                 _LOG.warning(f'Adding metadata_type "{product.metadata_type.name}" as it doesn\'t exist')
                 product.metadata_type = self._index.metadata_types.add(product.metadata_type,

--- a/datacube/index/memory/_products.py
+++ b/datacube/index/memory/_products.py
@@ -179,5 +179,5 @@ class ProductResource(AbstractProductResource):
     def temporal_extent(self, product: str | Product) -> tuple[datetime.datetime, datetime.datetime]:
         if isinstance(product, str):
             product = self._index.products.get_by_name_unsafe(product)
-        ids = self._index.datasets.by_product.get(product.name, [])
+        ids = self._index.datasets._by_product.get(product.name, [])
         return self._index.datasets.temporal_extent(ids)

--- a/datacube/index/null/_datasets.py
+++ b/datacube/index/null/_datasets.py
@@ -130,6 +130,16 @@ class DatasetResource(AbstractDatasetResource):
     def search_by_metadata(self, metadata, archived=False):
         return []
 
+    @deprecat(
+        deprecated_args={
+            "source_filter": {
+                "reason": "Filtering by source metadata is deprecated and will be removed in future.",
+                "version": "1.9.0",
+                "category": ODC2DeprecationWarning
+
+            }
+        }
+    )
     def search(self, limit=None, archived=False, **query):
         return []
 

--- a/datacube/index/null/_datasets.py
+++ b/datacube/index/null/_datasets.py
@@ -136,7 +136,7 @@ class DatasetResource(AbstractDatasetResource):
     def search_by_product(self, **query):
         return []
 
-    def search_returning(self, field_names, limit=None, **query):
+    def search_returning(self, field_names=None, limit=None, **query):
         return []
 
     def count(self, **query):
@@ -151,6 +151,12 @@ class DatasetResource(AbstractDatasetResource):
     def count_product_through_time(self, period, **query):
         return []
 
+    @deprecat(
+        reason="This method is deprecated and will be removed in 2.0.  "
+               "Consider migrating to search_returning()",
+        version="1.9.0",
+        category=ODC2DeprecationWarning
+    )
     def search_summaries(self, **query):
         return []
 

--- a/datacube/index/null/_datasets.py
+++ b/datacube/index/null/_datasets.py
@@ -161,5 +161,5 @@ class DatasetResource(AbstractDatasetResource):
     def search_returning_datasets_light(self, field_names: tuple, custom_offsets=None, limit=None, **query):
         return []
 
-    def spatial_extent(self, ids, crs=None):
+    def spatial_extent(self, ids=None, product=None, crs=None):
         return None

--- a/datacube/index/null/_datasets.py
+++ b/datacube/index/null/_datasets.py
@@ -127,28 +127,28 @@ class DatasetResource(AbstractDatasetResource):
     def restore_location(self, id_, uri):
         raise NotImplementedError()
 
-    def search_by_metadata(self, metadata):
+    def search_by_metadata(self, metadata, archived=False):
         return []
 
-    def search(self, limit=None, **query):
+    def search(self, limit=None, archived=False, **query):
         return []
 
-    def search_by_product(self, **query):
+    def search_by_product(self, archived=False, **query):
         return []
 
-    def search_returning(self, field_names=None, limit=None, **query):
+    def search_returning(self, field_names=None, limit=None, archived=False, **query):
         return []
 
-    def count(self, **query):
+    def count(self, archived=False, **query):
         return 0
 
-    def count_by_product(self, **query):
+    def count_by_product(self, archived=False, **query):
         return []
 
-    def count_by_product_through_time(self, period, **query):
+    def count_by_product_through_time(self, period, archived=False, **query):
         return []
 
-    def count_product_through_time(self, period, **query):
+    def count_product_through_time(self, period, archived=False, **query):
         return []
 
     @deprecat(
@@ -164,7 +164,9 @@ class DatasetResource(AbstractDatasetResource):
         raise KeyError(str(ids))
 
     # pylint: disable=redefined-outer-name
-    def search_returning_datasets_light(self, field_names: tuple, custom_offsets=None, limit=None, **query):
+    def search_returning_datasets_light(self,
+                                        field_names: tuple,
+                                        custom_offsets=None, limit=None, archived=False, **query):
         return []
 
     def spatial_extent(self, ids=None, product=None, crs=None):

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -766,6 +766,8 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                     select_fields = tuple(field for name, field in dataset_fields.items()
                                           if not field.affects_row_selection)
                 else:
+                    # Allow place holder columns for requested fields that are not
+                    # valid for this product query.
                     select_fields = tuple(dataset_fields[field_name]
                                           for field_name in select_field_names
                                           if field_name in dataset_fields)

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -616,6 +616,16 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             for dataset in self._make_many(connection.search_datasets_by_metadata(metadata, archived)):
                 yield dataset
 
+    @deprecat(
+        deprecated_args={
+            "source_filter": {
+                "reason": "Filtering by source metadata is deprecated and will be removed in future.",
+                "version": "1.9.0",
+                "category": ODC2DeprecationWarning
+
+            }
+        }
+    )
     def search(self, limit=None, archived: bool | None = False, **query):
         """
         Perform a search, returning results as Dataset objects.

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -671,7 +671,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                 }
                 yield result_type(**kwargs)
 
-    def count(self, **query):
+    def count(self, archived: bool | None = False, **query):
         """
         Perform a search, returning count of results.
 
@@ -680,12 +680,12 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         """
         # This may be optimised into one query in the future.
         result = 0
-        for product_type, count in self._do_count_by_product(query):
+        for product_type, count in self._do_count_by_product(query, archived=archived):
             result += count
 
         return result
 
-    def count_by_product(self, **query):
+    def count_by_product(self, archived: bool | None = False, **query):
         """
         Perform a search, returning a count of for each matching product type.
 
@@ -693,7 +693,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         :returns: Sequence of (product, count)
         :rtype: __generator[(Product,  int)]]
         """
-        return self._do_count_by_product(query)
+        return self._do_count_by_product(query, archived=archived)
 
     def count_by_product_through_time(self, period, **query):
         """
@@ -770,14 +770,14 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                            archived=archived
                        ))
 
-    def _do_count_by_product(self, query):
+    def _do_count_by_product(self, query, archived: bool | None = False):
         product_queries = self._get_product_queries(query)
 
         for q, product in product_queries:
             dataset_fields = product.metadata_type.dataset_fields
             query_exprs = tuple(fields.to_expressions(dataset_fields.get, **q))
             with self._db_connection() as connection:
-                count = connection.count_datasets(query_exprs)
+                count = connection.count_datasets(query_exprs, archived=archived)
             if count > 0:
                 yield product, count
 

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -830,7 +830,9 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                 yield output
 
     # pylint: disable=redefined-outer-name
-    def search_returning_datasets_light(self, field_names: tuple, custom_offsets=None, limit=None, **query):
+    def search_returning_datasets_light(self, field_names: tuple, custom_offsets=None,
+                                        limit=None, archived: bool | None = False,
+                                        **query):
         """
         This is a dataset search function that returns the results as objects of a dynamically
         generated Dataset class that is a subclass of tuple.
@@ -876,7 +878,8 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                 results = connection.search_unique_datasets(
                     query_exprs,
                     select_fields=select_fields,
-                    limit=limit
+                    limit=limit,
+                    archived=archived
                 )
 
             for result in results:

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -22,7 +22,8 @@ from datacube.drivers.postgis._api import non_native_fields, extract_dataset_fie
 from datacube.utils.uris import split_uri
 from datacube.drivers.postgis._spatial import generate_dataset_spatial_values, extract_geometry_from_eo3_projection
 from datacube.migration import ODC2DeprecationWarning
-from datacube.index.abstract import AbstractDatasetResource, DatasetSpatialMixin, DSID, BatchStatus, DatasetTuple
+from datacube.index.abstract import AbstractDatasetResource, DatasetSpatialMixin, DSID, BatchStatus, DatasetTuple, \
+    JsonDict
 from datacube.index.postgis._transaction import IndexResourceAddIn
 from datacube.model import Dataset, Product, Range, LineageTree
 from datacube.model.fields import Field
@@ -602,7 +603,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         """
         return (self._make(dataset, product=product) for dataset in query_result)
 
-    def search_by_metadata(self, metadata):
+    def search_by_metadata(self, metadata: JsonDict, archived: bool | None = False):
         """
         Perform a search using arbitrary metadata, returning results as Dataset objects.
 
@@ -612,7 +613,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         :rtype: list[Dataset]
         """
         with self._db_connection() as connection:
-            for dataset in self._make_many(connection.search_datasets_by_metadata(metadata)):
+            for dataset in self._make_many(connection.search_datasets_by_metadata(metadata, archived)):
                 yield dataset
 
     def search(self, limit=None, **query):

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -616,7 +616,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             for dataset in self._make_many(connection.search_datasets_by_metadata(metadata, archived)):
                 yield dataset
 
-    def search(self, limit=None, **query):
+    def search(self, limit=None, archived: bool | None = False, **query):
         """
         Perform a search, returning results as Dataset objects.
 
@@ -627,20 +627,21 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         source_filter = query.pop('source_filter', None)
         for product, datasets in self._do_search_by_product(query,
                                                             source_filter=source_filter,
-                                                            limit=limit):
+                                                            limit=limit,
+                                                            archived=archived):
             yield from self._make_many(datasets, product)
 
-    def search_by_product(self, **query):
+    def search_by_product(self, archived: bool | None = False, **query):
         """
         Perform a search, returning datasets grouped by product type.
 
         :param dict[str,str|float|datacube.model.Range] query:
         :rtype: __generator[(Product,  __generator[Dataset])]]
         """
-        for product, datasets in self._do_search_by_product(query):
+        for product, datasets in self._do_search_by_product(query, archived=archived):
             yield product, self._make_many(datasets, product)
 
-    def search_returning(self, field_names=None, limit=None, **query):
+    def search_returning(self, field_names=None, limit=None, archived: bool | None = False, **query):
         """
         Perform a search, returning only the specified fields.
 
@@ -660,7 +661,8 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         for _, results in self._do_search_by_product(query,
                                                      return_fields=True,
                                                      select_field_names=field_names,
-                                                     limit=limit):
+                                                     limit=limit,
+                                                     archived=archived):
             for columns in results:
                 coldict = columns._asdict()
                 kwargs = {
@@ -726,8 +728,8 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
     # pylint: disable=too-many-locals
     def _do_search_by_product(self, query, return_fields=False, select_field_names=None,
-                              with_source_ids=False, source_filter=None,
-                              limit=None):
+                              with_source_ids=False, source_filter=None, limit=None,
+                              archived: bool | None = False):
         assert not with_source_ids
         assert source_filter is None
         product_queries = list(self._get_product_queries(query))
@@ -764,7 +766,8 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                            select_fields=select_fields,
                            limit=limit,
                            with_source_ids=with_source_ids,
-                           geom=geom
+                           geom=geom,
+                           archived=archived
                        ))
 
     def _do_count_by_product(self, query):
@@ -813,14 +816,14 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         version="1.9.0",
         category=ODC2DeprecationWarning
     )
-    def search_summaries(self, **query):
+    def search_summaries(self, archived: bool | None = False, **query):
         """
         Perform a search, returning just the search fields of each dataset.
 
         :param dict[str,str|float|datacube.model.Range] query:
         :rtype: __generator[dict]
         """
-        for _, results in self._do_search_by_product(query, return_fields=True):
+        for _, results in self._do_search_by_product(query, return_fields=True, archived=archived):
             for columns in results:
                 output = columns._asdict()
                 _LOG.warning("search results: %s (%s)", output["id"], output["product"])

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -589,6 +589,16 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             for dataset in self._make_many(connection.search_datasets_by_metadata(metadata, archived)):
                 yield dataset
 
+    @deprecat(
+        deprecated_args={
+            "source_filter": {
+                "reason": "Filtering by source metadata is deprecated and will be removed in future.",
+                "version": "1.9.0",
+                "category": ODC2DeprecationWarning
+
+            }
+        }
+    )
     def search(self, limit=None, source_filter=None, archived: bool | None = False, **query):
         """
         Perform a search, returning results as Dataset objects.

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -577,7 +577,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         """
         return (self._make(dataset, product=product) for dataset in query_result)
 
-    def search_by_metadata(self, metadata):
+    def search_by_metadata(self, metadata, archived: bool | None = False):
         """
         Perform a search using arbitrary metadata, returning results as Dataset objects.
 
@@ -587,7 +587,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         :rtype: list[Dataset]
         """
         with self._db_connection() as connection:
-            for dataset in self._make_many(connection.search_datasets_by_metadata(metadata)):
+            for dataset in self._make_many(connection.search_datasets_by_metadata(metadata, archived)):
                 yield dataset
 
     def search(self, limit=None, source_filter=None, **query):

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -743,8 +743,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             if return_fields:
                 # if no fields specified, select all
                 if select_field_names is None:
-                    select_fields = tuple(field for name, field in dataset_fields.items()
-                                          if not field.affects_row_selection)
+                    select_fields = None
                 else:
                     select_fields = tuple(
                         dataset_fields[field_name]

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -760,7 +760,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                     select_fields = tuple(
                         dataset_fields[field_name]
                         for field_name in select_field_names
-                        if field_name in dataset_fields  # and not dataset_fields[field_name].affects_row_selection
+                        if field_name in dataset_fields
                     )
             with self._db_connection() as connection:
                 yield (product,

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -15,7 +15,6 @@ from typing import Iterable, List, Union, Mapping, Any, Optional
 from uuid import UUID
 from deprecat import deprecat
 
-from datacube.migration import ODC2DeprecationWarning
 from datacube.drivers.postgres._fields import SimpleDocField
 from datacube.drivers.postgres._schema import DATASET
 from datacube.index.abstract import (AbstractDatasetResource, DatasetSpatialMixin, DSID,
@@ -751,7 +750,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                     select_fields = tuple(
                         dataset_fields[field_name]
                         for field_name in select_field_names
-                        if field_name in dataset_fields # and not dataset_fields[field_name].affects_row_selection
+                        if field_name in dataset_fields  # and not dataset_fields[field_name].affects_row_selection
                     )
             with self._db_connection() as connection:
                 yield (product,
@@ -976,9 +975,6 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             custom_exprs.append(fields.as_expression(custom_field, custom_query[key]))
 
         return custom_exprs
-
-    def spatial_extent(self, ids=None, product=None, crs=None):
-        return None
 
     def get_all_docs_for_product(self, product: Product, batch_size: int = 1000) -> Iterable[DatasetTuple]:
         product_search_key = [product.name]

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -834,7 +834,9 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         raise NotImplementedError("Sorry Temporal Extent by dataset ids is not supported in postgres driver.")
 
     # pylint: disable=redefined-outer-name
-    def search_returning_datasets_light(self, field_names: tuple, custom_offsets=None, limit=None, **query):
+    def search_returning_datasets_light(self, field_names: tuple, custom_offsets=None, limit=None,
+                                        archived: bool | None = False,
+                                        **query):
         """
         This is a dataset search function that returns the results as objects of a dynamically
         generated Dataset class that is a subclass of tuple.
@@ -880,7 +882,8 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                 results = connection.search_unique_datasets(
                     query_exprs,
                     select_fields=select_fields,
-                    limit=limit
+                    limit=limit,
+                    archived=archived
                 )
 
             for result in results:

--- a/datacube/scripts/search_tool.py
+++ b/datacube/scripts/search_tool.py
@@ -95,7 +95,7 @@ def datasets(ctx, index, expressions):
     """
     ctx.obj['write_results'](
         sorted(index.products.get_field_names()),
-        index.datasets.search_summaries(**expressions)
+        (tup._asdict() for tup in index.datasets.search_returning(**expressions))
     )
 
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -33,7 +33,7 @@ v1.9.next
 - Add product argument to spatial_extent method, as per EP13. (:pull:`1539`)
 - Index driver API type hint cleanup. (:pull:`1541`)
 - Deprecate multiple locations. (:pull:`1546`)
-- Deprecate search_eager and search_summaries and add `archived` arg to all dataset search/count methods. (:pull:`1549`)
+- Deprecate search_eager and search_summaries and add `archived` arg to all dataset search/count methods. (:pull:`1550`)
 
 
 v1.8.next

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -33,6 +33,7 @@ v1.9.next
 - Add product argument to spatial_extent method, as per EP13. (:pull:`1539`)
 - Index driver API type hint cleanup. (:pull:`1541`)
 - Deprecate multiple locations. (:pull:`1546`)
+- Deprecate search_eager and search_summaries and add `archived` arg to all dataset search/count methods. (:pull:`1549`)
 
 
 v1.8.next

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -71,12 +71,12 @@ _pseudo_telemetry_dataset_type = {
 
 
 def test_archive_datasets(index, ls8_eo3_dataset):
-    datasets = index.datasets.search_eager()
+    datasets = list(index.datasets.search())
     assert len(datasets) == 1
     assert not datasets[0].is_archived
 
     index.datasets.archive([ls8_eo3_dataset.id])
-    datasets = index.datasets.search_eager()
+    datasets = list(index.datasets.search())
     assert len(datasets) == 0
 
     # The model should show it as archived now.
@@ -84,7 +84,7 @@ def test_archive_datasets(index, ls8_eo3_dataset):
     assert indexed_dataset.is_archived
 
     index.datasets.restore([ls8_eo3_dataset.id])
-    datasets = index.datasets.search_eager()
+    datasets = list(index.datasets.search())
     assert len(datasets) == 1
 
     # And now active
@@ -147,13 +147,13 @@ def test_archive_less_mature_bool(index, final_dataset, nrt_dataset):
 
 def test_purge_datasets(index, ls8_eo3_dataset):
     assert index.datasets.has(ls8_eo3_dataset.id)
-    datasets = index.datasets.search_eager()
+    datasets = list(index.datasets.search())
     assert len(datasets) == 1
     assert not datasets[0].is_archived
 
     # Archive dataset
     index.datasets.archive([ls8_eo3_dataset.id])
-    datasets = index.datasets.search_eager()
+    datasets = list(index.datasets.search())
     assert len(datasets) == 0
 
     # The model should show it as archived now.

--- a/integration_tests/index/test_location.py
+++ b/integration_tests/index/test_location.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2015-2024 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 
+from uuid import uuid4
 from datacube.model import Dataset
 
 

--- a/integration_tests/index/test_location.py
+++ b/integration_tests/index/test_location.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2015-2024 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from uuid import uuid4
 from datacube.model import Dataset
 
 

--- a/integration_tests/index/test_memory_index.py
+++ b/integration_tests/index/test_memory_index.py
@@ -471,6 +471,19 @@ def test_mem_ds_search_and_count(mem_eo3_data: tuple):
     with pytest.raises(ValueError):
         lds = list(dc.index.datasets.search(product_family='addams'))
 
+    lds = list(dc.index.datasets.search(archived=None, platform='landsat-8'))
+    assert len(lds) == 2
+    lds = list(dc.index.datasets.search(archived=True, platform='landsat-8'))
+    assert len(lds) == 0
+
+    dc.index.datasets.archive([ls8_id, wo_id])
+    lds = list(dc.index.datasets.search(platform='landsat-8'))
+    assert len(lds) == 0
+    lds = list(dc.index.datasets.search(archived=None, platform='landsat-8'))
+    assert len(lds) == 2
+    lds = list(dc.index.datasets.search(archived=True, platform='landsat-8'))
+    assert len(lds) == 2
+
 
 def test_mem_ds_search_and_count_by_product(mem_eo3_data: tuple):
     dc, ls8_id, wo_id = mem_eo3_data
@@ -527,6 +540,16 @@ def test_mem_ds_search_returning_datasets_light(mem_eo3_data: tuple):
         assert res.__class__.__name__ == 'DatasetLight'
         assert res.platform == "landsat-8"
         assert res.id in (str(ls8_id), str(wo_id))
+    lds = list(dc.index.datasets.search_returning_datasets_light(
+        archived=None,
+        field_names=['platform', 'id'],
+        platform='landsat-8'))
+    assert len(lds) == 2
+    lds = list(dc.index.datasets.search_returning_datasets_light(
+        archived=True,
+        field_names=['platform', 'id'],
+        platform='landsat-8'))
+    assert len(lds) == 0
 
 
 def test_mem_ds_search_by_metadata(mem_eo3_data: tuple):
@@ -539,6 +562,10 @@ def test_mem_ds_search_by_metadata(mem_eo3_data: tuple):
     assert len(lds) == 0
     lds = list(dc.index.datasets.search_by_metadata({"properties": {"eo:platform": "landsat-8"}}))
     assert len(lds) == 2
+    lds = list(dc.index.datasets.search_by_metadata({"properties": {"eo:platform": "landsat-8"}}, archived=None))
+    assert len(lds) == 2
+    lds = list(dc.index.datasets.search_by_metadata({"properties": {"eo:platform": "landsat-8"}}, archived=True))
+    assert len(lds) == 0
 
 
 def test_mem_ds_count_product_through_time(mem_eo3_data: tuple):

--- a/integration_tests/index/test_memory_index.py
+++ b/integration_tests/index/test_memory_index.py
@@ -566,6 +566,13 @@ def test_mem_ds_search_by_metadata(mem_eo3_data: tuple):
     assert len(lds) == 2
     lds = list(dc.index.datasets.search_by_metadata({"properties": {"eo:platform": "landsat-8"}}, archived=True))
     assert len(lds) == 0
+    dc.index.datasets.archive([ls8_id, wo_id])
+    lds = list(dc.index.datasets.search_by_metadata({"properties": {"eo:platform": "landsat-8"}}))
+    assert len(lds) == 0
+    lds = list(dc.index.datasets.search_by_metadata({"properties": {"eo:platform": "landsat-8"}}, archived=None))
+    assert len(lds) == 2
+    lds = list(dc.index.datasets.search_by_metadata({"properties": {"eo:platform": "landsat-8"}}, archived=True))
+    assert len(lds) == 2
 
 
 def test_mem_ds_count_product_through_time(mem_eo3_data: tuple):

--- a/integration_tests/index/test_memory_index.py
+++ b/integration_tests/index/test_memory_index.py
@@ -499,15 +499,22 @@ def test_mem_ds_search_returning(mem_eo3_data: tuple):
     for res in lds:
         assert res.platform == "landsat-8"
         assert res.id in (str(ls8_id), str(wo_id))
+    lds = list(dc.index.datasets.search_returning(
+        platform='landsat-8'
+    ))
+    assert len(lds) == 2
+    for res in lds:
+        assert res.platform == "landsat-8"
+        assert res.id in (str(ls8_id), str(wo_id))
 
 
 def test_mem_ds_search_summary(mem_eo3_data: tuple):
     dc, ls8_id, wo_id = mem_eo3_data
-    lds = list(dc.index.datasets.search_summaries(platform='landsat-8'))
+    lds = list(dc.index.datasets.search_returning(platform='landsat-8'))
     assert len(lds) == 2
     for res in lds:
-        assert res["platform"] == "landsat-8"
-        assert res["id"] in (str(ls8_id), str(wo_id))
+        assert res.platform == "landsat-8"
+        assert res.id in (str(ls8_id), str(wo_id))
 
 
 def test_mem_ds_search_returning_datasets_light(mem_eo3_data: tuple):

--- a/integration_tests/index/test_null_index.py
+++ b/integration_tests/index/test_null_index.py
@@ -134,8 +134,8 @@ def test_null_dataset_resource(null_config: ODCEnvironment):
         assert dc.index.datasets.count_by_product(foo="bar", baz=12) == []
         assert dc.index.datasets.count_by_product_through_time("1 month", foo="bar", baz=12) == []
         assert dc.index.datasets.count_product_through_time("1 month", foo="bar", baz=12) == []
-        assert dc.index.datasets.search_summaries(foo="bar", baz=12) == []
-        assert dc.index.datasets.search_eager(foo="bar", baz=12) == []
+        assert dc.index.datasets.search_summaries(foo="bar", baz=12) == []  # Coverage test of deprecated method
+        assert dc.index.datasets.search_eager(foo="bar", baz=12) == []  # Coverage test of deprecated base class method
         assert dc.index.datasets.search_returning_datasets_light(("foo", "baz"), foo="bar", baz=12) == []
 
 

--- a/integration_tests/index/test_postgis_index.py
+++ b/integration_tests/index/test_postgis_index.py
@@ -187,7 +187,7 @@ def test_spatial_search(index,
     index.create_spatial_index(epsg3577)
     index.update_spatial_index(crses=[epsg3577])
     # Test old style lat/lon search
-    dss = index.datasets.search_eager(
+    dss = index.datasets.search(
         product=ls8_eo3_dataset.product.name,
         lat=Range(begin=-37.5, end=37.0),
         lon=Range(begin=148.5, end=149.0)

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -38,25 +38,25 @@ def test_search_by_metadata(index: Index, ls8_eo3_product, wo_eo3_product):
 
 
 def test_search_dataset_equals_eo3(index: Index, ls8_eo3_dataset: Dataset):
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         platform='landsat-8'
-    )
+    ))
     assert len(datasets) == 1
     assert datasets[0].id == ls8_eo3_dataset.id
 
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         platform='landsat-8',
         instrument='OLI_TIRS'
-    )
+    ))
     assert len(datasets) == 1
     assert datasets[0].id == ls8_eo3_dataset.id
 
     # Wrong product family
     with pytest.raises(ValueError):
-        datasets = index.datasets.search_eager(
+        next(index.datasets.search(
             platform='landsat-8',
             product_family='splunge',
-        )
+        ))
 
 
 def test_search_dataset_range_eo3(index: Index,
@@ -66,30 +66,30 @@ def test_search_dataset_range_eo3(index: Index,
                                   ls8_eo3_dataset4: Dataset,
                                   ):
     # Less Than
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         product=ls8_eo3_dataset.product.name,
         cloud_cover=Range(None, 50.0)
-    )
+    ))
     assert len(datasets) == 2
     ids = [ds.id for ds in datasets]
     assert ls8_eo3_dataset3.id in ids
     assert ls8_eo3_dataset4.id in ids
 
     # Greater than
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         product=ls8_eo3_dataset.product.name,
         cloud_cover=Range(50.0, None)
-    )
+    ))
     assert len(datasets) == 2
     ids = [ds.id for ds in datasets]
     assert ls8_eo3_dataset.id in ids
     assert ls8_eo3_dataset2.id in ids
 
     # Full Range comparison
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         product=ls8_eo3_dataset.product.name,
         cloud_cover=Range(20.0, 55.0)
-    )
+    ))
     assert len(datasets) == 2
     ids = [ds.id for ds in datasets]
     assert ls8_eo3_dataset2.id in ids
@@ -113,112 +113,112 @@ def test_search_dataset_by_metadata_eo3(index: Index, ls8_eo3_dataset: Dataset) 
 
 def test_search_day_eo3(index: Index, ls8_eo3_dataset: Dataset) -> None:
     # Matches day
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         time=datetime.date(2016, 5, 12)
-    )
+    ))
     assert len(datasets) == 1
     assert datasets[0].id == ls8_eo3_dataset.id
 
     # Different day: no match
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         time=datetime.date(2016, 5, 13)
-    )
+    ))
     assert len(datasets) == 0
 
 
 def test_search_dataset_ranges_eo3(index: Index, ls8_eo3_dataset: Dataset) -> None:
     # In the lat bounds.
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         lat=Range(-37.5, -36.5),
         time=Range(
             datetime.datetime(2016, 5, 12, 23, 0, 0),
             datetime.datetime(2016, 5, 12, 23, 59, 59)
         )
-    )
+    ))
     assert len(datasets) == 1
     assert datasets[0].id == ls8_eo3_dataset.id
 
     # Out of the lat bounds.
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         lat=Range(28, 32),
         time=Range(
             datetime.datetime(2016, 5, 12, 23, 0, 0),
             datetime.datetime(2016, 5, 12, 23, 59, 59)
         )
-    )
+    ))
     assert len(datasets) == 0
 
     # Out of the time bounds
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         lat=Range(-37.5, -36.5),
         time=Range(
             datetime.datetime(2014, 7, 26, 21, 48, 0),
             datetime.datetime(2014, 7, 26, 21, 50, 0)
         )
-    )
+    ))
     assert len(datasets) == 0
 
     # A dataset that overlaps but is not fully contained by the search bounds.
     # Should we distinguish between 'contains' and 'overlaps'?
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         lat=Range(-40, -37.1)
-    )
+    ))
     assert len(datasets) == 1
     assert datasets[0].id == ls8_eo3_dataset.id
 
     # Single point search
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         lat=-37.0,
         time=Range(
             datetime.datetime(2016, 5, 12, 23, 0, 0),
             datetime.datetime(2016, 5, 12, 23, 59, 59)
         )
-    )
+    ))
     assert len(datasets) == 1
     assert datasets[0].id == ls8_eo3_dataset.id
 
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         lat=30.0,
         time=Range(
             datetime.datetime(2016, 5, 12, 23, 0, 0),
             datetime.datetime(2016, 5, 12, 23, 59, 59)
         )
-    )
+    ))
     assert len(datasets) == 0
 
     # Single timestamp search
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         lat=Range(-37.5, -36.5),
         time=datetime.datetime(2016, 5, 12, 23, 50, 40),
-    )
+    ))
     assert len(datasets) == 1
     assert datasets[0].id == ls8_eo3_dataset.id
 
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         lat=Range(-37.5, -36.5),
         time=datetime.datetime(2016, 5, 12, 23, 0, 0)
-    )
+    ))
     assert len(datasets) == 0
 
 
 def test_zero_width_range_search(index: Index, ls8_eo3_dataset4: Dataset) -> None:
     # Test time search against zero-width time metadata
-    datasets = index.datasets.search_eager(time=Range(
+    datasets = list(index.datasets.search(time=Range(
         begin=datetime.datetime(2013, 7, 21, 0, 57, 26, 432563, tzinfo=datetime.timezone.utc),
         end=datetime.datetime(2013, 7, 21, 0, 57, 26, 432563, tzinfo=datetime.timezone.utc)
-    ))
+    )))
     assert len(datasets) == 1
 
-    datasets = index.datasets.search_eager(time=Range(
+    datasets = list(index.datasets.search(time=Range(
         begin=datetime.datetime(2013, 7, 21, 0, 57, 26, 432563, tzinfo=datetime.timezone.utc),
         end=datetime.datetime(2013, 7, 21, 0, 57, 27, 432563, tzinfo=datetime.timezone.utc)
-    ))
+    )))
     assert len(datasets) == 1
 
-    datasets = index.datasets.search_eager(time=Range(
+    datasets = list(index.datasets.search(time=Range(
         begin=datetime.datetime(2013, 7, 21, 0, 57, 25, 432563, tzinfo=datetime.timezone.utc),
         end=datetime.datetime(2013, 7, 21, 0, 57, 26, 432563, tzinfo=datetime.timezone.utc)
-    ))
+    )))
     assert len(datasets) == 1
 
 
@@ -303,35 +303,35 @@ def test_search_or_expressions_eo3(index: Index,
     # - two landsat8 ard
     # - one wo
 
-    all_datasets = index.datasets.search_eager()
+    all_datasets = list(index.datasets.search())
     assert len(all_datasets) == 3
     all_ids = set(dataset.id for dataset in all_datasets)
 
     # OR all instruments: should return all datasets
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         instrument=['WOOLI_TIRS', 'OLI_TIRS', 'OLI_TIRS2']
-    )
+    ))
     assert len(datasets) == 3
     ids = set(dataset.id for dataset in datasets)
     assert ids == all_ids
 
     # OR expression with only one clause.
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         instrument=['OLI_TIRS']
-    )
+    ))
     assert len(datasets) == 1
     assert datasets[0].id == ls8_eo3_dataset.id
 
     # OR both products: return all
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         product=[ls8_eo3_dataset.product.name, wo_eo3_dataset.product.name]
-    )
+    ))
     assert len(datasets) == 3
     ids = set(dataset.id for dataset in datasets)
     assert ids == all_ids
 
     # eo OR eo3: return all
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         metadata_type=[
             # LS5 + children
             ls8_eo3_dataset.metadata_type.name,
@@ -339,15 +339,15 @@ def test_search_or_expressions_eo3(index: Index,
             # LS8 dataset
             wo_eo3_dataset.metadata_type.name
         ]
-    )
+    ))
     assert len(datasets) == 3
     ids = set(dataset.id for dataset in datasets)
     assert ids == all_ids
 
     # Redundant ORs should have no effect.
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         product=[wo_eo3_dataset.product.name, wo_eo3_dataset.product.name, wo_eo3_dataset.product.name]
-    )
+    ))
     assert len(datasets) == 1
     assert datasets[0].id == wo_eo3_dataset.id
 
@@ -403,6 +403,15 @@ def test_search_returning_eo3(index: Index,
     expected_time = creation_time.astimezone(tz.tzutc()).replace(tzinfo=None)
     assert expected_time.isoformat() == ls8_eo3_dataset.metadata.creation_dt
     assert label == ls8_eo3_dataset.metadata.label
+
+    # All Fields
+    results = list(index.datasets.search_returning(
+        platform='landsat-8',
+    ))
+    assert len(results) == 3
+
+    assert ls8_eo3_dataset.id in (result.id for result in results)
+
 
 
 def test_search_returning_rows_eo3(index,
@@ -467,101 +476,101 @@ def test_searches_only_type_eo3(index: Index,
     assert ls8_eo3_dataset.metadata_type.name != wo_eo3_dataset.metadata_type.name
 
     # One result in the product
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         product=wo_eo3_dataset.product.name,
         platform='landsat-8'
-    )
+    ))
     assert len(datasets) == 1
     assert datasets[0].id == wo_eo3_dataset.id
 
     # One result in the metadata type
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         metadata_type="eo3",
         platform='landsat-8'
-    )
+    ))
     assert len(datasets) == 1
     assert datasets[0].id == wo_eo3_dataset.id
 
     # No results when searching for a different dataset type.
     with pytest.raises(ValueError):
-        datasets = index.datasets.search_eager(
+        next(index.datasets.search(
             product="spam_and_eggs",
             platform='landsat-8'
-        )
+        ))
 
     # Two result when no types specified.
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         platform='landsat-8'
-    )
+    ))
     assert len(datasets) == 2
     assert set(ds.id for ds in datasets) == {ls8_eo3_dataset.id, wo_eo3_dataset.id}
 
     # No results for different metadata type.
     with pytest.raises(ValueError):
-        datasets = index.datasets.search_eager(
+        next(index.datasets.search(
             metadata_type='spam_type',
             platform='landsat-8',
-        )
+        ))
 
 
 def test_search_special_fields_eo3(index: Index,
                                    ls8_eo3_dataset: Dataset,
                                    wo_eo3_dataset: Dataset) -> None:
     # 'product' is a special case
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         product=ls8_eo3_dataset.product.name
-    )
+    ))
     assert len(datasets) == 1
     assert datasets[0].id == ls8_eo3_dataset.id
 
     # Unknown field: no results
     with pytest.raises(ValueError):
-        datasets = index.datasets.search_eager(
+        next(index.datasets.search(
             platform='landsat-8',
             flavour='vanilla',
-        )
+        ))
 
 
 def test_search_by_uri_eo3(index, ls8_eo3_dataset, ls8_eo3_dataset2, eo3_ls8_dataset_doc):
-    datasets = index.datasets.search_eager(product=ls8_eo3_dataset.product.name,
-                                           uri=eo3_ls8_dataset_doc[1])
+    datasets = list(index.datasets.search(product=ls8_eo3_dataset.product.name,
+                                           uri=eo3_ls8_dataset_doc[1]))
     assert len(datasets) == 1
 
-    datasets = index.datasets.search_eager(product=ls8_eo3_dataset.product.name,
-                                           uri='file:///x/yz')
+    datasets = list(index.datasets.search(product=ls8_eo3_dataset.product.name,
+                                           uri='file:///x/yz'))
     assert len(datasets) == 0
 
 
 def test_search_conflicting_types(index, ls8_eo3_dataset):
     # Should return no results.
     with pytest.raises(ValueError):
-        index.datasets.search_eager(
+        next(index.datasets.search(
             product=ls8_eo3_dataset.product.name,
             # The ls8 type is not of type storage_unit.
             metadata_type='storage_unit'
-        )
+        ))
 
 
 def test_fetch_all_of_md_type(index: Index, ls8_eo3_dataset: Dataset) -> None:
     # Get every dataset of the md type.
     assert ls8_eo3_dataset.metadata_type is not None  # to shut up mypy
-    results = index.datasets.search_eager(
+    results = list(index.datasets.search(
         metadata_type=ls8_eo3_dataset.metadata_type.name
-    )
+    ))
     assert len(results) == 1
     assert results[0].id == ls8_eo3_dataset.id
     # Get every dataset of the type.
-    results = index.datasets.search_eager(
+    results = list(index.datasets.search(
         product=ls8_eo3_dataset.product.name
-    )
+    ))
     assert len(results) == 1
     assert results[0].id == ls8_eo3_dataset.id
 
     # No results for another.
     with pytest.raises(ValueError):
-        results = index.datasets.search_eager(
+        next(index.datasets.search(
             metadata_type='spam_and_eggs'
-        )
+        ))
 
 
 def test_count_searches(index: Index,
@@ -772,7 +781,7 @@ def test_find_duplicates_eo3(index,
                              ls8_eo3_dataset3, ls8_eo3_dataset4,
                              wo_eo3_dataset):
     # Our four ls8 datasets and one wo.
-    all_datasets = index.datasets.search_eager()
+    all_datasets = list(index.datasets.search())
     assert len(all_datasets) == 5
 
     # First two ls8 datasets have the same path/row, last two have a different row.
@@ -817,7 +826,7 @@ def test_find_duplicates_with_time(index, nrt_dataset, final_dataset, ls8_eo3_da
     assert not index.datasets.get(nrt_dataset.id).is_archived
     assert not index.datasets.get(final_dataset.id).is_archived
 
-    all_datasets = index.datasets.search_eager()
+    all_datasets = list(index.datasets.search())
     assert len(all_datasets) == 3
 
     dupe_fields = namedtuple('search_result', ['region_code', 'time'])

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -325,6 +325,34 @@ def test_search_limit_eo3(index, ls8_eo3_dataset, ls8_eo3_dataset2, wo_eo3_datas
     assert len(datasets) == 3
 
 
+def test_search_archived_eo3(index, ls8_eo3_dataset, ls8_eo3_dataset2, wo_eo3_dataset):
+    prod = ls8_eo3_dataset.product.name
+    datasets = list(index.datasets.search(archived=False, product=prod))
+    assert len(datasets) == 2
+    datasets = list(index.datasets.search(archived=None, product=prod))
+    assert len(datasets) == 2
+    datasets = list(index.datasets.search(archived=True, product=prod))
+    assert len(datasets) == 0
+
+    index.datasets.archive([ls8_eo3_dataset.id])
+
+    datasets = list(index.datasets.search(archived=False, product=prod))
+    assert len(datasets) == 1
+    datasets = list(index.datasets.search(archived=None, product=prod))
+    assert len(datasets) == 2
+    datasets = list(index.datasets.search(archived=True, product=prod))
+    assert len(datasets) == 1
+
+    index.datasets.archive([ls8_eo3_dataset2.id])
+
+    datasets = list(index.datasets.search(archived=False, product=prod))
+    assert len(datasets) == 0
+    datasets = list(index.datasets.search(archived=None, product=prod))
+    assert len(datasets) == 2
+    datasets = list(index.datasets.search(archived=True, product=prod))
+    assert len(datasets) == 2
+
+
 def test_search_or_expressions_eo3(index: Index,
                                    ls8_eo3_dataset: Dataset,
                                    ls8_eo3_dataset2: Dataset,

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -471,7 +471,6 @@ def test_search_returning_eo3(index: Index,
     assert ls8_eo3_dataset.id in (result.id for result in results)
 
 
-
 def test_search_returning_rows_eo3(index,
                                    eo3_ls8_dataset_doc,
                                    eo3_ls8_dataset2_doc,
@@ -591,11 +590,10 @@ def test_search_special_fields_eo3(index: Index,
 
 def test_search_by_uri_eo3(index, ls8_eo3_dataset, ls8_eo3_dataset2, eo3_ls8_dataset_doc):
     datasets = list(index.datasets.search(product=ls8_eo3_dataset.product.name,
-                                           uri=eo3_ls8_dataset_doc[1]))
+                                          uri=eo3_ls8_dataset_doc[1]))
     assert len(datasets) == 1
-
     datasets = list(index.datasets.search(product=ls8_eo3_dataset.product.name,
-                                           uri='file:///x/yz'))
+                                          uri='file:///x/yz'))
     assert len(datasets) == 0
 
 

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -109,6 +109,36 @@ def test_search_dataset_by_metadata_eo3(index: Index, ls8_eo3_dataset: Dataset) 
     )
     datasets = list(datasets)
     assert len(datasets) == 0
+    datasets = index.datasets.search_by_metadata(
+        {"properties": {"eo:platform": "landsat-8", "eo:instrument": "OLI_TIRS"}},
+        archived=None
+    )
+    datasets = list(datasets)
+    assert len(datasets) == 1
+    assert datasets[0].id == ls8_eo3_dataset.id
+    datasets = index.datasets.search_by_metadata(
+        {"properties": {"eo:platform": "landsat-8", "eo:instrument": "OLI_TIRS"}},
+        archived=True
+    )
+    datasets = list(datasets)
+    assert len(datasets) == 0
+
+    index.datasets.archive([ls8_eo3_dataset.id])
+
+    datasets = index.datasets.search_by_metadata(
+        {"properties": {"eo:platform": "landsat-8", "eo:instrument": "OLI_TIRS"}},
+        archived=None
+    )
+    datasets = list(datasets)
+    assert len(datasets) == 1
+    assert datasets[0].id == ls8_eo3_dataset.id
+    datasets = index.datasets.search_by_metadata(
+        {"properties": {"eo:platform": "landsat-8", "eo:instrument": "OLI_TIRS"}},
+        archived=True
+    )
+    datasets = list(datasets)
+    assert len(datasets) == 1
+    assert datasets[0].id == ls8_eo3_dataset.id
 
 
 def test_search_day_eo3(index: Index, ls8_eo3_dataset: Dataset) -> None:

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -710,6 +710,25 @@ def test_count_by_product_searches_eo3(index: Index,
     ))
     assert products == ()
 
+    index.datasets.archive([ls8_eo3_dataset.id])
+    products = tuple(index.datasets.count_by_product(
+        product=ls8_eo3_dataset.product.name,
+        platform='landsat-8'
+    ))
+    assert products == ((ls8_eo3_dataset.product, 1),)
+    products = tuple(index.datasets.count_by_product(
+        archived=True,
+        product=ls8_eo3_dataset.product.name,
+        platform='landsat-8'
+    ))
+    assert products == ((ls8_eo3_dataset.product, 1),)
+    products = tuple(index.datasets.count_by_product(
+        archived=None,
+        product=ls8_eo3_dataset.product.name,
+        platform='landsat-8'
+    ))
+    assert products == ((ls8_eo3_dataset.product, 2),)
+
 
 def test_count_time_groups(index: Index,
                            ls8_eo3_dataset: Dataset) -> None:

--- a/integration_tests/index/test_search_legacy.py
+++ b/integration_tests/index/test_search_legacy.py
@@ -278,6 +278,33 @@ def test_search_dataset_by_metadata(index: Index, pseudo_ls8_dataset: Dataset) -
     datasets = list(datasets)
     assert len(datasets) == 0
 
+    datasets = index.datasets.search_by_metadata(
+        {"platform": {"code": "LANDSAT_8"}, "instrument": {"name": "OLI_TIRS"}},
+        archived=None
+    )
+    datasets = list(datasets)
+    assert len(datasets) == 1
+    datasets = index.datasets.search_by_metadata(
+        {"platform": {"code": "LANDSAT_8"}, "instrument": {"name": "OLI_TIRS"}},
+        archived=True
+    )
+    datasets = list(datasets)
+    assert len(datasets) == 0
+
+    index.datasets.archive([pseudo_ls8_dataset.id])
+    datasets = index.datasets.search_by_metadata(
+        {"platform": {"code": "LANDSAT_8"}, "instrument": {"name": "OLI_TIRS"}},
+        archived=True
+    )
+    datasets = list(datasets)
+    assert len(datasets) == 1
+    datasets = index.datasets.search_by_metadata(
+        {"platform": {"code": "LANDSAT_8"}, "instrument": {"name": "OLI_TIRS"}},
+        archived=False
+    )
+    datasets = list(datasets)
+    assert len(datasets) == 0
+
 
 @pytest.mark.parametrize('datacube_env_name', ('datacube', ))
 def test_search_day(index: Index, pseudo_ls8_dataset: Dataset) -> None:

--- a/integration_tests/index/test_search_legacy.py
+++ b/integration_tests/index/test_search_legacy.py
@@ -102,6 +102,7 @@ def pseudo_ls8_dataset(index, pseudo_ls8_type):
             id_,
             pseudo_ls8_type.id
         )
+        was_inserted = was_inserted and connection.insert_dataset_location(id_, "file://tmp/a/b/c")
     assert was_inserted
     d = index.datasets.get(id_)
     # The dataset should have been matched to the telemetry type.
@@ -155,6 +156,7 @@ def pseudo_ls8_dataset2(index, pseudo_ls8_type):
             id_,
             pseudo_ls8_type.id
         )
+        was_inserted = was_inserted and connection.insert_dataset_location(id_, "file://tmp/d/e/f")
     assert was_inserted
     d = index.datasets.get(id_)
     # The dataset should have been matched to the telemetry type.
@@ -549,6 +551,8 @@ def test_search_returning_rows(index, pseudo_ls8_type,
                                pseudo_ls8_dataset, pseudo_ls8_dataset2,
                                indexed_ls5_scene_products):
     dataset = pseudo_ls8_dataset
+    index.datasets.remove_location(pseudo_ls8_dataset.id, pseudo_ls8_dataset.uri)  # Test of deprecated method
+    index.datasets.remove_location(pseudo_ls8_dataset2.id, pseudo_ls8_dataset2.uri)  # Test of deprecated method
 
     # If returning a field like uri, there will be one result per location.
 
@@ -967,6 +971,8 @@ def test_csv_search_via_cli(clirunner: Any,
                             pseudo_ls8_dataset2: Dataset) -> None:
     """
     Search datasets via the cli with csv output
+
+    NB behaviour of CLI search when datasets have zero or multiple locations has changed in 1.9.
     """
 
     # Test dataset is:

--- a/integration_tests/index/test_search_legacy.py
+++ b/integration_tests/index/test_search_legacy.py
@@ -235,25 +235,25 @@ def ls5_dataset_nbar_type(ls5_dataset_w_children: Dataset,
 
 @pytest.mark.parametrize('datacube_env_name', ('datacube', ))
 def test_search_dataset_equals(index: Index, pseudo_ls8_dataset: Dataset):
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         platform='LANDSAT_8'
-    )
+    ))
     assert len(datasets) == 1
     assert datasets[0].id == pseudo_ls8_dataset.id
 
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         platform='LANDSAT_8',
         instrument='OLI_TIRS'
-    )
+    ))
     assert len(datasets) == 1
     assert datasets[0].id == pseudo_ls8_dataset.id
 
     # Wrong sensor name
     with pytest.raises(ValueError):
-        datasets = index.datasets.search_eager(
+        next(index.datasets.search(
             platform='LANDSAT-8',
             instrument='TM',
-        )
+        ))
 
 
 @pytest.mark.parametrize('datacube_env_name', ('datacube', ))
@@ -280,93 +280,93 @@ def test_search_dataset_by_metadata(index: Index, pseudo_ls8_dataset: Dataset) -
 @pytest.mark.parametrize('datacube_env_name', ('datacube', ))
 def test_search_day(index: Index, pseudo_ls8_dataset: Dataset) -> None:
     # Matches day
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         time=datetime.date(2014, 7, 26)
-    )
+    ))
     assert len(datasets) == 1
     assert datasets[0].id == pseudo_ls8_dataset.id
 
     # Different day: no match
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         time=datetime.date(2014, 7, 27)
-    )
+    ))
     assert len(datasets) == 0
 
 
 @pytest.mark.parametrize('datacube_env_name', ('datacube', ))
 def test_search_dataset_ranges(index: Index, pseudo_ls8_dataset: Dataset) -> None:
     # In the lat bounds.
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         lat=Range(-30.5, -29.5),
         time=Range(
             datetime.datetime(2014, 7, 26, 23, 0, 0),
             datetime.datetime(2014, 7, 26, 23, 59, 0)
         )
-    )
+    ))
     assert len(datasets) == 1
     assert datasets[0].id == pseudo_ls8_dataset.id
 
     # Out of the lat bounds.
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         lat=Range(28, 32),
         time=Range(
             datetime.datetime(2014, 7, 26, 23, 48, 0),
             datetime.datetime(2014, 7, 26, 23, 50, 0)
         )
-    )
+    ))
     assert len(datasets) == 0
 
     # Out of the time bounds
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         lat=Range(-30.5, -29.5),
         time=Range(
             datetime.datetime(2014, 7, 26, 21, 48, 0),
             datetime.datetime(2014, 7, 26, 21, 50, 0)
         )
-    )
+    ))
     assert len(datasets) == 0
 
     # A dataset that overlaps but is not fully contained by the search bounds.
     # TODO: Do we want overlap as the default behaviour?
     # Should we distinguish between 'contains' and 'overlaps'?
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         lat=Range(-40, -30)
-    )
+    ))
     assert len(datasets) == 1
     assert datasets[0].id == pseudo_ls8_dataset.id
 
     # Single point search
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         lat=-30.0,
         time=Range(
             datetime.datetime(2014, 7, 26, 23, 0, 0),
             datetime.datetime(2014, 7, 26, 23, 59, 0)
         )
-    )
+    ))
     assert len(datasets) == 1
     assert datasets[0].id == pseudo_ls8_dataset.id
 
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         lat=30.0,
         time=Range(
             datetime.datetime(2014, 7, 26, 23, 0, 0),
             datetime.datetime(2014, 7, 26, 23, 59, 0)
         )
-    )
+    ))
     assert len(datasets) == 0
 
     # Single timestamp search
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         lat=Range(-30.5, -29.5),
         time=datetime.datetime(2014, 7, 26, 23, 50, 0)
-    )
+    ))
     assert len(datasets) == 1
     assert datasets[0].id == pseudo_ls8_dataset.id
 
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         lat=Range(-30.5, -29.5),
         time=datetime.datetime(2014, 7, 26, 23, 30, 0)
-    )
+    ))
     assert len(datasets) == 0
 
 
@@ -439,35 +439,35 @@ def test_search_or_expressions(index: Index,
     # - type=ls5_level1_scene
     # - type=ls5_satellite_telemetry_data
 
-    all_datasets = index.datasets.search_eager()
+    all_datasets = list(index.datasets.search())
     assert len(all_datasets) == 4
     all_ids = set(dataset.id for dataset in all_datasets)
 
     # OR all platforms: should return all datasets
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         platform=['LANDSAT_5', 'LANDSAT_7', 'LANDSAT_8']
-    )
+    ))
     assert len(datasets) == 4
     ids = set(dataset.id for dataset in datasets)
     assert ids == all_ids
 
     # OR expression with only one clause.
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         platform=['LANDSAT_8']
-    )
+    ))
     assert len(datasets) == 1
     assert datasets[0].id == pseudo_ls8_dataset.id
 
     # OR two products: return two
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         product=[pseudo_ls8_type.name, ls5_dataset_nbar_type.name]
-    )
+    ))
     assert len(datasets) == 2
     ids = set(dataset.id for dataset in datasets)
     assert ids == {pseudo_ls8_dataset.id, ls5_dataset_w_children.id}
 
     # eo OR telemetry: return all
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         metadata_type=[
             # LS5 + children
             default_metadata_type.name,
@@ -476,15 +476,15 @@ def test_search_or_expressions(index: Index,
             # LS8 dataset
             pseudo_ls8_type.metadata_type.name
         ]
-    )
+    ))
     assert len(datasets) == 4
     ids = set(dataset.id for dataset in datasets)
     assert ids == all_ids
 
     # Redundant ORs should have no effect.
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         product=[pseudo_ls8_type.name, pseudo_ls8_type.name, pseudo_ls8_type.name]
-    )
+    ))
     assert len(datasets) == 1
     assert datasets[0].id == pseudo_ls8_dataset.id
 
@@ -569,7 +569,7 @@ def test_search_returning_rows(index, pseudo_ls8_type,
         instrument='OLI_TIRS',
     ))
     assert len(results) == 1
-    assert results == [(dataset.id, test_uri)]
+    assert (dataset.id, test_uri) in results
 
     # Add a second location and we should get two results
     test_uri2 = 'file:///tmp/test2'
@@ -609,49 +609,49 @@ def test_searches_only_type(index: Index,
                             ls5_telem_type) -> None:
     # The dataset should have been matched to the telemetry type.
     assert pseudo_ls8_dataset.product.id == pseudo_ls8_type.id
-    assert index.datasets.search_eager()
+    assert next(index.datasets.search())
 
     # One result in the telemetry type
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         product=pseudo_ls8_type.name,
         platform='LANDSAT_8',
         instrument='OLI_TIRS',
-    )
+    ))
     assert len(datasets) == 1
     assert datasets[0].id == pseudo_ls8_dataset.id
 
     # One result in the metadata type
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         metadata_type=pseudo_ls8_type.metadata_type.name,
         platform='LANDSAT_8',
         instrument='OLI_TIRS',
-    )
+    ))
     assert len(datasets) == 1
     assert datasets[0].id == pseudo_ls8_dataset.id
 
     # No results when searching for a different dataset type.
     with pytest.raises(ValueError):
-        datasets = index.datasets.search_eager(
+        next(index.datasets.search(
             product=ls5_telem_type.name,
             platform='LANDSAT_8',
             instrument='OLI_TIRS'
-        )
+        ))
 
     # One result when no types specified.
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         platform='LANDSAT_8',
         instrument='OLI_TIRS'
-    )
+    ))
     assert len(datasets) == 1
     assert datasets[0].id == pseudo_ls8_dataset.id
 
     # No results for different metadata type.
     with pytest.raises(ValueError):
-        datasets = index.datasets.search_eager(
+        next(index.datasets.search(
             metadata_type='telemetry',
             platform='LANDSAT_8',
             instrument='OLI_TIRS'
-        )
+        ))
 
 
 @pytest.mark.parametrize('datacube_env_name', ('datacube', ))
@@ -660,28 +660,28 @@ def test_search_special_fields(index: Index,
                                pseudo_ls8_dataset: Dataset,
                                ls5_dataset_w_children) -> None:
     # 'product' is a special case
-    datasets = index.datasets.search_eager(
+    datasets = list(index.datasets.search(
         product=pseudo_ls8_type.name
-    )
+    ))
     assert len(datasets) == 1
     assert datasets[0].id == pseudo_ls8_dataset.id
 
     # Unknown field: no results
     with pytest.raises(ValueError):
-        datasets = index.datasets.search_eager(
+        next(index.datasets.search(
             platform='LANDSAT_8',
             flavour='chocolate',
-        )
+        ))
 
 
 @pytest.mark.parametrize('datacube_env_name', ('datacube', ))
 def test_search_by_uri(index, ls5_dataset_w_children):
-    datasets = index.datasets.search_eager(product=ls5_dataset_w_children.product.name,
-                                           uri=ls5_dataset_w_children.local_uri)
+    datasets = list(index.datasets.search(product=ls5_dataset_w_children.product.name,
+                                          uri=ls5_dataset_w_children.local_uri))
     assert len(datasets) == 1
 
-    datasets = index.datasets.search_eager(product=ls5_dataset_w_children.product.name,
-                                           uri='file:///x/yz')
+    datasets = list(index.datasets.search(product=ls5_dataset_w_children.product.name,
+                                          uri='file:///x/yz'))
     assert len(datasets) == 0
 
 
@@ -716,7 +716,7 @@ def test_count_by_product_searches(index: Index,
                                    ls5_telem_type: Product) -> None:
     # The dataset should have been matched to the telemetry type.
     assert pseudo_ls8_dataset.product.id == pseudo_ls8_type.id
-    assert index.datasets.search_eager()
+    assert next(index.datasets.search())
 
     # One result in the telemetry type
     products = tuple(index.datasets.count_by_product(
@@ -772,28 +772,28 @@ def test_source_filter(clirunner, index, example_ls5_dataset_path):
         ]
     )
 
-    all_nbar = index.datasets.search_eager(product='ls5_nbar_scene')
+    all_nbar = list(index.datasets.search(product='ls5_nbar_scene'))
     assert len(all_nbar) == 1
-    all_level1 = index.datasets.search_eager(product='ls5_level1_scene')
+    all_level1 = list(index.datasets.search(product='ls5_level1_scene'))
     assert len(all_level1) == 1
     assert all_level1[0].metadata.gsi == 'ASA'
 
-    dss = index.datasets.search_eager(
+    dss = list(index.datasets.search(
         product='ls5_nbar_scene',
         source_filter={'product': 'ls5_level1_scene', 'gsi': 'ASA'}
-    )
+    ))
     assert dss == all_nbar
-    dss = index.datasets.search_eager(
+    dss = list(index.datasets.search(
         product='ls5_nbar_scene',
         source_filter={'product': 'ls5_level1_scene', 'gsi': 'GREG'}
-    )
+    ))
     assert dss == []
 
     with pytest.raises(RuntimeError):
-        dss = index.datasets.search_eager(
+        next(index.datasets.search(
             product='ls5_nbar_scene',
             source_filter={'gsi': 'ASA'}
-        )
+        ))
 
 
 @pytest.mark.parametrize('datacube_env_name', ('datacube', ))
@@ -882,7 +882,7 @@ def test_find_duplicates(index, pseudo_ls8_type,
                          pseudo_ls8_dataset, pseudo_ls8_dataset2, pseudo_ls8_dataset3, pseudo_ls8_dataset4,
                          ls5_dataset_w_children):
     # Our four ls8 datasets and three ls5.
-    all_datasets = index.datasets.search_eager()
+    all_datasets = list(index.datasets.search())
     assert len(all_datasets) == 7
 
     # First two ls8 datasets have the same path/row, last two have a different row.

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -196,7 +196,7 @@ def alter_product_for_testing(product, metadata_type=None):
 
 
 def ensure_datasets_are_indexed(index, valid_uuids):
-    datasets = index.datasets.search_eager(product='ls5_nbar_scene')
+    datasets = list(index.datasets.search(product='ls5_nbar_scene'))
     assert len(datasets) == len(valid_uuids)
     for dataset in datasets:
         assert dataset.id in valid_uuids


### PR DESCRIPTION
### Reason for this pull request

See EP13


### Proposed changes

- Correct type hints of `search_by_metadata`.
- Expand `search_returning()` so that it covers `search_summaries()` use cases.
- Deprecate `search_summaries()` and `search_eager()`.
- Deprecate `source_filter` on `search()` method.
- Replace all internal calls to `search_summaries()` and `search_returning()` with `search_returning()` and plain old  `search()`.
- Add `archived` argument to all search and count methods. (False/default - exclude archived datasets; None: include archived datasets; True: return/count archived datasets only)
- Some internal cleanup of memory driver.


Backwards incompatible side-effects of this PR:

1. The `datacube dataset search` CLI command behaves differently for datasets with no location or multiple locations (now always one result per dataset)
2. The `search_by_metadata()` method used to include archived datasets - this was inconsistent with all other search methods and undocumented.  Now honours the archived parameter, which defaults to False as for all other search methods.

 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
