### PR TITLE
Compatibility fix for passing `odc-geo` GeoBoxes to `dc.load(like=...)`

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -875,10 +875,17 @@ def output_geobox(like=None, output_crs=None, resolution=None, align=None,
         assert output_crs is None, "'like' and 'output_crs' are not supported together"
         assert resolution is None, "'like' and 'resolution' are not supported together"
         assert align is None, "'like' and 'align' are not supported together"
+        
+        # If user passes a GeoBox, return as-is
         if isinstance(like, GeoBox):
             return like
 
-        return like.geobox
+        # For `odc-geo` GeoBox compatibility: if `.geobox` does not exist
+        # as an attribute, use `.compat` to produce a Datacube-style GeoBox
+        try:
+            return like.geobox
+        except AttributeError:
+            return like.compat
 
     if load_hints:
         if output_crs is None:

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -882,8 +882,8 @@ def output_geobox(like=None, output_crs=None, resolution=None, align=None,
 
         # For `odc-geo` GeoBox compatibility: use "compat" attribute if
         # it exists to convert to a Datacube-style GeoBox
-        if hasattr(like, "compat"):
-            return like.compat
+        if isinstance(compat := getattr(like, "compat", None), GeoBox):
+            return compat
 
         return like.geobox
 

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -875,7 +875,7 @@ def output_geobox(like=None, output_crs=None, resolution=None, align=None,
         assert output_crs is None, "'like' and 'output_crs' are not supported together"
         assert resolution is None, "'like' and 'resolution' are not supported together"
         assert align is None, "'like' and 'align' are not supported together"
-        
+
         # If user passes a GeoBox, return as-is
         if isinstance(like, GeoBox):
             return like

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -880,12 +880,13 @@ def output_geobox(like=None, output_crs=None, resolution=None, align=None,
         if isinstance(like, GeoBox):
             return like
 
-        # For `odc-geo` GeoBox compatibility: if `.geobox` does not exist
-        # as an attribute, use `.compat` to produce a Datacube-style GeoBox
-        try:
-            return like.geobox
-        except AttributeError:
+        # For `odc-geo` GeoBox compatibility: use "compat" attribute if
+        # it exists to convert to a Datacube-style GeoBox
+        if hasattr(like, "compat"):
             return like.compat
+
+        return like.geobox
+
 
     if load_hints:
         if output_crs is None:

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -887,7 +887,6 @@ def output_geobox(like=None, output_crs=None, resolution=None, align=None,
 
         return like.geobox
 
-
     if load_hints:
         if output_crs is None:
             output_crs = load_hints.get('output_crs', None)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -15,6 +15,7 @@ v1.8.next
 - Update github-Dockerhub credential-passing mechanism. (:pull:`1528`)
 - Tweak ``list_products`` logic for getting crs and resolution values (:pull:`1535`)
 - Add new ODC Cheatsheet reference doc to Data Access & Analysis documentation page (:pull:`1543`)
+- Compatibility fix to allow users to supply ``odc.geo``-style GeoBoxes to ``dc.load(like=...)`` (:pull:`1551`)
 
 v1.8.17 (8th November 2023)
 ===========================

--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -332,7 +332,7 @@ def check_odcgeo_geobox_load(index):
     # Create mock odc-geo GeoBox
     class ODC_geo_geobox:
         compat = GeoBox(
-            100, 100, Affine(0.0002, 0.0, 153.45, 0.0, -0.0002, -28.9), "EPSG:4326"
+            500, 500, Affine(0.002, 0.0, 149.0, 0.0, -0.002, -35.0), "EPSG:4326"
         )
         coords = compat.coords
 

--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -343,8 +343,6 @@ def check_odcgeo_geobox_load(index):
         product="ls5_nbar_albers",
         measurements=["blue"],
         like=odc_geo_geobox.compat,
-        output_crs="EPSG:4326",
-        resolution=(-0.0000125, 0.0000125),
     )
     assert "blue" in ds_compat.data_vars
 
@@ -353,8 +351,6 @@ def check_odcgeo_geobox_load(index):
         product="ls5_nbar_albers",
         measurements=["blue"],
         like=odc_geo_geobox,
-        output_crs="EPSG:4326",
-        resolution=(-0.0000125, 0.0000125),
     )
     assert "blue" in ds_odcgeo.data_vars
 
@@ -364,7 +360,5 @@ def check_odcgeo_geobox_load(index):
         measurements=["blue"],
         like=odc_geo_geobox,
         time="1992-03-23T23:14:25.500000",
-        output_crs="EPSG:4326",
-        resolution=(-0.0000125, 0.0000125),
     )
     assert "blue" in ds_odcgeo_time.data_vars

--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -7,9 +7,11 @@ from pathlib import Path
 import numpy
 import pytest
 import rasterio
+from affine import Affine
 
 from datacube.api.query import query_group_by
 from datacube.api.core import Datacube
+from datacube.utils.geometry import GeoBox
 
 from integration_tests.utils import prepare_test_ingestion_configuration
 
@@ -318,7 +320,7 @@ def check_legacy_open(index):
         assert xx_lazy['blue'].data.dask
         assert xx_lazy.blue[0, :, :].equals(xx.blue[0, :, :])
 
-        
+
 def check_odcgeo_geobox_load(index):
     """
     Test that users can use `dc.load(like=...)` by passing an

--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -118,6 +118,7 @@ def test_end_to_end(clirunner, index, testdata_dir, ingest_configs, datacube_env
     check_open_with_dc(index)
     check_open_with_grid_workflow(index)
     check_load_via_dss(index)
+    check_odcgeo_geobox_load(index)
 
 
 def check_open_with_dc(index):

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -170,6 +170,7 @@ geo
 geobase
 GeoBox
 geobox
+GeoBoxes
 GeoboxTiles
 GEOGCS
 GeoJSON


### PR DESCRIPTION
### Reason for this pull request
Support users passing `odc.geo` GeoBoxes to `datacube.load(like=...)`. For more details, see #1549.

Temporary fix until `odc-geo` is officially integrated in version 1.9.

### Proposed changes
If the passed object is not a Datacube-style Geobox but has a `odc-geo` ".compat" attribute, try using that ".compat" method to convert the `odc-geo` style GeoBox to a `datacube`-style GeoBox.

(I deliberately didn't use a check for whether it was the object was a `odc.geo.geobox.Geobox` object because I didn't know if we wanted to add `odc-geo` to the package dependencies yet - happy to change to that though if you'd prefer!) 


 - [x] Closes #1549
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1551.org.readthedocs.build/en/1551/

<!-- readthedocs-preview datacube-core end -->