### PR TITLE
fetch_all argument for dataset search methods

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,4 +179,4 @@ jobs:
       with:
         file: ./coverage.xml
         fail_ci_if_error: false
-        token: ${{ env.CODECOV_TOKEN }}
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,3 +179,4 @@ jobs:
       with:
         file: ./coverage.xml
         fail_ci_if_error: false
+        token: ${{ env.CODECOV_TOKEN }}

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -1578,7 +1578,8 @@ class AbstractDatasetResource(ABC):
     @abstractmethod
     def search_by_metadata(self,
                            metadata: JsonDict,
-                           archived: bool | None = False
+                           archived: bool | None = False,
+                           fetch_all: bool = False
                           ) -> Iterable[Dataset]:
         """
         Perform a search using arbitrary metadata, returning results as Dataset objects.
@@ -1607,6 +1608,7 @@ class AbstractDatasetResource(ABC):
                limit: int | None = None,
                source_filter: QueryDict | None = None,
                archived: bool | None = False,
+               fetch_all: bool = False,
                **query: QueryField) -> Iterable[Dataset]:
         """
         Perform a search, returning results as Dataset objects.
@@ -1736,6 +1738,7 @@ class AbstractDatasetResource(ABC):
     @abstractmethod
     def search_by_product(self,
                           archived: bool | None = False,
+                          fetch_all: bool = False,
                           **query: QueryField
                          ) -> Iterable[tuple[Iterable[Dataset], Product]]:
         """
@@ -1753,6 +1756,7 @@ class AbstractDatasetResource(ABC):
                          field_names: Iterable[str] | None = None,
                          limit: int | None = None,
                          archived: bool | None = False,
+                         fetch_all: bool = False,
                          **query: QueryField
                         ) -> Iterable[tuple]:
         """
@@ -1847,7 +1851,7 @@ class AbstractDatasetResource(ABC):
 
     @deprecat(
         reason="This method is deprecated and will be removed in 2.0.  "
-               "Please use list(dc.index.datasets.search(...)) instead",
+               "Please use 'dc.index.datasets.search(fetch_all=True, ...)' instead",
         version="1.9.0",
         category=ODC2DeprecationWarning
     )
@@ -1858,7 +1862,7 @@ class AbstractDatasetResource(ABC):
         :param query: search query parameters
         :return: Fully instantiated list of matching dataset models
         """
-        return list(self.search(**query))  # type: ignore[arg-type]   # mypy isn't being very smart here :(
+        return self.search(fetch_all=True, **query)  # type: ignore[arg-type]   # mypy isn't being very smart here :(
 
     @abstractmethod
     def temporal_extent(self, ids: Iterable[DSID]) -> tuple[datetime.datetime, datetime.datetime]:
@@ -1893,6 +1897,7 @@ class AbstractDatasetResource(ABC):
                                         custom_offsets: Mapping[str, Offset] | None = None,
                                         limit: int | None = None,
                                         archived: bool | None = False,
+                                        fetch_all: bool = False,
                                         **query: QueryField
                                        ) -> Iterable[tuple]:
         """

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -1602,9 +1602,8 @@ class AbstractDatasetResource(ABC):
 
     @abstractmethod
     def _search_by_metadata(self,
-                           metadata: JsonDict,
-                           archived: bool | None = False,
-                           ) -> Iterable[Dataset]:
+                            metadata: JsonDict,
+                            archived: bool | None = False) -> Iterable[Dataset]:
         """
         abstract method for generator-style implementation of search_by_metadata()
 
@@ -1656,13 +1655,12 @@ class AbstractDatasetResource(ABC):
         else:
             return _results
 
-
     @abstractmethod
     def _search(self,
-               limit: int | None = None,
-               source_filter: QueryDict | None = None,
-               archived: bool | None = False,
-               **query: QueryField) -> Iterable[Dataset]:
+                limit: int | None = None,
+                source_filter: QueryDict | None = None,
+                archived: bool | None = False,
+                **query: QueryField) -> Iterable[Dataset]:
         """
         abstract method for generator-style implementation of search()
 
@@ -1810,10 +1808,9 @@ class AbstractDatasetResource(ABC):
 
     @abstractmethod
     def _search_by_product(self,
-                          archived: bool | None = False,
-                          fetch_all_per_product: bool = False,
-                          **query: QueryField
-                         ) -> Iterable[tuple[Product, Iterable[Dataset]]]:
+                           archived: bool | None = False,
+                           fetch_all_per_product: bool = False,
+                           **query: QueryField) -> Iterable[tuple[Product, Iterable[Dataset]]]:
         """
         abstract method for generator-style implementation of search_by_product()
 
@@ -1858,11 +1855,10 @@ class AbstractDatasetResource(ABC):
 
     @abstractmethod
     def _search_returning(self,
-                         field_names: Iterable[str] | None = None,
-                         limit: int | None = None,
-                         archived: bool | None = False,
-                         **query: QueryField
-                        ) -> Iterable[tuple]:
+                          field_names: Iterable[str] | None = None,
+                          limit: int | None = None,
+                          archived: bool | None = False,
+                          **query: QueryField) -> Iterable[tuple]:
         """
         abstract method for generator-style implementation of search_returning()
 
@@ -2040,12 +2036,11 @@ class AbstractDatasetResource(ABC):
 
     @abstractmethod
     def _search_returning_datasets_light(self,
-                                        field_names: tuple[str, ...],
-                                        custom_offsets: Mapping[str, Offset] | None = None,
-                                        limit: int | None = None,
-                                        archived: bool | None = False,
-                                        **query: QueryField
-                                       ) -> Iterable[tuple]:
+                                         field_names: tuple[str, ...],
+                                         custom_offsets: Mapping[str, Offset] | None = None,
+                                         limit: int | None = None,
+                                         archived: bool | None = False,
+                                         **query: QueryField) -> Iterable[tuple]:
         """
         abstract method for generator-style implementation of search_returning_datasets_light()
 

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -537,16 +537,6 @@ class DatasetResource(AbstractDatasetResource):
     def _get_prod_queries(self, **query: QueryField) -> Iterable[Tuple[Mapping[str, QueryField], Product]]:
         return ((q, product) for product, q in self._index.products.search_robust(**query))
 
-    @deprecat(
-        deprecated_args={
-            "source_filter": {
-                "reason": "Filtering by source metadata is deprecated and will be removed in future.",
-                "version": "1.9.0",
-                "category": ODC2DeprecationWarning
-
-            }
-        }
-    )
     def _search(self,
                 limit: Optional[int] = None,
                 source_filter: Optional[Mapping[str, QueryField]] = None,

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -453,9 +453,9 @@ class DatasetResource(AbstractDatasetResource):
         for ds in dss:
             if metadata_subset(metadata, ds.metadata_doc):
                 if fetch_all:
-                    yield ds
-                else:
                     results.append(ds)
+                else:
+                    yield ds
         if fetch_all:
             return results
 

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -437,8 +437,8 @@ class DatasetResource(AbstractDatasetResource):
         return True
 
     def search_by_metadata(self,
-                            metadata: Mapping[str, QueryField],
-                            archived: bool | None = False, fetch_all: bool = False):
+                           metadata: Mapping[str, QueryField],
+                           archived: bool | None = False, fetch_all: bool = False):
         _results = self._search_by_metadata(metadata, archived=archived)
         if fetch_all:
             return list(_results)
@@ -446,8 +446,8 @@ class DatasetResource(AbstractDatasetResource):
             return _results
 
     def _search_by_metadata(self,
-                           metadata: Mapping[str, QueryField],
-                           archived: bool | None = False):
+                            metadata: Mapping[str, QueryField],
+                            archived: bool | None = False):
         if archived:
             # True: Return archived datasets only
             dss = self._archived_by_id.values()
@@ -621,19 +621,19 @@ class DatasetResource(AbstractDatasetResource):
                          fetch_all: bool = False,
                          **query: QueryField) -> Iterable[Tuple]:
         _results = self._search_returning(field_names,
-                                         limit=limit,
-                                         archived=archived,
-                                         **query)
+                                          limit=limit,
+                                          archived=archived,
+                                          **query)
         if fetch_all:
             return list(_results)
         else:
             return _results
 
     def _search_returning(self,
-                         field_names: Iterable[str] | None = None,
-                         limit: Optional[int] = None,
-                         archived: bool | None = False,
-                         **query: QueryField) -> Iterable[Tuple]:
+                          field_names: Iterable[str] | None = None,
+                          limit: Optional[int] = None,
+                          archived: bool | None = False,
+                          **query: QueryField) -> Iterable[Tuple]:
         if field_names is None:
             field_names = self._index.products.get_field_names()
         else:

--- a/datacube/index/null/_datasets.py
+++ b/datacube/index/null/_datasets.py
@@ -127,26 +127,16 @@ class DatasetResource(AbstractDatasetResource):
     def restore_location(self, id_, uri):
         raise NotImplementedError()
 
-    def search_by_metadata(self, metadata, archived=False, fetch_all=False):
-        return []
+    def _search_by_metadata(self, metadata, archived=False):
+        yield from []
 
-    @deprecat(
-        deprecated_args={
-            "source_filter": {
-                "reason": "Filtering by source metadata is deprecated and will be removed in future.",
-                "version": "1.9.0",
-                "category": ODC2DeprecationWarning
+    def _search(self, limit=None, archived=False, **query):
+        yield from []
 
-            }
-        }
-    )
-    def search(self, limit=None, archived=False, fetch_all=False, **query):
-        return []
+    def _search_by_product(self, archived=False, fetch_all_per_product=False, **query):
+        yield from []
 
-    def search_by_product(self, archived=False, fetch_all=False, **query):
-        return []
-
-    def search_returning(self, field_names=None, limit=None, archived=False, fetch_all=False, **query):
+    def _search_returning(self, field_names=None, limit=None, archived=False, **query):
         return []
 
     def count(self, archived=False, **query):
@@ -174,10 +164,10 @@ class DatasetResource(AbstractDatasetResource):
         raise KeyError(str(ids))
 
     # pylint: disable=redefined-outer-name
-    def search_returning_datasets_light(self,
+    def _search_returning_datasets_light(self,
                                         field_names: tuple,
-                                        custom_offsets=None, limit=None, archived=False, fetch_all=False, **query):
-        return []
+                                        custom_offsets=None, limit=None, archived=False, **query):
+        yield from []
 
     def spatial_extent(self, ids=None, product=None, crs=None):
         return None

--- a/datacube/index/null/_datasets.py
+++ b/datacube/index/null/_datasets.py
@@ -127,7 +127,7 @@ class DatasetResource(AbstractDatasetResource):
     def restore_location(self, id_, uri):
         raise NotImplementedError()
 
-    def search_by_metadata(self, metadata, archived=False):
+    def search_by_metadata(self, metadata, archived=False, fetch_all=False):
         return []
 
     @deprecat(
@@ -140,13 +140,13 @@ class DatasetResource(AbstractDatasetResource):
             }
         }
     )
-    def search(self, limit=None, archived=False, **query):
+    def search(self, limit=None, archived=False, fetch_all=False, **query):
         return []
 
-    def search_by_product(self, archived=False, **query):
+    def search_by_product(self, archived=False, fetch_all=False, **query):
         return []
 
-    def search_returning(self, field_names=None, limit=None, archived=False, **query):
+    def search_returning(self, field_names=None, limit=None, archived=False, fetch_all=False, **query):
         return []
 
     def count(self, archived=False, **query):
@@ -176,7 +176,7 @@ class DatasetResource(AbstractDatasetResource):
     # pylint: disable=redefined-outer-name
     def search_returning_datasets_light(self,
                                         field_names: tuple,
-                                        custom_offsets=None, limit=None, archived=False, **query):
+                                        custom_offsets=None, limit=None, archived=False, fetch_all=False, **query):
         return []
 
     def spatial_extent(self, ids=None, product=None, crs=None):

--- a/datacube/index/null/_datasets.py
+++ b/datacube/index/null/_datasets.py
@@ -165,8 +165,9 @@ class DatasetResource(AbstractDatasetResource):
 
     # pylint: disable=redefined-outer-name
     def _search_returning_datasets_light(self,
-                                        field_names: tuple,
-                                        custom_offsets=None, limit=None, archived=False, **query):
+                                         field_names: tuple, custom_offsets=None,
+                                         limit=None, archived=False,
+                                         **query):
         yield from []
 
     def spatial_extent(self, ids=None, product=None, crs=None):

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -688,8 +688,8 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             return _results
 
     def _search_returning(self, field_names=None,
-                         limit=None, archived: bool | None = False,
-                         **query):
+                          limit=None, archived: bool | None = False,
+                          **query):
         """
         Perform a search, returning only the specified fields.
 
@@ -891,8 +891,8 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                                                          **query)
 
     def _search_returning_datasets_light(self, field_names: tuple, custom_offsets=None,
-                                        limit=None, archived: bool | None = False,
-                                        **query):
+                                         limit=None, archived: bool | None = False,
+                                         **query):
         """
         THIS implementation is a stub, the method it calls on the connection object is NOT implemented in this
         driver.

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -607,6 +607,13 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             return (self._make(dataset, product=product) for dataset in query_result)
 
     def search_by_metadata(self, metadata: JsonDict, archived: bool | None = False, fetch_all: bool = False):
+        _results = self._search_by_metadata(metadata, archived=archived)
+        if fetch_all:
+            return list(_results)
+        else:
+            return _results
+
+    def _search_by_metadata(self, metadata: JsonDict, archived: bool | None = False):
         """
         Perform a search using arbitrary metadata, returning results as Dataset objects.
 
@@ -615,16 +622,9 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         :param dict metadata:
         :rtype: list[Dataset]
         """
-        if fetch_all:
-            results = []
         with self._db_connection() as connection:
             for dataset in self._make_many(connection.search_datasets_by_metadata(metadata, archived)):
-                if fetch_all:
-                    results.append(dataset)
-                else:
-                    yield dataset
-        if fetch_all:
-            return results
+                yield dataset
 
     @deprecat(
         deprecated_args={
@@ -637,6 +637,14 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         }
     )
     def search(self, limit=None, archived: bool | None = False, fetch_all: bool = False, **query):
+        _results = self._search(limit=limit, archived=archived, **query)
+
+        if fetch_all:
+            return list(_results)
+        else:
+            return _results
+
+    def _search(self, limit=None, archived: bool | None = False, **query):
         """
         Perform a search, returning results as Dataset objects.
 
@@ -645,38 +653,42 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         :rtype: __generator[Dataset]
         """
         source_filter = query.pop('source_filter', None)
-        if fetch_all:
-            results = []
         for product, datasets in self._do_search_by_product(query,
                                                             source_filter=source_filter,
                                                             limit=limit,
                                                             archived=archived):
-            if fetch_all:
-                results.append(self._make_many(datasets, product))
-            else:
-                yield from self._make_many(datasets, product)
-        if fetch_all:
-            return results
+            yield from self._make_many(datasets, product)
 
     def search_by_product(self, archived: bool | None = False, fetch_all: bool = False, **query):
+        _results = self._search_by_product(archived=archived, fetch_all=fetch_all, **query)
+
+        if fetch_all:
+            return list(_results)
+        else:
+            return _results
+
+    def _search_by_product(self, archived: bool | None = False, fetch_all: bool = False, **query):
         """
         Perform a search, returning datasets grouped by product type.
 
         :param dict[str,str|float|datacube.model.Range] query:
         :rtype: __generator[(Product,  __generator[Dataset])]]
         """
-        if fetch_all:
-            results = []
         for product, datasets in self._do_search_by_product(query, archived=archived):
-            if fetch_all:
-                results.append((product, self._make_many(datasets, product, fetch_all=True)))
-            else:
-                yield product, self._make_many(datasets, product)
-        if fetch_all:
-            return results
+            yield product, self._make_many(datasets, product, fetch_all=fetch_all)
 
     def search_returning(self, field_names=None,
-                         limit=None, archived: bool | None = False, fetch_all: bool = None,
+                         limit=None, archived: bool | None = False,
+                         fetch_all: bool = None,
+                         **query):
+        _results = self._search_returning(field_names=field_names, limit=limit, archived=archived, **query)
+        if fetch_all:
+            return list(_results)
+        else:
+            return _results
+
+    def _search_returning(self, field_names=None,
+                         limit=None, archived: bool | None = False,
                          **query):
         """
         Perform a search, returning only the specified fields.
@@ -694,8 +706,6 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             field_names = self._index.products.get_field_names()
         result_type = namedtuple('search_result', field_names)
 
-        if fetch_all:
-            results = []
         for _, results in self._do_search_by_product(query,
                                                      return_fields=True,
                                                      select_field_names=field_names,
@@ -707,12 +717,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                     field: coldict.get(field)
                     for field in field_names
                 }
-                if fetch_all:
-                    results.append(result_type(**kwargs))
-                else:
-                    yield result_type(**kwargs)
-        if fetch_all:
-            return results
+                yield result_type(**kwargs)
 
     def count(self, archived: bool | None = False, **query):
         """
@@ -879,6 +884,15 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                                         limit=None, archived: bool | None = False,
                                         fetch_all: bool = False,
                                         **query):
+        _results = self._search_returning_datasets_light(field_names,
+                                                         custom_offsets=custom_offsets,
+                                                         limit=limit,
+                                                         archived=archived,
+                                                         **query)
+
+    def _search_returning_datasets_light(self, field_names: tuple, custom_offsets=None,
+                                        limit=None, archived: bool | None = False,
+                                        **query):
         """
         THIS implementation is a stub, the method it calls on the connection object is NOT implemented in this
         driver.
@@ -886,8 +900,6 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
         assert field_names
 
-        if fetch_all:
-            full_results = []
         for product, query_exprs in self.make_query_expr(query, custom_offsets):
 
             select_fields = self.make_select_fields(product, field_names, custom_offsets)
@@ -918,12 +930,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                     else:
                         field_values[field.name] = result[i_]
 
-                if fetch_all:
-                    full_results.append(DatasetLight(**field_values))
-                else:
-                    yield DatasetLight(**field_values)  # type: ignore
-        if fetch_all:
-            return full_results
+                yield DatasetLight(**field_values)  # type: ignore
 
     def make_select_fields(self, product, field_names, custom_offsets):
         """

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -658,7 +658,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         if fetch_all:
             return results
 
-    def search_by_product(self, archived: bool | None = False, fetch_all: bool = True, **query):
+    def search_by_product(self, archived: bool | None = False, fetch_all: bool = False, **query):
         """
         Perform a search, returning datasets grouped by product type.
 

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -661,10 +661,10 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             return _results
 
     def _search_returning(self,
-                         field_names=None,
-                         limit=None,
-                         archived: bool | None = False,
-                         **query):
+                          field_names=None,
+                          limit=None,
+                          archived: bool | None = False,
+                          **query):
         """
         Perform a search, returning only the specified fields.
 
@@ -897,8 +897,8 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             return _results
 
     def _search_returning_datasets_light(self, field_names: tuple, custom_offsets=None, limit=None,
-                                        archived: bool | None = False,
-                                        **query):
+                                         archived: bool | None = False,
+                                         **query):
         """
         This is a dataset search function that returns the results as objects of a dynamically
         generated Dataset class that is a subclass of tuple.

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -579,13 +579,6 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         else:
             return (self._make(dataset, product=product) for dataset in query_result)
 
-    def search_by_metadata(self, metadata, archived: bool | None = False, fetch_all: bool = False):
-        _results = self._search_by_metadata(metadata, archived=archived)
-        if fetch_all:
-            return list(_results)
-        else:
-            return _results
-
     def _search_by_metadata(self, metadata, archived: bool | None = False):
         """
         Perform a search using arbitrary metadata, returning results as Dataset objects.
@@ -598,23 +591,6 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         with self._db_connection() as connection:
             for dataset in self._make_many(connection.search_datasets_by_metadata(metadata, archived)):
                 yield dataset
-
-    @deprecat(
-        deprecated_args={
-            "source_filter": {
-                "reason": "Filtering by source metadata is deprecated and will be removed in future.",
-                "version": "1.9.0",
-                "category": ODC2DeprecationWarning
-
-            }
-        }
-    )
-    def search(self, limit=None, source_filter=None, archived: bool | None = False, fetch_all: bool = False, **query):
-        _results = self._search(limit=limit, source_filter=source_filter, archived=archived, **query)
-        if fetch_all:
-            return list(_results)
-        else:
-            return (_results)
 
     def _search(self, limit=None, source_filter=None, archived: bool | None = False, **query):
         """
@@ -631,14 +607,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                                                             archived=archived):
             yield from self._make_many(datasets, product)
 
-    def search_by_product(self, archived: bool | None = False, fetch_all: bool = False, **query):
-        _results = self._search_by_product(archived=archived, fetch_all=fetch_all, **query)
-        if fetch_all:
-            return list(_results)
-        else:
-            return _results
-
-    def _search_by_product(self, archived: bool | None = False, fetch_all: bool = False, **query):
+    def _search_by_product(self, archived: bool | None = False, fetch_all_per_product: bool = False, **query):
         """
         Perform a search, returning datasets grouped by product type.
 
@@ -646,19 +615,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         :rtype: __generator[(Product,  __generator[Dataset])]]
         """
         for product, datasets in self._do_search_by_product(query, archived=archived):
-            yield product, self._make_many(datasets, product, fetch_all=fetch_all)
-
-    def search_returning(self,
-                         field_names=None,
-                         limit=None,
-                         archived: bool | None = False,
-                         fetch_all: bool = False,
-                         **query):
-        _results = self._search_returning(field_names, limit=limit, archived=archived, **query)
-        if fetch_all:
-            return list(_results)
-        else:
-            return _results
+            yield product, self._make_many(datasets, product, fetch_all=fetch_all_per_product)
 
     def _search_returning(self,
                           field_names=None,
@@ -880,21 +837,6 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         Returns the minimum and maximum acquisition time of the specified datasets.
         """
         raise NotImplementedError("Sorry Temporal Extent by dataset ids is not supported in postgres driver.")
-
-    # pylint: disable=redefined-outer-name
-    def search_returning_datasets_light(self, field_names: tuple, custom_offsets=None, limit=None,
-                                        archived: bool | None = False,
-                                        fetch_all: bool = False,
-                                        **query):
-        _results = self._search_returning_datasets_light(field_names,
-                                                         custom_offsets=custom_offsets,
-                                                         limit=limit,
-                                                         archived=archived,
-                                                         **query)
-        if fetch_all:
-            return list(_results)
-        else:
-            return _results
 
     def _search_returning_datasets_light(self, field_names: tuple, custom_offsets=None, limit=None,
                                          archived: bool | None = False,

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -623,8 +623,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         for product, datasets in self._do_search_by_product(query,
                                                             source_filter=source_filter,
                                                             limit=limit,
-                                                            archived=archived,
-                                                            fetch_all=fetch_all):
+                                                            archived=archived):
             if fetch_all:
                 results.extend(self._make_many(datasets, product))
             else:

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -34,6 +34,7 @@ v1.9.next
 - Index driver API type hint cleanup. (:pull:`1541`)
 - Deprecate multiple locations. (:pull:`1546`)
 - Deprecate search_eager and search_summaries and add `archived` arg to all dataset search/count methods. (:pull:`1550`)
+- Add `fetch_all` argument to all non-deprecated dataset search methods. (:pull:`1553`)
 
 
 v1.8.next

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -34,7 +34,7 @@ v1.9.next
 - Index driver API type hint cleanup. (:pull:`1541`)
 - Deprecate multiple locations. (:pull:`1546`)
 - Deprecate search_eager and search_summaries and add `archived` arg to all dataset search/count methods. (:pull:`1550`)
-- Add `fetch_all` argument to all non-deprecated dataset search methods. (:pull:`1553`)
+- Add `fetch_all` argument to all non-deprecated dataset search methods and fix codecov upload. (:pull:`1553`)
 
 
 v1.8.next

--- a/integration_tests/index/test_memory_index.py
+++ b/integration_tests/index/test_memory_index.py
@@ -452,7 +452,7 @@ def test_mem_ds_search_and_count(mem_eo3_data: tuple):
     lds = list(dc.index.datasets.search(platform='landsat-8'))
     assert len(lds) == 2
     assert dc.index.datasets.count(platform='landsat-8') == 2
-    lds = list(dc.index.datasets.search(platform='landsat-8', limit=1))
+    lds = dc.index.datasets.search(platform='landsat-8', limit=1, fetch_all=True)
     assert len(lds) == 1
     lds = list(dc.index.datasets.search(source_filter={"product_family": 'ard'}))
     assert len(lds) == 1
@@ -471,7 +471,7 @@ def test_mem_ds_search_and_count(mem_eo3_data: tuple):
     with pytest.raises(ValueError):
         lds = list(dc.index.datasets.search(product_family='addams'))
 
-    lds = list(dc.index.datasets.search(archived=None, platform='landsat-8'))
+    lds = dc.index.datasets.search(archived=None, platform='landsat-8', fetch_all=True)
     assert len(lds) == 2
     lds = list(dc.index.datasets.search(archived=True, platform='landsat-8'))
     assert len(lds) == 0
@@ -488,7 +488,7 @@ def test_mem_ds_search_and_count(mem_eo3_data: tuple):
 def test_mem_ds_search_and_count_by_product(mem_eo3_data: tuple):
     dc, ls8_id, wo_id = mem_eo3_data
     # No source_filter; no results
-    assert not list(dc.index.datasets.search_by_product(platform="deplatformed"))
+    assert not dc.index.datasets.search_by_product(platform="deplatformed", fetch_all=True)
     lds = list(dc.index.datasets.search_by_product(platform='landsat-8'))
     assert len(lds) == 2
     for dss, product in lds:
@@ -502,12 +502,13 @@ def test_mem_ds_search_and_count_by_product(mem_eo3_data: tuple):
 
 def test_mem_ds_search_returning(mem_eo3_data: tuple):
     dc, ls8_id, wo_id = mem_eo3_data
-    lds = list(dc.index.datasets.search_returning(
+    lds = dc.index.datasets.search_returning(
         field_names=[
             "platform", "id", "product_family"
         ],
-        platform='landsat-8'
-    ))
+        platform='landsat-8',
+        fetch_all=True
+    )
     assert len(lds) == 2
     for res in lds:
         assert res.platform == "landsat-8"
@@ -540,10 +541,10 @@ def test_mem_ds_search_returning_datasets_light(mem_eo3_data: tuple):
         assert res.__class__.__name__ == 'DatasetLight'
         assert res.platform == "landsat-8"
         assert res.id in (str(ls8_id), str(wo_id))
-    lds = list(dc.index.datasets.search_returning_datasets_light(
+    lds = dc.index.datasets.search_returning_datasets_light(
         archived=None,
         field_names=['platform', 'id'],
-        platform='landsat-8'))
+        platform='landsat-8', fetch_all=True)
     assert len(lds) == 2
     lds = list(dc.index.datasets.search_returning_datasets_light(
         archived=True,
@@ -560,7 +561,7 @@ def test_mem_ds_search_by_metadata(mem_eo3_data: tuple):
     assert len(lds) == 1
     lds = list(dc.index.datasets.search_by_metadata({"properties": {"platform": "landsat-8"}}))
     assert len(lds) == 0
-    lds = list(dc.index.datasets.search_by_metadata({"properties": {"eo:platform": "landsat-8"}}))
+    lds = dc.index.datasets.search_by_metadata({"properties": {"eo:platform": "landsat-8"}}, fetch_all=True)
     assert len(lds) == 2
     lds = list(dc.index.datasets.search_by_metadata({"properties": {"eo:platform": "landsat-8"}}, archived=None))
     assert len(lds) == 2

--- a/integration_tests/index/test_null_index.py
+++ b/integration_tests/index/test_null_index.py
@@ -126,17 +126,20 @@ def test_null_dataset_resource(null_config: ODCEnvironment):
             dc.index.datasets.get_product_time_bounds("product1")  # Test deprecated method
 
         assert dc.index.datasets.search_product_duplicates(MagicMock()) == []
-        assert dc.index.datasets.search_by_metadata({}) == []
-        assert dc.index.datasets.search(foo="bar", baz=12) == []
-        assert dc.index.datasets.search_by_product(foo="bar", baz=12) == []
-        assert dc.index.datasets.search_returning(["foo", "bar"], foo="bar", baz=12) == []
+        assert list(dc.index.datasets.search_by_metadata({})) == []
+        assert dc.index.datasets.search_by_metadata({}, fetch_all=True) == []
+        assert dc.index.datasets.search(foo="bar", baz=12, fetch_all=True) == []
+        assert dc.index.datasets.search_by_product(foo="bar", baz=12, fetch_all=True) == []
+        assert dc.index.datasets.search_returning(["foo", "bar"], foo="bar", baz=12, fetch_all=True) == []
         assert dc.index.datasets.count(foo="bar", baz=12) == 0
         assert dc.index.datasets.count_by_product(foo="bar", baz=12) == []
         assert dc.index.datasets.count_by_product_through_time("1 month", foo="bar", baz=12) == []
         assert dc.index.datasets.count_product_through_time("1 month", foo="bar", baz=12) == []
         assert dc.index.datasets.search_summaries(foo="bar", baz=12) == []  # Coverage test of deprecated method
         assert dc.index.datasets.search_eager(foo="bar", baz=12) == []  # Coverage test of deprecated base class method
-        assert dc.index.datasets.search_returning_datasets_light(("foo", "baz"), foo="bar", baz=12) == []
+        assert dc.index.datasets.search_returning_datasets_light(
+            ("foo", "baz"), foo="bar", baz=12, fetch_all=True
+        ) == []
 
 
 def test_null_transactions(null_config: ODCEnvironment):

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -38,9 +38,10 @@ def test_search_by_metadata(index: Index, ls8_eo3_product, wo_eo3_product):
 
 
 def test_search_dataset_equals_eo3(index: Index, ls8_eo3_dataset: Dataset):
-    datasets = list(index.datasets.search(
-        platform='landsat-8'
-    ))
+    datasets = index.datasets.search(
+        platform='landsat-8',
+        fetch_all=True
+    )
     assert len(datasets) == 1
     assert datasets[0].id == ls8_eo3_dataset.id
 
@@ -86,10 +87,11 @@ def test_search_dataset_range_eo3(index: Index,
     assert ls8_eo3_dataset2.id in ids
 
     # Full Range comparison
-    datasets = list(index.datasets.search(
+    datasets = index.datasets.search(
         product=ls8_eo3_dataset.product.name,
-        cloud_cover=Range(20.0, 55.0)
-    ))
+        cloud_cover=Range(20.0, 55.0),
+        fetch_all=True
+    )
     assert len(datasets) == 2
     ids = [ds.id for ds in datasets]
     assert ls8_eo3_dataset2.id in ids
@@ -98,9 +100,9 @@ def test_search_dataset_range_eo3(index: Index,
 
 def test_search_dataset_by_metadata_eo3(index: Index, ls8_eo3_dataset: Dataset) -> None:
     datasets = index.datasets.search_by_metadata(
-        {"properties": {"eo:platform": "landsat-8", "eo:instrument": "OLI_TIRS"}}
+        {"properties": {"eo:platform": "landsat-8", "eo:instrument": "OLI_TIRS"}},
+        fetch_all=True
     )
-    datasets = list(datasets)
     assert len(datasets) == 1
     assert datasets[0].id == ls8_eo3_dataset.id
 
@@ -272,12 +274,13 @@ def test_search_by_product_eo3(index: Index,
     assert dataset_count == 2
 
     # Query one product
-    products = _load_product_query(index.datasets.search_by_product(
+    products = index.datasets.search_by_product(
         platform='landsat-8',
-        product_family='wo'
-    ))
+        product_family='wo',
+        fetch_all=True
+    )
     assert len(products) == 1
-    [dataset] = products[base_eo3_product_doc["name"]]
+    [dataset] = products[0][1]
     assert dataset.id == wo_eo3_dataset.id
     assert dataset.is_eo3
     assert dataset.type == dataset.product  # DEPRECATED MEMBER
@@ -296,7 +299,7 @@ def test_search_limit_eo3(index, ls8_eo3_dataset, ls8_eo3_dataset2, wo_eo3_datas
     datasets = list(index.datasets.search(limit=5, product=prod))
     assert len(datasets) == 2
 
-    datasets = list(index.datasets.search_returning(('id',), product=prod))
+    datasets = index.datasets.search_returning(('id',), product=prod, fetch_all=True)
     assert len(datasets) == 2
     datasets = list(index.datasets.search_returning(('id',), limit=1, product=prod))
     assert len(datasets) == 1
@@ -463,9 +466,10 @@ def test_search_returning_eo3(index: Index,
     assert label == ls8_eo3_dataset.metadata.label
 
     # All Fields
-    results = list(index.datasets.search_returning(
+    results = index.datasets.search_returning(
         platform='landsat-8',
-    ))
+        fetch_all=True
+    )
     assert len(results) == 3
 
     assert ls8_eo3_dataset.id in (result.id for result in results)

--- a/integration_tests/test_index_datasets_search.py
+++ b/integration_tests/test_index_datasets_search.py
@@ -34,7 +34,7 @@ def test_index_datasets_search_light(index, tmpdir, clirunner,
 
     # Test derived properties such as 'extent'
     results = index.datasets.search_returning_datasets_light(field_names=('id', 'extent', 'time'),
-                                                                  product='ls5_nbar_scene', fetch_all=True)
+                                                             product='ls5_nbar_scene', fetch_all=True)
     for dataset in results:
         assert dataset.id in valid_uuids
         # Assume projection is defined as
@@ -61,11 +61,11 @@ def test_index_datasets_search_light(index, tmpdir, clirunner,
     assert len(results) > 0
 
     results = index.datasets.search_returning_datasets_light(field_names=('id', 'zone'),
-                                                                  custom_offsets={'zone': ['grid_spatial',
-                                                                                           'projection', 'zone']},
-                                                                  product='ls5_nbar_scene',
-                                                                  zone='-65',
-                                                                  fetch_all=True)
+                                                             custom_offsets={'zone': ['grid_spatial',
+                                                                                      'projection', 'zone']},
+                                                             product='ls5_nbar_scene',
+                                                             zone='-65',
+                                                             fetch_all=True)
     assert len(results) == 0
 
     # Test uris

--- a/integration_tests/test_index_datasets_search.py
+++ b/integration_tests/test_index_datasets_search.py
@@ -33,8 +33,8 @@ def test_index_datasets_search_light(index, tmpdir, clirunner,
     valid_uuids = index_products()
 
     # Test derived properties such as 'extent'
-    results = list(index.datasets.search_returning_datasets_light(field_names=('id', 'extent', 'time'),
-                                                                  product='ls5_nbar_scene'))
+    results = index.datasets.search_returning_datasets_light(field_names=('id', 'extent', 'time'),
+                                                                  product='ls5_nbar_scene', fetch_all=True)
     for dataset in results:
         assert dataset.id in valid_uuids
         # Assume projection is defined as
@@ -60,11 +60,12 @@ def test_index_datasets_search_light(index, tmpdir, clirunner,
                                                                   zone='-55'))
     assert len(results) > 0
 
-    results = list(index.datasets.search_returning_datasets_light(field_names=('id', 'zone'),
+    results = index.datasets.search_returning_datasets_light(field_names=('id', 'zone'),
                                                                   custom_offsets={'zone': ['grid_spatial',
                                                                                            'projection', 'zone']},
                                                                   product='ls5_nbar_scene',
-                                                                  zone='-65'))
+                                                                  zone='-65',
+                                                                  fetch_all=True)
     assert len(results) == 0
 
     # Test uris
@@ -89,15 +90,17 @@ def test_index_datasets_search_light(index, tmpdir, clirunner,
     new_loc = PurePosixPath(tmpdir.strpath) / 'temp_location' / 'agdc-metadata.yaml'
     index.datasets.add_location(valid_uuids[0], new_loc.as_uri())  # Test of deprecated functionality
 
-    results_with_uri = list(index.datasets.search_returning_datasets_light(field_names=('id', 'uris'),
-                                                                           product='ls5_nbar_scene',
-                                                                           id=valid_uuids[0]))
+    results_with_uri = index.datasets.search_returning_datasets_light(field_names=('id', 'uris'),
+                                                                      product='ls5_nbar_scene',
+                                                                      id=valid_uuids[0],
+                                                                      fetch_all=True)
     assert len(results_with_uri) == 1
     assert len(results_with_uri[0].uris) == 2
 
-    results_with_uri = list(index.datasets.search_returning_datasets_light(field_names=('id', 'uri'),
-                                                                           product='ls5_nbar_scene',
-                                                                           id=valid_uuids[0]))
+    results_with_uri = index.datasets.search_returning_datasets_light(field_names=('id', 'uri'),
+                                                                      product='ls5_nbar_scene',
+                                                                      id=valid_uuids[0],
+                                                                      fetch_all=True)
     assert len(results_with_uri) == 1
     assert len(results_with_uri[0].uri) == 2
 


### PR DESCRIPTION
### Reason for this pull request

Add `fetch_all: bool = False` argument to all (non-deprecated) dataset search methods, as per EP-13.

### Proposed changes

- `fetch_all: bool` argument (defaulting to `False`) added to all non-deprecated dataset search methods.  When true, all search results are gathered and returned in a fully instantiated list.  When false (the default), the method acts as a generator and yields a result at a time.  


Notes: 

1. This typically requires wrapper methods as simply having a `yield` statement in a method/function makes it act as a generator - you can't decide dynamically whether to yield or return from a function.  Basic form looks like:
```
def method(self, ..., fetch_all: bool = False, **query):
    _results = self._method(...., **query)
    if fetch_all:
        return list(_results)   # return as instantiated list
    else:
        return _results         # return as generator.
```
2. The `search_by_products()` method has two layers of lazy evaluation (in generator mode, yields tuples containing a product and a nested generator that yields datasets.  The `fetch_all=True` version fully instantiates both layers.


 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
