### PR TITLE
Fix codecov action and update whats_new.rst

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,3 +179,4 @@ jobs:
       with:
         file: ./coverage.xml
         fail_ci_if_error: false
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -15,6 +15,7 @@ v1.8.next
 - Update github-Dockerhub credential-passing mechanism. (:pull:`1528`)
 - Tweak ``list_products`` logic for getting crs and resolution values (:pull:`1535`)
 - Add new ODC Cheatsheet reference doc to Data Access & Analysis documentation page (:pull:`1543`)
+- Fix broken codecov github action. (:pull:`1554`)
 
 v1.8.17 (8th November 2023)
 ===========================


### PR DESCRIPTION
### Reason for this pull request

Codecov github action was broken by #1542.  This PR fixes it.

Note that this change is applied for `develop-1.9`  in #1553 


### Proposed changes

- Pass Codecov auth token as repo secret, as required by codecov-action@v4


 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1554.org.readthedocs.build/en/1554/

<!-- readthedocs-preview datacube-core end -->