### PR TITLE
Fix pkg resource deprecation waring

### DIFF
--- a/datacube/drivers/driver_cache.py
+++ b/datacube/drivers/driver_cache.py
@@ -51,8 +51,8 @@ def load_drivers(group: str) -> Dict[str, Any]:
         return driver
 
     def resolve_all(group: str) -> Iterable[Tuple[str, Any]]:
-        from pkg_resources import iter_entry_points
-        for ep in iter_entry_points(group=group, name=None):
+        from importlib_metadata import entry_points
+        for ep in entry_points(group=group, name=None):
             driver = safe_load(ep)
             if driver is not None:
                 yield (ep.name, driver)

--- a/datacube/drivers/driver_cache.py
+++ b/datacube/drivers/driver_cache.py
@@ -26,14 +26,9 @@ def load_drivers(group: str) -> Dict[str, Any]:
     """
 
     def safe_load(ep):
-        from pkg_resources import DistributionNotFound
         # pylint: disable=broad-except,bare-except
         try:
             driver_init = ep.load()
-        except DistributionNotFound:
-            # This happens when entry points were marked with extra features,
-            # but extra feature were not requested for installation
-            return None
         except Exception as e:
             _LOG.warning('Failed to resolve driver %s::%s', group, ep.name)
             _LOG.warning('Error was: %s', repr(e))
@@ -52,7 +47,7 @@ def load_drivers(group: str) -> Dict[str, Any]:
 
     def resolve_all(group: str) -> Iterable[Tuple[str, Any]]:
         from importlib_metadata import entry_points
-        for ep in entry_points(group=group, name=None):
+        for ep in entry_points(group=group):
             driver = safe_load(ep)
             if driver is not None:
                 yield (ep.name, driver)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -34,6 +34,7 @@ v1.9.next
 - Index driver API type hint cleanup. (:pull:`1541`)
 - Deprecate multiple locations. (:pull:`1546`)
 - Deprecate search_eager and search_summaries and add `archived` arg to all dataset search/count methods. (:pull:`1550`)
+- Migrate away from deprecated Python pkg_resources module (:pull:`1558`)
 
 
 v1.8.next


### PR DESCRIPTION
### Reason for this pull request

Migrate from deprecated `pkg_resources.iter_entry_points` to `importlib_metadata.entry_points` to squash deprecation warning.



 - [x] Closes #1555
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
