### PR TITLE
Updating all DEA Knowledge Hub links in entire repo

### DIFF
--- a/docs/about-core-concepts/existing-deployments.rst
+++ b/docs/about-core-concepts/existing-deployments.rst
@@ -7,10 +7,10 @@ If you are using `Digital Earth Australia`_, see the
 `Digital Earth Australia User Guide`_ for instructions on accessing data on the `NCI`_, `AWS`_ and the `DEA Sandbox`_.
 
 .. _`Digital Earth Australia`: https://www.ga.gov.au/dea
-.. _`Digital Earth Australia User Guide`: https://docs.dea.ga.gov.au/
-.. _`NCI`: https://docs.dea.ga.gov.au/setup/NCI/README.html
-.. _`AWS`: https://docs.dea.ga.gov.au/setup/AWS/data_and_metadata.html
-.. _`DEA Sandbox`: https://docs.dea.ga.gov.au/setup/sandbox.html
+.. _`Digital Earth Australia User Guide`: https://knowledge.dea.ga.gov.au/
+.. _`NCI`: https://knowledge.dea.ga.gov.au/setup/NCI/README.html
+.. _`AWS`: https://knowledge.dea.ga.gov.au/setup/AWS/data_and_metadata.html
+.. _`DEA Sandbox`: https://knowledge.dea.ga.gov.au/setup/sandbox.html
 
 
 Digital Earth Africa

--- a/docs/data-access-analysis/advanced-topics/virtual-products.rst
+++ b/docs/data-access-analysis/advanced-topics/virtual-products.rst
@@ -21,7 +21,7 @@ pixel-by-pixel.
 The source code for virtual products is in the :mod:`datacube.virtual` module.
 An example notebook using virtual products can be found in the `DEA`_ notebooks collection.
 
-.. _DEA: https://docs.dea.ga.gov.au/notebooks/Frequently_used_code/Virtual_products.html
+.. _DEA: https://knowledge.dea.ga.gov.au/notebooks/Frequently_used_code/Virtual_products.html
 
 
 Using virtual products

--- a/docs/data-access-analysis/tools-exploring-data/using-juypter.rst
+++ b/docs/data-access-analysis/tools-exploring-data/using-juypter.rst
@@ -23,9 +23,9 @@ Digital Earth Australia Notebooks
 * `Real world examples`_: More complex workflows demonstrating how Open Data Cube can be used to address real-world challenges
 
 .. _`Digital Earth Australia Notebooks`: https://github.com/GeoscienceAustralia/dea-notebooks/
-.. _`Beginners guide`: https://docs.dea.ga.gov.au/notebooks/Beginners_guide/README.html
-.. _`Frequently used code`: https://docs.dea.ga.gov.au/notebooks/Frequently_used_code/README.html
-.. _`Real world examples`: https://docs.dea.ga.gov.au/notebooks/Real_world_examples/README.html
+.. _`Beginners guide`: https://knowledge.dea.ga.gov.au/notebooks/Beginners_guide/README.html
+.. _`Frequently used code`: https://knowledge.dea.ga.gov.au/notebooks/Frequently_used_code/README.html
+.. _`Real world examples`: https://knowledge.dea.ga.gov.au/notebooks/Real_world_examples/README.html
 .. _Jupyter Notebooks: https://jupyter.org/
 
 


### PR DESCRIPTION
### Reason for this pull request

The URL of Geoscience Australia's DEA Knowledge Hub has changed to <https://knowledge.dea.ga.gov.au/>

### Proposed changes

- In the entire repo, change all "docs.dea.ga.gov.au" links to "knowledge.dea.ga.gov.au". 

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1559.org.readthedocs.build/en/1559/

<!-- readthedocs-preview datacube-core end -->