### PR TITLE
Refine _time_to_search_dims logic

### DIFF
--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -125,7 +125,11 @@ class Query(object):
             if 'time' not in self.search:
                 time_coord = like.coords.get('time')
                 if time_coord is not None:
-                    self.search['time'] = _time_to_search_dims((time_coord.values[0], time_coord.values[-1]))
+                    self.search['time'] = _time_to_search_dims(
+                        # convert from np.datetime64 to datetime.datetime
+                        (pandas_to_datetime(time_coord.values[0]).to_pydatetime(),
+                         pandas_to_datetime(time_coord.values[-1]).to_pydatetime())
+                    )
 
     @property
     def search_terms(self):
@@ -302,7 +306,6 @@ def _values_to_search(**kwargs):
 def _time_to_search_dims(time_range):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
-
         tr_start, tr_end = time_range, time_range
 
         if hasattr(time_range, '__iter__') and not isinstance(time_range, str):

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -57,7 +57,7 @@ OTHER_KEYS = ('measurements', 'group_by', 'output_crs', 'resolution', 'set_nan',
               'source_filter')
 
 
-class Query():
+class Query:
     def __init__(self, index=None, product=None, geopolygon=None, like=None, **search_terms):
         """Parses search terms in preparation for querying the Data Cube Index.
 

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -321,7 +321,7 @@ def _time_to_search_dims(time_range):
         if tr_start is None:
             start = datetime.datetime.fromtimestamp(0)
         elif not isinstance(tr_start, datetime.datetime):
-            # ensure consistency between different datetime types
+            # convert to datetime.datetime
             if hasattr(tr_start, 'isoformat'):
                 tr_start = tr_start.isoformat()
             start = pandas_to_datetime(tr_start).to_pydatetime()
@@ -330,15 +330,12 @@ def _time_to_search_dims(time_range):
 
         if tr_end is None:
             tr_end = datetime.datetime.now().strftime("%Y-%m-%d")
-        if not isinstance(tr_end, datetime.datetime):
-            # Attempt conversion to isoformat
-            # allows pandas.Period to handle date objects
-            if hasattr(tr_end, 'isoformat'):
-                tr_end = tr_end.isoformat()
-            end = pandas.Period(tr_end).end_time.to_pydatetime()
-        else:
-            # if it's already a datetime, no need to extrapolate the period end
-            end = tr_end
+        # Attempt conversion to isoformat
+        # allows pandas.Period to handle datetime objects
+        if hasattr(tr_end, 'isoformat'):
+            tr_end = tr_end.isoformat()
+        # get end of period to ensure range is inclusive
+        end = pandas.Period(tr_end).end_time.to_pydatetime()
 
         tr = Range(tz_aware(start), tz_aware(end))
         if start == end:

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -68,7 +68,7 @@ class Query(object):
         Use by accessing :attr:`search_terms`:
 
         >>> query.search_terms['time']  # doctest: +NORMALIZE_WHITESPACE
-        Range(begin=datetime.datetime(2001, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), \
+        Range(begin=datetime.datetime(2001, 1, 1, 0, 0, tzinfo=tzutc()), \
         end=datetime.datetime(2002, 1, 1, 23, 59, 59, 999999, tzinfo=tzutc()))
 
         By passing in an ``index``, the search parameters will be validated as existing on the ``product``.

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -16,7 +16,8 @@ v1.8.next
 - Tweak ``list_products`` logic for getting crs and resolution values (:pull:`1535`)
 - Add new ODC Cheatsheet reference doc to Data Access & Analysis documentation page (:pull:`1543`)
 - Fix broken codecov github action. (:pull:`1554`)
-- Fix handling of date value as int in Query construction (:pull:`1561`)
+- Throw error if ``time`` dimension is provided as an int or float to Query construction
+  instead of assuming it to be seconds since epoch (:pull:`1561`)
 
 v1.8.17 (8th November 2023)
 ===========================

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -16,6 +16,7 @@ v1.8.next
 - Tweak ``list_products`` logic for getting crs and resolution values (:pull:`1535`)
 - Add new ODC Cheatsheet reference doc to Data Access & Analysis documentation page (:pull:`1543`)
 - Fix broken codecov github action. (:pull:`1554`)
+- Fix handling of date value as int in Query construction (:pull:`1561`)
 
 v1.8.17 (8th November 2023)
 ===========================

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -145,8 +145,6 @@ testdata = [
      format_test('2008-01-01T00:00:00', datetime.datetime.now().strftime("%Y-%m-%dT23:59:59.999999"))),
     ((None, '2008'),
      format_test(datetime.datetime.fromtimestamp(0).strftime("%Y-%m-%dT%H:%M:%S"), '2008-12-31T23:59:59.999999')),
-    ((2008),
-     format_test('2008-01-01T00:00:00', '2008-12-31T23:59:59.999999')),
 ]
 
 
@@ -155,6 +153,11 @@ def test_time_handling(time_param, expected):
     query = Query(time=time_param)
     assert 'time' in query.search_terms
     assert query.search_terms['time'] == expected
+
+
+def test_time_handling_int():
+    with pytest.raises(TypeError):
+        Query(time=2008)
 
 
 def test_solar_day():

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -144,7 +144,9 @@ testdata = [
     ((datetime.date(2008, 1, 1), None),
      format_test('2008-01-01T00:00:00', datetime.datetime.now().strftime("%Y-%m-%dT23:59:59.999999"))),
     ((None, '2008'),
-     format_test(datetime.datetime.fromtimestamp(0).strftime("%Y-%m-%dT%H:%M:%S"), '2008-12-31T23:59:59.999999'))
+     format_test(datetime.datetime.fromtimestamp(0).strftime("%Y-%m-%dT%H:%M:%S"), '2008-12-31T23:59:59.999999')),
+    ((2008),
+     format_test('2008-01-01T00:00:00', '2008-12-31T23:59:59.999999')),
 ]
 
 


### PR DESCRIPTION
### Reason for this pull request

Passing `time` as an int/float to `dc.load` was causing the query to return an unexpected date range due to the value being interpreted as seconds since epoch. Int/float is not documented as an accepted type for `time` in the first place and could be ambiguous.


### Proposed changes

- Raise error if time is not provided as some form of datetime or a string
- Tweak and consolidate logic in `_time_to_search_dims` and `_to_datetime`
- Remove added millisecond in time range from `like` as it appears unnecessary



 - [ ] Closes #xxxx
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1561.org.readthedocs.build/en/1561/

<!-- readthedocs-preview datacube-core end -->