### PR TITLE
Postgis join hints

### DIFF
--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -666,11 +666,7 @@ class PostgisDbAPI:
         select_query = self.search_datasets_query(expressions, source_exprs,
                                                   select_fields, with_source_ids,
                                                   limit, geom=geom, archived=archived)
-        try:
-            str_qry = str(select_query)
-        except AmbiguousForeignKeysError as e:
-            pass
-        _LOG.debug("search_datasets SQL: %s", str_qry)
+        _LOG.debug("search_datasets SQL: %s", str(select_query))
         return self._connection.execute(select_query)
 
     def bulk_simple_dataset_search(self, products=None, batch_size=0):

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -23,7 +23,7 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.sql.expression import Select
 from sqlalchemy import select, text, and_, or_, func
 from sqlalchemy.dialects.postgresql import INTERVAL
-from sqlalchemy.exc import IntegrityError, AmbiguousForeignKeysError
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.engine import Row
 
 from typing import Iterable, Sequence, Optional, Set, Any

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -124,7 +124,7 @@ def get_native_fields() -> dict[str, NativeField]:
             'Metadata type name of dataset',
             MetadataType.name,
             join_clause=(MetadataType.id == Dataset.metadata_type_ref),
-    ),
+        ),
         'metadata_type_id': NativeField(
             'metadata_type_id',
             'ID of a metadata type',

--- a/datacube/drivers/postgis/_fields.py
+++ b/datacube/drivers/postgis/_fields.py
@@ -10,7 +10,7 @@ import math
 from collections import namedtuple
 from datetime import datetime, date
 from decimal import Decimal
-from typing import Any, Callable, Tuple, Union, cast as type_cast
+from typing import Any, Callable, Tuple, Union
 
 from psycopg2.extras import NumericRange, DateTimeTZRange
 from sqlalchemy import cast, func, and_

--- a/docker/constraints.in
+++ b/docker/constraints.in
@@ -37,7 +37,7 @@ sphinx-click
 sphinx_autodoc_typehints
 sphinx_rtd_theme
 alembic
-sqlalchemy>=2.0
+sqlalchemy>=2.0.18
 toolz
 xarray>=2023.9.0
 odc-geo

--- a/docker/constraints.txt
+++ b/docker/constraints.txt
@@ -401,7 +401,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.8
+sqlalchemy==2.0.24
     # via
     #   -r constraints.in
     #   alembic

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -37,6 +37,7 @@ v1.9.next
 - Migrate away from deprecated Python pkg_resources module (:pull:`1558`)
 - Add `custom_offsets` and `order_by` arguments to search_retunrning() - order_by still unimplemented. (:pull:`1557`)
 - Fix and enhance typehints, automated static type checking with mypy.  (:pull:`1562`)
+- Improve SQLAlchemy join hints, addressing an recurring but intermittent bug.  (:pull:`1564`)
 
 
 v1.8.next

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -471,6 +471,21 @@ def test_search_returning_eo3(index: Index,
     assert ls8_eo3_dataset.id in (result.id for result in results)
 
 
+@pytest.mark.parametrize('datacube_env_name', ('experimental', ))
+def test_temp_special(index,
+                      cfg_env: ODCEnvironment,
+                      ls8_eo3_dataset: Dataset,
+                      ls8_eo3_dataset2: Dataset,
+                      wo_eo3_dataset: Dataset) -> None:
+    # All Fields
+    results = list(index.datasets.search_returning(
+        platform='landsat-8',
+    ))
+    assert len(results) == 3
+
+    assert ls8_eo3_dataset.id in (result.id for result in results)
+
+
 def test_search_returning_rows_eo3(index,
                                    eo3_ls8_dataset_doc,
                                    eo3_ls8_dataset2_doc,

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -471,21 +471,6 @@ def test_search_returning_eo3(index: Index,
     assert ls8_eo3_dataset.id in (result.id for result in results)
 
 
-@pytest.mark.parametrize('datacube_env_name', ('experimental', ))
-def test_temp_special(index,
-                      cfg_env: ODCEnvironment,
-                      ls8_eo3_dataset: Dataset,
-                      ls8_eo3_dataset2: Dataset,
-                      wo_eo3_dataset: Dataset) -> None:
-    # All Fields
-    results = list(index.datasets.search_returning(
-        platform='landsat-8',
-    ))
-    assert len(results) == 3
-
-    assert ls8_eo3_dataset.id in (result.id for result in results)
-
-
 def test_search_returning_rows_eo3(index,
                                    eo3_ls8_dataset_doc,
                                    eo3_ls8_dataset2_doc,


### PR DESCRIPTION
### Reason for this pull request

For complex queries (as can occur when using `search_returning`), SQLAlchemy was non-deterministically failing to resolve a join strategy. This was caused some tests to fail intermittently.  A re-run (or 2, or 3) of the tests was usually sufficient to bypass but it shouldn't have been happening and needed to be addressed.


### Proposed changes

- Improved type hints in `driver.postgis._fields` 
- Made `NativeField`s smart enough to generate an `onclause` parameter for the SQLA `join` function, and wire in to the query generation code.

Running a temporary minimal test that triggered the issue, this change took us from failing roughly 1 run in 4 to not failing at all for 25+ sequential test runs.

 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
