### PR TITLE
Update whats_new.rst for 1.8.18 release.

### DIFF
--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -7,6 +7,10 @@ What's New
 
 v1.8.next
 =========
+
+v1.8.18 (27th March 2024)
+=========================
+
 - Add dataset cli tool ``find-duplicates`` to identify duplicate indexed datasets (:pull:`1517`)
 - Make solar_day() timezone aware (:pull:`1521`)
 - Warn if non-eo3 dataset has eo3 metadata type (:pull:`1523`)
@@ -20,6 +24,7 @@ v1.8.next
 - Throw error if ``time`` dimension is provided as an int or float to Query construction
   instead of assuming it to be seconds since epoch (:pull:`1561`)
 - Add generic NOT operator and for ODC queries and ``Not`` type wrapper (:pull:`1563`)
+- Update whats_new.rst for release (:pull:`15xx`)
 
 v1.8.17 (8th November 2023)
 ===========================

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -21,6 +21,7 @@ v1.8.18 (27th March 2024)
 - Add new ODC Cheatsheet reference doc to Data Access & Analysis documentation page (:pull:`1543`)
 - Compatibility fix to allow users to supply ``odc.geo``-style GeoBoxes to ``dc.load(like=...)`` (:pull:`1551`)
 - Fix broken codecov github action. (:pull:`1554`)
+- Update documentation links to DEA Knowledge Hub (:pull:`1559`)
 - Throw error if ``time`` dimension is provided as an int or float to Query construction
   instead of assuming it to be seconds since epoch (:pull:`1561`)
 - Add generic NOT operator and for ODC queries and ``Not`` type wrapper (:pull:`1563`)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -24,7 +24,7 @@ v1.8.18 (27th March 2024)
 - Throw error if ``time`` dimension is provided as an int or float to Query construction
   instead of assuming it to be seconds since epoch (:pull:`1561`)
 - Add generic NOT operator and for ODC queries and ``Not`` type wrapper (:pull:`1563`)
-- Update whats_new.rst for release (:pull:`15xx`)
+- Update whats_new.rst for release (:pull:`1568`)
 
 v1.8.17 (8th November 2023)
 ===========================


### PR DESCRIPTION
### Reason for this pull request

Administrivia ready for 1.8.18 release

### Proposed changes

- Update `whats_new.rst`.

 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1568.org.readthedocs.build/en/1568/

<!-- readthedocs-preview datacube-core end -->