### PR TITLE
Get PyPI and Github pre-release numbers back in sync.

### DIFF
--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,12 @@ What's New
 v1.9.next
 =========
 
+v1.9.0-rc3 (27th March 2024)
+============================
+
+Re-pre-release of 1.9.0-rc1 to get PyPI version numbers back in sync.
+
+
 v1.9.0-rc1 (27th March 2024)
 ============================
 


### PR DESCRIPTION
### Reason for this pull request

The `1.9.0-pre01` release went to PyPI as `1.9.0-rc1` for reasons I don't understand. I can't fix it on PyPI so I have to fix it here.


