### PR TITLE
Refine default behaviour of config engine to support easier migration from 1.8

### DIFF
--- a/datacube/cfg/api.py
+++ b/datacube/cfg/api.py
@@ -220,7 +220,9 @@ class ODCConfig:
                               "this fallback behaviour is deprecated and may change in a future release.")
                 item = "datacube"
             else:
-                raise ConfigException("No environment specified and no default environment could be identified.")
+                # No explicitly defined (known) environments - assume default and hope there's config
+                # available in environment variables.
+                item = "default"
         if item not in self.known_environments:
             self.known_environments[item] = ODCEnvironment(self, item, {}, True)
         return self.known_environments[item]

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,7 +8,8 @@ What's New
 v1.9.next
 =========
 
-- Standardize resampling input supported to `odc.geo.warp.Resampling`.
+- Standardize resampling input supported to `odc.geo.warp.Resampling` (:pull:`1571`)
+- Refine default behaviour for config engine to support easier migration from 1.8 (:pull:`1573`)
 
 
 v1.9.0-rc3 (27th March 2024)

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -542,5 +542,4 @@ def test_default_environment(simple_config, monkeypatch):
         'weirdname': {"index_driver": "memory"},
         'stupidenv': {"index_driver": "null"},
     })
-    with pytest.raises(ConfigException):
-        cfg[None]._name
+    assert cfg[None]._name == "default"

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -525,7 +525,7 @@ def test_raw_by_environment(simple_config, monkeypatch):
 
 
 def test_default_environment(simple_config, monkeypatch):
-    from datacube.cfg import ODCConfig, ConfigException
+    from datacube.cfg import ODCConfig
     cfg = ODCConfig(text=simple_config)
     assert cfg[None]._name == 'legacy'
     monkeypatch.setenv('ODC_ENVIRONMENT', 'exp2')


### PR DESCRIPTION
### Reason for this pull request

Previously when:

1. no config file exists in the search path (or the config file does not defined a `default` or `datacube` environment); and 
2. config is being passed in with the legacy `$DB_*` environment variables; and
3. no environment is explicitly nominated:

a `ConfigException` was raised.

This is a very common scenario in existing 1.8.x ODC applications, and throwing an error is unexpected behaviour that makes migration from 1.8 to 1.9 more complex than it needs to be.

### Proposed changes

When:
1. no config file exists in the search path (or the config file does not define a `default` or `datacube` environment); and 
2. no environment is explicitly nominated:

The environment now defaults to `default` on the assumption that configuration will be available in the next step via environment variables.

 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes
