### PR TITLE
Handle database URLs a bit better

### DIFF
--- a/datacube/cfg/opt.py
+++ b/datacube/cfg/opt.py
@@ -208,15 +208,15 @@ class PostgresURLOptionHandler(ODCOptionHandler):
     def handle_dependent_options(self, value: Any) -> None:
         if value is None:
             handlers: tuple[ODCOptionHandler, ...] = (
-                    ODCOptionHandler("db_username", self.env, legacy_env_aliases=['DB_USERNAME'],
-                                     default=_DEFAULT_DB_USER),
-                    ODCOptionHandler("db_password", self.env, legacy_env_aliases=['DB_PASSWORD']),
-                    ODCOptionHandler("db_hostname", self.env, legacy_env_aliases=['DB_HOSTNAME'],
-                                     default=_DEFAULT_HOSTNAME),
-                    IntOptionHandler("db_port", self.env, default=5432, legacy_env_aliases=['DB_PORT'],
-                                     minval=1, maxval=49151),
-                    ODCOptionHandler("db_database", self.env, legacy_env_aliases=['DB_DATABASE'],
-                                     default=_DEFAULT_DATABASE),
+                ODCOptionHandler("db_username", self.env, legacy_env_aliases=['DB_USERNAME'],
+                                 default=_DEFAULT_DB_USER),
+                ODCOptionHandler("db_password", self.env, legacy_env_aliases=['DB_PASSWORD']),
+                ODCOptionHandler("db_hostname", self.env, legacy_env_aliases=['DB_HOSTNAME'],
+                                 default=_DEFAULT_HOSTNAME),
+                IntOptionHandler("db_port", self.env, default=5432, legacy_env_aliases=['DB_PORT'],
+                                 minval=1, maxval=49151),
+                ODCOptionHandler("db_database", self.env, legacy_env_aliases=['DB_DATABASE'],
+                                 default=_DEFAULT_DATABASE),
             )
         else:
             # These pseudo-handlers extract the equivalent config from the url returned by this handler.
@@ -230,6 +230,7 @@ class PostgresURLOptionHandler(ODCOptionHandler):
 
         for handler in handlers:
             self.env._option_handlers.append(handler)
+
 
 class PostgresURLPartHandler(ODCOptionHandler):
     def __init__(self, urlhandler: PostgresURLOptionHandler, urlpart: str, name: str, env: "ODCEnvironment"):

--- a/datacube/cfg/opt.py
+++ b/datacube/cfg/opt.py
@@ -207,7 +207,7 @@ class PostgresURLOptionHandler(ODCOptionHandler):
 
     def handle_dependent_options(self, value: Any) -> None:
         if value is None:
-            handlers = (
+            handlers: tuple[ODCOptionHandler, ...] = (
                     ODCOptionHandler("db_username", self.env, legacy_env_aliases=['DB_USERNAME'],
                                      default=_DEFAULT_DB_USER),
                     ODCOptionHandler("db_password", self.env, legacy_env_aliases=['DB_PASSWORD']),

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,9 +8,14 @@ What's New
 v1.9.next
 =========
 
+v1.9.0-rc4 (15th April 2024)
+============================
+
 - Standardize resampling input supported to `odc.geo.warp.Resampling` (:pull:`1571`)
 - Refine default behaviour for config engine to support easier migration from 1.8 (:pull:`1573`)
 - Convert legacy GeoBoxes to odc.geo GeoBoxes in the core API (:pull:`1574`)
+- Add URL component pseudo to config layer to expose components to the api when configured as a URL,
+  and reformat whats_new for 1.9.0-rc4 release. (:pull:`1575`)
 
 
 v1.9.0-rc3 (27th March 2024)

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -467,6 +467,12 @@ def test_pgurl_from_config(simple_dict):
         psql_url_from_config(
             cfg["memory"]
         )
+    assert cfg["exp2"].db_url == "postgresql://foo:bar@server.subdomain.domain/mytestdb"
+    assert cfg["exp2"].db_username == "foo"
+    assert cfg["exp2"].db_password == "bar"
+    assert cfg["exp2"].db_hostname == "server.subdomain.domain"
+    assert not cfg["exp2"].db_port
+    assert cfg["exp2"].db_database == "mytestdb"
 
     cfg = ODCConfig(raw_dict={
         "foo": {

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -213,8 +213,9 @@ def test_single_env(single_env_config):
 
     assert cfg['experimental'].index_driver == "postgis"
     assert cfg['experimental'].db_url == "postgresql://foo:bar@server.subdomain.domain/mytestdb"
+    assert cfg['experimental'].db_username == "foo"
     with pytest.raises(AttributeError):
-        assert cfg['experimental'].db_username
+        assert cfg['experimental'].not_an_option
     assert cfg['experimental']['db_iam_authentication']
     assert cfg['experimental'].db_iam_timeout == 600
     assert cfg['experimental']['db_connection_timeout'] == 60
@@ -257,8 +258,9 @@ def assert_simple_options(cfg):
         assert cfg['default']["db_iam_timeout"]
 
     assert cfg['exp2'].db_url == "postgresql://foo:bar@server.subdomain.domain/mytestdb"
+    assert cfg['exp2'].db_username == "foo"
     with pytest.raises(AttributeError):
-        assert cfg['exp2'].db_username
+        assert cfg['exp2'].not_an_option
     assert cfg['exp2']['db_iam_authentication']
     assert cfg['exp2'].db_iam_timeout == 300
     assert cfg['exp2']['db_connection_timeout'] == 60
@@ -284,8 +286,7 @@ def test_noenv_overrides_in_text(simple_config, monkeypatch):
     cfg = ODCConfig(text=simple_config)
 
     assert cfg["legacy"].db_username != 'bar'
-    with pytest.raises(AttributeError):
-        cfg["experimental"].db_username
+    assert cfg["experimental"].db_username != "bar"
 
 
 @pytest.fixture
@@ -389,8 +390,7 @@ def test_envvar_overrides(path_to_yaml_config, monkeypatch):
     assert cfg["experimental"].db_iam_authentication
     assert cfg["exp2"].db_iam_authentication
     assert cfg["exp2"].db_connection_timeout == 20
-    with pytest.raises(AttributeError):
-        assert cfg["experimental"].db_username == 'bar'
+    assert cfg["experimental"].db_username != 'bar'
 
 
 def test_intopt_validation():


### PR DESCRIPTION
### Reason for this pull request

Some downstream libraries (e.g. OWS) customise their test behaviour depending on the database configuration.  They want to be able to be able to see e.g. the db username being used to connect to the database.  This was not possible in the new config API if the database config was passed in as a url - Only the url was visible, forcing the client to parse the url.


### Proposed changes

- If the database config is passed in as a URL, pseudo-option handlers are added to the environment for the various url component options.  The values for these are then read directly from the environment url.

Note that the reverse is NOT possible because of the order in which option handlers are evaluated.  However the API method `datacube.cfg.psql_url_from_config` is already provided for this use case.

 - [x] Closes #xxxx
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

N.B. This PR also updates `whats_new.rst` to be ready for an rc4 release.

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
