### PR TITLE
Fix dark theme rtd styling

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -105,6 +105,10 @@
     padding: 40px;
 }
 
+.bd-container {
+    padding-top: var(--pst-header-height);
+}
+
 .section p {
     line-height: 1.8rem;
 }
@@ -184,4 +188,25 @@ dt:target, span.highlighted {
 .footer .container {
     max-width: 100%;
     font-size: 0.9rem;
+}
+
+html[data-theme="dark"] {
+    --pst-color-text-base: var(--pst-color-text-muted);
+    --pst-color-sidebar-link-active: var(--pst-color-link);
+}
+
+html[data-theme="dark"] .container-xl {
+    background-color: #3B3B3B;
+}
+
+html[data-theme="dark"] .editthispage a {
+    color: var(--pst-color-link);
+}
+
+html[data-theme="dark"] .bd-sidebar {
+    border-right: 3px solid #ffffff1a;
+}
+
+html[data-theme="dark"] .navbar-light>.container-xl {
+    background-color: var(--pst-color-surface);
 }

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,8 @@ What's New
 v1.8.next
 =========
 
+- Update readthedocs stylesheet for dark theme (:pull:`1579`)
+
 v1.8.18 (27th March 2024)
 =========================
 

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -445,6 +445,7 @@ stacker
 stacspec
 stdlib
 str
+stylesheet
 subcommands
 sudo
 sv


### PR DESCRIPTION
### Reason for this pull request

Readthedocs dark theme styling only changes the colour for some elements, making text difficult to read.


### Proposed changes

- Update css theme colours for when dark mode is selected



 - [x] Closes #1576
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1579.org.readthedocs.build/en/1579/

<!-- readthedocs-preview datacube-core end -->