### PR TITLE
Delete Product CLI Command

### DIFF
--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -25,7 +25,6 @@ from sqlalchemy import select, text, and_, or_, func
 from sqlalchemy.dialects.postgresql import INTERVAL
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.engine import Row
-from deprecat import deprecat
 
 from typing import Iterable, Sequence, Optional, Set, Any
 from typing import cast as type_cast
@@ -36,7 +35,6 @@ from odc.geo import CRS, Geometry
 from datacube.utils.uris import split_uri
 from datacube.index.abstract import DSID
 from datacube.model.lineage import LineageRelation, LineageDirection
-from datacube.migration import ODC2DeprecationWarning
 from . import _core
 from ._fields import parse_fields, Expression, PgField, PgExpression, DateRangeDocField  # noqa: F401
 from ._fields import NativeField, DateDocField, SimpleDocField, UnindexableValue
@@ -733,37 +731,6 @@ class PostgisDbAPI:
             values
         )
         return res.rowcount, requested - res.rowcount
-
-    @staticmethod
-    def search_unique_datasets_query(expressions, select_fields, limit, archived: bool | None = False):
-        """
-        'unique' here refer to that the query results do not contain datasets
-        having the same 'id' more than once.
-
-        We are not dealing with dataset_source table here and we are not joining
-        dataset table with dataset_location table. We are aggregating stuff
-        in dataset_location per dataset basis if required. It returns the constructed
-        query.
-        """
-        # TODO
-        raise NotImplementedError()
-
-    @deprecat(
-        reason="This method is unnecessary as multiple locations have been deprecated. Use search_datasets instead.",
-        version='1.9.0',
-        category=ODC2DeprecationWarning)
-    def search_unique_datasets(self, expressions, select_fields=None, limit=None, archived: bool | None = False):
-        """
-        Processes a search query without duplicating datasets.
-
-        'unique' here refer to that the results do not contain datasets having the same 'id'
-        more than once. we achieve this by not allowing dataset table to join with
-        dataset_location or dataset_source tables. Joining with other tables would not
-        result in multiple records per dataset due to the direction of cardinality.
-        """
-        select_query = self.search_unique_datasets_query(expressions, select_fields, limit, archived=archived)
-
-        return self._connection.execute(select_query)
 
     def get_duplicates(self, match_fields: Sequence[PgField], expressions: Sequence[PgExpression]) -> Iterable[Row]:
         # TODO

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -642,11 +642,16 @@ class AbstractProductResource(ABC):
         return self.add(type_)
 
     @abstractmethod
-    def delete(self, product: Product) -> None:
+    def delete(self, products: Iterable[Product], allow_delete_active: bool = False) -> None:
         """
-        Delete the specified product.
+        Delete the specified products.
 
-        :param product: Product to be deleted
+        :param products: Products to be deleted
+        :param bool allow_delete_active:
+            Whether to allow the deletion of a Product with active datasets
+            (and thereby said active datasets). Use with caution.
+
+            If false (default), will error if a Product has active datasets.
         """
 
     def get(self, id_: int) -> Product | None:
@@ -1406,11 +1411,12 @@ class AbstractDatasetResource(ABC):
         """
 
     @abstractmethod
-    def purge(self, ids: Iterable[DSID]) -> None:
+    def purge(self, ids: Iterable[DSID], allow_delete_active: bool = False) -> None:
         """
-        Delete archived datasets
+        Delete datasets
 
         :param ids: iterable of dataset ids to purge
+        :param allow_delete_active: if false, only archived datasets can be deleted
         """
 
     @abstractmethod

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -642,7 +642,7 @@ class AbstractProductResource(ABC):
         return self.add(type_)
 
     @abstractmethod
-    def delete(self, products: Iterable[Product], allow_delete_active: bool = False) -> None:
+    def delete(self, products: Iterable[Product], allow_delete_active: bool = False) -> Sequence[Product]:
         """
         Delete the specified products.
 
@@ -652,6 +652,7 @@ class AbstractProductResource(ABC):
             (and thereby said active datasets). Use with caution.
 
             If false (default), will error if a Product has active datasets.
+        :return: list of deleted Products
         """
 
     def get(self, id_: int) -> Product | None:
@@ -1411,12 +1412,13 @@ class AbstractDatasetResource(ABC):
         """
 
     @abstractmethod
-    def purge(self, ids: Iterable[DSID], allow_delete_active: bool = False) -> None:
+    def purge(self, ids: Iterable[DSID], allow_delete_active: bool = False) -> Sequence[DSID]:
         """
         Delete datasets
 
         :param ids: iterable of dataset ids to purge
         :param allow_delete_active: if false, only archived datasets can be deleted
+        :return: list of purged dataset ids
         """
 
     @abstractmethod

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -642,7 +642,7 @@ class AbstractProductResource(ABC):
         return self.add(type_)
 
     @abstractmethod
-    def delete(self, product: Product):
+    def delete(self, product: Product) -> None:
         """
         Delete the specified product.
 

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -587,7 +587,7 @@ class AbstractProductResource(ABC):
 
     @abstractmethod
     def update(self,
-               metadata_type: Product,
+               product: Product,
                allow_unsafe_updates: bool = False,
                allow_table_lock: bool = False
                ) -> Product:
@@ -597,7 +597,7 @@ class AbstractProductResource(ABC):
         (An unsafe change is anything that may potentially make the product
         incompatible with existing datasets of that type)
 
-        :param metadata_type: Product model with unpersisted updates
+        :param product: Product model with unpersisted updates
         :param allow_unsafe_updates: Allow unsafe changes. Use with caution.
         :param allow_table_lock:
             Allow an exclusive lock to be taken on the table while creating the indexes.
@@ -640,6 +640,14 @@ class AbstractProductResource(ABC):
         """
         type_ = self.from_doc(definition)
         return self.add(type_)
+
+    @abstractmethod
+    def delete(self, product: Product):
+        """
+        Delete the specified product.
+
+        :param product: Product to be deleted
+        """
 
     def get(self, id_: int) -> Product | None:
         """

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -11,7 +11,7 @@ from itertools import chain
 from deprecat import deprecat
 from collections import namedtuple
 from time import monotonic
-from typing import (Any, Callable, Iterable, Mapping, cast)
+from typing import (Any, Callable, Iterable, Mapping, Sequence, cast)
 from uuid import UUID
 
 from datacube.migration import ODC2DeprecationWarning
@@ -278,7 +278,7 @@ class DatasetResource(AbstractDatasetResource):
                 self._archived_by_product[ds.product.name].remove(ds.id)
                 self._by_product[ds.product.name].add(ds.id)
 
-    def purge(self, ids: Iterable[DSID], allow_delete_active: bool = False) -> Iterable[DSID]:
+    def purge(self, ids: Iterable[DSID], allow_delete_active: bool = False) -> Sequence[DSID]:
         purged = []
         for id_ in ids:
             id_ = dsid_to_uuid(id_)

--- a/datacube/index/memory/_products.py
+++ b/datacube/index/memory/_products.py
@@ -116,10 +116,12 @@ class ProductResource(AbstractProductResource):
         return cast(Product, self.get_by_name(product.name))
 
     def delete(self, product: Product):
-        ids: Iterable[UUID] = self._index.datasets.search_returning(archived=None, product=product.name)
-        self._index.datasets.purge(ids)
+        datasets = self._index.datasets.search_returning(('id',), archived=None, product=product.name)
+        if datasets:
+            self._index.datasets.purge([ds.id for ds in datasets])  # type: ignore[attr-defined]
 
-        del self.by_id[product.id]
+        if product.id is not None:
+            del self.by_id[product.id]
         del self.by_name[product.name]
 
     def get_unsafe(self, id_: int) -> Product:

--- a/datacube/index/memory/_products.py
+++ b/datacube/index/memory/_products.py
@@ -5,7 +5,7 @@
 import datetime
 import logging
 
-from typing import Iterable, cast
+from typing import Iterable, Sequence, cast
 from uuid import UUID
 
 from datacube.index.fields import as_expression
@@ -115,7 +115,7 @@ class ProductResource(AbstractProductResource):
         self.by_name[persisted.name] = persisted
         return cast(Product, self.get_by_name(product.name))
 
-    def delete(self, products: Iterable[Product], allow_delete_active: bool = False) -> Iterable[Product]:
+    def delete(self, products: Iterable[Product], allow_delete_active: bool = False) -> Sequence[Product]:
         deleted = []
         for product in products:
             datasets = self._index.datasets.search_returning(('id',), archived=None, product=product.name)

--- a/datacube/index/memory/_products.py
+++ b/datacube/index/memory/_products.py
@@ -122,7 +122,7 @@ class ProductResource(AbstractProductResource):
             if datasets:
                 purged = self._index.datasets.purge([ds.id for ds in datasets],  # type: ignore[attr-defined]
                                                     allow_delete_active)
-                if len(purged) != len(datasets):
+                if len(purged) != len(list(datasets)):
                     _LOG.warning(f"Product {product.name} cannot be deleted because it has active datasets.")
                     continue
             if product.id is not None:

--- a/datacube/index/memory/_products.py
+++ b/datacube/index/memory/_products.py
@@ -115,6 +115,13 @@ class ProductResource(AbstractProductResource):
         self.by_name[persisted.name] = persisted
         return cast(Product, self.get_by_name(product.name))
 
+    def delete(self, product: Product):
+        ids: Iterable[UUID] = self._index.datasets.search_returning(archived=None, product=product.name)
+        self._index.datasets.purge(ids)
+
+        del self.by_id[product.id]
+        del self.by_name[product.name]
+
     def get_unsafe(self, id_: int) -> Product:
         return self.clone(self.by_id[id_])
 

--- a/datacube/index/null/_datasets.py
+++ b/datacube/index/null/_datasets.py
@@ -51,7 +51,7 @@ class DatasetResource(AbstractDatasetResource):
     def restore(self, ids):
         raise NotImplementedError()
 
-    def purge(self, ids: Iterable[DSID]):
+    def purge(self, ids: Iterable[DSID], allow_delete_active: bool = False):
         raise NotImplementedError()
 
     def get_all_dataset_ids(self, archived: bool):

--- a/datacube/index/null/_products.py
+++ b/datacube/index/null/_products.py
@@ -23,7 +23,7 @@ class ProductResource(AbstractProductResource):
     def update(self, product: Product, allow_unsafe_updates=False, allow_table_lock=False):
         raise NotImplementedError()
 
-    def delete(self, products: Iterable[Product]):
+    def delete(self, products: Iterable[Product], allow_delete_active: bool = False):
         raise NotImplementedError()
 
     def get_unsafe(self, id_):

--- a/datacube/index/null/_products.py
+++ b/datacube/index/null/_products.py
@@ -23,7 +23,7 @@ class ProductResource(AbstractProductResource):
     def update(self, product: Product, allow_unsafe_updates=False, allow_table_lock=False):
         raise NotImplementedError()
 
-    def delete(self, product: Product):
+    def delete(self, products: Iterable[Product]):
         raise NotImplementedError()
 
     def get_unsafe(self, id_):

--- a/datacube/index/null/_products.py
+++ b/datacube/index/null/_products.py
@@ -23,6 +23,9 @@ class ProductResource(AbstractProductResource):
     def update(self, product: Product, allow_unsafe_updates=False, allow_table_lock=False):
         raise NotImplementedError()
 
+    def delete(self, product: Product):
+        raise NotImplementedError()
+
     def get_unsafe(self, id_):
         raise KeyError(id_)
 

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -11,7 +11,7 @@ import logging
 import warnings
 from collections import namedtuple
 from time import monotonic
-from typing import Iterable, Mapping, Union, Optional, Any, NamedTuple, cast
+from typing import Iterable, Mapping, Union, Optional, Any, NamedTuple, Sequence, cast
 from uuid import UUID
 
 from deprecat import deprecat
@@ -404,12 +404,13 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             for id_ in ids:
                 transaction.restore_dataset(id_)
 
-    def purge(self, ids: Iterable[DSID], allow_delete_active: bool = False) -> Iterable[DSID]:
+    def purge(self, ids: Iterable[DSID], allow_delete_active: bool = False) -> Sequence[DSID]:
         """
         Delete datasets
 
         :param ids: iterable of dataset ids to purge
         :param allow_delete_active: whether active datasets can be deleted
+        :return: list of purged dataset ids
         """
         purged = []
         with self._db_connection(transaction=True) as transaction:
@@ -887,6 +888,12 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                 _LOG.warning("search results: %s (%s)", output["id"], output["product"])
                 yield output
 
+    @deprecat(
+        reason="This method is deprecated and will be removed in 2.0.  "
+               "Consider migrating to search_returning()",
+        version="1.9.0",
+        category=ODC2DeprecationWarning
+    )
     # pylint: disable=redefined-outer-name
     def search_returning_datasets_light(self, field_names: tuple, custom_offsets=None,
                                         limit=None, archived: bool | None = False,

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -414,7 +414,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             for id_ in ids:
                 transaction.delete_dataset(id_)
 
-    def get_all_dataset_ids(self, archived: bool):
+    def get_all_dataset_ids(self, archived: bool | None = False):
         """
         Get list of all dataset IDs based only on archived status
 
@@ -922,7 +922,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                     __slots__ = ()
 
             with self._db_connection() as connection:
-                results = connection.search_unique_datasets(
+                results = connection.search_datasets(
                     query_exprs,
                     select_fields=select_fields,
                     limit=limit,

--- a/datacube/index/postgis/_products.py
+++ b/datacube/index/postgis/_products.py
@@ -242,7 +242,7 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
         """
         # First find and delete all related datasets
         product_datasets = self._index.datasets.search_returning(('id',), archived=None, product=product.name)
-        self._index.datasets.purge([ds.id for ds in product_datasets])
+        self._index.datasets.purge([ds.id for ds in product_datasets])  # type: ignore[attr-defined]
 
         # Now we can safely delete the Product
         with self._db_connection() as conn:

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -375,15 +375,26 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             for id_ in ids:
                 transaction.restore_dataset(id_)
 
-    def purge(self, ids: Iterable[DSID]):
+    def purge(self, ids: Iterable[DSID], allow_delete_active: bool = False) -> Iterable[DSID]:
         """
-        Delete archived datasets
+        Delete datasets
 
         :param ids: iterable of dataset ids to purge
+        :param allow_delete_active: whether active datasets can be deleted
         """
+        purged = []
         with self._db_connection(transaction=True) as transaction:
             for id_ in ids:
+                ds = self.get(id_)
+                if ds is None:
+                    continue
+                if not ds.is_archived and not allow_delete_active:
+                    _LOG.warning(f"Cannot purge unarchived dataset: {id_}")
+                    continue
                 transaction.delete_dataset(id_)
+                purged.append(id_)
+
+        return purged
 
     def get_all_dataset_ids(self, archived: bool | None = False):
         """

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -385,7 +385,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             for id_ in ids:
                 transaction.delete_dataset(id_)
 
-    def get_all_dataset_ids(self, archived: bool):
+    def get_all_dataset_ids(self, archived: bool | None = False):
         """
         Get list of all dataset IDs based only on archived status
 
@@ -748,7 +748,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
     def _get_product_queries(self, query):
         for product, q in self.products.search_robust(**query):
-            q['dataset_type_id'] = product.id
+            q['product_id'] = product.id
             yield q, product
 
     # pylint: disable=too-many-locals

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -11,7 +11,7 @@ import logging
 import warnings
 from collections import namedtuple
 from time import monotonic
-from typing import Iterable, List, Union, Mapping, Any, Optional
+from typing import Iterable, List, Union, Mapping, Any, Optional, Sequence
 from uuid import UUID
 from deprecat import deprecat
 
@@ -375,12 +375,13 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             for id_ in ids:
                 transaction.restore_dataset(id_)
 
-    def purge(self, ids: Iterable[DSID], allow_delete_active: bool = False) -> Iterable[DSID]:
+    def purge(self, ids: Iterable[DSID], allow_delete_active: bool = False) -> Sequence[DSID]:
         """
         Delete datasets
 
         :param ids: iterable of dataset ids to purge
         :param allow_delete_active: whether active datasets can be deleted
+        :return: list of purged dataset ids
         """
         purged = []
         with self._db_connection(transaction=True) as transaction:
@@ -887,6 +888,12 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         """
         raise NotImplementedError("Sorry Temporal Extent by dataset ids is not supported in postgres driver.")
 
+    @deprecat(
+        reason="This method is deprecated and will be removed in 2.0.  "
+               "Consider migrating to search_returning()",
+        version="1.9.0",
+        category=ODC2DeprecationWarning
+    )
     # pylint: disable=redefined-outer-name
     def search_returning_datasets_light(self, field_names: tuple, custom_offsets=None, limit=None,
                                         archived: bool | None = False,
@@ -933,7 +940,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                     __slots__ = ()
 
             with self._db_connection() as connection:
-                results = connection.search_unique_datasets(
+                results = connection.search_datasets(
                     query_exprs,
                     select_fields=select_fields,
                     limit=limit,

--- a/datacube/index/postgres/_products.py
+++ b/datacube/index/postgres/_products.py
@@ -6,7 +6,7 @@ import datetime
 import logging
 
 from cachetools.func import lru_cache
-from typing import Iterable, cast
+from typing import Iterable, Sequence, cast
 
 from datacube.index import fields
 from datacube.index.abstract import AbstractProductResource, JsonDict
@@ -226,20 +226,21 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
             allow_table_lock=allow_table_lock,
         )
 
-    def delete(self, products: Iterable[Product], allow_delete_active: bool = False) -> Iterable[Product]:
+    def delete(self, products: Iterable[Product], allow_delete_active: bool = False) -> Sequence[Product]:
         """
         Delete Products, as well as all related datasets
 
         :param products: the Products to delete
         :param bool allow_delete_active:
             Whether to delete products with active datasets
+        :return: list of deleted products
         """
         deleted = []
         for product in products:
             with self._db_connection(transaction=True) as conn:
                 # First find and delete all related datasets
-                product_datasets = list(self._index.datasets.search_returning(('id',),
-                                                                              archived=None, product=product.name))
+                product_datasets = self._index.datasets.search_returning(('id',),
+                                                                         archived=None, product=product.name)
                 product_datasets = [ds.id for ds in product_datasets]  # type: ignore[attr-defined]
                 purged = self._index.datasets.purge(product_datasets, allow_delete_active)
                 # if not all product datasets are purged, it must be because

--- a/datacube/index/postgres/_products.py
+++ b/datacube/index/postgres/_products.py
@@ -226,26 +226,35 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
             allow_table_lock=allow_table_lock,
         )
 
-    def delete(self, product: Product):
+    def delete(self, products: Iterable[Product], allow_delete_active: bool = False) -> Iterable[Product]:
         """
-        Delete a Product, as well as all related datasets
+        Delete Products, as well as all related datasets
 
-        :param product: the Product to delete
+        :param products: the Products to delete
+        :param bool allow_delete_active:
+            Whether to delete products with active datasets
         """
-        # First find and delete all related datasets
-        product_datasets = self._index.datasets.search_returning(('id',), archived=None, product=product.name)
-        self._index.datasets.purge([ds.id for ds in product_datasets])  # type: ignore[attr-defined]
-
-        # Now we can safely delete the Product
-        # Pass along metadata type information as well to update indexes/views
-        with self._db_connection(transaction=True) as conn:
-            mt = product.metadata_type
-            conn.delete_product(
-                name=product.name,
-                mt_id=mt.id,
-                mt_name=mt.name,
-                mt_def=mt.definition
-            )
+        deleted = []
+        for product in products:
+            with self._db_connection(transaction=True) as conn:
+                # First find and delete all related datasets
+                product_datasets = list(self._index.datasets.search_returning(('id',),
+                                                                              archived=None, product=product.name))
+                product_datasets = [ds.id for ds in product_datasets]  # type: ignore[attr-defined]
+                purged = self._index.datasets.purge(product_datasets, allow_delete_active)
+                # if not all product datasets are purged, it must be because
+                # we're not allowing active datasets to be purged
+                if len(purged) != len(product_datasets):
+                    _LOG.warning(f"Product {product.name} cannot be deleted because it has active datasets.")
+                    continue
+                # Now we can safely delete the Product
+                conn.delete_product(
+                    name=product.name,
+                    fields=product.metadata_type.dataset_fields,
+                    definition=product.definition,
+                )
+                deleted.append(product)
+        return deleted
 
     # This is memoized in the constructor
     # pylint: disable=method-hidden

--- a/datacube/index/postgres/_products.py
+++ b/datacube/index/postgres/_products.py
@@ -234,7 +234,7 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
         """
         # First find and delete all related datasets
         product_datasets = self._index.datasets.search_returning(('id',), archived=None, product=product.name)
-        self._index.datasets.purge([ds.id for ds in product_datasets])
+        self._index.datasets.purge([ds.id for ds in product_datasets])  # type: ignore[attr-defined]
 
         # Now we can safely delete the Product
         # Pass along metadata type information as well to update indexes/views

--- a/datacube/index/postgres/_products.py
+++ b/datacube/index/postgres/_products.py
@@ -230,7 +230,7 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
         """
         Delete a Product, as well as all related datasets
 
-        :param product: the Proudct to delete
+        :param product: the Product to delete
         """
         # First find and delete all related datasets
         product_datasets = self._index.datasets.search_returning(('id',), archived=None, product=product.name)

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -610,20 +610,20 @@ def purge_cmd(index: Index, dry_run: bool, all_ds: bool, ids: List[str]):
         sys.exit(1)
 
     if all_ds:
-        datasets_for_archive = {dsid: True for dsid in index.datasets.get_all_dataset_ids(archived=True)}
+        datasets_for_purge = {dsid: True for dsid in index.datasets.get_all_dataset_ids(archived=True)}
     else:
-        datasets_for_archive = {UUID(dataset_id): exists
-                                for dataset_id, exists in zip(ids, index.datasets.bulk_has(ids))}
+        datasets_for_purge = {UUID(dataset_id): exists
+                              for dataset_id, exists in zip(ids, index.datasets.bulk_has(ids))}
 
         # Check for non-existent datasets
-        if False in datasets_for_archive.values():
-            for dataset_id, exists in datasets_for_archive.items():
+        if False in datasets_for_purge.values():
+            for dataset_id, exists in datasets_for_purge.items():
                 if not exists:
                     click.echo(f'No dataset found with id: {dataset_id}')
             sys.exit(-1)
 
         # Check for unarchived datasets
-        datasets = index.datasets.bulk_get(datasets_for_archive.keys())
+        datasets = index.datasets.bulk_get(datasets_for_purge.keys())
         unarchived_datasets = False
         for d in datasets:
             if not d.is_archived:
@@ -632,15 +632,15 @@ def purge_cmd(index: Index, dry_run: bool, all_ds: bool, ids: List[str]):
         if unarchived_datasets:
             sys.exit(-1)
 
-    for dataset in datasets_for_archive.keys():
+    for dataset in datasets_for_purge.keys():
         click.echo(f'Purging dataset: {dataset}')
 
     if not dry_run:
         # Perform purge
-        index.datasets.purge(datasets_for_archive.keys())
-        click.echo(f'{len(datasets_for_archive)} datasets purged')
+        index.datasets.purge(datasets_for_purge.keys())
+        click.echo(f'{len(datasets_for_purge)} datasets purged')
     else:
-        click.echo(f'{len(datasets_for_archive)} datasets not purged (dry run)')
+        click.echo(f'{len(datasets_for_purge)} datasets not purged (dry run)')
 
     click.echo('Completed dataset purge.')
 

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -626,7 +626,7 @@ def purge_cmd(index: Index, dry_run: bool, all_ds: bool, force: bool, ids: List[
                     click.echo(f'No dataset found with id: {dataset_id}')
             sys.exit(-1)
 
-    if force:
+    if sys.stdin.isatty() and force:
         click.confirm("Warning: you may be deleting active datasets. Proceed?", abort=True)
 
     if not dry_run:

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -634,7 +634,8 @@ def purge_cmd(index: Index, dry_run: bool, all_ds: bool, force: bool, ids: List[
         purged = index.datasets.purge(datasets_for_purge.keys(), force)
         not_purged = set(datasets_for_purge.keys()).difference(set(purged))
         if not force and not_purged:
-            click.echo(f"The following datasets are still active and could not be purged: {', '.join(not_purged)} "
+            click.echo("The following datasets are still active and could not be purged: "
+                       f"{', '.join([str(id_) for id_ in not_purged])}\n"
                        "Use the --force option to delete anyway.")
         click.echo(f'{len(purged)} of {len(datasets_for_purge)} datasets purged')
     else:

--- a/datacube/scripts/product.py
+++ b/datacube/scripts/product.py
@@ -156,7 +156,7 @@ def delete_products(index: Index, force: bool, dry_run: bool, product_names: Lis
         click.echo(str(e))
         sys.exit(1)
 
-    if force:
+    if sys.stdin.isatty() and force:
         click.confirm("Warning: you may be deleting active datasets. Proceed?", abort=True)
 
     if not dry_run:

--- a/datacube/scripts/product.py
+++ b/datacube/scripts/product.py
@@ -161,7 +161,8 @@ def delete_products(index: Index, force: bool, dry_run: bool, product_names: Lis
     for name in product_names:
         active_ds = list(index.datasets.search_returning(('id',), archived=False, product=name))
         if len(active_ds):
-            click.echo(f"Product {name} has active datasets: {' '.join([str(ds.id) for ds in active_ds])}")
+            click.echo(f"Product {name} has active datasets: "
+                       f"{' '.join([str(ds.id) for ds in active_ds])}")  # type: ignore[attr-defined]
             active_product = True
 
     if active_product:

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,8 @@ What's New
 v1.9.next
 =========
 
+- Add Product delete methods to API and command in CLI, plus misc cleanup of the surrounds (:pull:`1583`)
+
 v1.9.0-rc4 (15th April 2024)
 ============================
 

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -398,7 +398,7 @@ def test_product_delete_cli(index: Index,
                             extended_eo3_metadata_type: MetadataType) -> None:
     from pathlib import Path
     TESTDIR = Path(__file__).parent.parent / "data" / "eo3"
-    # prduct with some archived and some active datasets
+    # product with some archived and some active datasets
     clirunner(['dataset', 'archive', 'c21648b1-a6fa-4de0-9dc3-9c445d8b295a', '4a30d008-4e82-4d67-99af-28bc1629f766'])
     runner = clirunner(['product', 'delete', 'ga_ls8c_ard_3'], verbose_flag=False, expect_success=False)
     assert "Product ga_ls8c_ard_3 has active datasets" in runner.output

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -10,7 +10,6 @@ import copy
 import pytest
 import yaml
 from sqlalchemy import text
-from unittest import mock
 
 from datacube.drivers.postgres._fields import NumericRangeDocField as PgrNumericRangeDocField, PgField as PgrPgField
 from datacube.drivers.postgis._fields import NumericRangeDocField as PgsNumericRangeDocField, PgField as PgsPgField
@@ -426,20 +425,14 @@ def test_product_delete_cli(index: Index,
     assert index.products.get_by_name("ga_ls8c_ard_3") is not None
     assert index.products.get_by_name("ga_ls_wo_3") is None
 
-    # force without confirmation
-    runner = clirunner(['product', 'delete', 'ga_ls8c_ard_3', '--force'], verbose_flag=False, expect_success=False)
-    assert "Proceed?" in runner.output
-    assert runner.exit_code == 1
-
     # adding back product should cause error since it still exists
     add = clirunner(['product', 'add', str(TESTDIR / "ard_ls8.odc-product.yaml")])
     assert "is already in the database" in add.output
 
     # ensure deletion involving active datasets works with force
-    with mock.patch('click.confirm', return_value=True):
-        runner = clirunner(['product', 'delete', 'ga_ls8c_ard_3', '--force'], verbose_flag=False)
-        assert "Completed product deletion" in runner.output
-        assert runner.exit_code == 0
+    runner = clirunner(['product', 'delete', 'ga_ls8c_ard_3', '--force'], verbose_flag=False)
+    assert "Completed product deletion" in runner.output
+    assert runner.exit_code == 0
 
     runner = clirunner(['dataset', 'archive', '4a30d008-4e82-4d67-99af-28bc1629f766'],
                        verbose_flag=False, expect_success=False)

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -169,7 +169,10 @@ def test_purge_datasets_cli(index, ls8_eo3_dataset, clirunner):
     dsid = ls8_eo3_dataset.id
 
     # Attempt to purge non-archived dataset should fail
-    clirunner(['dataset', 'purge', str(dsid)], expect_success=False)
+    runner = clirunner(['dataset', 'purge', str(dsid)])
+    assert "could not be purged" in runner.output
+    assert str(dsid) in runner.output
+    assert "0 of 1 datasets purged" in runner.output
 
     # Archive dataset
     index.datasets.archive([dsid])

--- a/integration_tests/index/test_memory_index.py
+++ b/integration_tests/index/test_memory_index.py
@@ -156,6 +156,7 @@ def test_mem_product_resource(mem_index_fresh: Datacube,
             assert unmatched == {}
         else:
             assert unmatched["platform"] == 'landsat-8'
+    # Test search_by_metadata
     lds = list(mem_index_fresh.index.products.search_by_metadata({"product_family": "ard"}))
     assert len(lds) == 0
     lds = list(mem_index_fresh.index.products.search_by_metadata({"odc:product_family": "ard"}))
@@ -164,6 +165,9 @@ def test_mem_product_resource(mem_index_fresh: Datacube,
     assert len(lds) == 0
     lds = list(mem_index_fresh.index.products.search_by_metadata({"eo:platform": "landsat-8"}))
     assert len(lds) == 1
+    # Test delete
+    mem_index_fresh.index.products.delete(ls8_fresh)
+    assert mem_index_fresh.index.products.get_by_name("ga_ls8c_ard_3") is None
 
 
 # Hand crafted tests with recent real-world eo3 examples

--- a/integration_tests/index/test_memory_index.py
+++ b/integration_tests/index/test_memory_index.py
@@ -166,7 +166,7 @@ def test_mem_product_resource(mem_index_fresh: Datacube,
     lds = list(mem_index_fresh.index.products.search_by_metadata({"eo:platform": "landsat-8"}))
     assert len(lds) == 1
     # Test delete
-    mem_index_fresh.index.products.delete(ls8_fresh)
+    mem_index_fresh.index.products.delete([ls8_fresh])
     assert mem_index_fresh.index.products.get_by_name("ga_ls8c_ard_3") is None
 
 

--- a/integration_tests/index/test_null_index.py
+++ b/integration_tests/index/test_null_index.py
@@ -80,6 +80,8 @@ def test_null_product_resource(null_config: ODCEnvironment):
             dc.index.products.can_update(MagicMock())
         with pytest.raises(NotImplementedError) as e:
             dc.index.products.update(MagicMock())
+        with pytest.raises(NotImplementedError) as e:
+            dc.index.products.delete(MagicMock())
 
 
 def test_null_dataset_resource(null_config: ODCEnvironment):

--- a/integration_tests/test_cli_output.py
+++ b/integration_tests/test_cli_output.py
@@ -31,6 +31,14 @@ def test_cli_product_subcommand(index_empty, clirunner, dataset_add_configs):
     assert "All files are empty, exit" in runner.output
     assert runner.exit_code == 1
 
+    runner = clirunner(['product', 'delete'], verbose_flag=False, expect_success=False)
+    assert "Usage:  [OPTIONS] [PRODUCT_NAMES]" in runner.output
+    assert "Delete products" in runner.output
+
+    runner = clirunner(['product', 'delete', 'ga_ls8c_ard_3'], verbose_flag=False, expect_success=False)
+    assert '"ga_ls8c_ard_3" is not a valid Product name' in runner.output
+    assert runner.exit_code == 1
+
 
 def test_cli_metadata_subcommand(index_empty, clirunner, dataset_add_configs):
     runner = clirunner(['metadata', 'update'], verbose_flag=False, expect_success=False)
@@ -116,6 +124,7 @@ def test_cli_dataset_subcommand(index, clirunner,
     assert runner.exit_code == 1
 
     runner = clirunner(['dataset', 'archive', "--all"], verbose_flag=False)
+    assert "Archiving dataset:" in runner.output
     assert "Completed dataset archival." in runner.output
     assert "Usage:  [OPTIONS] [IDS]" not in runner.output
     assert "Archive datasets" not in runner.output

--- a/integration_tests/test_index_datasets_search.py
+++ b/integration_tests/test_index_datasets_search.py
@@ -5,101 +5,8 @@
 import datetime
 
 import pytest
-from pathlib import PurePosixPath
 
 from integration_tests.utils import ensure_datasets_are_indexed
-
-
-# Current formulation of this test relies on non-EO3 test data
-@pytest.mark.parametrize('datacube_env_name', ('datacube', ))
-@pytest.mark.usefixtures('default_metadata_type',
-                         'indexed_ls5_scene_products')
-def test_index_datasets_search_light(index, tmpdir, clirunner,
-                                     example_ls5_dataset_paths):
-    def index_dataset(path):
-        return clirunner(['dataset', 'add', str(path)])
-
-    def index_products():
-        valid_uuids = []
-        for uuid, ls5_dataset_path in example_ls5_dataset_paths.items():
-            valid_uuids.append(uuid)
-            index_dataset(ls5_dataset_path)
-
-        # Ensure that datasets are actually indexed
-        ensure_datasets_are_indexed(index, valid_uuids)
-
-        return valid_uuids
-
-    valid_uuids = index_products()
-
-    # Test derived properties such as 'extent'
-    results = list(index.datasets.search_returning_datasets_light(field_names=('id', 'extent', 'time'),
-                                                                  product='ls5_nbar_scene'))
-    for dataset in results:
-        assert dataset.id in valid_uuids
-        # Assume projection is defined as
-        #         datum: GDA94
-        #         ellipsoid: GRS80
-        #         zone: -55
-        # for all datasets. This should give us epsg 28355
-        assert dataset.extent.crs.epsg == 28355
-
-    # test custom fields
-    results = list(index.datasets.search_returning_datasets_light(field_names=('id', 'zone'),
-                                                                  custom_offsets={'zone': ['grid_spatial',
-                                                                                           'projection', 'zone']},
-                                                                  product='ls5_nbar_scene'))
-    for dataset in results:
-        assert dataset.zone == -55
-
-    # Test conditional queries involving custom fields
-    results = list(index.datasets.search_returning_datasets_light(field_names=('id', 'zone'),
-                                                                  custom_offsets={'zone': ['grid_spatial',
-                                                                                           'projection', 'zone']},
-                                                                  product='ls5_nbar_scene',
-                                                                  zone='-55'))
-    assert len(results) > 0
-
-    results = list(index.datasets.search_returning_datasets_light(field_names=('id', 'zone'),
-                                                                  custom_offsets={'zone': ['grid_spatial',
-                                                                                           'projection', 'zone']},
-                                                                  product='ls5_nbar_scene',
-                                                                  zone='-65'))
-    assert len(results) == 0
-
-    # Test uris
-
-    # Test datasets with just one uri location
-    results_no_uri = list(index.datasets.search_returning_datasets_light(field_names=('id'),
-                                                                         product='ls5_nbar_scene'))
-    results_with_uri = list(index.datasets.search_returning_datasets_light(field_names=('id', 'uris'),
-                                                                           product='ls5_nbar_scene'))
-    assert len(results_no_uri) == len(results_with_uri)
-    for result in results_with_uri:
-        assert len(result.uris) == 1
-
-    # 'uri' field bahave same as 'uris' ('uri' could be deprecated!)
-    results_with_uri = list(index.datasets.search_returning_datasets_light(field_names=('id', 'uri'),
-                                                                           product='ls5_nbar_scene'))
-    assert len(results_no_uri) == len(results_with_uri)
-    for result in results_with_uri:
-        assert len(result.uri) == 1
-
-    # Add a new uri to a dataset
-    new_loc = PurePosixPath(tmpdir.strpath) / 'temp_location' / 'agdc-metadata.yaml'
-    index.datasets.add_location(valid_uuids[0], new_loc.as_uri())  # Test of deprecated functionality
-
-    results_with_uri = list(index.datasets.search_returning_datasets_light(field_names=('id', 'uris'),
-                                                                           product='ls5_nbar_scene',
-                                                                           id=valid_uuids[0]))
-    assert len(results_with_uri) == 1
-    assert len(results_with_uri[0].uris) == 2
-
-    results_with_uri = list(index.datasets.search_returning_datasets_light(field_names=('id', 'uri'),
-                                                                           product='ls5_nbar_scene',
-                                                                           id=valid_uuids[0]))
-    assert len(results_with_uri) == 1
-    assert len(results_with_uri[0].uri) == 2
 
 
 # Current formulation of this test relies on non-EO3 test data
@@ -124,8 +31,8 @@ def test_index_get_product_time_bounds(index, clirunner, example_ls5_dataset_pat
     valid_uuids = index_products()
 
     # lets get time values
-    dataset_times = list(index.datasets.search_returning_datasets_light(field_names=('time',),
-                                                                        product='ls5_nbar_scene'))
+    dataset_times = list(index.datasets.search_returning(field_names=('time',),
+                                                         product='ls5_nbar_scene'))
 
     # get time bounds
     time_bounds = index.datasets.get_product_time_bounds(product='ls5_nbar_scene')  # Test of deprecated method


### PR DESCRIPTION
### Reason for this pull request

Functionality to delete products via the CLI has long been requested.


### Proposed changes

- Add `datacube product delete` CLI command that deletes the specified products and all related datasets. By default, products with active datasets will not be permitted to be deleted, but this can be overwritten with the `--force` option.
- Misc cleanup in surrounding code; mostly minor changes that should have no user impact
- Mark `search_unique_datasets` as deprecated since without multiple locations, it doesn't seem to provide anything beyond what `search_datasets` or `search_returning` already do.



 - [x] Closes #177
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
