### PR TITLE
Make "default" an alias instead of the canonical driver name.

### DIFF
--- a/datacube/drivers/indexes.py
+++ b/datacube/drivers/indexes.py
@@ -14,8 +14,13 @@ class IndexDriverCache(object):
         self._drivers = load_drivers(group)
 
         if len(self._drivers) == 0:
-            from datacube.index.postgres.index import index_driver_init
-            self._drivers = dict(default=index_driver_init())
+            # Driver load has failed.  Something is very wrong, but try to manually load the main drivers anyway.
+            from datacube.index.postgres.index import index_driver_init as pg_index_driver_init
+            from datacube.index.postgres.index import index_driver_init as pgis_index_driver_init
+            from datacube.index.memory.index import index_driver_init as mem_index_driver_init
+            self._drivers = dict(postgres=pg_index_driver_init(),
+                                 postgis=pgis_index_driver_init(),
+                                 memory=mem_index_driver_init())
 
         for driver in list(self._drivers.values()):
             if hasattr(driver, 'aliases'):

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -186,8 +186,8 @@ class Index(AbstractIndex):
                 yield conn
 
 
-class DefaultIndexDriver(AbstractIndexDriver):
-    aliases = ['postgres', 'legacy']
+class PostgresIndexDriver(AbstractIndexDriver):
+    aliases = ['legacy', 'default']
 
     @classmethod
     def index_class(cls) -> Type[AbstractIndex]:
@@ -213,4 +213,4 @@ class DefaultIndexDriver(AbstractIndexDriver):
 
 
 def index_driver_init():
-    return DefaultIndexDriver()
+    return PostgresIndexDriver()

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,8 @@ What's New
 v1.9.next
 =========
 
+- The canonical name of tthe postgres driver is now "postgres" with "default" as an alias instead of the other
+  way around. (:pull:`1590`)
 - Update docker image to GDAL 3.9/Python 3.12/Ubuntu 24.04 (:pull:`1588`)
 - Fix typos in docs (:pull:`1577`)
 - Merge in 1.8.x branch changes. (:pull:`1568`, :pull:`1579`)

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ setup(
             *extra_plugins['write'],
         ],
         'datacube.plugins.index': [
-            'default = datacube.index.postgres.index:index_driver_init',
+            'postgres = datacube.index.postgres.index:index_driver_init',
             'null = datacube.index.null.index:index_driver_init',
             'memory = datacube.index.memory.index:index_driver_init',
             'postgis = datacube.index.postgis.index:index_driver_init',

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -54,7 +54,7 @@ def test_index_drivers():
 
 def test_default_injection():
     cache = IndexDriverCache('datacube.plugins.index-no-such-prefix')
-    assert cache.drivers() == ['default', 'postgres', 'legacy']
+    assert set(cache.drivers()) == set(['default', 'postgres', 'legacy', 'postgis'])
 
 
 def test_netcdf_driver_import():

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -54,7 +54,7 @@ def test_index_drivers():
 
 def test_default_injection():
     cache = IndexDriverCache('datacube.plugins.index-no-such-prefix')
-    assert set(cache.drivers()) == set(['default', 'postgres', 'legacy', 'postgis'])
+    assert set(cache.drivers()) == set(['default', 'postgres', 'legacy', 'postgis', 'memory'])
 
 
 def test_netcdf_driver_import():


### PR DESCRIPTION
### Reason for this pull request

- The canonical name of the postgres driver  was "default", with "postgres" and "legacy" as aliases.
- If dynamic driver loading failed, only the "postgres" driver was being forcibly injected.

### Proposed changes

- The canonical name of the postgres driver  is "postgres", with "default" and "legacy" as aliases.
- If dynamic driver loading fails, the "postgres", "postgis" and "memory" drivers are forcibly injected.

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
