### PR TITLE
Ensure eo3 datasets read directly from another index can be indexed directly into a new index

### DIFF
--- a/datacube/index/eo3.py
+++ b/datacube/index/eo3.py
@@ -251,10 +251,10 @@ def prep_eo3(doc: Dict[str, Any],
                     else:
                         return {name: {'id': stringify(uuids[0])}}
 
-                out = {}
+                out: dict[str, Any] = {}
                 for idx, uuid in enumerate(uuids, start=1):
                     if isinstance(uuids, dict):
-                        out[idx] = uuid
+                        out[name] = uuid
                     else:
                         out[name+str(idx)] = {'id': stringify(uuid)}
                 return out

--- a/datacube/index/eo3.py
+++ b/datacube/index/eo3.py
@@ -151,8 +151,10 @@ def add_eo3_parts(doc: Dict[str, Any],
                   resolution: Optional[float] = None) -> Dict[str, Any]:
     """Add spatial keys the DB requires to eo3 metadata
     """
-    return dict(**doc,
-                **eo3_grid_spatial(doc, resolution=resolution))
+    # Clone and update to ensure idempotency
+    out = dict(**doc)
+    out.update(eo3_grid_spatial(doc, resolution=resolution))
+    return out
 
 
 def is_doc_eo3(doc: Dict[str, Any]) -> bool:
@@ -206,6 +208,9 @@ def prep_eo3(doc: Dict[str, Any],
              resolution: Optional[float] = None,
              remap_lineage=True) -> Dict[str, Any]:
     """ Modify spatial and lineage sections of eo3 metadata
+
+    Should be idempotent:  prep_eo3(doc, **kwargs) == prep_eo3(prep_eo3(doc, **kwargs), **kwargs)
+
     :param doc: input document
     :param auto_skip: If true check if dataset is EO3 and if not
                       silently return input dataset without modifications
@@ -229,25 +234,34 @@ def prep_eo3(doc: Dict[str, Any],
     doc = add_eo3_parts(doc, resolution=resolution)
     if remap_lineage:
         lineage = doc.pop('lineage', {})
+        if isinstance(lineage, dict) and "source_datasets" in lineage:
+            # Is already in pseudo-embedded rewritten form - keep as is.
+            doc['lineage'] = lineage
+        else:
+            def lineage_remap(name, uuids) -> Dict[str, Any]:
+                """ Turn name, [uuid] -> {name: {id: uuid}}
+                """
+                if len(uuids) == 0:
+                    return {}
+                if isinstance(uuids, dict) or isinstance(uuids[0], dict):
+                    raise ValueError("Embedded lineage not supported for eo3 metadata types")
+                if len(uuids) == 1:
+                    if isinstance(uuids[0], dict):
+                        return {name: uuids}
+                    else:
+                        return {name: {'id': stringify(uuids[0])}}
 
-        def lineage_remap(name, uuids) -> Dict[str, Any]:
-            """ Turn name, [uuid] -> {name: {id: uuid}}
-            """
-            if len(uuids) == 0:
-                return {}
-            if isinstance(uuids, dict) or isinstance(uuids[0], dict):
-                raise ValueError("Embedded lineage not supported for eo3 metadata types")
-            if len(uuids) == 1:
-                return {name: {'id': stringify(uuids[0])}}
+                out = {}
+                for idx, uuid in enumerate(uuids, start=1):
+                    if isinstance(uuids, dict):
+                        out[idx] = uuid
+                    else:
+                        out[name+str(idx)] = {'id': stringify(uuid)}
+                return out
 
-            out = {}
-            for idx, uuid in enumerate(uuids, start=1):
-                out[name+str(idx)] = {'id': stringify(uuid)}
-            return out
+            sources = {}
+            for name, uuids in lineage.items():
+                sources.update(lineage_remap(name, uuids))
 
-        sources = {}
-        for name, uuids in lineage.items():
-            sources.update(lineage_remap(name, uuids))
-
-        doc['lineage'] = dict(source_datasets=sources)
+            doc['lineage'] = dict(source_datasets=sources)
     return doc

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,7 @@ What's New
 v1.9.next
 =========
 
+- Ensure pre-prepared EO3 datasets can be indexed. (i.e. ensure the `prep_eo3()` function is idempotent) (:pull:`1591`)
 - The canonical name of tthe postgres driver is now "postgres" with "default" as an alias instead of the other
   way around. (:pull:`1590`)
 - Update docker image to GDAL 3.9/Python 3.12/Ubuntu 24.04 (:pull:`1588`)

--- a/tests/test_eo3.py
+++ b/tests/test_eo3.py
@@ -252,6 +252,24 @@ def test_prep_eo3(sample_doc, sample_doc_180, eo3_metadata):
         prep_eo3(non_eo3_doc)
 
 
+def test_prep_eo3_idempotency(sample_doc, sample_doc_180):
+    # without lineage
+    call1 = prep_eo3(sample_doc, remap_lineage=False)
+    call2 = prep_eo3(call1, remap_lineage=False)
+    assert call1 == call2
+    call1 = prep_eo3(sample_doc_180, remap_lineage=False)
+    call2 = prep_eo3(call1, remap_lineage=False)
+    assert call1 == call2
+
+    # with lineage
+    call1 = prep_eo3(sample_doc)
+    call2 = prep_eo3(call1)
+    assert call1 == call2
+    call1 = prep_eo3(sample_doc_180)
+    call2 = prep_eo3(call1)
+    assert call1 == call2
+
+
 def test_val_eo3_offset():
     from datacube.model.eo3 import validate_eo3_offset
     # Simple offsets


### PR DESCRIPTION
### Reason for this pull request

On indexing an eo3 dataset, the `prep_eo3()` method is called, which generates the `extent` and `grid_spatial` sections from the grids already defined, and adds those new sections into the dataset metadata for storage, and also rewrites lineage metadata into a new format.

If dataset metadata is copied directly from an existing ODC index, this "preparation" is already applied, and calling `prep_eo3()` on the dataset again fails with an ugly error. 

### Proposed changes

Modify the `prep_eo3()` function so that it is idempotent.  E.g. after this PR:

`prep_eo3(doc, **kwargs) == prep_eo3(prep_eo3(doc, **kwargs), **kwargs)`

 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

