### PR TITLE
Expand extra dimension support

### DIFF
--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -406,8 +406,8 @@ class Measurement(dict):
     """
     REQUIRED_KEYS = ('name', 'dtype', 'nodata', 'units')
     OPTIONAL_KEYS = ('aliases', 'spectral_definition', 'flags_definition', 'scale_factor', 'add_offset',
-                     'extra_dim')
-    ATTR_SKIP = set(['name', 'dtype', 'aliases', 'resampling_method', 'fuser', 'extra_dim', 'extra_dim_index'])
+                     'extra_dim', 'dims')
+    ATTR_SKIP = set(['name', 'dtype', 'aliases', 'resampling_method', 'fuser', 'extra_dim', 'dims', 'extra_dim_index'])
 
     def __init__(self, canonical_name=None, **kwargs):
         missing_keys = set(self.REQUIRED_KEYS) - set(kwargs)

--- a/datacube/model/schema/dataset-type-schema.yaml
+++ b/datacube/model/schema/dataset-type-schema.yaml
@@ -140,6 +140,12 @@ definitions:
                         type: string
             extra_dim:
                 type: string
+            dims:
+                type: array
+                description: Captures information about extra dimensions, e.g. `[y, x, wavelength]`
+                items:
+                    type: string
+
         required:
           - name
           - dtype

--- a/datacube/model/schema/dataset-type-schema.yaml
+++ b/datacube/model/schema/dataset-type-schema.yaml
@@ -67,6 +67,8 @@ definitions:
                     type: number
             dtype:
                 "$ref": "#/definitions/dtype"
+            units:
+                type: string
         required:
         - name
         - values

--- a/datacube/storage/_base.py
+++ b/datacube/storage/_base.py
@@ -84,6 +84,7 @@ class BandInfo:
                  'crs',
                  'transform',
                  'format',
+                 'dims',
                  'driver_data')
 
     def __init__(self,
@@ -123,6 +124,7 @@ class BandInfo:
         self.crs = ds.crs
         self.transform = ds.transform
         self.format = ds.format or ''
+        self.dims = mp.get('dims', None)
         self.driver_data = _extract_driver_data(ds, mm)
 
     @property

--- a/datacube/storage/_base.py
+++ b/datacube/storage/_base.py
@@ -83,7 +83,6 @@ class BandInfo:
                  'units',
                  'crs',
                  'transform',
-                 'center_time',
                  'format',
                  'driver_data')
 

--- a/datacube/storage/_base.py
+++ b/datacube/storage/_base.py
@@ -45,8 +45,14 @@ def _get_band_and_layer(b: Dict[str, Any]) -> Tuple[Optional[int], Optional[str]
         return (band, layer)
 
 
-def _extract_driver_data(ds: Dataset) -> Optional[Any]:
-    return ds.metadata_doc.get('driver_data', None)
+def _extract_driver_data(ds: Dataset, mm: Dict[str, Any]) -> Optional[Any]:
+    ds_data = ds.metadata_doc.get("driver_data", None)
+    mm_data = mm.get("driver_data", None)
+    if isinstance(ds_data, dict) and isinstance(mm_data, str):
+        return ds_data.get(mm_data, {})
+    if mm_data is not None:
+        return mm_data
+    return ds_data
 
 
 def measurement_paths(ds: Dataset) -> Dict[str, str]:
@@ -118,7 +124,7 @@ class BandInfo:
         self.crs = ds.crs
         self.transform = ds.transform
         self.format = ds.format or ''
-        self.driver_data = _extract_driver_data(ds)
+        self.driver_data = _extract_driver_data(ds, mm)
 
     @property
     def uri_scheme(self) -> str:

--- a/datacube/utils/serialise.py
+++ b/datacube/utils/serialise.py
@@ -17,6 +17,7 @@ import yaml
 
 from datacube.utils.documents import transform_object_tree
 from datacube.model._base import Range
+from odc.geo.crs import CRS
 
 
 class SafeDatacubeDumper(yaml.SafeDumper):  # pylint: disable=too-many-ancestors
@@ -71,9 +72,7 @@ def jsonify_document(doc):
             return v.isoformat()
         if isinstance(v, numpy.dtype):
             return v.name
-        if isinstance(v, UUID):
-            return str(v)
-        if isinstance(v, Decimal):
+        if isinstance(v, (UUID, Decimal, CRS)):
             return str(v)
         return v
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,7 @@ What's New
 v1.9.next
 =========
 
+- Expand extra dimension support, WIP (:pull:`1593`) 
 - Ensure pre-prepared EO3 datasets can be indexed. (i.e. ensure the `prep_eo3()` function is idempotent) (:pull:`1591`)
 - The canonical name of tthe postgres driver is now "postgres" with "default" as an alias instead of the other
   way around. (:pull:`1590`)


### PR DESCRIPTION
### Reason for this pull request

Part of hyperspectral work.

Generalize extra dimension description in the measurement metadata dictionary to allow specifying order of the extra dimensions. Also adds `units` field when defining extra coordinates for extra dimensions.

### Proposed changes

instead of 
```yaml
extra_dim = b
```

do

```yaml
dims = [b, y, x]
```

which also enables `yxb` arrangement

```yaml
dims = [y, x, rgb]
```

 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes