### PR TITLE
Fix race condition initialising ODCEnvironment objects

### DIFF
--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,8 @@ What's New
 v1.9.next
 =========
 
+- Fix multi-threading race condition in config API. (:pull:`1596`)
+
 v1.9.0-rc5 (5th June 2024)
 ==========================
 


### PR DESCRIPTION
### Reason for this pull request

`ODCEnvironment` do not actually read from config at creation time.  The actual reading of config has be deferred until after environment aliases have been processed, but this creates a race condition in multi-threaded environments.


### Proposed changes

- Create an environment thread lock at creation time.
- Perform the deferred config reading within that environment lock.


 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
