### PR TITLE
Fix alembic ini finder

### DIFF
--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -37,17 +37,9 @@ SQL_NAMING_CONVENTIONS = {
     # tix: test-index, created by hand for testing, particularly in dev.
 }
 
-SRC_CODE_ROOT = os.path.dirname(  # Source code root
-    os.path.dirname(              # datacube
-        os.path.dirname(          # drivers
-            os.path.dirname(      # postgis
-                __file__          # This file
-            )
-        )
-    )
-)
+POSTGIS_DRIVER_DIR = os.path.dirname(__file__)
 
-ALEMBIC_INI_LOCATION = os.path.join(SRC_CODE_ROOT, "alembic.ini")
+ALEMBIC_INI_LOCATION = os.path.join(POSTGIS_DRIVER_DIR, "alembic.ini")
 
 METADATA = MetaData(naming_convention=SQL_NAMING_CONVENTIONS, schema=SCHEMA_NAME)
 

--- a/datacube/drivers/postgis/alembic.ini
+++ b/datacube/drivers/postgis/alembic.ini
@@ -8,7 +8,7 @@
 
 [alembic]
 # path to migration scripts
-script_location = %(here)s/datacube/drivers/postgis/alembic
+script_location = %(here)s/alembic
 
 # sys.path path, will be prepended to sys.path if present.
 # defaults to the current working directory.

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -9,6 +9,7 @@ v1.9.next
 =========
 
 - Fix multi-threading race condition in config API. (:pull:`1596`)
+- Move alembic.ini to a location where it will get installed by pip (without -e). (:pull:`1597`)
 
 v1.9.0-rc5 (5th June 2024)
 ==========================


### PR DESCRIPTION
### Reason for this pull request

The `alembic.ini` file was previously kept in the root directory of the repo, which is fine if installed locally with `pip install -e .` but doesn't work when installing from PyPI.


### Proposed changes

- Move alembic.ini to the drivers/postgis directory.


 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
