### PR TITLE
Default floating point bands to nodata=nan when writing COGs.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
         password: ${{ secrets.DOCKERHUBPASSWD }}
 
     - name: Build Docker
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v6
       with:
         file: docker/Dockerfile
         context: .
@@ -108,7 +108,7 @@ jobs:
         github.event_name == 'push'
         && github.ref == 'refs/heads/develop'
         && steps.changes.outputs.docker == 'true'
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v6
       with:
         file: docker/Dockerfile
         context: .

--- a/datacube/testutils/__init__.py
+++ b/datacube/testutils/__init__.py
@@ -416,10 +416,10 @@ def gen_tiff_dataset(bands,
 
         gbox = meta.gbox
         bdict = dict(name=name,
-                       path=fname,
-                       layer=1,
-                       nodata=band.nodata,
-                       dtype=meta.dtype)
+                     path=fname,
+                     layer=1,
+                     nodata=band.nodata,
+                     dtype=meta.dtype)
         mm.append(bdict)
 
     uri = Path(base_folder_of_record/'metadata.yaml').absolute().as_uri()

--- a/datacube/testutils/__init__.py
+++ b/datacube/testutils/__init__.py
@@ -415,11 +415,12 @@ def gen_tiff_dataset(bands,
                            **kwargs)
 
         gbox = meta.gbox
-
-        mm.append(dict(name=name,
+        bdict = dict(name=name,
                        path=fname,
                        layer=1,
-                       dtype=meta.dtype))
+                       nodata=band.nodata,
+                       dtype=meta.dtype)
+        mm.append(bdict)
 
     uri = Path(base_folder_of_record/'metadata.yaml').absolute().as_uri()
     ds = mk_sample_dataset(mm,

--- a/datacube/utils/cog.py
+++ b/datacube/utils/cog.py
@@ -133,6 +133,10 @@ def _write_cog(
         compress="DEFLATE",
     )
 
+    # If nodata is not set, but the array is of floating point type, force nodata=nan
+    if nodata is None and np.issubdtype(pix.dtype, np.floating):
+        nodata = np.nan
+
     if nodata is not None:
         rio_opts.update(nodata=nodata)
 

--- a/datacube/utils/math.py
+++ b/datacube/utils/math.py
@@ -178,6 +178,7 @@ def num2numpy(x, dtype, ignore_range=None):
     :param x int|float: Numerical value to convert to numpy.type
     :param dtype str|numpy.dtype|numpy.type: Destination dtype
     :param ignore_range: If set to True skip range check and cast anyway (for example: -1 -> 255)
+                         (Not supported in numpy 2.0+)
 
     :returns: None if x is None
     :returns: None if x is outside the valid range of dtype and ignore_range is not set

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,7 @@ What's New
 v1.8.next
 =========
 
+- Always write floating point bands to cogs with nodata=nan for ESRI and GDAL compatibility (:pull:`1602`)
 - Add deprecation warning for config environment names that will not be supported in 1.9 (:pull:`1592`)
 - Update docker image to GDAL 3.9/Python 3.12/Ubuntu 24.04 (:pull:`1587`)
 - Update readthedocs stylesheet for dark theme (:pull:`1579`)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ tests_require = [
     'pytest-cov',
     'pytest-timeout',
     'pytest-httpserver',
-    'moto',
+    'moto<5.0',  # 5.0 will require changes to some tests.
 ]
 doc_require = [
     'Sphinx',

--- a/tests/test_3d.py
+++ b/tests/test_3d.py
@@ -68,8 +68,8 @@ def test_extra_dimensions(eo3_metadata, cover_z_dataset_type):
     # Check chunk size
     assert dt.extra_dimensions.chunk_size() == (("z",), (30,))
 
-    # String representation
-    readable = (
+    # String representation (numpy 1.x and numpy 2.x formats - numpy 2.x reports total size in bytes)
+    readable_1 = (
         "ExtraDimensions(extra_dim={'z': {'name': 'z', 'values': [5, 10, 15, "
         "20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100, "
         "105, 110, 115, 120, 125, 130, 135, 140, 145, 150], 'dtype': "
@@ -80,8 +80,19 @@ def test_extra_dimensions(eo3_metadata, cover_z_dataset_type):
         "140., 145., 150.])\nCoordinates:\n  * z        (z) int64 5 10 15 20 "
         "25 30 35 40 ... 120 125 130 135 140 145 150} )"
     )
-    assert str(dt.extra_dimensions) == readable
-    assert f"{dt.extra_dimensions!r}" == readable
+    readable_2 = (
+        "ExtraDimensions(extra_dim={'z': {'name': 'z', 'values': [5, 10, 15, "
+        "20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100, "
+        "105, 110, 115, 120, 125, 130, 135, 140, 145, 150], 'dtype': "
+        "'float64'}}, dim_slice={'z': (0, 30)} coords={'z': <xarray.DataArray "
+        "'z' (z: 30)> Size: 240B\narray([  5.,  10.,  15.,  20.,  25.,  30.,  35.,  "
+        "40.,  45.,  50.,  55.,\n        60.,  65.,  70.,  75.,  80.,  85.,  "
+        "90.,  95., 100., 105., 110.,\n       115., 120., 125., 130., 135., "
+        "140., 145., 150.])\nCoordinates:\n  * z        (z) int64 240B 5 10 15 20 "
+        "25 30 35 ... 120 125 130 135 140 145 150} )"
+    )
+    assert str(dt.extra_dimensions) in (readable_1, readable_2)
+    assert f"{dt.extra_dimensions!r}" in (readable_1, readable_2)
 
 
 def test_extra_dimensions_exceptions(eo3_metadata, cover_z_dataset_type):

--- a/tests/test_utils_cog.py
+++ b/tests/test_utils_cog.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2015-2024 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import pytest
+import math
 from pathlib import Path
 import numpy as np
 import xarray as xr
@@ -19,8 +20,8 @@ from datacube.testutils.io import native_load, rio_slurp_xarray, rio_slurp
 from datacube.utils.cog import write_cog, to_cog, _write_cog
 
 
-def gen_test_data(prefix, dask=False, shape=None):
-    w, h, dtype, nodata, ndw = 96, 64, "int16", -999, 7
+def gen_test_data(prefix, dask=False, shape=None, dtype="int16", nodata=-999):
+    w, h, ndw = 96, 64, 7
     if shape is not None:
         h, w = shape
 
@@ -108,6 +109,20 @@ def test_cog_file(tmpdir, opts):
 
     with pytest.warns(UserWarning):
         write_cog(xx, pp / "cog_badblocksize.tif", blocksize=50)
+
+    # check writing floating point COG with no explicit nodata
+    zz, ds = gen_test_data(pp, dtype="float32", nodata=None)
+    # write to file
+    ff = write_cog(
+        zz,
+        pp / "cog_float.tif",
+        **opts
+    )
+    assert isinstance(ff, Path)
+    assert ff == pp / "cog_float.tif"
+    assert ff.exists()
+    aa = rio_slurp_xarray(pp / "cog_float.tif")
+    assert aa.attrs["nodata"] == "nan" or math.isnan(aa.attrs["nodata"])
 
 
 def test_cog_file_dask(tmpdir):

--- a/tests/test_utils_other.py
+++ b/tests/test_utils_other.py
@@ -588,7 +588,12 @@ def test_num2numpy():
     assert num2numpy(256, 'uint8') is None
     assert num2numpy(-1, 'uint16') is None
     assert num2numpy(-1, 'uint32') is None
-    assert num2numpy(-1, 'uint8', ignore_range=True) == np.uint8(255)
+    try:
+        # Numpy 1.x supports wrapping of unsisinged types
+        assert num2numpy(-1, 'uint8', ignore_range=True) == np.uint8(255)
+    except OverflowError:
+        # Numpy 2.0 will throw Overflow error rather than wrapping
+        pass
 
     assert num2numpy(0, 'uint8') == 0
     assert num2numpy(255, 'uint8') == 255

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -150,6 +150,7 @@ EP
 EPSG
 epsg
 ESPA
+ESRI
 evironments
 f'file
 fd


### PR DESCRIPTION
### Reason for this pull request

Issue #1595


### Proposed changes

- Always write `nodata=nan` to COGs for all floating point bands (unless another nodata value is explicitly set) and test.
- Update tests to pass with numpy 2.x and numpy 1.x
- Pin `moto<5` (Moto API has changed slightly in v5 and several tests will need to be rewritten to support).



 - [x] Closes #1595
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1602.org.readthedocs.build/en/1602/

<!-- readthedocs-preview datacube-core end -->