### PR TITLE
Handle empty config file

### DIFF
--- a/datacube/cfg/api.py
+++ b/datacube/cfg/api.py
@@ -104,7 +104,7 @@ class ODCConfig:
         self.allow_envvar_overrides = not text and not raw_dict
 
         if not raw_dict and not text:
-            # No explict config passed in.  Check for ODC_CONFIG environmnet variables
+            # No explict config passed in.  Check for ODC_CONFIG environment variables
             if os.environ.get("ODC_CONFIG"):
                 text = os.environ["ODC_CONFIG"]
             else:

--- a/datacube/cfg/utils.py
+++ b/datacube/cfg/utils.py
@@ -54,5 +54,5 @@ def smells_like_ini(cfg_text: str):
             return True
         else:
             return False
-    # Doesn't smell like anything
-    return False
+    # Empty file - parse as ini so we end up with the right high level structure at least
+    return True

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,8 @@ What's New
 v1.9.next
 =========
 
+- Ensure config API works with a blank config/empty file. (:pull:`1604`)
+
 v1.9.0-rc8 (18th June 2024)
 ===========================
 

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -45,7 +45,7 @@ spagoots:
 aasdfer\\faw043[]]][""")
 
     # Pure white space
-    assert not smells_like_ini("   \n  \n    \n \n  \t  \t  \n   \n")
+    assert smells_like_ini("   \n  \n    \n \n  \t  \t  \n   \n")
 
 
 @pytest.fixture


### PR DESCRIPTION
### Reason for this pull request

An empty/blank/pure white space config file triggered an error.

### Proposed changes

- Parse empty/blank/pure white space config files as INI files instead of YAML files.  This results in the correct high level structure being returned to the Config API (i.e. an empty dictionary instead of `None`).


 - [x] Closes #1603
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
