### PR TITLE
New driver based loader

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -256,6 +256,7 @@ class Datacube:
              progress_cbk: ProgressFunction | None = None,
              patch_url: Callable[[str], str] | None = None,
              limit: int | None = None,
+             driver: Any | None = None,
              **query: QueryField):
         r"""
         Load data as an ``xarray.Dataset`` object.
@@ -546,7 +547,8 @@ class Datacube:
                                 skip_broken_datasets=skip_broken_datasets,
                                 progress_cbk=progress_cbk,
                                 extra_dims=extra_dims,
-                                patch_url=patch_url)
+                                patch_url=patch_url,
+                                driver=driver)
 
         return result
 
@@ -940,6 +942,13 @@ class Datacube:
         .. seealso:: :meth:`find_datasets` :meth:`group_datasets`
         """
         measurements = per_band_load_data_settings(measurements, resampling=resampling, fuse_func=fuse_func)
+        if driver := extra.pop('driver', None):
+            from ..storage._loader import driver_based_load
+
+            return driver_based_load(driver, sources, geobox, measurements, dask_chunks,
+                                     skip_broken_datasets=skip_broken_datasets,
+                                     extra_dims=extra_dims,
+                                     patch_url=patch_url)
 
         if dask_chunks is not None:
             return Datacube._dask_load(sources, geobox, measurements, dask_chunks,

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -469,6 +469,9 @@ class Datacube:
         :param limit:
             Optional. If provided, limit the maximum number of datasets returned. Useful for testing and debugging.
 
+        :param driver:
+            Optional. If provided, use the specified driver to load the data.
+
         :param **query:
             Search parameters for products and dimension ranges as described above.
             For example: ``'x', 'y', 'time', 'crs'``.
@@ -891,6 +894,7 @@ class Datacube:
                   progress_cbk: ProgressFunction | None = None,
                   extra_dims: ExtraDimensions | None = None,
                   patch_url: Callable[[str], str] | None = None,
+                  driver: Any | None = None,
                   **extra) -> xarray.Dataset:
         """
         Load data from :meth:`group_datasets` into an :class:`xarray.Dataset`.
@@ -937,12 +941,15 @@ class Datacube:
         :param Callable[[str], str], patch_url:
             if supplied, will be used to patch/sign the url(s), as required to access some commercial archives.
 
+        :param driver:
+            Optional. If provided, use the specified driver to load the data.
+
         :rtype: xarray.Dataset
 
         .. seealso:: :meth:`find_datasets` :meth:`group_datasets`
         """
         measurements = per_band_load_data_settings(measurements, resampling=resampling, fuse_func=fuse_func)
-        if driver := extra.pop('driver', None):
+        if driver is not None:
             from ..storage._loader import driver_based_load
 
             return driver_based_load(driver, sources, geobox, measurements, dask_chunks,

--- a/datacube/storage/_loader.py
+++ b/datacube/storage/_loader.py
@@ -1,0 +1,176 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2024 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""
+odc.loader based load.
+
+separate file to reduce formatting issues.
+
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from typing import Sequence
+
+import xarray as xr
+from odc.geo.geobox import GeoBox, GeoboxTiles
+from odc.loader import (
+    FixedCoord,
+    RasterBandMetadata,
+    RasterGroupMetadata,
+    RasterLoadParams,
+    RasterSource,
+    chunked_load,
+    reader_driver,
+    resolve_chunk_shape,
+)
+from odc.loader.types import ReaderDriverSpec
+
+from ..model import Dataset, ExtraDimensions, Measurement
+from . import BandInfo
+
+
+def ds_geobox(ds: Dataset, **kw) -> GeoBox | None:
+    from ..testutils.io import eo3_geobox
+
+    try:
+        return eo3_geobox(ds, **kw)
+    except ValueError:
+        return None
+
+
+def _extract_coords(extra_dims: ExtraDimensions) -> list[FixedCoord]:
+    coords = extra_dims.dims
+
+    return [
+        FixedCoord(
+            name=k,
+            values=d["values"],
+            dtype=str(d.get("dtype", "float32")),
+            dim=k,
+            units=d.get("units", None),
+        )
+        for k, d in coords.items()
+    ]
+
+
+def driver_based_load(
+    driver: ReaderDriverSpec,
+    sources: xr.DataArray,
+    geobox: GeoBox,
+    measurements: Sequence[Measurement],
+    dask_chunks=None,
+    skip_broken_datasets=False,
+    progress_cbk=None,
+    extra_dims: ExtraDimensions | None = None,
+    patch_url=None,
+):
+    fail_on_error = not skip_broken_datasets
+
+    if extra_dims is None:
+        extra_coords = []
+    else:
+        extra_coords = _extract_coords(extra_dims)
+
+    tss = [
+        datetime.fromtimestamp(float(ts) * 1e-9)
+        for ts in sources.coords["time"].data.ravel()
+    ]
+    band_query: list[str] = [m.name for m in measurements]
+    template = RasterGroupMetadata(
+        bands={
+            (m.name, 1): RasterBandMetadata(
+                m.dtype, m.nodata, m.units, dims=tuple(m.get("dims", ()))
+            )
+            for m in measurements
+        },
+        aliases={name: [(name, 1)] for name in band_query},
+        extra_dims={coord.dim: len(coord.values) for coord in extra_coords},
+        extra_coords=extra_coords,
+    )
+
+    load_cfg = {
+        m.name: RasterLoadParams(
+            m.dtype,
+            m.nodata,
+            resampling=m.get("resampling", "nearest"),
+            fail_on_error=fail_on_error,
+            dims=tuple(m.get("dims", ())),
+        )
+        for m in measurements
+    }
+
+    chunks = dask_chunks
+
+    if chunks is not None:
+        chunk_shape = resolve_chunk_shape(
+            len(tss), geobox, chunks, "float32", cfg=load_cfg
+        )
+    else:
+        chunk_shape = (1, 2048, 2048)
+
+    gbt = GeoboxTiles(geobox, (chunk_shape[1], chunk_shape[2]))
+
+    tyx_bins: dict[tuple[int, int, int], list[int]] = {}
+    srcs = []
+
+    if patch_url is None:
+        patch_url = lambda x: x  # noqa: E731
+
+    def _dss():
+        for tidx, dss in enumerate(sources.data):
+            for ds in dss:
+                yield tidx, ds
+
+    def _ds_extract(ds: Dataset) -> dict[str, RasterSource]:
+        out = {}
+        for n in band_query:
+            bi = BandInfo(ds, n)
+            band_idx = bi.band if bi.band is not None else 1
+
+            if bi.dims is not None and len(bi.dims) > 2:
+                band_idx = 0  # 0 indicates extra dims
+
+            out[n] = RasterSource(
+                patch_url(bi.uri),
+                band=band_idx,
+                subdataset=bi.layer,
+                geobox=ds_geobox(ds, band=n),
+                meta=template.bands[(n, band_idx or 1)],
+                driver_data=bi.driver_data,
+            )
+
+        return out
+
+    for tidx, ds in _dss():
+        srcs.append(_ds_extract(ds))
+        for iy, ix in gbt.tiles(ds.extent):
+            tyx_bins.setdefault((tidx, iy, ix), []).append(len(srcs) - 1)
+
+    if driver == "kk-debug":
+        return SimpleNamespace(
+            load_cfg=load_cfg,
+            template=template,
+            srcs=srcs,
+            tyx_bins=tyx_bins,
+            gbt=gbt,
+            tss=tss,
+        )
+
+    rdr = reader_driver(driver)
+
+    return chunked_load(
+        load_cfg,
+        template,
+        srcs,
+        tyx_bins=tyx_bins,
+        gbt=gbt,
+        tss=tss,
+        env=rdr.capture_env(),
+        rdr=rdr,
+        chunks=dask_chunks,
+        progress=progress_cbk,
+    )

--- a/tests/test_new_loader.py
+++ b/tests/test_new_loader.py
@@ -1,0 +1,40 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2024 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from datacube import Datacube
+from datacube.testutils import gen_tiff_dataset, mk_test_image
+
+odc_loader = pytest.importorskip("odc.loader")
+
+
+def test_with_driver(tmpdir):
+    tmpdir = Path(str(tmpdir))
+
+    spatial = dict(
+        resolution=(15, -15),
+        offset=(11230, 1381110),
+    )
+
+    nodata = -999
+    aa = mk_test_image(96, 64, "int16", nodata=nodata)
+
+    ds, geobox = gen_tiff_dataset(
+        [SimpleNamespace(name="aa", values=aa, nodata=nodata)],
+        tmpdir,
+        prefix="ds1-",
+        timestamp="2018-07-19",
+        **spatial
+    )
+    assert ds.time is not None
+    mm = ["aa"]
+    mm = [ds.product.measurements[k] for k in mm]
+    sources = Datacube.group_datasets([ds], "time")
+
+    ds_data = Datacube.load_data(sources, geobox, mm, driver="rio", dask_chunks={})
+    assert ds_data is not None


### PR DESCRIPTION
Use `odc.loader` routines for loading data when `driver=` is supplied in the `dc.load` command.

This will become standard way of loading eventually.

At this moment, the `odc.loader` code is installed with [odc-stac](https://github.com/opendatacube/odc-stac), starting with [version 0.3.10](https://github.com/opendatacube/odc-stac/releases/tag/v0.3.10)

To try this out

1. Install `odc-stac==0.3.10`
2. Use your normal `dc.load` but add `driver="rio"` to route to `odc.loader` logic, same as used by `odc.stac.load`


 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
