### PR TITLE
fix: use correct docker image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
     - name: Verify and Run Tests
       run: |
         echo "Verify that twine is installed"
-        docker run --rm opendatacube/datacube-tests:latest twine --version
+        docker run --rm ${{ env.DOCKER_IMAGE }} twine --version
 
         echo "Run tests"
         cat <<EOF | docker run --rm -i -v $(pwd):/code ${{ env.DOCKER_IMAGE }} bash -


### PR DESCRIPTION
### Reason for this pull request

GH Actions were pulling in "latest" docker image on `1.9` branch instead of `:latest1.9`


### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
