### PR TITLE
Geospatial search api and ready for 1.9.0-rc9 release

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -27,9 +27,9 @@ from datacube.model import ExtraDimensions, ExtraDimensionSlices, Dataset, Measu
 from datacube.model.utils import xr_apply
 
 from .query import Query, query_group_by, GroupBy
-from ..index import index_connect, Index
+from ..index import index_connect, Index, extract_geom_from_query
 from ..drivers import new_datasource
-from ..index.abstract import QueryField, AbstractDatasetResource
+from ..model import QueryField
 from ..migration import ODC2DeprecationWarning
 from ..storage._load import ProgressFunction, FuserFunction
 
@@ -1083,7 +1083,7 @@ def output_geobox(like: GeoBox | xarray.Dataset | xarray.DataArray | None = None
     #  3. Computed from dataset footprints
     #  4. fail with ValueError
     if geopolygon is None:
-        geopolygon = AbstractDatasetResource.extract_geom_from_query(**query)
+        geopolygon = extract_geom_from_query(**query)
 
         if geopolygon is None:
             if datasets is None:

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -26,10 +26,10 @@ from odc.geo.geobox import GeoBox, GeoboxTiles
 from datacube.model import ExtraDimensions, ExtraDimensionSlices, Dataset, Measurement, GridSpec
 from datacube.model.utils import xr_apply
 
-from .query import Query, query_group_by, query_geopolygon, GroupBy
+from .query import Query, query_group_by, GroupBy
 from ..index import index_connect, Index
 from ..drivers import new_datasource
-from ..index.abstract import QueryField
+from ..index.abstract import QueryField, AbstractDatasetResource
 from ..migration import ODC2DeprecationWarning
 from ..storage._load import ProgressFunction, FuserFunction
 
@@ -1083,7 +1083,7 @@ def output_geobox(like: GeoBox | xarray.Dataset | xarray.DataArray | None = None
     #  3. Computed from dataset footprints
     #  4. fail with ValueError
     if geopolygon is None:
-        geopolygon = query_geopolygon(**query)
+        geopolygon = AbstractDatasetResource.extract_geom_from_query(**query)
 
         if geopolygon is None:
             if datasets is None:

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -16,11 +16,9 @@ import pandas
 
 from pandas import to_datetime as pandas_to_datetime
 import numpy as np
-
-
+from ..index import extract_geom_from_query, strip_all_spatial_fields_from_query
 from ..model import Range, Dataset
 from ..utils.dates import normalise_dt, tz_aware
-from ..index.abstract import AbstractDatasetResource
 from odc.geo import Geometry
 from odc.geo.geom import lonlat_bounds, mid_longitude
 
@@ -90,13 +88,13 @@ class Query:
         """
         self.index = index
         self.product = product
-        self.geopolygon = AbstractDatasetResource.extract_geom_from_query(geopolygon=geopolygon, **search_terms)
+        self.geopolygon = extract_geom_from_query(geopolygon=geopolygon, **search_terms)
         if 'source_filter' in search_terms and search_terms['source_filter'] is not None:
             self.source_filter = Query(**search_terms['source_filter'])
         else:
             self.source_filter = None
 
-        search_terms = AbstractDatasetResource.strip_spatial_fields_from_query(search_terms)
+        search_terms = strip_all_spatial_fields_from_query(search_terms)
         remaining_keys = set(search_terms.keys()) - set(OTHER_KEYS)
         if self.index:
             # Retrieve known keys for extra dimensions

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -146,11 +146,11 @@ class Query:
                 kwargs['geopolygon'] = self.geopolygon
             else:
                 geo_bb = lonlat_bounds(self.geopolygon, resolution="auto")
-                if math.isclose(geo_bb.bottom, geo_bb.top, tol=1e-5):
+                if math.isclose(geo_bb.bottom, geo_bb.top, abs_tol=1e-5):
                     kwargs['lat'] = geo_bb.bottom
                 else:
                     kwargs['lat'] = Range(geo_bb.bottom, geo_bb.top)
-                if math.isclose(geo_bb.left, geo_bb.right, tol=1e-5):
+                if math.isclose(geo_bb.left, geo_bb.right, abs_tol=1e-5):
                     kwargs['lon'] = geo_bb.left
                 else:
                     kwargs['lon'] = Range(geo_bb.left, geo_bb.right)

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -79,7 +79,8 @@ class Query:
         Range(begin=datetime.datetime(2001, 1, 1, 0, 0, tzinfo=tzutc()), \
         end=datetime.datetime(2002, 1, 1, 23, 59, 59, 999999, tzinfo=tzutc()))
 
-        By passing in an ``index``, the search parameters will be validated as existing on the ``product``.
+        By passing in an ``index``, the search parameters will be validated as existing on the ``product``,
+        and a spatial search appropriate for the index driver can be extracted.
 
         Used by :meth:`datacube.Datacube.find_datasets` and :meth:`datacube.Datacube.load`.
 

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -10,6 +10,7 @@ Storage Query and Access API module
 import logging
 import datetime
 import collections
+import math
 import warnings
 from typing import Optional, Union
 import pandas
@@ -144,15 +145,15 @@ class Query:
             if self.index and self.index.supports_spatial_indexes:
                 kwargs['geopolygon'] = self.geopolygon
             else:
-                geo_bb = lonlat_bounds(self.geopolygon, resolution=100_000)  # TODO: pick resolution better
-                if geo_bb.bottom != geo_bb.top:
-                    kwargs['lat'] = Range(geo_bb.bottom, geo_bb.top)
-                else:
+                geo_bb = lonlat_bounds(self.geopolygon, resolution="auto")
+                if math.isclose(geo_bb.bottom, geo_bb.top, tol=1e-5):
                     kwargs['lat'] = geo_bb.bottom
-                if geo_bb.left != geo_bb.right:
-                    kwargs['lon'] = Range(geo_bb.left, geo_bb.right)
                 else:
+                    kwargs['lat'] = Range(geo_bb.bottom, geo_bb.top)
+                if math.isclose(geo_bb.left, geo_bb.right, tol=1e-5):
                     kwargs['lon'] = geo_bb.left
+                else:
+                    kwargs['lon'] = Range(geo_bb.left, geo_bb.right)
         if self.product:
             kwargs['product'] = self.product
         if self.source_filter:

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -77,7 +77,11 @@ class Query:
 
         :param datacube.index.Index index: An optional `index` object, if checking of field names is desired.
         :param str product: name of product
-        :type geopolygon: geometry.Geometry | None the spatial boundaries of the search
+        :type geopolygon: the spatial boundaries of the search, can be:
+                          odc.geo.geom.Geometry: A Geometry object
+                          Any string or JsonLike object that can be converted to a Geometry object.
+                          An iterable of either of the above; or
+                          None: no geopolygon defined (may be derived from like or lat/lon/x/y/crs search terms)
         :param xarray.Dataset like: spatio-temporal bounds of `like` are used for the search
         :param search_terms:
          * `measurements` - list of measurements to retrieve

--- a/datacube/index/__init__.py
+++ b/datacube/index/__init__.py
@@ -7,11 +7,14 @@ Modules for interfacing with the index/database.
 """
 
 from ._api import index_connect
+from ._spatial import strip_all_spatial_fields_from_query, extract_geom_from_query
 from .fields import UnknownFieldError
 from .exceptions import DuplicateRecordError, MissingRecordError, IndexSetupError
 from datacube.index.abstract import AbstractIndex as Index
 
 __all__ = [
+    'strip_all_spatial_fields_from_query',
+    'extract_geom_from_query',
     'index_connect',
     'Index',
 

--- a/datacube/index/_spatial.py
+++ b/datacube/index/_spatial.py
@@ -1,0 +1,104 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2024 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+from typing import cast
+from odc.geo.geom import CRS, Geometry, box
+from datacube.model import Range, QueryDict, QueryField
+from datacube.utils.documents import JsonDict
+
+H_SPATIAL_KEYS = ("lon", "longitude", "x")
+V_SPATIAL_KEYS = ("lat", "latitude", "y")
+COORDS_SPATIAL_KEYS = H_SPATIAL_KEYS + V_SPATIAL_KEYS
+
+CRS_SPATIAL_KEYS = ("crs", "coordinate_reference_system")
+SPATIAL_KEYS = COORDS_SPATIAL_KEYS + CRS_SPATIAL_KEYS
+
+ALL_SPATIAL_KEYS = SPATIAL_KEYS + ("geopolygon",)
+
+
+def strip_all_spatial_fields_from_query(q: QueryDict) -> QueryDict:
+    return {
+        k: v
+        for k, v in q.items()
+        if k not in ALL_SPATIAL_KEYS
+    }
+
+
+@staticmethod
+def extract_geom_from_query(**q: QueryField) -> Geometry | None:
+    """
+    Utility method for index drivers supporting spatial indexes.
+
+    Extract a Geometry from a dataset query.  Backwards compatible with old lat/lon style queries.
+
+    :param q: A query dictionary
+    :return: A polygon or multipolygon type Geometry.  None if no spatial query clauses.
+    """
+    geom: Geometry | None = None
+    if q.get("geopolygon") is not None:
+        # New geometry-style spatial query
+        geom_term = cast(JsonDict | Geometry, q.get("geopolygon"))
+        try:
+            geom = Geometry(geom_term)
+        except ValueError:
+            # Can't convert to single Geometry. If it is an iterable of Geometries, return the union
+            for term in geom_term:
+                if geom is None:
+                    geom = Geometry(term)
+                else:
+                    geom = geom.union(Geometry(term))
+        for spatial_key in SPATIAL_KEYS:
+            if spatial_key in q:
+                raise ValueError(f"Cannot specify spatial key {spatial_key} AND geopolygon in the same query")
+        assert geom and geom.crs
+    else:
+        # Old lat/lon--style spatial query (or no spatial query)
+        # TODO: latitude/longitude/x/y aliases for lat/lon
+        #       Also some stuff is precalced at the api.core.Datacube level.
+        #       THAT needs to offload to index driver when it can.
+        lon = lat = None
+        for coord in H_SPATIAL_KEYS:
+            if coord in q:
+                if lon is not None:
+                    raise ValueError(
+                        "Multiple horizontal coordinate ranges supplied: use only one of x, lon, longitude")
+                lon = q.get(coord)
+        for coord in V_SPATIAL_KEYS:
+            if coord in q:
+                if lat is not None:
+                    raise ValueError(
+                        "Multiple vertical coordinate ranges supplied: use only one of y, lat, latitude")
+                lat = q.get(coord)
+        crs_in = None
+        for coord in CRS_SPATIAL_KEYS:
+            if coord in q:
+                if crs_in is not None:
+                    raise ValueError("CRS is supplied twice")
+                crs_in = q.get(coord)
+        if crs_in is None:
+            crs = CRS("epsg:4326")
+        else:
+            crs = CRS(crs_in)
+        if lat is None and lon is None:
+            # No spatial query
+            return None
+
+        # Old lat/lon--style spatial query
+        # Normalise input to numeric ranges.
+        delta = 0.000001
+        if lat is None:
+            lat = Range(begin=-90, end=90)
+        elif isinstance(lat, (int, float)):
+            lat = Range(lat - delta, lat + delta)
+        else:
+            lat = Range(*lat)
+
+        if lon is None:
+            lon = Range(begin=-180, end=180)
+        elif isinstance(lon, (int, float)):
+            lon = Range(lon - delta, lon + delta)
+        else:
+            lon = Range(*lon)
+        geom = box(lon.begin, lat.begin, lon.end, lat.end, crs=crs)
+    return geom

--- a/datacube/index/_spatial.py
+++ b/datacube/index/_spatial.py
@@ -12,16 +12,19 @@ V_SPATIAL_KEYS = ("lat", "latitude", "y")
 COORDS_SPATIAL_KEYS = H_SPATIAL_KEYS + V_SPATIAL_KEYS
 
 CRS_SPATIAL_KEYS = ("crs", "coordinate_reference_system")
-SPATIAL_KEYS = COORDS_SPATIAL_KEYS + CRS_SPATIAL_KEYS
 
-ALL_SPATIAL_KEYS = SPATIAL_KEYS + ("geopolygon",)
+# All of the above
+NON_GEOPOLYGON_SPATIAL_KEYS = COORDS_SPATIAL_KEYS + CRS_SPATIAL_KEYS
+
+# All of the above plus geopolygon
+SPATIAL_KEYS = NON_GEOPOLYGON_SPATIAL_KEYS + ("geopolygon",)
 
 
 def strip_all_spatial_fields_from_query(q: QueryDict) -> QueryDict:
     return {
         k: v
         for k, v in q.items()
-        if k not in ALL_SPATIAL_KEYS
+        if k not in SPATIAL_KEYS
     }
 
 
@@ -47,7 +50,7 @@ def extract_geom_from_query(**q: QueryField | tuple) -> Geometry | None:
                     geom = Geometry(term)
                 else:
                     geom = geom.union(Geometry(term))
-        for spatial_key in SPATIAL_KEYS:
+        for spatial_key in NON_GEOPOLYGON_SPATIAL_KEYS:
             if spatial_key in q:
                 raise ValueError(f"Cannot specify spatial key {spatial_key} AND geopolygon in the same query")
         assert geom and geom.crs

--- a/datacube/index/_spatial.py
+++ b/datacube/index/_spatial.py
@@ -25,8 +25,7 @@ def strip_all_spatial_fields_from_query(q: QueryDict) -> QueryDict:
     }
 
 
-@staticmethod
-def extract_geom_from_query(**q: QueryField) -> Geometry | None:
+def extract_geom_from_query(**q: QueryField | tuple) -> Geometry | None:
     """
     Utility method for index drivers supporting spatial indexes.
 
@@ -92,13 +91,17 @@ def extract_geom_from_query(**q: QueryField) -> Geometry | None:
         elif isinstance(lat, (int, float)):
             lat = Range(lat - delta, lat + delta)
         else:
-            lat = Range(*lat)
+            # Treat as tuple
+            begin, end = cast(tuple[int | float, int | float], lat)
+            lat = Range(begin, end)
 
         if lon is None:
             lon = Range(begin=-180, end=180)
         elif isinstance(lon, (int, float)):
             lon = Range(lon - delta, lon + delta)
         else:
-            lon = Range(*lon)
+            # Treat as tuple
+            begin, end = cast(tuple[int | float, int | float], lon)
+            lon = Range(begin, end)
         geom = box(lon.begin, lat.begin, lon.end, lat.end, crs=crs)
     return geom

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -1633,6 +1633,7 @@ class AbstractDatasetResource(ABC):
         :param archived: False (default): Return active datasets only.
                          None: Include archived and active datasets.
                          True: Return archived datasets only.
+        :param geopolygon: Spatial search polygon (only supported if index supports_spatial_indexes)
         :param query: search query parameters
         :return: Matching datasets
         """
@@ -1759,6 +1760,7 @@ class AbstractDatasetResource(ABC):
         :param archived: False (default): Return active datasets only.
                          None: Include archived and active datasets.
                          True: Return archived datasets only.
+        :param geopolygon: Spatial search polygon (only supported if index supports_spatial_indexes)
         :param query: search query parameters
         :return: Matching datasets, grouped by Product
         """
@@ -1791,6 +1793,7 @@ class AbstractDatasetResource(ABC):
                          True: Return archived datasets only.
         :param order_by: a field name or field by which to sort output.  None is unsorted and may allow faster return
                          of first result depending on the index driver's implementation.
+        :param geopolygon: Spatial search polygon (only supported if index supports_spatial_indexes)
         :param query: search query parameters
         :return: Namedtuple of requested fields, for each matching dataset.
         """
@@ -1803,6 +1806,7 @@ class AbstractDatasetResource(ABC):
         :param archived: False (default): Count active datasets only.
                          None: Count archived and active datasets.
                          True: Count archived datasets only.
+        :param geopolygon: Spatial search polygon (only supported if index supports_spatial_indexes)
         :param query: search query parameters
         :return: Count of matching datasets in index
         """
@@ -1812,6 +1816,10 @@ class AbstractDatasetResource(ABC):
         """
         Perform a search, returning a count of for each matching product type.
 
+        :param geopolygon: Spatial search polygon (only supported if index supports_spatial_indexes)
+        :param archived: False (default): Count active datasets only.
+                         None: Count archived and active datasets.
+                         True: Count archived datasets only.
         :param query: search query parameters
         :return: Counts of matching datasets in index, grouped by product.
         """
@@ -1850,6 +1858,7 @@ class AbstractDatasetResource(ABC):
         :param archived: False (default): Count active datasets only.
                          None: Count archived and active datasets.
                          True: Count archived datasets only.
+        :param geopolygon: Spatial search polygon (only supported if index supports_spatial_indexes)
         :param query: search query parameters
         :returns: The product, a list of time ranges and the count of matching datasets.
         """
@@ -1865,6 +1874,7 @@ class AbstractDatasetResource(ABC):
         """
         Perform a search, returning just the search fields of each dataset.
 
+        :param geopolygon: Spatial search polygon (only supported if index supports_spatial_indexes)
         :param query: search query parameters
         :return: Mappings of search fields for matching datasets
         """
@@ -1973,9 +1983,9 @@ class AbstractDatasetResource(ABC):
         :return: A polygon or multipolygon type Geometry.  None if no spatial query clauses.
         """
         geom: Geometry | None = None
-        if "geometry" in q:
+        if "geopolygon" in q:
             # New geometry-style spatial query
-            geom_term = cast(JsonDict | Geometry, q.pop("geometry"))
+            geom_term = cast(JsonDict | Geometry, q.pop("geopolygon"))
             try:
                 geom = Geometry(geom_term)
             except ValueError:

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -17,7 +17,8 @@ from uuid import UUID
 from datacube.migration import ODC2DeprecationWarning
 from datacube.index import fields
 from datacube.index.abstract import (AbstractDatasetResource, DSID, dsid_to_uuid, BatchStatus,
-                                     QueryField, DatasetSpatialMixin, NoLineageResource, AbstractIndex, JsonDict)
+                                     DatasetSpatialMixin, NoLineageResource, AbstractIndex)
+from datacube.model._base import QueryField
 from datacube.index.fields import Field
 from datacube.index.memory._fields import build_custom_fields, get_dataset_fields
 from datacube.model import Dataset, LineageRelation, Product, Range, ranges_overlap
@@ -25,7 +26,7 @@ from datacube.utils import jsonify_document, _readable_offset
 from datacube.utils import changes
 from datacube.utils.changes import AllowPolicy, Change, Offset, get_doc_changes
 from datacube.utils.dates import tz_aware
-from datacube.utils.documents import metadata_subset
+from datacube.utils.documents import metadata_subset, JsonDict
 
 _LOG = logging.getLogger(__name__)
 

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -470,6 +470,8 @@ class DatasetResource(AbstractDatasetResource):
             archived: bool | None = False,
             **query: QueryField
     ) -> Iterable[Dataset | tuple[Iterable[Dataset], Product]]:
+        if "geopolygon" in query:
+            raise NotImplementedError("Spatial search index API not supported by this index.")
         if source_filter:
             product_queries = list(self._get_prod_queries(**source_filter))
             if not product_queries:
@@ -606,10 +608,12 @@ class DatasetResource(AbstractDatasetResource):
                          archived: bool | None = False,
                          order_by: str | Field | None = None,
                          **query: QueryField) -> Iterable[tuple]:
-        # Note that this implementation relies on dictionaries being ordered by insertion - this has been the case
-        # since Py3.6, and officially guaranteed behaviour since Py3.7.
+        if "geopolygon" in query:
+            raise NotImplementedError("Spatial search index API not supported by this index.")
         if order_by:
             raise ValueError("order_by argument is not currently supported by the memory index driver.")
+        # Note that this implementation relies on dictionaries being ordered by insertion - this has been the case
+        # since Py3.6, and officially guaranteed behaviour since Py3.7.
         if field_names is None and custom_offsets is None:
             field_name_d = {f: None for f in self._index.products.get_field_names()}
         elif field_names:

--- a/datacube/index/memory/_products.py
+++ b/datacube/index/memory/_products.py
@@ -9,12 +9,12 @@ from typing import Iterable, Sequence, cast
 from uuid import UUID
 
 from datacube.index.fields import as_expression
-from datacube.index.abstract import AbstractProductResource, QueryField, QueryDict, JsonDict, AbstractIndex
+from datacube.index.abstract import AbstractProductResource, AbstractIndex
+from datacube.model._base import QueryField, QueryDict
 from datacube.model import Product
 from datacube.utils import changes, jsonify_document, _readable_offset
 from datacube.utils.changes import AllowPolicy, Change, Offset, check_doc_unchanged, get_doc_changes, classify_changes
-from datacube.utils.documents import metadata_subset
-
+from datacube.utils.documents import metadata_subset, JsonDict
 
 _LOG = logging.getLogger(__name__)
 

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -798,7 +798,8 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         for q, product in product_queries:
             _LOG.warning("Querying product %s", product)
             # Extract Geospatial search geometry
-            geom = self._extract_geom_from_query(q)
+            geom = self.extract_geom_from_query(**q)
+            q = self.strip_spatial_fields_from_query(q)
             dataset_fields = product.metadata_type.dataset_fields
             if additional_fields:
                 dataset_fields.update(additional_fields)

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -832,7 +832,8 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         product_queries = self._get_product_queries(query)
 
         for q, product in product_queries:
-            geom = self._extract_geom_from_query(q)
+            geom = extract_geom_from_query(**q)
+            q = strip_all_spatial_fields_from_query(q)
             dataset_fields = product.metadata_type.dataset_fields
             query_exprs = tuple(fields.to_expressions(dataset_fields.get, **q))
             with self._db_connection() as connection:

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -22,15 +22,16 @@ from datacube.drivers.postgis._api import non_native_fields, extract_dataset_fie
 from datacube.utils.uris import split_uri
 from datacube.drivers.postgis._spatial import generate_dataset_spatial_values, extract_geometry_from_eo3_projection
 from datacube.migration import ODC2DeprecationWarning
-from datacube.index.abstract import AbstractDatasetResource, DatasetSpatialMixin, DSID, BatchStatus, DatasetTuple, \
-    JsonDict, QueryField
+from datacube.index.abstract import AbstractDatasetResource, DatasetSpatialMixin, DSID, BatchStatus, DatasetTuple
+from datacube.utils.documents import JsonDict
+from datacube.model._base import QueryField
 from datacube.index.postgis._transaction import IndexResourceAddIn
 from datacube.model import Dataset, Product, Range, LineageTree
 from datacube.model.fields import Field
 from datacube.utils import jsonify_document, _readable_offset, changes
 from datacube.utils.changes import get_doc_changes, Offset
 from odc.geo import CRS, Geometry
-from datacube.index import fields
+from datacube.index import fields, extract_geom_from_query, strip_all_spatial_fields_from_query
 
 _LOG = logging.getLogger(__name__)
 
@@ -798,8 +799,8 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         for q, product in product_queries:
             _LOG.warning("Querying product %s", product)
             # Extract Geospatial search geometry
-            geom = self.extract_geom_from_query(**q)
-            q = self.strip_spatial_fields_from_query(q)
+            geom = extract_geom_from_query(**q)
+            q = strip_all_spatial_fields_from_query(q)
             dataset_fields = product.metadata_type.dataset_fields
             if additional_fields:
                 dataset_fields.update(additional_fields)

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -799,9 +799,6 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             _LOG.warning("Querying product %s", product)
             # Extract Geospatial search geometry
             geom = self._extract_geom_from_query(q)
-            assert "lat" not in q
-            assert "lon" not in q
-
             dataset_fields = product.metadata_type.dataset_fields
             if additional_fields:
                 dataset_fields.update(additional_fields)
@@ -813,7 +810,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                     select_fields = tuple(field for name, field in dataset_fields.items()
                                           if not field.affects_row_selection)
                 else:
-                    # Allow place holder columns for requested fields that are not
+                    # Allow placeholder columns for requested fields that are not
                     # valid for this product query.
                     select_fields = tuple(dataset_fields[field_name]
                                           for field_name in select_field_names

--- a/datacube/index/postgis/_products.py
+++ b/datacube/index/postgis/_products.py
@@ -10,7 +10,8 @@ from cachetools.func import lru_cache
 
 from odc.geo.geom import CRS, Geometry
 from datacube.index import fields
-from datacube.index.abstract import AbstractProductResource, BatchStatus, JsonDict
+from datacube.index.abstract import AbstractProductResource, BatchStatus
+from datacube.utils.documents import JsonDict
 from datacube.index.postgis._transaction import IndexResourceAddIn
 from datacube.model import Product, MetadataType
 from datacube.utils import jsonify_document, changes, _readable_offset

--- a/datacube/index/postgis/_products.py
+++ b/datacube/index/postgis/_products.py
@@ -306,7 +306,7 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
 
             # Check that all the keys they specified match this product.
             for key, value in list(remaining_matchable.items()):
-                if key == "geometry":
+                if key == "geopolygon":
                     # Geometry field is handled elsewhere by index drivers that support spatial indexes.
                     continue
                 field = type_.metadata_type.dataset_fields.get(key)

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -770,6 +770,8 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                               with_source_ids=False, source_filter=None,
                               limit=None,
                               archived: bool | None = False):
+        if "geopolygon" in query:
+            raise NotImplementedError("Spatial search API not supported by this index.")
         if source_filter:
             product_queries = list(self._get_product_queries(source_filter))
             if not product_queries:
@@ -820,6 +822,8 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                        ))
 
     def _do_count_by_product(self, query, archived: bool | None = False):
+        if "geopolygon" in query:
+            raise NotImplementedError("Spatial index API not supported by this index.")
         product_queries = self._get_product_queries(query)
 
         for q, product in product_queries:
@@ -831,6 +835,8 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                 yield product, count
 
     def _do_time_count(self, period, query, ensure_single=False):
+        if "geopolygon" in query:
+            raise NotImplementedError("Spatial index API not supported by this index.")
         if 'time' not in query:
             raise ValueError('Counting through time requires a "time" range query argument')
 

--- a/datacube/index/postgres/_products.py
+++ b/datacube/index/postgres/_products.py
@@ -9,7 +9,8 @@ from cachetools.func import lru_cache
 from typing import Iterable, Sequence, cast
 
 from datacube.index import fields
-from datacube.index.abstract import AbstractProductResource, JsonDict
+from datacube.index.abstract import AbstractProductResource
+from datacube.utils.documents import JsonDict
 from datacube.index.postgres._transaction import IndexResourceAddIn
 from datacube.model import MetadataType, Product
 from datacube.utils import jsonify_document, changes, _readable_offset

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -20,7 +20,7 @@ from urllib.parse import urlparse
 from datacube.utils import without_lineage_sources, parse_time, cached_property, uri_to_local_path, \
     schema_validated, DocReader
 from .fields import Field, get_dataset_fields
-from ._base import Range, ranges_overlap, Not  # noqa: F401
+from ._base import Range, ranges_overlap, Not, QueryField, QueryDict  # noqa: F401
 from .eo3 import validate_eo3_compatible_type
 from .lineage import LineageDirection, LineageTree, LineageRelation, InconsistentLineageException  # noqa: F401
 
@@ -29,6 +29,7 @@ __all__ = [
     "Range", "ranges_overlap",
     "LineageDirection", "LineageTree", "LineageRelation", "InconsistentLineageException",
     "Dataset", "Product", "MetadataType", "Measurement", "GridSpec",
+    "QueryField", "QueryDict",
     "metadata_from_doc",
     "ExtraDimensions"
 ]

--- a/datacube/model/_base.py
+++ b/datacube/model/_base.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2015-2024 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+import datetime
 from collections import namedtuple
 
 Range = namedtuple('Range', ('begin', 'end'))
@@ -21,3 +22,5 @@ def ranges_overlap(ra: Range, rb: Range) -> bool:
 
 
 Not = namedtuple('Not', 'value')
+QueryField = str | float | int | Range | datetime.datetime | Not
+QueryDict = dict[str, QueryField]

--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -34,6 +34,11 @@ except ImportError:
 from datacube.utils.generic import map_with_lookahead
 from datacube.utils.uris import mk_part_uri, as_url, uri_to_local_path
 
+
+JsonAtom = None | bool | str | float | int
+JsonLike = JsonAtom | list["JsonLike"] | dict[str, "JsonLike"]
+JsonDict = dict[str, JsonLike]
+
 PY35 = sys.version_info <= (3, 6)
 _LOG = logging.getLogger(__name__)
 

--- a/docker/constraints.in
+++ b/docker/constraints.in
@@ -57,7 +57,7 @@ alembic
 sqlalchemy>=2.0.18
 toolz
 xarray>=2023.9.0
-odc-geo
+odc-geo>=0.4
 # For Python 3.12 support
 wrapt>=1.16.0
 

--- a/docker/constraints.txt
+++ b/docker/constraints.txt
@@ -148,7 +148,6 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==6.0.0
     # via
-    #   compliance-checker
     #   keyring
     #   twine
 iniconfig==2.0.0
@@ -234,7 +233,7 @@ numpy==1.26.4
     #   shapely
     #   snuggs
     #   xarray
-odc-geo==0.3.3
+odc-geo==0.4.7
     # via -r constraints.in
 owslib==0.27.2
     # via compliance-checker

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,12 +8,15 @@ What's New
 v1.9.next
 =========
 
+v1.9.0-rc9 (3rd July 2024)
+==========================
+
 - Ensure config API works with a blank config/empty file. (:pull:`1604`)
 - Various minor maintenance fixes. (:pull:`1607`)
 - Misc cleanup, and add support for geospatial queries to count methods in postgis driver. (:pull:`1608`)
 - Add new driver based loader (via odc.loader) (:pull:`1609`)
 - Fix 1.9 docker image in GHA (:pull:`1610`)
-- Consolidate spatial search argument handling in index layer (:pull:`1611`)
+- Consolidate spatial search argument handling in index layer and prepare for release. (:pull:`1611`)
 
 v1.9.0-rc8 (18th June 2024)
 ===========================
@@ -123,6 +126,10 @@ v1.9.0-rc1 (27th March 2024)
 v1.8.next
 =========
 
+v1.8.19 (2nd July 2024)
+=======================
+
+- Update whats_new for 1.8.19 release (:pull:`1612`)
 - Always write floating point bands to cogs with nodata=nan for ESRI and GDAL compatibility (:pull:`1602`)
 - Add deprecation warning for config environment names that will not be supported in 1.9 (:pull:`1592`)
 - Update docker image to GDAL 3.9/Python 3.12/Ubuntu 24.04 (:pull:`1587`)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -10,8 +10,10 @@ v1.9.next
 
 - Ensure config API works with a blank config/empty file. (:pull:`1604`)
 - Various minor maintenance fixes. (:pull:`1607`)
-- Add new driver based loader (via odc.loader) (:pull:`1609`)
 - Misc cleanup, and add support for geospatial queries to count methods in postgis driver. (:pull:`1608`)
+- Add new driver based loader (via odc.loader) (:pull:`1609`)
+- Fix 1.9 docker image in GHA (:pull:`1610`)
+- Consolidate spatial search argument handling in index layer (:pull:`1611`)
 
 v1.9.0-rc8 (18th June 2024)
 ===========================

--- a/integration_tests/index/test_postgis_index.py
+++ b/integration_tests/index/test_postgis_index.py
@@ -201,26 +201,26 @@ def test_spatial_search(index,
     exact1_3577 = ls8_eo3_dataset.extent.to_crs(epsg3577)
     exact3_4326 = ls8_eo3_dataset3.extent.to_crs(epsg4326)
     exact3_3577 = ls8_eo3_dataset3.extent.to_crs(epsg3577)
-    dssids = set(ds.id for ds in index.datasets.search(product=ls8_eo3_dataset.product.name, geometry=exact1_4326))
+    dssids = set(ds.id for ds in index.datasets.search(product=ls8_eo3_dataset.product.name, geopolygon=exact1_4326))
     assert len(dssids) == 2
     assert ls8_eo3_dataset.id in dssids
     assert ls8_eo3_dataset2.id in dssids
-    assert index.datasets.count(product=ls8_eo3_dataset.product.name, geometry=exact1_4326) == 2
-    dssids = [ds.id for ds in index.datasets.search(product=ls8_eo3_dataset.product.name, geometry=exact1_3577)]
+    assert index.datasets.count(product=ls8_eo3_dataset.product.name, geopolygon=exact1_4326) == 2
+    dssids = [ds.id for ds in index.datasets.search(product=ls8_eo3_dataset.product.name, geopolygon=exact1_3577)]
     assert len(dssids) == 2
     assert ls8_eo3_dataset.id in dssids
     assert ls8_eo3_dataset2.id in dssids
-    assert index.datasets.count(product=ls8_eo3_dataset.product.name, geometry=exact1_3577) == 2
-    dssids = [ds.id for ds in index.datasets.search(product=ls8_eo3_dataset.product.name, geometry=exact3_4326)]
+    assert index.datasets.count(product=ls8_eo3_dataset.product.name, geopolygon=exact1_3577) == 2
+    dssids = [ds.id for ds in index.datasets.search(product=ls8_eo3_dataset.product.name, geopolygon=exact3_4326)]
     assert len(dssids) == 2
     assert ls8_eo3_dataset3.id in dssids
     assert ls8_eo3_dataset3.id in dssids
-    assert index.datasets.count(product=ls8_eo3_dataset.product.name, geometry=exact3_4326) == 2
-    dssids = [ds.id for ds in index.datasets.search(product=ls8_eo3_dataset.product.name, geometry=exact3_3577)]
+    assert index.datasets.count(product=ls8_eo3_dataset.product.name, geopolygon=exact3_4326) == 2
+    dssids = [ds.id for ds in index.datasets.search(product=ls8_eo3_dataset.product.name, geopolygon=exact3_3577)]
     assert len(dssids) == 2
     assert ls8_eo3_dataset3.id in dssids
     assert ls8_eo3_dataset3.id in dssids
-    assert index.datasets.count(product=ls8_eo3_dataset.product.name, geometry=exact3_3577) == 2
+    assert index.datasets.count(product=ls8_eo3_dataset.product.name, geopolygon=exact3_3577) == 2
 
 
 @pytest.mark.parametrize('datacube_env_name', ('experimental',))

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ setup(
         'toolz',
         'xarray>=0.9',  # >0.9 fixes most problems with `crs` attributes being lost
         'packaging',
-        'odc-geo',
+        'odc-geo>=0.4',
         'deprecat',
         'importlib_metadata>3.5;python_version<"3.10"',
     ],

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -57,7 +57,6 @@ def test_query_kwargs(mock_index):
 
     query = Query(index=mock_index, latitude=-35, longitude=148)
 
-
     query = Query(index=mock_index, y=(-4174726, -4180011), x=(1515184, 1523263), crs='EPSG:3577')
     assert query.geopolygon
     assert 'lat' in query.search_terms
@@ -119,6 +118,7 @@ def test_query_kwargs_postgis(mock_index, test_geom):
     query = Query(index=mock_index, geopolygon=test_geom)
     assert query.geopolygon
     assert 'geopolygon' in query.search_terms
+
 
 def format_test(start_out, end_out):
     return Range(pandas.to_datetime(start_out, utc=True).to_pydatetime(),

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -18,7 +18,21 @@ from odc.geo import CRS
 @pytest.fixture
 def mock_index():
     from unittest.mock import MagicMock
-    return MagicMock()
+    idx = MagicMock()
+    idx.supports_spatial_indexes = False
+    return idx
+
+
+@pytest.fixture
+def test_geom():
+    from odc.geo.geom import polygon
+    return polygon([
+        (-35.0, 110.0),
+        (-35.0, 125.0),
+        (-45.0, 125.0),
+        (-45.0, 110),
+        (-35.0, 110),
+    ], crs="EPSG:4326")
 
 
 def test_query_kwargs(mock_index):
@@ -41,6 +55,9 @@ def test_query_kwargs(mock_index):
     assert 'lat' in query.search_terms
     assert 'lon' in query.search_terms
 
+    query = Query(index=mock_index, latitude=-35, longitude=148)
+
+
     query = Query(index=mock_index, y=(-4174726, -4180011), x=(1515184, 1523263), crs='EPSG:3577')
     assert query.geopolygon
     assert 'lat' in query.search_terms
@@ -61,6 +78,7 @@ def test_query_kwargs(mock_index):
     assert 'lat' in query.search_terms
     assert 'lon' in query.search_terms
 
+    mock_index.supports_spatial_indexes = True
     query = Query(index=mock_index, time='2001')
     assert 'time' in query.search
 
@@ -88,6 +106,19 @@ def test_query_kwargs(mock_index):
     assert isinstance(gb, GroupBy)
     assert query_group_by(group_by=gb) is gb
 
+
+def test_query_kwargs_postgis(mock_index, test_geom):
+    mock_index.supports_spatial_indexes = True
+
+    query = Query(index=mock_index, latitude=-35, longitude=148)
+    assert query.geopolygon
+    assert 'lat' not in query.search_terms
+    assert 'lon' not in query.search_terms
+    assert 'geopolygon' in query.search_terms
+
+    query = Query(index=mock_index, geopolygon=test_geom)
+    assert query.geopolygon
+    assert 'geopolygon' in query.search_terms
 
 def format_test(start_out, end_out):
     return Range(pandas.to_datetime(start_out, utc=True).to_pydatetime(),

--- a/tests/index/test_spatial.py
+++ b/tests/index/test_spatial.py
@@ -1,0 +1,30 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2024 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from odc.geo.geom import box, CRS
+
+
+def test_extract_geom():
+    p1 = box(-122.2, 44.7, -120.8, 45.0, crs="epsg:4326")
+    p2 = box(-102.5, 44.1, -100.2, 46.2, crs="epsg:4326")
+    p3 = box(-112.7, 42.4, -109.6, 45.1, crs="epsg:4326")
+
+    from datacube.index._spatial import extract_geom_from_query
+    geom = extract_geom_from_query(geopolygon=[p1, p2, p3])
+    assert geom.contains(p1)
+    assert geom.contains(p2)
+    assert geom.contains(p3)
+    geom = extract_geom_from_query(lon=(-122.3, -100.2))
+    assert geom.crs == CRS("epsg:4326")
+    assert geom.contains(p1)
+    assert geom.contains(p2)
+    assert geom.contains(p3)
+
+    with pytest.raises(ValueError):
+        geom = extract_geom_from_query(geopolygon=p3, crs="epsg:3577")
+
+    with pytest.raises(ValueError):
+        geom = extract_geom_from_query(latitude=(22, 23), y=(10011.1, 585585.5), crs="epsg:3577")

--- a/tests/index/test_spatial.py
+++ b/tests/index/test_spatial.py
@@ -28,3 +28,6 @@ def test_extract_geom():
 
     with pytest.raises(ValueError):
         geom = extract_geom_from_query(latitude=(22, 23), y=(10011.1, 585585.5), crs="epsg:3577")
+
+    with pytest.raises(ValueError):
+        geom = extract_geom_from_query(lon=(22, 23), x=(10011.1, 585585.5), crs="epsg:3577")


### PR DESCRIPTION
### Reason for this pull request

Spatial search conventions differed between the core API (e.g. `dc.load`) and index API (e.g. `dc.index.datasets.search`) and were implemented similarly but differently in both places.

### Proposed changes

- Keep `dc.load()` API unchanged
- Update index spatial search API to match core API (Use `geopolygon` instead of `geometry`)
- Consolidate spatial search argument handling out of the core API and into the lower shared levels of the index layer.
- Ugly hack to get netcdf writing with all recent versions of odc-geo
- Update whats_new.rst ready for 1.9.0-r 9 release.


 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
