### PR TITLE
Permissions management cleanup

### DIFF
--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -94,8 +94,7 @@ def ensure_db(engine, with_permissions=True):
         if with_permissions:
             _LOG.info('Ensuring user roles.')
             _ensure_role(c, 'odc_user')
-            _ensure_role(c, 'odc_ingest', inherits_from='odc_user')
-            _ensure_role(c, 'odc_manage', inherits_from='odc_ingest')
+            _ensure_role(c, 'odc_manage', inherits_from='odc_user')
             _ensure_role(c, 'odc_admin', inherits_from='odc_manage', add_user=True)
 
             c.execute(text(f"""
@@ -136,10 +135,10 @@ def ensure_db(engine, with_permissions=True):
 
             grant insert on {SCHEMA_NAME}.dataset,
                             {SCHEMA_NAME}.location,
-                            {SCHEMA_NAME}.dataset_lineage to odc_ingest;
-            grant usage, select on all sequences in schema {SCHEMA_NAME} to odc_ingest;
+                            {SCHEMA_NAME}.dataset_lineage to odc_manage;
+            grant usage, select on all sequences in schema {SCHEMA_NAME} to odc_manage;
 
-            -- (We're only granting deletion of types that have nothing written yet: they can't delete the data itself)
+            -- Manage allows deletion of types that have nothing written yet (admin needed delete the data itself)
             grant insert, delete on {SCHEMA_NAME}.product,
                                     {SCHEMA_NAME}.metadata_type to odc_manage;
             -- Allow creation of indexes, views

--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -24,7 +24,7 @@ from datacube.drivers.postgis.sql import (INSTALL_TRIGGER_SQL_TEMPLATE,
                                           UPDATE_TIMESTAMP_SQL,
                                           escape_pg_identifier)
 
-USER_ROLES = ('odc_user', 'odc_ingest', 'odc_manage', 'odc_admin')
+USER_ROLES = ('odc_user', 'odc_manage', 'odc_admin')
 
 SQL_NAMING_CONVENTIONS = {
     "ix": 'ix_%(column_0_label)s',
@@ -265,8 +265,8 @@ def to_pg_role(role):
 
     Why are we even doing this? Can't we use the same names internally and externally?
 
-    >>> to_pg_role('ingest')
-    'odc_ingest'
+    >>> to_pg_role('user')
+    'odc_user'
     >>> to_pg_role('fake')
     Traceback (most recent call last):
     ...

--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -138,7 +138,7 @@ def ensure_db(engine, with_permissions=True):
                             {SCHEMA_NAME}.dataset_lineage to odc_manage;
             grant usage, select on all sequences in schema {SCHEMA_NAME} to odc_manage;
 
-            -- Manage allows deletion of types that have nothing written yet (admin needed delete the data itself)
+            -- Manage allows deletion of types that have nothing written yet (admin needed to delete the data itself)
             grant insert, delete on {SCHEMA_NAME}.product,
                                     {SCHEMA_NAME}.metadata_type to odc_manage;
             -- Allow creation of indexes, views

--- a/datacube/drivers/postgis/_spatial.py
+++ b/datacube/drivers/postgis/_spatial.py
@@ -158,11 +158,11 @@ def ensure_spindex(engine: Engine, sp_idx: Type[SpatialIndex]) -> None:
     with engine.connect() as c:
         for command in [
             # Read access to odc_user
-            f"grant select on {SCHEMA_NAME}.{sp_idx.__tablename__} to odc_user;",
+            f"grant select on {SCHEMA_NAME}.{sp_idx.__tablename__} to odc_user;",  # type: ignore[attr-defined]
             # Insert access to odc_manage
-            f"grant insert on {SCHEMA_NAME}.{sp_idx.__tablename__} to odc_manage;",
+            f"grant insert on {SCHEMA_NAME}.{sp_idx.__tablename__} to odc_manage;",  # type: ignore[attr-defined]
             # Full access to odc_admin
-            f"grant all on {SCHEMA_NAME}.{sp_idx.__tablename__} to odc_admin;",
+            f"grant all on {SCHEMA_NAME}.{sp_idx.__tablename__} to odc_admin;",  # type: ignore[attr-defined]
         ]:
             c.execute(text(command))
     return

--- a/datacube/drivers/postgis/_spatial.py
+++ b/datacube/drivers/postgis/_spatial.py
@@ -15,7 +15,7 @@ from sqlalchemy.dialects import postgresql as postgres
 from geoalchemy2 import Geometry
 
 from sqlalchemy.engine import Engine
-from sqlalchemy import Column
+from sqlalchemy import Column, text
 from sqlalchemy.orm import Session
 
 from odc.geo import CRS, Geometry as Geom
@@ -154,6 +154,17 @@ def ensure_spindex(engine: Engine, sp_idx: Type[SpatialIndex]) -> None:
         session.add(SpatialIndexRecord.from_spindex(sp_idx))
         session.commit()
         session.flush()
+    # Permissions Management
+    with engine.connect() as c:
+        for command in [
+            # Read access to odc_user
+            f"grant select on {SCHEMA_NAME}.{sp_idx.__tablename__} to odc_user;",
+            # Insert access to odc_manage
+            f"grant insert on {SCHEMA_NAME}.{sp_idx.__tablename__} to odc_manage;",
+            # Full access to odc_admin
+            f"grant all on {SCHEMA_NAME}.{sp_idx.__tablename__} to odc_admin;",
+        ]:
+            c.execute(text(command))
     return
 
 

--- a/datacube/scripts/user.py
+++ b/datacube/scripts/user.py
@@ -20,7 +20,7 @@ from datacube.utils.serialise import SafeDatacubeDumper
 from datacube.index.abstract import AbstractIndex
 
 _LOG = logging.getLogger('datacube-user')
-USER_ROLES = ('user', 'ingest', 'manage', 'admin')
+USER_ROLES = ('user', 'manage', 'admin')
 
 
 @cli.group(name='user', help='User management commands')

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,8 @@ What's New
 v1.9.next
 =========
 
+- Permissions management cleanup in postgis driver. (:pull:`1613`)
+
 v1.9.0-rc9 (3rd July 2024)
 ==========================
 

--- a/integration_tests/test_config_tool.py
+++ b/integration_tests/test_config_tool.py
@@ -251,7 +251,7 @@ def test_user_creation(clirunner, example_user):
     username, user_description = example_user
 
     # Create them
-    args = ['user', 'create', 'ingest', username]
+    args = ['user', 'create', 'user', username]
     if user_description:
         args.extend(['--description', user_description])
     clirunner(args)


### PR DESCRIPTION
### Reason for this pull request

Cleanup of permissions management in postgis driver.

### Proposed changes

- Permissions for spatial index table are now granted to the odc database roles (read-only to `odc_user`, insert to `odc_manage`, all to `odc_admin`.
- `odc_ingest` db role is no longer created by the postgis driver and is no longer supported by the 'datacube user` CLI.

 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
