### PR TITLE
Configure Dependabot for Docker image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: docker
+    directory: "/docker"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
### Reason for this pull request

This will cause Dependabot to make
pull requests for the Dockerfile
when there are new releases of GDAL.

### Proposed changes

Repo-internal change to make Dependabot submit pull requests for the Dockerfile.

 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

