### PR TITLE
CI: make docpreview pass for pull requests

### DIFF
--- a/.github/workflows/doc-qa.yaml
+++ b/.github/workflows/doc-qa.yaml
@@ -8,6 +8,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  pull-requests: write
+
 jobs:
   pyspell:
     runs-on: ubuntu-latest

--- a/.github/workflows/doc-qa.yaml
+++ b/.github/workflows/doc-qa.yaml
@@ -1,12 +1,9 @@
 name: Doc QA
 on:
   # Triggers the workflow on pull request events for the main branch
-  pull_request:
-    branches:
-      - 'develop'
-
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+  pull_request_target:
+    types:
+      - opened
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
### Reason for this pull request

The docpreview job fails for me on a pull request where I didn't update any documentation. Bring in the changes from datacube-ows (https://github.com/opendatacube/datacube-ows/pull/972, https://github.com/opendatacube/datacube-ows/pull/974) that I think fixed the same issue.

### Proposed changes


 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes
