### PR TITLE
Fix some Docker warnings

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@
 ## SPDX-License-Identifier: Apache-2.0
 ##
 # gdal:ubuntu-small no longer comes with netcdf support compiled into gdal
-FROM ghcr.io/osgeo/gdal:ubuntu-full-3.9.0 as builder
+FROM ghcr.io/osgeo/gdal:ubuntu-full-3.9.0 AS builder
 FROM ghcr.io/osgeo/gdal:ubuntu-full-3.9.0
 ARG V_PG=16
 ARG V_PGIS=16-postgis-3

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,14 +34,13 @@ RUN apt-get update -y \
 # Build constrained python environment
 
 RUN virtualenv /env
-ENV PYENV /env
-ENV GDAL_CONFIG /usr/bin/gdal-config
+# Set the locale, this is required for some of the Python packages
+ENV PYENV=/env \
+    GDAL_CONFIG=/usr/bin/gdal-config \
+    LC_ALL=C.UTF-8
 
 # Needed to build cf-units wheels.
 ARG UDUNITS2_XML_PATH=/usr/share/xml/udunits/udunits2-common.xml
-
-# Set the locale, this is required for some of the Python packages
-ENV LC_ALL C.UTF-8
 
 COPY docker/constraints.in /conf/requirements.txt
 COPY docker/constraints.txt docker/nobinary.txt /conf/


### PR DESCRIPTION
### Reason for this pull request

Fix the warnings emitted by recent Docker releases.

### Proposed changes

Fix the warnings, and bring together all the ENV lines into a single layer to save a little bit of space in the produced image.



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

