### PR TITLE
Don't error in dataset add if `product.id` is None

### DIFF
--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -165,7 +165,12 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             return dataset
         with self._db_connection(transaction=True) as transaction:
             # 1a. insert (if not already exists)
-            is_new = transaction.insert_dataset(dataset.metadata_doc_without_lineage(), dataset.id, dataset.product.id)
+            product_id = dataset.product.id
+            if product_id is None:
+                # don't assume the product has an id value since it's optional
+                # but we should error if the product doesn't exist in the db
+                product_id = self._index.products.get_by_name_unsafe(dataset.product.name).id
+            is_new = transaction.insert_dataset(dataset.metadata_doc_without_lineage(), dataset.id, product_id)
             if is_new:
                 # 1b. Prepare spatial index extents
                 transaction.update_spindex(dsids=[dataset.id])

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -169,7 +169,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             if product_id is None:
                 # don't assume the product has an id value since it's optional
                 # but we should error if the product doesn't exist in the db
-                product_id = self._index.products.get_by_name_unsafe(dataset.product.name).id
+                product_id = self.products.get_by_name_unsafe(dataset.product.name).id
             is_new = transaction.insert_dataset(dataset.metadata_doc_without_lineage(), dataset.id, product_id)
             if is_new:
                 # 1b. Prepare spatial index extents

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -155,7 +155,12 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
             # First insert all new datasets
             for ds in dss:
-                is_new = transaction.insert_dataset(ds.metadata_doc_without_lineage(), ds.id, ds.product.id)
+                product_id = ds.product.id
+                if product_id is None:
+                    # don't assume the product has an id value since it's optional
+                    # but we should error if the product doesn't exist in the db
+                    product_id = self._index.products.get_by_name_unsafe(ds.product.name).id
+                is_new = transaction.insert_dataset(ds.metadata_doc_without_lineage(), ds.id, product_id)
                 sources = ds.sources
                 if is_new and sources is not None:
                     edges.extend((name, ds.id, src.id)

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -159,7 +159,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                 if product_id is None:
                     # don't assume the product has an id value since it's optional
                     # but we should error if the product doesn't exist in the db
-                    product_id = self._index.products.get_by_name_unsafe(ds.product.name).id
+                    product_id = self.products.get_by_name_unsafe(ds.product.name).id
                 is_new = transaction.insert_dataset(ds.metadata_doc_without_lineage(), ds.id, product_id)
                 sources = ds.sources
                 if is_new and sources is not None:

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -7,6 +7,7 @@ What's New
 
 v1.8.next
 =========
+- Don't error when adding a dataset whose product doesn't have an id value (:pull:`1630`)
 
 v1.8.19 (2nd July 2024)
 =======================

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -18,7 +18,8 @@ from dateutil import tz
 
 from datacube.index.exceptions import MissingRecordError
 from datacube.index import Index
-from datacube.model import Dataset, MetadataType
+from datacube.model import Dataset, Product, MetadataType
+from datacube.index.eo3 import prep_eo3
 
 _telemetry_uuid = UUID('4ec8fe97-e8b9-11e4-87ff-1040f381a756')
 _telemetry_dataset = {
@@ -256,6 +257,14 @@ def test_get_dataset(index: Index, ls8_eo3_dataset: Dataset) -> None:
 
     assert index.datasets.bulk_get(['f226a278-e422-11e6-b501-185e0f80a5c0',
                                     'f226a278-e422-11e6-b501-185e0f80a5c1']) == []
+
+
+def test_add_dataset_no_product_id(index: Index, extended_eo3_metadata_type, ls8_eo3_product, eo3_ls8_dataset_doc):
+    product_no_id = Product(extended_eo3_metadata_type, ls8_eo3_product.definition)
+    assert product_no_id.id is None
+    dataset_doc, _ = eo3_ls8_dataset_doc
+    dataset = Dataset(product_no_id, prep_eo3(dataset_doc))
+    assert index.datasets.add(dataset, with_lineage=False)
 
 
 def test_transactions_api_ctx_mgr(index,

--- a/tests/index/test_api_index_dataset.py
+++ b/tests/index/test_api_index_dataset.py
@@ -208,6 +208,9 @@ class MockTypesResource:
     def get_by_name(self, *args, **kwargs):
         return self.type
 
+    def get_by_name_unsafe(self, *args, **kwargs):
+        return self.type
+
     @contextmanager
     def _db_connection(self, transaction=False):
         yield MockDb()


### PR DESCRIPTION
### Reason for this pull request

`index.datasets.add` uses the `dataset.product.id` to determine the value of `metadata_type_ref` when inserting into the db. However, the Product `id` attribute is optional and thus might be `None`, causing the insertion to error even with a valid `dataset.product`.


### Proposed changes

- Retrieve the product id from the database if isn't accessible via `dataset.product.id`



 - [ ] Closes #xxxx
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1630.org.readthedocs.build/en/1630/

<!-- readthedocs-preview datacube-core end -->