### PR TITLE
Update docs README to give suitable instructions for local docs build

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -8,22 +8,60 @@ Developing Locally
 
 Requires a Unix like system that includes ``make``.
 
-#. Install NodeJS + NPM
-#. Install Browser Sync
+#. Clone the datacube-core repository. If you don't have permissions to push to the datacube-core library, you will need to fork the repo and clone your fork.
 
 .. code-block:: bash
 
-   npm install -g browser-sync
+   git clone https://github.com/opendatacube/datacube-core.git
 
-#. Install Python dependencies
+#. Check out a new branch for the documentation feature you're working on
 
 .. code-block:: bash
 
-   pip install -r requirements.txt
-   pip install git+https://github.com/carrotandcompany/sphinx-autobuild.git@feature_event_delay
+   git switch -c docs-<feature>
 
-#. Start the auto-building development server.
+#. Change directory to the docs folder
+
+.. code-block:: bash
+
+   cd docs
+
+#. Create a conda environment for python 3.11, with conda-forge as the channel
+
+.. code-block:: bash
+
+   conda create --name datacubecoredocs -c conda-forge python=3.11
+
+#. Activate the conda environment
+
+.. code-block:: bash
+
+   conda activate datacubecoredocs
+
+#. Install pandoc
+
+.. code-block:: bash
+
+   conda install pandoc
+
+#. Install requirements with pip
+
+.. code-block:: bash
+
+   pip install -r requirements.txt 
+
+#. Run the autobuild.
 
 .. code-block:: bash
 
    sphinx-autobuild . _build/html
+
+#. Open a browser and navigate to the URL provided by the autobuild
+
+#. Make changes to the docs. The terminal with the autobuild will continue to update the docs view in the browser.
+
+#. When finished, quit the autobuild process using ``ctrl-c`` in the terminal.
+
+#. Stage and commit your changes.
+
+#. When ready for review, push your changes and create a pull request.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -179,7 +179,7 @@ platformdirs==3.0.0
     # via jupyter-core
 psutil==5.9.4
     # via distributed
-psycopg2==2.9.5
+#psycopg2==2.9.5
     # via datacube (setup.py)
 pydata-sphinx-theme==0.9.0
     # via datacube (setup.py)


### PR DESCRIPTION
### Reason for this pull request

Current docs instructions aren't sufficient for building a local copy of the docs. Node isn't required, and I have found it's possible (with help from @lachlanhurst) to set up a conda environment and get the docs building locally.

### Proposed changes

- Update docs README.rst with clearer instructions on how to set up local build
- Update requirements to exclude `psycopg2` which wasn't required

Additional work would be to:
- Remove all dependencies that aren't required to build the docs
- Move to a conda-forge only requirements file
- Build a docker container to allow users on Windows, Mac, and Linux to have a consistent local development experience for docs.


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1631.org.readthedocs.build/en/1631/

<!-- readthedocs-preview datacube-core end -->