### PR TITLE
Drop valid area checks and am-fix 3857.

### DIFF
--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -225,9 +225,8 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                 metadata_doc["grid_spatial"]["projection"]  # type: ignore[misc,call-overload,index]
             )
             if extent:
-                geo_extent = extent.to_crs(CRS("EPSG:4326"))
                 for crs in crses:
-                    values = generate_dataset_spatial_values(dsid, crs, extent, geo_extent=geo_extent)
+                    values = generate_dataset_spatial_values(dsid, crs, extent)
                     if values is not None:
                         batch.spatial_indexes[crs].append(values)
             if prod.metadata_type.name in cache:

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -14,6 +14,8 @@ v1.9.next
 - Remove workaround for an odc-geo bug that is now fixed. (:pull:`1622`)
 - Fix call to geopolygon search. (:pull:`1627`)
 - Use antimeridian package to "fix" extent polygons. (:pull:`1628`)
+- Update schema logic (:pull:`1634`)
+- Drop valid-area check and anti-meridian fix 3857 extents (:pull:1635)
 
 v1.9.0-rc9 (3rd July 2024)
 ==========================

--- a/integration_tests/index/test_postgis_index.py
+++ b/integration_tests/index/test_postgis_index.py
@@ -144,11 +144,11 @@ def test_spatial_index_crs_sanitise():
     ), crs=epsg3857)
 
     am_3832 = polygon((
-       (3116945, 2857692),
-       (3562223, 2857692),
-       (3562223, 2615329),
-       (3116945, 2615329),
-       (3116945, 2857692)
+        (3116945, 2857692),
+        (3562223, 2857692),
+        (3562223, 2615329),
+        (3116945, 2615329),
+        (3116945, 2857692)
     ), crs=epsg3832)
 
     from datacube.drivers.postgis._spatial import sanitise_extent


### PR DESCRIPTION
### Reason for this pull request

The valid region check doesn't work because 4326.

### Proposed changes

- Remove the valid region check altogether
- Allow EPSG's other than 4326 to be anti-meridian corrected if it makes sense.  3857 is the only one I'm aware of that makes sense but there may be others identified later.
- Resultant test changes.


 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
