### PR TITLE
CI: update to checkout@v4

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -47,7 +47,7 @@ jobs:
         python-version: [3.9]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup conda
         uses: s-weigand/setup-conda@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ on:
       - '!contrib/**'
 
   workflow_dispatch:
-  
+
 env:
   DOCKER_USER: gadockersvc
   DOCKER_IMAGE: opendatacube/datacube-tests:latest
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
### Reason for this pull request

This fixes the warning:

> The following actions use a deprecated Node.js version and will be forced to run on node20:
> actions/checkout@v3, actions/github-script@v6. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/


### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1638.org.readthedocs.build/en/1638/

<!-- readthedocs-preview datacube-core end -->