### PR TITLE
CI: fix failing spellcheck job

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -8,7 +8,7 @@ Developing Locally
 
 Requires a Unix like system that includes ``make``.
 
-#. Clone the datacube-core repository. If you don't have permissions to push to the datacube-core library, you will need to fork the repo and clone your fork.
+#. Clone the datacube-core repository. If you don't have permissions to push to the datacube-core library, you will need to fork the repository and clone your fork.
 
 .. code-block:: bash
 
@@ -48,7 +48,7 @@ Requires a Unix like system that includes ``make``.
 
 .. code-block:: bash
 
-   pip install -r requirements.txt 
+   pip install -r requirements.txt
 
 #. Run the autobuild.
 

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -89,6 +89,7 @@ CRSMismatchError
 CSIRO
 csiro
 CSV
+ctrl
 cubeenv
 currentmodule
 cyear
@@ -100,6 +101,7 @@ DataArray
 DataCube
 Datacube
 datacube
+datacubecoredocs
 dataflow
 DataFrame
 DataSet


### PR DESCRIPTION
### Reason for this pull request

The CI spellcheck job fails, so spell out the word "repository" and add the two other words to the wordlist.


### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1639.org.readthedocs.build/en/1639/

<!-- readthedocs-preview datacube-core end -->