### PR TITLE
Dockerflie: tweak pip install parameters

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,17 +46,17 @@ COPY docker/constraints.in /conf/requirements.txt
 COPY docker/constraints.txt docker/nobinary.txt /conf/
 
 
-RUN . /env/bin/activate && python3 -m pip install --no-cache-dir --upgrade pip setuptools
-RUN . /env/bin/activate && python3 -m pip install --no-cache-dir -r /conf/requirements.txt \
+RUN . /env/bin/activate && python3 -m pip --disable-pip-version-check install --no-cache-dir --upgrade pip setuptools
+RUN . /env/bin/activate && python3 -m pip --disable-pip-version-check install --no-cache-dir -r /conf/requirements.txt \
                            -c /conf/constraints.txt \
                            -c /conf/nobinary.txt
 
 # Copy datacube-core source code into container and install from source (with addons for tests).
 COPY . /code
 
-RUN . /env/bin/activate && python3 -m pip install --no-cache-dir '/code/[all]' \
-    && python3 -m pip install --no-cache-dir /code/examples/io_plugin \
-    && python3 -m pip install --no-cache-dir /code/tests/drivers/fail_drivers
+RUN . /env/bin/activate && python3 -m pip --disable-pip-version-check install --no-cache-dir '/code/[all]' \
+    && python3 -m pip --disable-pip-version-check install --no-cache-dir /code/examples/io_plugin \
+    && python3 -m pip --disable-pip-version-check install --no-cache-dir /code/tests/drivers/fail_drivers
 
 # Copy bootstrap script into image.
 COPY docker/assets/with_bootstrap /usr/local/bin/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,17 +46,17 @@ COPY docker/constraints.in /conf/requirements.txt
 COPY docker/constraints.txt docker/nobinary.txt /conf/
 
 
-RUN . /env/bin/activate && python3 -m pip install --upgrade pip setuptools
-RUN . /env/bin/activate && python3 -m pip install -r /conf/requirements.txt \
+RUN . /env/bin/activate && python3 -m pip install --no-cache-dir --upgrade pip setuptools
+RUN . /env/bin/activate && python3 -m pip install --no-cache-dir -r /conf/requirements.txt \
                            -c /conf/constraints.txt \
                            -c /conf/nobinary.txt
 
 # Copy datacube-core source code into container and install from source (with addons for tests).
 COPY . /code
 
-RUN . /env/bin/activate && python3 -m pip install '/code/[all]' \
-    && python3 -m pip install /code/examples/io_plugin \
-    && python3 -m pip install /code/tests/drivers/fail_drivers
+RUN . /env/bin/activate && python3 -m pip install --no-cache-dir '/code/[all]' \
+    && python3 -m pip install --no-cache-dir /code/examples/io_plugin \
+    && python3 -m pip install --no-cache-dir /code/tests/drivers/fail_drivers
 
 # Copy bootstrap script into image.
 COPY docker/assets/with_bootstrap /usr/local/bin/


### PR DESCRIPTION
### Reason for this pull request

Stop keeping a pip cache to reduce the image size, and stop contacting remote servers during the image build.


### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1642.org.readthedocs.build/en/1642/

<!-- readthedocs-preview datacube-core end -->