### PR TITLE
Make psycopg2 an optional dependency

### DIFF
--- a/datacube/drivers/postgis/_connections.py
+++ b/datacube/drivers/postgis/_connections.py
@@ -100,21 +100,25 @@ class PostGisDb:
 
     @staticmethod
     def _create_engine(url, application_name=None, iam_rds_auth=False, iam_rds_timeout=600, pool_timeout=60) -> Engine:
-        engine = create_engine(
-            url,
-            echo=False,
-            echo_pool=False,
+        try:
+            engine = create_engine(
+                url,
+                echo=False,
+                echo_pool=False,
 
-            # 'AUTOCOMMIT' here means READ-COMMITTED isolation level with autocommit on.
-            # When a transaction is needed we will do an explicit begin/commit.
-            isolation_level='AUTOCOMMIT',
-            json_serializer=_to_json,
-            # If a connection is idle for this many seconds, SQLAlchemy will renew it rather
-            # than assuming it's still open. Allows servers to close idle connections without clients
-            # getting errors.
-            pool_recycle=pool_timeout,
-            connect_args={'application_name': application_name},
-        )
+                # 'AUTOCOMMIT' here means READ-COMMITTED isolation level with autocommit on.
+                # When a transaction is needed we will do an explicit begin/commit.
+                isolation_level='AUTOCOMMIT',
+                json_serializer=_to_json,
+                # If a connection is idle for this many seconds, SQLAlchemy will renew it rather
+                # than assuming it's still open. Allows servers to close idle connections without clients
+                # getting errors.
+                pool_recycle=pool_timeout,
+                connect_args={'application_name': application_name},
+            )
+        except ModuleNotFoundError:
+            raise IndexSetupError('psycopg2 is required to work with the database. '
+                                  'Please install the [postgres] or [test] depdencies.')
 
         if iam_rds_auth:
             from datacube.utils.aws import obtain_new_iam_auth_token

--- a/datacube/drivers/postgis/_connections.py
+++ b/datacube/drivers/postgis/_connections.py
@@ -118,7 +118,7 @@ class PostGisDb:
             )
         except ModuleNotFoundError:
             raise IndexSetupError('psycopg2 is required to work with the database. '
-                                  'Please install the [postgres] or [test] depdencies.')
+                                  'Please install the [postgres] or [test] dependencies.')
 
         if iam_rds_auth:
             from datacube.utils.aws import obtain_new_iam_auth_token

--- a/datacube/drivers/postgis/_connections.py
+++ b/datacube/drivers/postgis/_connections.py
@@ -118,7 +118,8 @@ class PostGisDb:
             )
         except ModuleNotFoundError:
             raise IndexSetupError('psycopg2 is required to work with the database. '
-                                  'Please install the [postgres] or [test] dependencies.')
+                                  'Please install the [postgres] or [test] dependencies, '
+                                  'or manually install psycopg2 or psycopg2-binary.')
 
         if iam_rds_auth:
             from datacube.utils.aws import obtain_new_iam_auth_token

--- a/datacube/drivers/postgis/_fields.py
+++ b/datacube/drivers/postgis/_fields.py
@@ -13,7 +13,6 @@ from datetime import datetime, date
 from decimal import Decimal
 from typing import Any, Callable, Type, Tuple, Union
 
-from psycopg2.extras import NumericRange, DateTimeTZRange
 from sqlalchemy.types import TIMESTAMP
 from sqlalchemy import cast, func, and_
 from sqlalchemy.dialects import postgresql as postgres
@@ -300,7 +299,7 @@ class NumericDocField(SimpleDocField):
     def between(self, low, high):
         # Numeric fields actually stored as ranges in current schema.
         # return ValueBetweenExpression(self, low, high)
-        return RangeBetweenExpression(self, low, high, _range_class=NumericRange)
+        return RangeBetweenExpression(self, low, high, _range_class=PgRange)
 
     def parse_value(self, value):
         return Decimal(value)
@@ -448,7 +447,7 @@ class NumericRangeDocField(RangeDocField):
         """
         :rtype: Expression
         """
-        return RangeBetweenExpression(self, low, high, _range_class=NumericRange)
+        return RangeBetweenExpression(self, low, high, _range_class=PgRange)
 
 
 class IntRangeDocField(NumericRangeDocField):
@@ -512,7 +511,7 @@ class DateRangeDocField(RangeDocField):
                 self,
                 tz_as_utc(low).astimezone(timezone.utc),
                 tz_as_utc(high).astimezone(timezone.utc),
-                _range_class=DateTimeTZRange
+                _range_class=PgRange
             )
         else:
             raise ValueError("Unknown comparison type for date range: "

--- a/datacube/drivers/postgres/_connections.py
+++ b/datacube/drivers/postgres/_connections.py
@@ -93,21 +93,25 @@ class PostgresDb(object):
 
     @staticmethod
     def _create_engine(url, application_name=None, iam_rds_auth=False, iam_rds_timeout=600, pool_timeout=60):
-        engine = create_engine(
-            url,
-            echo=False,
-            echo_pool=False,
+        try:
+            engine = create_engine(
+                url,
+                echo=False,
+                echo_pool=False,
 
-            # 'AUTOCOMMIT' here means READ-COMMITTED isolation level with autocommit on.
-            # When a transaction is needed we will do an explicit begin/commit.
-            isolation_level='AUTOCOMMIT',
-            json_serializer=_to_json,
-            # If a connection is idle for this many seconds, SQLAlchemy will renew it rather
-            # than assuming it's still open. Allows servers to close idle connections without clients
-            # getting errors.
-            pool_recycle=pool_timeout,
-            connect_args={'application_name': application_name}
-        )
+                # 'AUTOCOMMIT' here means READ-COMMITTED isolation level with autocommit on.
+                # When a transaction is needed we will do an explicit begin/commit.
+                isolation_level='AUTOCOMMIT',
+                json_serializer=_to_json,
+                # If a connection is idle for this many seconds, SQLAlchemy will renew it rather
+                # than assuming it's still open. Allows servers to close idle connections without clients
+                # getting errors.
+                pool_recycle=pool_timeout,
+                connect_args={'application_name': application_name}
+            )
+        except ModuleNotFoundError:
+            raise IndexSetupError('psycopg2 is required to work with the database. '
+                                  'Please install the [postgres] or [test] depdencies.')
 
         if iam_rds_auth:
             from datacube.utils.aws import obtain_new_iam_auth_token

--- a/datacube/drivers/postgres/_connections.py
+++ b/datacube/drivers/postgres/_connections.py
@@ -111,7 +111,8 @@ class PostgresDb(object):
             )
         except ModuleNotFoundError:
             raise IndexSetupError('psycopg2 is required to work with the database. '
-                                  'Please install the [postgres] or [test] dependencies.')
+                                  'Please install the [postgres] or [test] dependencies, '
+                                  'or manually install psycopg2 or psycopg2-binary.')
 
         if iam_rds_auth:
             from datacube.utils.aws import obtain_new_iam_auth_token

--- a/datacube/drivers/postgres/_connections.py
+++ b/datacube/drivers/postgres/_connections.py
@@ -111,7 +111,7 @@ class PostgresDb(object):
             )
         except ModuleNotFoundError:
             raise IndexSetupError('psycopg2 is required to work with the database. '
-                                  'Please install the [postgres] or [test] depdencies.')
+                                  'Please install the [postgres] or [test] dependencies.')
 
         if iam_rds_auth:
             from datacube.utils.aws import obtain_new_iam_auth_token

--- a/datacube/drivers/postgres/_fields.py
+++ b/datacube/drivers/postgres/_fields.py
@@ -10,7 +10,6 @@ from datetime import datetime, date
 from decimal import Decimal
 from typing import Any, Callable, Tuple, Union
 
-from psycopg2.extras import NumericRange, DateTimeTZRange
 from sqlalchemy import cast, func, and_
 from sqlalchemy.dialects import postgresql as postgres
 from sqlalchemy.dialects.postgresql import INT4RANGE
@@ -355,7 +354,7 @@ class NumericRangeDocField(RangeDocField):
         """
         :rtype: Expression
         """
-        return RangeBetweenExpression(self, low, high, _range_class=NumericRange)
+        return RangeBetweenExpression(self, low, high, _range_class=postgres.Range)
 
 
 class IntRangeDocField(RangeDocField):
@@ -375,7 +374,7 @@ class IntRangeDocField(RangeDocField):
         """
         :rtype: Expression
         """
-        return RangeBetweenExpression(self, low, high, _range_class=NumericRange)
+        return RangeBetweenExpression(self, low, high, _range_class=postgres.Range)
 
 
 class DoubleRangeDocField(RangeDocField):
@@ -423,7 +422,7 @@ class DateRangeDocField(RangeDocField):
                 self,
                 tz_aware(low),
                 tz_aware(high),
-                _range_class=DateTimeTZRange
+                _range_class=postgres.Range
             )
         else:
             raise ValueError("Unknown comparison type for date range: "

--- a/datacube/scripts/search_tool.py
+++ b/datacube/scripts/search_tool.py
@@ -14,7 +14,7 @@ import sys
 from functools import partial
 
 import click
-from psycopg2._range import Range
+from sqlalchemy.dialects.postgresql import Range
 from functools import singledispatch
 
 from datacube.ui import click as ui
@@ -137,7 +137,7 @@ def printable_dt(val):
 @printable.register(Range)
 def printable_r(val):
     """
-    :type val: psycopg2._range.Range
+    :type val: sqlalchemy.dialects.postgresql.Range
     """
     if val.lower_inf:
         return printable(val.upper)

--- a/docker/constraints.txt
+++ b/docker/constraints.txt
@@ -9,43 +9,47 @@ affine==2.4.0
     #   -r constraints.in
     #   odc-geo
     #   rasterio
-alabaster==0.7.16
+alabaster==0.7.13
     # via sphinx
-alembic==1.13.3
+alembic==1.12.1
     # via -r constraints.in
 antlr4-python3-runtime==4.7.2
     # via cf-units
-astroid==3.3.5
+astroid==3.2.2
     # via pylint
-attrs==24.2.0
+async-timeout==4.0.2
+    # via redis
+attrs==22.2.0
     # via
     #   -r constraints.in
     #   fiona
     #   hypothesis
     #   jsonschema
+    #   pytest
     #   rasterio
     #   referencing
-babel==2.16.0
+babel==2.11.0
     # via sphinx
-boto3==1.35.48
+bleach==6.0.0
+    # via readme-renderer
+boto3==1.26.70
     # via
     #   -r constraints.in
     #   moto
-botocore==1.35.48
+botocore==1.29.70
     # via
     #   boto3
     #   moto
     #   s3transfer
-bottleneck==1.4.2
+bottleneck==1.3.6
     # via -r constraints.in
-cachetools==5.5.0
+cachetools==5.3.0
     # via
     #   -r constraints.in
     #   odc-geo
-certifi==2024.8.30
+certifi==2022.12.7
     # via
     #   fiona
-    #   netcdf4
     #   pyproj
     #   rasterio
     #   requests
@@ -53,20 +57,20 @@ cf-units==3.2.0
     # via
     #   -r constraints.in
     #   compliance-checker
-cffi==1.17.1
+cffi==1.16.0
     # via
     #   -r constraints.in
     #   cryptography
-cftime==1.6.4.post1
+cftime==1.6.2
     # via
     #   cf-units
     #   compliance-checker
     #   netcdf4
-charset-normalizer==3.4.0
+charset-normalizer==3.0.1
     # via requests
-ciso8601==2.3.1
+ciso8601==2.3.0
     # via -r constraints.in
-click==8.1.7
+click==8.1.3
     # via
     #   -r constraints.in
     #   click-plugins
@@ -84,83 +88,79 @@ cligj==0.7.2
     # via
     #   fiona
     #   rasterio
-cloudpickle==3.1.0
+cloudpickle==2.2.1
     # via
     #   -r constraints.in
     #   dask
     #   distributed
 commonmark==0.9.1
     # via recommonmark
-compliance-checker==5.1.1
+compliance-checker==5.1.0
     # via -r constraints.in
-contourpy==1.3.0
+contourpy==1.0.7
     # via matplotlib
-coverage==7.6.4
+coverage==7.1.0
     # via pytest-cov
-cryptography==43.0.3
+cryptography==39.0.1
     # via
     #   moto
     #   secretstorage
-cycler==0.12.1
+cycler==0.11.0
     # via matplotlib
-dask==2024.10.0
+dask==2023.2.0
     # via
     #   -r constraints.in
     #   distributed
-deprecat==2.1.3
+decorator==5.1.1
+    # via validators
+deprecat==2.1.1
     # via -r constraints.in
-dill==0.3.9
+dill==0.3.8
     # via pylint
-distributed==2024.10.0
+distributed==2023.2.0
     # via -r constraints.in
-docutils==0.19
+docutils==0.18.1
     # via
     #   readme-renderer
     #   recommonmark
     #   sphinx
     #   sphinx-click
     #   sphinx-rtd-theme
-fiona==1.10.1
+fiona==1.9.1
     # via -r constraints.in
-fonttools==4.54.1
+fonttools==4.38.0
     # via matplotlib
-fsspec==2024.10.0
+fsspec==2023.1.0
     # via dask
-geoalchemy2==0.15.2
+geoalchemy2==0.13.1
     # via -r constraints.in
-greenlet==3.1.1
+greenlet==3.0.3
     # via
     #   -r constraints.in
     #   sqlalchemy
-hypothesis==6.115.5
+heapdict==1.0.1
+    # via zict
+hypothesis==6.68.1
     # via -r constraints.in
-idna==3.10
+idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.5.0
-    # via
-    #   compliance-checker
-    #   twine
-importlib-resources==6.4.5
-    # via compliance-checker
+importlib-metadata==6.0.0
+    # via twine
 iniconfig==2.0.0
     # via pytest
-isodate==0.7.2
+isodate==0.6.1
     # via compliance-checker
-isort==5.13.2
+isort==4.3.21
     # via pylint
-jaraco-classes==3.4.0
-    # via keyring
-jaraco-context==6.0.1
-    # via keyring
-jaraco-functools==4.1.0
+jaraco-classes==3.2.3
     # via keyring
 jeepney==0.8.0
     # via
     #   keyring
     #   secretstorage
-jinja2==3.1.4
+jinja2==3.1.2
     # via
     #   cf-units
     #   compliance-checker
@@ -171,55 +171,52 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.23.0
+jsonschema==4.18.4
     # via -r constraints.in
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2023.7.1
     # via jsonschema
-keyring==25.4.1
+keyring==23.13.1
     # via twine
-kiwisolver==1.4.7
+kiwisolver==1.4.4
     # via matplotlib
-lark==1.2.2
+lark==1.1.5
     # via -r constraints.in
 locket==1.0.0
     # via
     #   distributed
     #   partd
-lxml==5.3.0
+lxml==5.2.2
     # via
     #   -r constraints.in
     #   compliance-checker
-    #   owslib
-mako==1.3.6
+mako==1.3.0
     # via alembic
-markdown-it-py==3.0.0
+markdown-it-py==2.1.0
     # via rich
-markupsafe==3.0.2
+markupsafe==2.1.2
     # via
     #   jinja2
     #   mako
     #   werkzeug
-matplotlib==3.9.2
+matplotlib==3.7.0
     # via -r constraints.in
-mccabe==0.7.0
+mccabe==0.6.1
     # via pylint
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.5.0
-    # via
-    #   jaraco-classes
-    #   jaraco-functools
-moto==4.2.14
+more-itertools==9.0.0
+    # via jaraco-classes
+moto==4.1.2
     # via -r constraints.in
-msgpack==1.1.0
+msgpack==1.0.4
     # via distributed
-netcdf4==1.7.2
+munch==2.5.0
+    # via fiona
+netcdf4==1.6.2
     # via
     #   -r constraints.in
     #   compliance-checker
-nh3==0.2.18
-    # via readme-renderer
-numpy==2.1.2
+numpy==1.26.4
     # via
     #   -r constraints.in
     #   bottleneck
@@ -232,14 +229,14 @@ numpy==2.1.2
     #   pandas
     #   rasterio
     #   shapely
+    #   snuggs
     #   xarray
-odc-geo==0.4.8
+odc-geo==0.4.7
     # via -r constraints.in
-owslib==0.32.0
+owslib==0.27.2
     # via compliance-checker
-packaging==24.1
+packaging==23.0
     # via
-    #   compliance-checker
     #   dask
     #   distributed
     #   geoalchemy2
@@ -248,62 +245,62 @@ packaging==24.1
     #   setuptools-scm
     #   sphinx
     #   xarray
-pandas==2.2.3
+pandas==2.1.4
     # via
     #   -r constraints.in
     #   xarray
-partd==1.4.2
+partd==1.3.0
     # via dask
 pendulum==3.0.0
     # via
     #   -r constraints.in
     #   compliance-checker
-pillow==11.0.0
+pillow==9.4.0
     # via matplotlib
-pkginfo==1.10.0
+pkginfo==1.9.6
     # via twine
-platformdirs==4.3.6
+platformdirs==4.2.2
     # via pylint
-pluggy==1.5.0
+pluggy==1.0.0
     # via pytest
-psutil==6.1.0
+psutil==5.9.4
     # via distributed
-psycopg2==2.9.10
+psycopg2==2.9.5
     # via -r constraints.in
-pycodestyle==2.12.1
+pycodestyle==2.5.0
     # via -r constraints.in
-pycparser==2.22
+pycparser==2.21
     # via cffi
-pygeoif==1.5.0
+pygeoif==1.0.0
     # via compliance-checker
-pygments==2.18.0
+pygments==2.14.0
     # via
     #   readme-renderer
     #   rich
     #   sphinx
-pylint==3.3.1
+pylint==3.2.2
     # via -r constraints.in
-pyparsing==3.2.0
+pyparsing==3.0.9
     # via
     #   matplotlib
-    #   rasterio
-pyproj==3.7.0
+    #   snuggs
+pyproj==3.6.1
     # via
     #   -r constraints.in
     #   compliance-checker
     #   odc-geo
-pytest==8.3.3
+pytest==7.2.1
     # via
     #   -r constraints.in
     #   pytest-cov
     #   pytest-timeout
-pytest-cov==5.0.0
+pytest-cov==4.0.0
     # via -r constraints.in
-pytest-httpserver==1.1.0
+pytest-httpserver==1.0.6
     # via -r constraints.in
-pytest-timeout==2.3.1
+pytest-timeout==2.1.0
     # via -r constraints.in
-python-dateutil==2.9.0.post0
+python-dateutil==2.8.2
     # via
     #   -r constraints.in
     #   botocore
@@ -313,30 +310,32 @@ python-dateutil==2.9.0.post0
     #   pandas
     #   pendulum
     #   time-machine
-pytz==2024.2
-    # via pandas
-pyyaml==6.0.2
+pytz==2022.7.1
+    # via
+    #   babel
+    #   owslib
+    #   pandas
+pyyaml==6.0.1
     # via
     #   -r constraints.in
     #   dask
     #   distributed
     #   owslib
-    #   responses
-rasterio==1.4.1
+rasterio==1.3.11
     # via -r constraints.in
-readme-renderer==43.0
+readme-renderer==37.3
     # via twine
 recommonmark==0.7.1
     # via -r constraints.in
-redis==5.2.0
+redis==4.5.1
     # via -r constraints.in
-referencing==0.35.1
+referencing==0.30.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-regex==2024.9.11
+regex==2022.10.31
     # via compliance-checker
-requests==2.32.3
+requests==2.28.2
     # via
     #   compliance-checker
     #   moto
@@ -345,37 +344,41 @@ requests==2.32.3
     #   responses
     #   sphinx
     #   twine
-requests-toolbelt==1.0.0
+requests-toolbelt==0.10.1
     # via twine
-responses==0.25.3
+responses==0.22.0
     # via moto
 rfc3986==2.0.0
     # via twine
-rich==13.9.3
+rich==13.3.1
     # via twine
-rpds-py==0.20.0
+rpds-py==0.9.2
     # via
     #   jsonschema
     #   referencing
-ruamel-yaml==0.18.6
+ruamel-yaml==0.17.21
     # via -r constraints.in
-ruamel-yaml-clib==0.2.12
-    # via ruamel-yaml
-s3transfer==0.10.3
+s3transfer==0.6.0
     # via boto3
 secretstorage==3.3.3
     # via keyring
-setuptools-scm==8.1.0
+setuptools-scm==7.1.0
     # via -r constraints.in
-shapely==2.0.6
+shapely==2.0.4
     # via
     #   -r constraints.in
     #   compliance-checker
     #   odc-geo
 six==1.16.0
-    # via python-dateutil
+    # via
+    #   bleach
+    #   isodate
+    #   munch
+    #   python-dateutil
 snowballstemmer==2.2.0
     # via sphinx
+snuggs==1.4.7
+    # via rasterio
 sortedcontainers==2.4.0
     # via
     #   distributed
@@ -387,86 +390,92 @@ sphinx==5.3.0
     #   sphinx-autodoc-typehints
     #   sphinx-click
     #   sphinx-rtd-theme
-    #   sphinxcontrib-jquery
-sphinx-autodoc-typehints==1.23.0
+sphinx-autodoc-typehints==1.22
     # via -r constraints.in
-sphinx-click==6.0.0
+sphinx-click==4.4.0
     # via -r constraints.in
-sphinx-rtd-theme==2.0.0
+sphinx-rtd-theme==1.2.0
     # via -r constraints.in
-sphinxcontrib-applehelp==2.0.0
+sphinxcontrib-applehelp==1.0.4
     # via sphinx
-sphinxcontrib-devhelp==2.0.0
+sphinxcontrib-devhelp==1.0.2
     # via sphinx
-sphinxcontrib-htmlhelp==2.1.0
+sphinxcontrib-htmlhelp==2.0.1
     # via sphinx
-sphinxcontrib-jquery==4.1
+sphinxcontrib-jquery==2.0.0
     # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==2.0.0
+sphinxcontrib-qthelp==1.0.3
     # via sphinx
-sphinxcontrib-serializinghtml==2.0.0
+sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.36
+sqlalchemy==2.0.24
     # via
     #   -r constraints.in
     #   alembic
     #   geoalchemy2
-tblib==3.0.0
+tblib==1.7.0
     # via distributed
-time-machine==2.16.0
+time-machine==2.14.1
     # via pendulum
 toml==0.10.2
-    # via -r constraints.in
-tomlkit==0.13.2
+    # via
+    #   -r constraints.in
+    #   responses
+tomlkit==0.12.5
     # via pylint
-toolz==1.0.0
+toolz==0.12.0
     # via
     #   -r constraints.in
     #   dask
     #   distributed
     #   partd
-tornado==6.4.1
+tornado==6.2
     # via distributed
-twine==5.1.1
+twine==4.0.2
     # via -r constraints.in
-typing-extensions==4.12.2
+types-toml==0.10.8.3
+    # via responses
+typing-extensions==4.12.0
     # via
     #   -r constraints.in
     #   alembic
     #   pygeoif
+    #   setuptools-scm
     #   sqlalchemy
-tzdata==2024.2
+tzdata==2023.4
     # via
     #   pandas
     #   pendulum
-urllib3==2.2.3
+urllib3==1.26.14
     # via
     #   botocore
     #   distributed
     #   requests
     #   responses
     #   twine
-validators==0.34.0
+validators==0.20.0
     # via compliance-checker
-werkzeug==3.0.5
+webencodings==0.5.1
+    # via bleach
+werkzeug==2.2.2
     # via
     #   moto
     #   pytest-httpserver
-wheel==0.44.0
+wheel==0.38.4
     # via -r constraints.in
 wrapt==1.16.0
     # via
     #   -r constraints.in
     #   deprecat
-xarray==2024.10.0
+xarray==2023.12.0
     # via -r constraints.in
-xmltodict==0.14.2
+xmltodict==0.13.0
     # via moto
-zict==3.0.0
+zict==2.2.0
     # via distributed
-zipp==3.20.2
+zipp==3.13.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/docker/constraints.txt
+++ b/docker/constraints.txt
@@ -9,47 +9,43 @@ affine==2.4.0
     #   -r constraints.in
     #   odc-geo
     #   rasterio
-alabaster==0.7.13
+alabaster==0.7.16
     # via sphinx
-alembic==1.12.1
+alembic==1.13.3
     # via -r constraints.in
 antlr4-python3-runtime==4.7.2
     # via cf-units
-astroid==3.2.2
+astroid==3.3.5
     # via pylint
-async-timeout==4.0.2
-    # via redis
-attrs==22.2.0
+attrs==24.2.0
     # via
     #   -r constraints.in
     #   fiona
     #   hypothesis
     #   jsonschema
-    #   pytest
     #   rasterio
     #   referencing
-babel==2.11.0
+babel==2.16.0
     # via sphinx
-bleach==6.0.0
-    # via readme-renderer
-boto3==1.26.70
+boto3==1.35.48
     # via
     #   -r constraints.in
     #   moto
-botocore==1.29.70
+botocore==1.35.48
     # via
     #   boto3
     #   moto
     #   s3transfer
-bottleneck==1.3.6
+bottleneck==1.4.2
     # via -r constraints.in
-cachetools==5.3.0
+cachetools==5.5.0
     # via
     #   -r constraints.in
     #   odc-geo
-certifi==2022.12.7
+certifi==2024.8.30
     # via
     #   fiona
+    #   netcdf4
     #   pyproj
     #   rasterio
     #   requests
@@ -57,20 +53,20 @@ cf-units==3.2.0
     # via
     #   -r constraints.in
     #   compliance-checker
-cffi==1.16.0
+cffi==1.17.1
     # via
     #   -r constraints.in
     #   cryptography
-cftime==1.6.2
+cftime==1.6.4.post1
     # via
     #   cf-units
     #   compliance-checker
     #   netcdf4
-charset-normalizer==3.0.1
+charset-normalizer==3.4.0
     # via requests
-ciso8601==2.3.0
+ciso8601==2.3.1
     # via -r constraints.in
-click==8.1.3
+click==8.1.7
     # via
     #   -r constraints.in
     #   click-plugins
@@ -88,79 +84,83 @@ cligj==0.7.2
     # via
     #   fiona
     #   rasterio
-cloudpickle==2.2.1
+cloudpickle==3.1.0
     # via
     #   -r constraints.in
     #   dask
     #   distributed
 commonmark==0.9.1
     # via recommonmark
-compliance-checker==5.1.0
+compliance-checker==5.1.1
     # via -r constraints.in
-contourpy==1.0.7
+contourpy==1.3.0
     # via matplotlib
-coverage==7.1.0
+coverage==7.6.4
     # via pytest-cov
-cryptography==39.0.1
+cryptography==43.0.3
     # via
     #   moto
     #   secretstorage
-cycler==0.11.0
+cycler==0.12.1
     # via matplotlib
-dask==2023.2.0
+dask==2024.10.0
     # via
     #   -r constraints.in
     #   distributed
-decorator==5.1.1
-    # via validators
-deprecat==2.1.1
+deprecat==2.1.3
     # via -r constraints.in
-dill==0.3.8
+dill==0.3.9
     # via pylint
-distributed==2023.2.0
+distributed==2024.10.0
     # via -r constraints.in
-docutils==0.18.1
+docutils==0.19
     # via
     #   readme-renderer
     #   recommonmark
     #   sphinx
     #   sphinx-click
     #   sphinx-rtd-theme
-fiona==1.9.1
+fiona==1.10.1
     # via -r constraints.in
-fonttools==4.38.0
+fonttools==4.54.1
     # via matplotlib
-fsspec==2023.1.0
+fsspec==2024.10.0
     # via dask
-geoalchemy2==0.13.1
+geoalchemy2==0.15.2
     # via -r constraints.in
-greenlet==3.0.3
+greenlet==3.1.1
     # via
     #   -r constraints.in
     #   sqlalchemy
-heapdict==1.0.1
-    # via zict
-hypothesis==6.68.1
+hypothesis==6.115.5
     # via -r constraints.in
-idna==3.4
+idna==3.10
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.0.0
-    # via twine
+importlib-metadata==8.5.0
+    # via
+    #   compliance-checker
+    #   twine
+importlib-resources==6.4.5
+    # via compliance-checker
 iniconfig==2.0.0
     # via pytest
-isodate==0.6.1
+isodate==0.7.2
     # via compliance-checker
-isort==4.3.21
+isort==5.13.2
     # via pylint
-jaraco-classes==3.2.3
+jaraco-classes==3.4.0
+    # via keyring
+jaraco-context==6.0.1
+    # via keyring
+jaraco-functools==4.1.0
     # via keyring
 jeepney==0.8.0
     # via
     #   keyring
     #   secretstorage
-jinja2==3.1.2
+jinja2==3.1.4
     # via
     #   cf-units
     #   compliance-checker
@@ -171,52 +171,55 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.18.4
+jsonschema==4.23.0
     # via -r constraints.in
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2024.10.1
     # via jsonschema
-keyring==23.13.1
+keyring==25.4.1
     # via twine
-kiwisolver==1.4.4
+kiwisolver==1.4.7
     # via matplotlib
-lark==1.1.5
+lark==1.2.2
     # via -r constraints.in
 locket==1.0.0
     # via
     #   distributed
     #   partd
-lxml==5.2.2
+lxml==5.3.0
     # via
     #   -r constraints.in
     #   compliance-checker
-mako==1.3.0
+    #   owslib
+mako==1.3.6
     # via alembic
-markdown-it-py==2.1.0
+markdown-it-py==3.0.0
     # via rich
-markupsafe==2.1.2
+markupsafe==3.0.2
     # via
     #   jinja2
     #   mako
     #   werkzeug
-matplotlib==3.7.0
+matplotlib==3.9.2
     # via -r constraints.in
-mccabe==0.6.1
+mccabe==0.7.0
     # via pylint
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==9.0.0
-    # via jaraco-classes
-moto==4.1.2
+more-itertools==10.5.0
+    # via
+    #   jaraco-classes
+    #   jaraco-functools
+moto==4.2.14
     # via -r constraints.in
-msgpack==1.0.4
+msgpack==1.1.0
     # via distributed
-munch==2.5.0
-    # via fiona
-netcdf4==1.6.2
+netcdf4==1.7.2
     # via
     #   -r constraints.in
     #   compliance-checker
-numpy==1.26.4
+nh3==0.2.18
+    # via readme-renderer
+numpy==2.1.2
     # via
     #   -r constraints.in
     #   bottleneck
@@ -229,14 +232,14 @@ numpy==1.26.4
     #   pandas
     #   rasterio
     #   shapely
-    #   snuggs
     #   xarray
-odc-geo==0.4.7
+odc-geo==0.4.8
     # via -r constraints.in
-owslib==0.27.2
+owslib==0.32.0
     # via compliance-checker
-packaging==23.0
+packaging==24.1
     # via
+    #   compliance-checker
     #   dask
     #   distributed
     #   geoalchemy2
@@ -245,62 +248,62 @@ packaging==23.0
     #   setuptools-scm
     #   sphinx
     #   xarray
-pandas==2.1.4
+pandas==2.2.3
     # via
     #   -r constraints.in
     #   xarray
-partd==1.3.0
+partd==1.4.2
     # via dask
 pendulum==3.0.0
     # via
     #   -r constraints.in
     #   compliance-checker
-pillow==9.4.0
+pillow==11.0.0
     # via matplotlib
-pkginfo==1.9.6
+pkginfo==1.10.0
     # via twine
-platformdirs==4.2.2
+platformdirs==4.3.6
     # via pylint
-pluggy==1.0.0
+pluggy==1.5.0
     # via pytest
-psutil==5.9.4
+psutil==6.1.0
     # via distributed
-psycopg2==2.9.5
+psycopg2==2.9.10
     # via -r constraints.in
-pycodestyle==2.5.0
+pycodestyle==2.12.1
     # via -r constraints.in
-pycparser==2.21
+pycparser==2.22
     # via cffi
-pygeoif==1.0.0
+pygeoif==1.5.0
     # via compliance-checker
-pygments==2.14.0
+pygments==2.18.0
     # via
     #   readme-renderer
     #   rich
     #   sphinx
-pylint==3.2.2
+pylint==3.3.1
     # via -r constraints.in
-pyparsing==3.0.9
+pyparsing==3.2.0
     # via
     #   matplotlib
-    #   snuggs
-pyproj==3.6.1
+    #   rasterio
+pyproj==3.7.0
     # via
     #   -r constraints.in
     #   compliance-checker
     #   odc-geo
-pytest==7.2.1
+pytest==8.3.3
     # via
     #   -r constraints.in
     #   pytest-cov
     #   pytest-timeout
-pytest-cov==4.0.0
+pytest-cov==5.0.0
     # via -r constraints.in
-pytest-httpserver==1.0.6
+pytest-httpserver==1.1.0
     # via -r constraints.in
-pytest-timeout==2.1.0
+pytest-timeout==2.3.1
     # via -r constraints.in
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   -r constraints.in
     #   botocore
@@ -310,32 +313,30 @@ python-dateutil==2.8.2
     #   pandas
     #   pendulum
     #   time-machine
-pytz==2022.7.1
-    # via
-    #   babel
-    #   owslib
-    #   pandas
-pyyaml==6.0.1
+pytz==2024.2
+    # via pandas
+pyyaml==6.0.2
     # via
     #   -r constraints.in
     #   dask
     #   distributed
     #   owslib
-rasterio==1.3.11
+    #   responses
+rasterio==1.4.1
     # via -r constraints.in
-readme-renderer==37.3
+readme-renderer==43.0
     # via twine
 recommonmark==0.7.1
     # via -r constraints.in
-redis==4.5.1
+redis==5.2.0
     # via -r constraints.in
-referencing==0.30.0
+referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
-regex==2022.10.31
+regex==2024.9.11
     # via compliance-checker
-requests==2.28.2
+requests==2.32.3
     # via
     #   compliance-checker
     #   moto
@@ -344,41 +345,37 @@ requests==2.28.2
     #   responses
     #   sphinx
     #   twine
-requests-toolbelt==0.10.1
+requests-toolbelt==1.0.0
     # via twine
-responses==0.22.0
+responses==0.25.3
     # via moto
 rfc3986==2.0.0
     # via twine
-rich==13.3.1
+rich==13.9.3
     # via twine
-rpds-py==0.9.2
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
-ruamel-yaml==0.17.21
+ruamel-yaml==0.18.6
     # via -r constraints.in
-s3transfer==0.6.0
+ruamel-yaml-clib==0.2.12
+    # via ruamel-yaml
+s3transfer==0.10.3
     # via boto3
 secretstorage==3.3.3
     # via keyring
-setuptools-scm==7.1.0
+setuptools-scm==8.1.0
     # via -r constraints.in
-shapely==2.0.4
+shapely==2.0.6
     # via
     #   -r constraints.in
     #   compliance-checker
     #   odc-geo
 six==1.16.0
-    # via
-    #   bleach
-    #   isodate
-    #   munch
-    #   python-dateutil
+    # via python-dateutil
 snowballstemmer==2.2.0
     # via sphinx
-snuggs==1.4.7
-    # via rasterio
 sortedcontainers==2.4.0
     # via
     #   distributed
@@ -390,92 +387,86 @@ sphinx==5.3.0
     #   sphinx-autodoc-typehints
     #   sphinx-click
     #   sphinx-rtd-theme
-sphinx-autodoc-typehints==1.22
+    #   sphinxcontrib-jquery
+sphinx-autodoc-typehints==1.23.0
     # via -r constraints.in
-sphinx-click==4.4.0
+sphinx-click==6.0.0
     # via -r constraints.in
-sphinx-rtd-theme==1.2.0
+sphinx-rtd-theme==2.0.0
     # via -r constraints.in
-sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
-sphinxcontrib-jquery==2.0.0
+sphinxcontrib-jquery==4.1
     # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.24
+sqlalchemy==2.0.36
     # via
     #   -r constraints.in
     #   alembic
     #   geoalchemy2
-tblib==1.7.0
+tblib==3.0.0
     # via distributed
-time-machine==2.14.1
+time-machine==2.16.0
     # via pendulum
 toml==0.10.2
-    # via
-    #   -r constraints.in
-    #   responses
-tomlkit==0.12.5
+    # via -r constraints.in
+tomlkit==0.13.2
     # via pylint
-toolz==0.12.0
+toolz==1.0.0
     # via
     #   -r constraints.in
     #   dask
     #   distributed
     #   partd
-tornado==6.2
+tornado==6.4.1
     # via distributed
-twine==4.0.2
+twine==5.1.1
     # via -r constraints.in
-types-toml==0.10.8.3
-    # via responses
-typing-extensions==4.12.0
+typing-extensions==4.12.2
     # via
     #   -r constraints.in
     #   alembic
     #   pygeoif
-    #   setuptools-scm
     #   sqlalchemy
-tzdata==2023.4
+tzdata==2024.2
     # via
     #   pandas
     #   pendulum
-urllib3==1.26.14
+urllib3==2.2.3
     # via
     #   botocore
     #   distributed
     #   requests
     #   responses
     #   twine
-validators==0.20.0
+validators==0.34.0
     # via compliance-checker
-webencodings==0.5.1
-    # via bleach
-werkzeug==2.2.2
+werkzeug==3.0.5
     # via
     #   moto
     #   pytest-httpserver
-wheel==0.38.4
+wheel==0.44.0
     # via -r constraints.in
 wrapt==1.16.0
     # via
     #   -r constraints.in
     #   deprecat
-xarray==2023.12.0
+xarray==2024.10.0
     # via -r constraints.in
-xmltodict==0.13.0
+xmltodict==0.14.2
     # via moto
-zict==2.2.0
+zict==3.0.0
     # via distributed
-zipp==3.13.0
+zipp==3.20.2
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -22,6 +22,7 @@ v1.9.next
 - Cherry picks from 1.8 (#1624-#1626, #1629-#1631) (:pull:`1637`)
 - Updates to index APIs - add `order_by` to dataset search, index name attribute, product most recent change method (:pull:`1643`)
 - Fix alembic migrations (:pull:`1645`)
+- Make psycopg2 an optional dependency (:pull:`1648`)
 
 v1.9.0-rc9 (3rd July 2024)
 ==========================

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ tests_require = [
     'pytest-timeout',
     'pytest-httpserver',
     'moto<5.0',  # 5.0 will require changes to some tests.
+    'psycopg2',
 ]
 
 types_require = [
@@ -47,6 +48,7 @@ extras_require = {
     "types": types_require,
     'cf': ['compliance-checker>=4.0.0'],
     'netcdf': ['netcdf4'],
+    'postgres': ['psycopg2'],
 }
 
 extras_require['dev'] = sorted(set(sum([extras_require[k] for k in [
@@ -57,6 +59,7 @@ extras_require['dev'] = sorted(set(sum([extras_require[k] for k in [
     's3',
     'distributed',
     'netcdf',
+    'postgres',
 ]], [])))
 
 # An 'all' option, following ipython naming conventions.
@@ -119,7 +122,6 @@ setup(
         'distributed',
         'jsonschema>=4.18',  # New reference resolution API
         'numpy',
-        'psycopg2',
         'lark',
         'pandas',
         'python-dateutil',

--- a/tests/index/test_query.py
+++ b/tests/index/test_query.py
@@ -6,7 +6,6 @@
 Module
 """
 
-# from psycopg2.extras import NumericRange
 from sqlalchemy.dialects.postgresql import Range as PgRange
 
 from datacube.drivers.postgres._fields import SimpleDocField, RangeBetweenExpression, EqualsExpression, \

--- a/tests/index/test_query.py
+++ b/tests/index/test_query.py
@@ -6,7 +6,8 @@
 Module
 """
 
-from psycopg2.extras import NumericRange
+# from psycopg2.extras import NumericRange
+from sqlalchemy.dialects.postgresql import Range as PgRange
 
 from datacube.drivers.postgres._fields import SimpleDocField, RangeBetweenExpression, EqualsExpression, \
     NumericRangeDocField
@@ -26,5 +27,5 @@ def test_build_query_expressions():
 
     assert [EqualsExpression(_sat_field, "LANDSAT_8")] == to_expressions(_fields.get, platform="LANDSAT_8")
     assert [RangeBetweenExpression(
-        _lat_field, 4, 23.0, _range_class=NumericRange
+        _lat_field, 4, 23.0, _range_class=PgRange
     )] == to_expressions(_fields.get, lat=Range(4, 23))

--- a/tests/scripts/test_search_tool.py
+++ b/tests/scripts/test_search_tool.py
@@ -9,7 +9,7 @@ Module
 import datetime
 
 from dateutil import tz
-from psycopg2._range import Range, NumericRange
+from sqlalchemy.dialects.postgresql import Range as PgRange
 
 from datacube.index.fields import Field
 from datacube.scripts.search_tool import write_csv, write_pretty
@@ -35,8 +35,8 @@ def test_csv_serialise():
         m,
         {"f1": Field("f1", ""), "f2": Field("f2", '')},
         [
-            {"f1": 12, "f2": NumericRange(1.0, 2.0)},
-            {"f1": datetime.datetime(2014, 7, 26, 23, 48, 0, tzinfo=tz.tzutc()), "f2": Range(-1.0, 2.0)},
+            {"f1": 12, "f2": PgRange(1.0, 2.0)},
+            {"f1": datetime.datetime(2014, 7, 26, 23, 48, 0, tzinfo=tz.tzutc()), "f2": PgRange(-1.0, 2.0)},
             {"f1": datetime.datetime(2014, 7, 26, 23, 48, 0), "f2": "landsat"}
         ]
     )
@@ -58,8 +58,8 @@ def test_pretty_serialise():
         m,
         {"f1": Field("f1", ""), "field 2": Field("f2", '')},
         [
-            {"f1": 12, "field 2": NumericRange(1.0, 2.0)},
-            {"f1": datetime.datetime(2014, 7, 26, 23, 48, 0, tzinfo=tz.tzutc()), "field 2": Range(-1.0, 2.0)},
+            {"f1": 12, "field 2": PgRange(1.0, 2.0)},
+            {"f1": datetime.datetime(2014, 7, 26, 23, 48, 0, tzinfo=tz.tzutc()), "field 2": PgRange(-1.0, 2.0)},
             {"f1": datetime.datetime(2014, 7, 26, 23, 48, 0), "field 2": "landsat"}
         ],
         terminal_size=(12, 12)


### PR DESCRIPTION
### Reason for this pull request

Make datacube more lightweight to install by only requiring psycopg2 when accessing a pg database.


### Proposed changes

- Move psycopg2 to `[test]` dependencies, and introduce new `[postgres]` option
- Switch from using psycopg2 Range types to the sqlalchemy version



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1648.org.readthedocs.build/en/1648/

<!-- readthedocs-preview datacube-core end -->