### PR TITLE
Update docs instructions to include installation of sphinx-autobuild

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -50,6 +50,12 @@ Requires a Unix like system that includes ``make``.
 
    pip install -r requirements.txt
 
+#. Install sphinx-autobuild with pip
+
+.. code-block:: bash
+
+   pip install sphinx-autobuild
+
 #. Run the autobuild.
 
 .. code-block:: bash


### PR DESCRIPTION
### Reason for this pull request

Previous instructions did not include sphinx-autobuild

### Proposed changes

- Update README.rst in docs to include installation of sphinx-autobuild


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1651.org.readthedocs.build/en/1651/

<!-- readthedocs-preview datacube-core end -->