### PR TITLE
Fix: Don't use importlib_metadata

### DIFF
--- a/datacube/drivers/driver_cache.py
+++ b/datacube/drivers/driver_cache.py
@@ -46,7 +46,7 @@ def load_drivers(group: str) -> Dict[str, Any]:
         return driver
 
     def resolve_all(group: str) -> Iterable[Tuple[str, Any]]:
-        from importlib_metadata import entry_points
+        from importlib.metadata import entry_points
         for ep in entry_points(group=group):
             driver = safe_load(ep)
             if driver is not None:

--- a/docs/click_utils.py
+++ b/docs/click_utils.py
@@ -33,10 +33,7 @@ def find_script_callable_from_env(name, env):
 
 
 def find_script_callable(name):
-    try:
-        from importlib_metadata import entry_points
-    except ModuleNotFoundError:
-        from importlib.metadata import entry_points
+    from importlib.metadata import entry_points
     return list(entry_points(
         group='console_scripts', name=name))[0].load()
 

--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,6 @@ setup(
         'packaging',
         'odc-geo>=0.4.8',
         'deprecat',
-        'importlib_metadata>3.5;python_version<"3.10"',
     ],
     extras_require=extras_require,
     tests_require=tests_require,


### PR DESCRIPTION
### Reason for this pull request

We only support Python 3.10+ now, which includes a fast built-in `importlib.metadata`.

### Proposed changes

Update the remaining refs to the compatibility package `importlib_metadata`, and remove it as a dependency.


 - [ ] Closes #xxxx
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes




<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1657.org.readthedocs.build/en/1657/

<!-- readthedocs-preview datacube-core end -->