### PR TITLE
Pin dask version so dask_load works and tests pass

### DIFF
--- a/docker/constraints.in
+++ b/docker/constraints.in
@@ -17,8 +17,8 @@ cloudpickle>=0.4
 # For Python 3.12 support
 compliance-checker>=5.1.0
 # dask 2024.11.x is broken.
-dask>=2021.10.1,<2024.11.0
-distributed>=2021.10.0,<2024.11.0
+dask>=2023.2.0,<2024.11.0
+distributed>=2024.2.0,<2024.11.0
 deprecat
 fiona
 geoalchemy2

--- a/docker/constraints.in
+++ b/docker/constraints.in
@@ -11,6 +11,7 @@ cachetools
 cf-units>3.1.1
 # For Python 3.12 support
 cffi>=1.16.0
+cftime>=1.6.4
 ciso8601
 click>=8.0
 cloudpickle>=0.4
@@ -31,7 +32,7 @@ lark
 lxml>=5.0.0
 matplotlib
 moto<5
-netcdf4>=1.5.8
+netcdf4>=1.7.1-post1
 # Numpy 2
 numpy>=2
 odc-geo>=0.4.8

--- a/docker/constraints.in
+++ b/docker/constraints.in
@@ -54,7 +54,7 @@ recommonmark
 redis
 ruamel.yaml
 # cython3 support
-shapely>=2.0.2
+shapely>=2.0.6
 sphinx-click
 sphinx_autodoc_typehints
 sphinx_rtd_theme

--- a/docker/constraints.in
+++ b/docker/constraints.in
@@ -1,6 +1,7 @@
 # datacube dependencies
 Sphinx<6.0.0 # be compatible to sphinx_rtd_theme
 affine
+antimeridian
 attrs>=18.1
 # boto is too huge, need to set lower bound
 boto3>1.17.0
@@ -15,8 +16,10 @@ click>=8.0
 cloudpickle>=0.4
 # For Python 3.12 support
 compliance-checker>=5.1.0
-dask>=2021.10.1
-distributed>=2021.10.0
+# dask 2024.11.x is broken.
+dask>=2021.10.1,<2024.11.0
+distributed>=2021.10.0,<2024.11.0
+deprecat
 fiona
 geoalchemy2
 # For Python 3.12 support
@@ -29,9 +32,10 @@ lxml>=5.0.0
 matplotlib
 moto<5
 netcdf4>=1.5.8
-# 1.26.0 is the first version to support Python 3.12
-numpy>=1.26.0
-pandas>=2.0
+# Numpy 2
+numpy>=2
+odc-geo>=0.4.8
+pandas>=2.2.2
 # For Python 3.12 support
 pendulum>=3.0
 psycopg2

--- a/docker/constraints.txt
+++ b/docker/constraints.txt
@@ -52,6 +52,7 @@ cachetools==5.3.0
 certifi==2022.12.7
     # via
     #   fiona
+    #   netcdf4
     #   pyproj
     #   rasterio
     #   requests
@@ -63,8 +64,9 @@ cffi==1.16.0
     # via
     #   -r constraints.in
     #   cryptography
-cftime==1.6.2
+cftime==1.6.4.post1
     # via
+    #   -r constraints.in
     #   cf-units
     #   compliance-checker
     #   netcdf4
@@ -212,7 +214,7 @@ msgpack==1.0.4
     # via distributed
 munch==2.5.0
     # via fiona
-netcdf4==1.6.2
+netcdf4==1.7.2
     # via
     #   -r constraints.in
     #   compliance-checker

--- a/docker/constraints.txt
+++ b/docker/constraints.txt
@@ -13,6 +13,8 @@ alabaster==0.7.13
     # via sphinx
 alembic==1.12.1
     # via -r constraints.in
+antimeridian==0.3.11
+    # via -r constraints.in
 antlr4-python3-runtime==4.7.2
     # via cf-units
 astroid==3.2.2
@@ -88,7 +90,7 @@ cligj==0.7.2
     # via
     #   fiona
     #   rasterio
-cloudpickle==2.2.1
+cloudpickle==3.1.0
     # via
     #   -r constraints.in
     #   dask
@@ -138,8 +140,6 @@ greenlet==3.0.3
     # via
     #   -r constraints.in
     #   sqlalchemy
-heapdict==1.0.1
-    # via zict
 hypothesis==6.68.1
     # via -r constraints.in
 idna==3.4
@@ -216,9 +216,10 @@ netcdf4==1.6.2
     # via
     #   -r constraints.in
     #   compliance-checker
-numpy==1.26.4
+numpy==2.1.3
     # via
     #   -r constraints.in
+    #   antimeridian
     #   bottleneck
     #   cf-units
     #   cftime
@@ -231,7 +232,7 @@ numpy==1.26.4
     #   shapely
     #   snuggs
     #   xarray
-odc-geo==0.4.7
+odc-geo==0.4.8
     # via -r constraints.in
 owslib==0.27.2
     # via compliance-checker
@@ -245,11 +246,11 @@ packaging==23.0
     #   setuptools-scm
     #   sphinx
     #   xarray
-pandas==2.1.4
+pandas==2.2.3
     # via
     #   -r constraints.in
     #   xarray
-partd==1.3.0
+partd==1.4.2
     # via dask
 pendulum==3.0.0
     # via
@@ -367,6 +368,7 @@ setuptools-scm==7.1.0
 shapely==2.0.4
     # via
     #   -r constraints.in
+    #   antimeridian
     #   compliance-checker
     #   odc-geo
 six==1.16.0
@@ -473,7 +475,7 @@ xarray==2023.12.0
     # via -r constraints.in
 xmltodict==0.13.0
     # via moto
-zict==2.2.0
+zict==3.0.0
     # via distributed
 zipp==3.13.0
     # via importlib-metadata

--- a/docker/constraints.txt
+++ b/docker/constraints.txt
@@ -109,7 +109,7 @@ cryptography==39.0.1
     #   secretstorage
 cycler==0.11.0
     # via matplotlib
-dask==2023.2.0
+dask==2024.10.0
     # via
     #   -r constraints.in
     #   distributed
@@ -119,7 +119,7 @@ deprecat==2.1.1
     # via -r constraints.in
 dill==0.3.8
     # via pylint
-distributed==2023.2.0
+distributed==2024.10.0
     # via -r constraints.in
 docutils==0.18.1
     # via

--- a/docker/constraints.txt
+++ b/docker/constraints.txt
@@ -367,7 +367,7 @@ secretstorage==3.3.3
     # via keyring
 setuptools-scm==7.1.0
     # via -r constraints.in
-shapely==2.0.4
+shapely==2.0.6
     # via
     #   -r constraints.in
     #   antimeridian

--- a/docker/nobinary.txt
+++ b/docker/nobinary.txt
@@ -3,3 +3,4 @@
 --no-binary fiona
 --no-binary shapely
 --no-binary cf-units
+--no-binary netcdf4

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -10,7 +10,7 @@ v1.9.next
 
 * Documentation fixes (:pull:`1659`)
 * Don't use importlib_metadata (:pull:`1657`)
-* Pin dask due to recent instabilities, esp. with numpy2 (:pull:`1659`)
+* Pin upstream libraries to get CI tests running with numpy2 (:pull:`1659`)
 
 v1.9.0-rc11 (28th October 2024)
 ===============================

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,10 @@ What's New
 v1.9.next
 =========
 
+* Documentation fixes (:pull:`1659`)
+* Don't use importlib_metadata (:pull:`1657`)
+* Pin dask due to recent instabilities, esp. with numpy2 (:pull:`1659`)
+
 v1.9.0-rc11 (28th October 2024)
 ===============================
 

--- a/setup.py
+++ b/setup.py
@@ -118,10 +118,10 @@ setup(
         'cachetools',
         'click>=5.0',
         'cloudpickle>=0.4',
-        'dask[array]',
-        'distributed',
+        'dask[array]<2024.11.0', # Dask versions from 2024.11 cause problems with numpy2
+        'distributed<2024.11.0',
         'jsonschema>=4.18',  # New reference resolution API
-        'numpy',
+        'numpy>=1.26.0',
         'lark',
         'pandas',
         'python-dateutil',

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ setup(
         'cachetools',
         'click>=5.0',
         'cloudpickle>=0.4',
-        'dask[array]<2024.11.0', # Dask versions from 2024.11 cause problems with numpy2
+        'dask[array]<2024.11.0',  # Dask versions from 2024.11 cause problems with numpy2
         'distributed<2024.11.0',
         'jsonschema>=4.18',  # New reference resolution API
         'numpy>=1.26.0',

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -74,6 +74,10 @@ def test_load_data(tmpdir):
 
     assert progress_call_data == [(1, 2), (2, 2)]
 
+    ds_data = Datacube.load_data(sources, geobox, mm, dask_chunks={'x': 8, 'y': 8})
+    assert ds_data.aa.nodata == nodata
+    np.testing.assert_array_equal(aa, ds_data.aa.values[0])
+
 
 def test_load_data_with_url_mangling(tmpdir):
     actual_tmpdir = Path(str(tmpdir))


### PR DESCRIPTION
### Reason for this pull request

- Recent versions of dask have been problematic (See #1656) - especially with numpy 2. 
- Other upstream libraries have been struggling with numpy 2 compatibility since it's release.

### Proposed changes

In both setup.py and the docker test image constraints:
- Pin dask min version to 2024.2.0 for numpy 2 support
- Pin dask max version to 2024.10.1 to avoid values bug.

In the docker test image contraints:
- Pin shapely, netcdf, cftime, and pandas to versions that work well with numpy.

People working with numpy1 can just use the dependencies in setup.py.  People working with numpy2 should refer to the additional pins in `docker/constraints.in` as they may be necessary to get a working environment.

 - [ ] Closes #1656  (no - separate PR to develop required)
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1661.org.readthedocs.build/en/1661/

<!-- readthedocs-preview datacube-core end -->