### PR TITLE
Fix spatial extents

### DIFF
--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -480,7 +480,9 @@ class PostgisDbAPI:
     def spatial_extent(self, ids, crs):
         SpatialIndex = self._db.spatial_index(crs)  # noqa: N806
         if SpatialIndex is None:
-            return None
+            # Requested a CRS that has no spatial index, so use 4326 (which always has a spatial index)
+            # and reproject to requested CRS.
+            return self.spatial_extent(ids, CRS("epsg:4326")).to_crs(crs)
         query = select(
             func.ST_AsGeoJSON(func.ST_Union(SpatialIndex.extent))
         ).select_from(

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -11,7 +11,7 @@ v1.9.next
 * Documentation fixes (:pull:`1659`)
 * Don't use importlib_metadata (:pull:`1657`)
 * Pin upstream libraries to get CI tests running with numpy2 (:pull:`1661`)
-* Calculate spatial extent in 4326 and reproject when no dedicated spatial extent for
+* Calculate spatial extent in epsg:4326 and reproject when no dedicated spatial extent for
   the requested CRS is available (:pull:`1662`)
 
 v1.9.0-rc11 (28th October 2024)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -10,7 +10,9 @@ v1.9.next
 
 * Documentation fixes (:pull:`1659`)
 * Don't use importlib_metadata (:pull:`1657`)
-* Pin upstream libraries to get CI tests running with numpy2 (:pull:`1659`)
+* Pin upstream libraries to get CI tests running with numpy2 (:pull:`1661`)
+* Calculate spatial extent in 4326 and reproject when no dedicated spatial extent for
+  the requested CRS is available (:pull:`1662`)
 
 v1.9.0-rc11 (28th October 2024)
 ===============================


### PR DESCRIPTION
### Reason for this pull request

In the postgis driver, the `dc.index.products.spatial_extent()` method was returning None if there was no dedicated spatial index defined for the requested CRS.

This issue was identified during the OWS anti-meridian work.

### Proposed changes

-  Calculate extent in `epsg:4326` (which is always available) if no dedicated spatial index defined for the requested CRS.

 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1662.org.readthedocs.build/en/1662/

<!-- readthedocs-preview datacube-core end -->