### PR TITLE
Pin off broken dask versions

### DIFF
--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,9 @@ What's New
 v1.8.next
 =========
 - Don't error when adding a dataset whose product doesn't have an id value (:pull:`1630`)
+- Update docs (:pull:`1631`,:pull:`1651`)
+- Update docker image and CI (multiple PRs)
+- Pin out bad versions of dask (:pull:`1663`)
 
 v1.8.19 (2nd July 2024)
 =======================

--- a/setup.py
+++ b/setup.py
@@ -95,8 +95,8 @@ setup(
         'cachetools',
         'click>=5.0',
         'cloudpickle>=0.4',
-        'dask[array]',
-        'distributed',
+        'dask[array]<2024.11.0',  # Dask versions from 2024.11 cause problems with numpy2
+        'distributed<2024.11.0',
         'jsonschema>=4.18',  # New reference resolution API
         'netcdf4',
         'numpy',


### PR DESCRIPTION
### Reason for this pull request

Some recent dask versions are broken as per #1656


### Proposed changes

- Pin `dask<=2024.11.0` until dask get their act together.


 - Doesn't close #1656 - leave open until dask get their act together and we can set a lower bound.
 - [ ] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
