### PR TITLE
Fix spelling mistakes/typos with codespell

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -6,7 +6,7 @@ In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
+level of experience, education, socioeconomic status, nationality, personal
 appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -385,7 +385,7 @@ class Datacube:
 
             Any form that can be converted to a CRS by odc-geo is accepted.
 
-            This differs from the ``crs`` parameter desribed above, which is used to define the CRS
+            This differs from the ``crs`` parameter described above, which is used to define the CRS
             of the coordinates in the query itself.
 
         :param resolution:

--- a/datacube/cfg/api.py
+++ b/datacube/cfg/api.py
@@ -104,7 +104,7 @@ class ODCConfig:
         self.allow_envvar_overrides = not text and not raw_dict
 
         if not raw_dict and not text:
-            # No explict config passed in.  Check for ODC_CONFIG environment variables
+            # No explicit config passed in.  Check for ODC_CONFIG environment variables
             if os.environ.get("ODC_CONFIG"):
                 text = os.environ["ODC_CONFIG"]
             else:

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -747,7 +747,7 @@ class PostgisDbAPI:
         """
         Insert bulk lineage records (e.g. for index cloning)
 
-        :param values: An array of values dicts for bulk inser
+        :param values: An array of values dicts for bulk insert
         :return: Tuple[count of rows loaded, count of rows skipped]
         """
         requested = len(values)

--- a/datacube/drivers/postgis/_connections.py
+++ b/datacube/drivers/postgis/_connections.py
@@ -53,7 +53,7 @@ class PostGisDb:
     or else use a separate instance of this class in each process.
     """
 
-    driver_name = 'postgis'  # Mostly to support parametised tests
+    driver_name = 'postgis'  # Mostly to support parametrised tests
 
     def __init__(self, engine: Engine):
         # We don't recommend using this constructor directly as it may change.
@@ -136,7 +136,7 @@ class PostGisDb:
         Close any idle connections in the pool.
 
         This is good practice if you are keeping this object in scope
-        but wont be using it for a while.
+        but won't be using it for a while.
 
         Connections should not be shared between processes, so this should be called
         before forking if the same instance will be used.

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -733,7 +733,7 @@ class PostgresDbAPI(object):
         """
         Insert bulk lineage records (e.g. for index cloning)
 
-        :param values: An array of values dicts for bulk inser
+        :param values: An array of values dicts for bulk insert
         :return: tuple[count of rows loaded, count of rows skipped]
         """
         requested = len(vals)

--- a/datacube/drivers/postgres/_connections.py
+++ b/datacube/drivers/postgres/_connections.py
@@ -50,7 +50,7 @@ class PostgresDb(object):
     or else use a separate instance of this class in each process.
     """
 
-    driver_name = 'postgres'   # Mostly to support parametised tests
+    driver_name = 'postgres'   # Mostly to support parametrised tests
 
     def __init__(self, engine):
         # We don't recommend using this constructor directly as it may change.
@@ -129,7 +129,7 @@ class PostgresDb(object):
         Close any idle connections in the pool.
 
         This is good practice if you are keeping this object in scope
-        but wont be using it for a while.
+        but won't be using it for a while.
 
         Connections should not be shared between processes, so this should be called
         before forking if the same instance will be used.

--- a/datacube/index/_api.py
+++ b/datacube/index/_api.py
@@ -35,7 +35,7 @@ def index_connect(config_env: ODCEnvironment | None = None,
 
     driver_name = config_env.index_driver
     index_driver = index_driver_by_name(driver_name)
-    # No neeed to check for missing index driver - already checked during config parsing.
+    # No need to check for missing index driver - already checked during config parsing.
     assert index_driver is not None
     return index_driver.connect_to_index(config_env,
                                          application_name=application_name,

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -704,7 +704,7 @@ class AbstractProductResource(ABC):
         """
         Return all products for given metadata types
 
-        :param types: An interable of MetadataType models
+        :param types: An iterable of MetadataType models
         :return: An iterable of Product models
         """
         mdts = set(mdt.name for mdt in types)
@@ -893,7 +893,7 @@ class AbstractLineageResource(ABC):
     @abstractmethod
     def merge(self, rels: LineageRelations, allow_updates: bool = False, validate_only: bool = False) -> None:
         """
-        Merge an entire LineageRelations collection into the databse.
+        Merge an entire LineageRelations collection into the database.
 
         :param rels: The LineageRelations collection to merge.
         :param allow_updates: If False and the merging rels would require index updates,
@@ -1347,7 +1347,7 @@ class AbstractDatasetResource(ABC):
         :return: Iterable of less mature datasets
         """
         if isinstance(delta, bool):
-            _LOG.warning("received delta as a boolean value. Int is prefered")
+            _LOG.warning("received delta as a boolean value. Int is preferred")
             if delta is True:  # treat True as default
                 delta = 500
             else:  # treat False the same as None
@@ -1432,7 +1432,7 @@ class AbstractDatasetResource(ABC):
         This will be very slow and inefficient for large databases, and is really
         only intended for small and/or experimental databases.
 
-        :param archived: If true, return all archived datasets, if false, all unarchived datatsets
+        :param archived: If true, return all archived datasets, if false, all unarchived datasets
         :return: Iterable of dataset ids
         """
 
@@ -1939,7 +1939,7 @@ class AbstractDatasetResource(ABC):
         generated Dataset class that is a subclass of tuple.
 
         Only the requested fields will be returned together with related derived attributes as property functions
-        similer to the datacube.model.Dataset class. For example, if 'extent'is requested all of
+        similar to the datacube.model.Dataset class. For example, if 'extent'is requested all of
         'crs', 'extent', 'transform', and 'bounds' are available as property functions.
 
         The field_names can be custom fields in addition to those specified in metadata_type, fixed fields, or
@@ -2176,7 +2176,7 @@ class AbstractIndex(ABC):
     #    Supports per-CRS spatial indexes (Requires supports_write)
     supports_spatial_indexes = False
 
-    # User managment support flags
+    # User management support flags
     #   support the index.users API
     supports_users = False
 
@@ -2267,7 +2267,7 @@ class AbstractIndex(ABC):
         """
         Create a spatial index for a CRS.
 
-        Note that a newly created spatial index is empty.  If there are already datatsets in the index whose
+        Note that a newly created spatial index is empty.  If there are already datasets in the index whose
         extents can be safely projected into the CRS, then it is necessary to also call update_spatial_index
         otherwise they will not be found by queries against that CRS.
 

--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -180,7 +180,7 @@ def resolve_with_lineage(doc: SimpleDocNav,
     """
     Dataset driver for the (new) external lineage API
 
-    API paramters
+    API parameters
     :param doc: Dataset docnav
     :param uri: location uri
 

--- a/datacube/index/memory/_metadata_types.py
+++ b/datacube/index/memory/_metadata_types.py
@@ -98,7 +98,7 @@ class MetadataTypeResource(AbstractMetadataTypeResource):
     def check_field_indexes(self, allow_table_lock: bool = False,
                             rebuild_views: bool = False, rebuild_indexes: bool = False) -> None:
         # Cannot implement this method without separating index implementation into
-        # separate layer from the API Resource implmentations.
+        # separate layer from the API Resource implementations.
         pass
 
     def get_all(self) -> Iterable[MetadataType]:

--- a/datacube/index/memory/index.py
+++ b/datacube/index/memory/index.py
@@ -37,7 +37,7 @@ class Index(AbstractIndex):
     #   Database/storage feature support flags
     supports_write = True
 
-    #   User managment support flags
+    #   User management support flags
     supports_users = True
 
     #   Lineage support flags

--- a/datacube/index/null/index.py
+++ b/datacube/index/null/index.py
@@ -29,7 +29,7 @@ class Index(AbstractIndex):
     supports_eo3 = True
     supports_nongeo = True
 
-    #   User managment support flags
+    #   User management support flags
     supports_users = True
 
     def __init__(self, env: ODCEnvironment) -> None:

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -890,7 +890,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         generated Dataset class that is a subclass of tuple.
 
         Only the requested fields will be returned together with related derived attributes as property functions
-        similer to the datacube.model.Dataset class. For example, if 'extent'is requested all of
+        similar to the datacube.model.Dataset class. For example, if 'extent'is requested all of
         'crs', 'extent', 'transform', and 'bounds' are available as property functions.
 
         The field_names can be custom fields in addition to those specified in metadata_type, fixed fields, or

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -60,7 +60,7 @@ class Index(AbstractIndex):
     supports_transactions = True
     supports_spatial_indexes = True
 
-    #   User managment support flags
+    #   User management support flags
     supports_users = True
 
     #   Lineage support flags
@@ -141,7 +141,7 @@ class Index(AbstractIndex):
         Close any idle connections database connections.
 
         This is good practice if you are keeping the Index instance in scope
-        but wont be using it for a while.
+        but won't be using it for a while.
 
         (Connections are normally closed automatically when this object is deleted: ie. no references exist)
         """

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -922,7 +922,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         generated Dataset class that is a subclass of tuple.
 
         Only the requested fields will be returned together with related derived attributes as property functions
-        similer to the datacube.model.Dataset class. For example, if 'extent'is requested all of
+        similar to the datacube.model.Dataset class. For example, if 'extent'is requested all of
         'crs', 'extent', 'transform', and 'bounds' are available as property functions.
 
         The field_names can be custom fields in addition to those specified in metadata_type, fixed fields, or

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -57,7 +57,7 @@ class Index(AbstractIndex):
     supports_persistance = True
     supports_transactions = True
 
-    #   User managment support flags
+    #   User management support flags
     supports_users = True
 
     #   Lineage support flags

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -939,7 +939,7 @@ class GridSpec:
            dimension order.
 
         :param BoundingBox bounds: Boundary coordinates of the required grid
-        :param dict geobox_cache: Optional cache to re-use geoboxes instead of creating new one each time
+        :param dict geobox_cache: Optional cache to reuse geoboxes instead of creating new one each time
         :return: iterator of grid cells with :py:class:`GeoBox` tiles
         """
         def geobox(tile_index):
@@ -975,7 +975,7 @@ class GridSpec:
         :param odc.geo.Geometry geopolygon: Polygon to tile
         :param tile_buffer: Optional <float,float> tuple, (extra padding for the query
                             in native units of this GridSpec)
-        :param dict geobox_cache: Optional cache to re-use geoboxes instead of creating new one each time
+        :param dict geobox_cache: Optional cache to reuse geoboxes instead of creating new one each time
         :return: iterator of grid cells with :py:class:`GeoBox` tiles
         """
         geopolygon = geopolygon.to_crs(self.crs)
@@ -1192,7 +1192,7 @@ class ExtraDimensions:
         return start_index, stop_index
 
     def chunk_size(self) -> Tuple[Tuple[str, ...], Tuple[int, ...]]:
-        """Returns the names and shapes of dimenions in dimension order
+        """Returns the names and shapes of dimensions in dimension order
 
         :return: A tuple containing the names and max sizes of each dimension
         """

--- a/datacube/model/eo3.py
+++ b/datacube/model/eo3.py
@@ -68,7 +68,7 @@ def validate_eo3_offsets(field_name, mdt_name, defn):
 
 def validate_eo3_compatible_type(doc):
     """
-    Valdate that a metadata type document is EO3 compatible.
+    Validate that a metadata type document is EO3 compatible.
 
     N.B. Assumes the document has already been validated as a valid ODC metadata type document.
 

--- a/datacube/model/lineage.py
+++ b/datacube/model/lineage.py
@@ -122,7 +122,7 @@ class LineageTree:
         """
         Finds subtree with root at dsid, if there is one.
 
-        Immediately retunrs the first match found with not-None children, but keeps track of first
+        Immediately returns the first match found with not-None children, but keeps track of first
         children=None match to return if no not-None matches.
 
 
@@ -318,7 +318,7 @@ class LineageRelations:
 
         Raises InconsistentLineageException if we already have this id with a different home
 
-        :param id_: The dataet id
+        :param id_: The dataset id
         :param home: The home string
         """
         if id_ in self._homes:
@@ -385,7 +385,7 @@ class LineageRelations:
         """
         Merge in a LineageTree, ensuring it is consistent with the collection so far.
 
-        Raises InconsistentLineageException if tree contains cyclic depenedencies or inconsistent direction
+        Raises InconsistentLineageException if tree contains cyclic dependencies or inconsistent direction
 
         :param tree: The LineageTree to merge
         :param parent_node: The parent node (used to mark recursive traversal - should be None on first call)
@@ -445,7 +445,7 @@ class LineageRelations:
         Intended to be used by index drivers when adding lineage data to an index.
 
         Raises InconsistentLineageException if updates are required and allow_updates is False, or if
-        merging the two LineageRelations would result in cyclic depenedencies.
+        merging the two LineageRelations would result in cyclic dependencies.
 
         :param existing_relations: The relations currently in an index.
         :param allow_updates: Whether updates to existing records are allowed.

--- a/datacube/model/schema/dataset-type-schema.yaml
+++ b/datacube/model/schema/dataset-type-schema.yaml
@@ -21,7 +21,7 @@ properties:
         type: object
     extra_dimensions:
         type: array
-        description: Describes extra dimenions between (t) and (y, x)
+        description: Describes extra dimensions between (t) and (y, x)
         items:
             "$ref": "#/definitions/extra_dimensions"
     storage:

--- a/datacube/testutils/__init__.py
+++ b/datacube/testutils/__init__.py
@@ -113,7 +113,7 @@ def _write_files_to_dir(directory_path, file_dict):
 
 def isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
     """
-    Testing aproximate equality for floats
+    Testing approximate equality for floats
     See https://docs.python.org/3/whatsnew/3.5.html#pep-485-a-function-for-testing-approximate-equality
     """
     return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)

--- a/datacube/utils/aws/__init__.py
+++ b/datacube/utils/aws/__init__.py
@@ -145,7 +145,7 @@ def get_creds_with_retry(session: Session,
                          sleep: float = 0.1) -> Optional[Credentials]:
     """ Attempt to obtain credentials upto `max_tries` times with back off
     :param session: botocore session, see mk_boto_session
-    :param max_tries: number of attempt before failing and returing None
+    :param max_tries: number of attempt before failing and returning None
     :param sleep: number of seconds to sleep after first failure (doubles on every consecutive failure)
     """
     for i in range(max_tries):

--- a/datacube/utils/changes.py
+++ b/datacube/utils/changes.py
@@ -12,12 +12,12 @@ from typing import cast, Any, Callable, List, Mapping, Sequence, Tuple, Union
 
 # Type that can be checked for changes.
 # (MyPy approximation without recursive references)
-Changable = Union[str, int, None, Sequence[Any], Mapping[str, Any]]
+Changeable = Union[str, int, None, Sequence[Any], Mapping[str, Any]]
 # More accurate recursive definition:
-# Changable = Union[str, int, None, Sequence["Changable"], Mapping[str, "Changable"]]
+# Changeable = Union[str, int, None, Sequence["Changeable"], Mapping[str, "Changeable"]]
 
 
-def contains(v1: Changable, v2: Changable, case_sensitive: bool = False) -> bool:
+def contains(v1: Changeable, v2: Changeable, case_sensitive: bool = False) -> bool:
     """
     Check that v1 is a superset of v2.
 
@@ -53,14 +53,14 @@ OffsetElem = Union[str, int]
 Offset = Tuple[OffsetElem, ...]
 
 # Representation of a changed value
-ChangedValue = Union[MissingSentinel, Changable]
+ChangedValue = Union[MissingSentinel, Changeable]
 
 # Representation of a change
 Change = Tuple[Offset, ChangedValue, ChangedValue]
 
 
-def get_doc_changes(original: Changable,
-                    new: Changable,
+def get_doc_changes(original: Changeable,
+                    new: Changeable,
                     base_prefix: Offset = ()
                     ) -> List[Change]:
     """
@@ -105,7 +105,7 @@ class DocumentMismatchError(Exception):
     pass
 
 
-def check_doc_unchanged(original: Changable, new: Changable, doc_name: str) -> None:
+def check_doc_unchanged(original: Changeable, new: Changeable, doc_name: str) -> None:
     """
     Raise an error if any fields have been modified on a document.
 

--- a/datacube/utils/uris.py
+++ b/datacube/utils/uris.py
@@ -154,7 +154,7 @@ def normalise_path(p: Union[str, pathlib.Path],
                    base: Optional[Union[str, pathlib.Path]] = None) -> pathlib.Path:
     """Turn path into absolute path resolving any `../` and `.`
 
-       If path is relative pre-pend `base` path to it, `base` if set should be
+       If path is relative prepend `base` path to it, `base` if set should be
        an absolute path. If not set, current working directory (as seen by the
        user launching the process, including any possible symlinks) will be
        used.

--- a/docs/MIGRATION-1.8-to-1.9.rst
+++ b/docs/MIGRATION-1.8-to-1.9.rst
@@ -127,7 +127,7 @@ Major Changes between 1.8.x and 1.9.x
 
    This is a work in progress and will not be available in 1.9.0. It will appear in a later 1.9.x release.
 
-7. The long-deprecated "ingestion" workflow and "excecutor" API have both been removed.
+7. The long-deprecated "ingestion" workflow and "executor" API have both been removed.
 
 8. Multiple locations per dataset is now deprecated.
 

--- a/docs/installation/setup/common_install.rst
+++ b/docs/installation/setup/common_install.rst
@@ -48,7 +48,7 @@ Set a password for the "postgres" database role using the command::
 
 and set the password when prompted. The password text will be hidden from the console for security purposes.
 
-Type **Control+D** or **\\q** to exit the posgreSQL prompt.
+Type **Control+D** or **\\q** to exit the postgresql prompt.
 
 By default in Ubuntu, Postgresql is configured to use ``ident sameuser`` authentication for any connections from the same machine which is useful for development. Check out the excellent Postgresql documentation for more information, but essentially this means that if your Ubuntu username is ``foo`` and you add ``foo`` as a Postgresql user then you can connect to a database without requiring a password for many functions.
 

--- a/integration_tests/index/test_update_columns.py
+++ b/integration_tests/index/test_update_columns.py
@@ -85,7 +85,7 @@ def test_added_column(clirunner, uninitialised_postgres_db):
 
 @pytest.mark.parametrize('datacube_env_name', ('datacube', ))
 def test_readd_column(clirunner, uninitialised_postgres_db):
-    # Run on an empty database. drop columns and readd
+    # Run on an empty database. drop columns and re-add
     result = clirunner(["--env", "datacube", "system", "init"])
     assert "Created." in result.output
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ AWS_ENV_VARS = (
 def example_gdal_path(data_folder):
     """Return the pathname of a sample geotiff file
 
-    Use this fixture by specifiying an argument named 'example_gdal_path' in your
+    Use this fixture by specifying an argument named 'example_gdal_path' in your
     test method.
     """
     return str(os.path.join(data_folder, "sample_tile_151_-29.tif"))
@@ -290,7 +290,7 @@ netcdf_num = 1
 
 @pytest.fixture
 def tmpnetcdf_filename(tmpdir):
-    """Return a generated filename for a non-existant netcdf file"""
+    """Return a generated filename for a non-existent netcdf file"""
     global netcdf_num
     filename = str(tmpdir.join("testfile_np_%s.nc" % netcdf_num))
     netcdf_num += 1

--- a/tests/data/lbg/gedi/GEDI02_B_3d_format.yaml
+++ b/tests/data/lbg/gedi/GEDI02_B_3d_format.yaml
@@ -64,7 +64,7 @@ measurements:
     aliases: [band_12]
     dtype: float32
     nodata: 0
-    units: na # Maxmimum canopy cover that can be penetrated considering the SNR of the waveform
+    units: na # Maximum canopy cover that can be penetrated considering the SNR of the waveform
   - name: "surface_flag"
     aliases: [band_13]
     dtype: uint8

--- a/tests/drivers/test_rio_reader.py
+++ b/tests/drivers/test_rio_reader.py
@@ -46,7 +46,7 @@ def test_rio_rd_entry():
     with pytest.raises(ValueError):
         rde.new_instance({'pool': []})
 
-    # check pool re-use
+    # check pool reuse
     pool = ThreadPoolExecutor(max_workers=1)
     rdr = rde.new_instance({'pool': pool})
     assert rdr._pool is pool

--- a/tests/test_ext_lineage.py
+++ b/tests/test_ext_lineage.py
@@ -561,7 +561,7 @@ def test_good_consistency_check(big_src_lineage_tree, src_lineage_tree, big_src_
 def test_bad_diamond(src_lineage_tree_with_bad_diamond, big_src_tree_ids):
     # Test detection of trees that have a diamond relationship in which both paths are extended.
     # E.g. If A->B->C->D  and A->E->C->D, the C->D relationship should only be recorded
-    # under one branch (B or A) and the other occurence of C should have no children recorded.
+    # under one branch (B or A) and the other occurrence of C should have no children recorded.
     with pytest.raises(InconsistentLineageException, match="Duplicate nodes in LineageTree"):
         rels = LineageRelations(tree=src_lineage_tree_with_bad_diamond)
 

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -236,7 +236,7 @@ hyperspectral
 iam
 IAM
 ident
-identifer
+identifier
 img
 importlib
 INEGI


### PR DESCRIPTION
### Reason for this pull request

I learnt about a cool tool called [codespell](https://github.com/codespell-project/codespell/), so I ran it and easily fixed a bunch of typos and spelling mistakes.



<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1672.org.readthedocs.build/en/1672/

<!-- readthedocs-preview datacube-core end -->