### PR TITLE
Ensure correct scalar precision

### DIFF
--- a/datacube/utils/geometry/tools.py
+++ b/datacube/utils/geometry/tools.py
@@ -72,7 +72,7 @@ def roi_boundary(roi, pts_per_side=2):
 
     roi needs to be in the normalised form, i.e. no open-ended start/stop, see roi_normalise
 
-    :returns: Nx2 float32 array of X,Y points on the perimeter of the envelope defined by `roi`
+    :returns: Nx2 float64 array of X,Y points on the perimeter of the envelope defined by `roi`
     """
     yy, xx = roi
     xx = np.linspace(xx.start, xx.stop, pts_per_side, dtype='float64')

--- a/datacube/utils/geometry/tools.py
+++ b/datacube/utils/geometry/tools.py
@@ -60,8 +60,8 @@ def gbox_boundary(gbox, pts_per_side=16):
 
     """
     H, W = gbox.shape[:2]
-    xx = np.linspace(0, W, pts_per_side, dtype='float32')
-    yy = np.linspace(0, H, pts_per_side, dtype='float32')
+    xx = np.linspace(0, W, pts_per_side, dtype='float64')
+    yy = np.linspace(0, H, pts_per_side, dtype='float64')
 
     return polygon_path(xx, yy).T[:-1]
 
@@ -75,8 +75,8 @@ def roi_boundary(roi, pts_per_side=2):
     :returns: Nx2 float32 array of X,Y points on the perimeter of the envelope defined by `roi`
     """
     yy, xx = roi
-    xx = np.linspace(xx.start, xx.stop, pts_per_side, dtype='float32')
-    yy = np.linspace(yy.start, yy.stop, pts_per_side, dtype='float32')
+    xx = np.linspace(xx.start, xx.stop, pts_per_side, dtype='float64')
+    yy = np.linspace(yy.start, yy.stop, pts_per_side, dtype='float64')
 
     return polygon_path(xx, yy).T[:-1]
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -11,6 +11,7 @@ v1.8.next
 - Update docs (:pull:`1631`,:pull:`1651`)
 - Update docker image and CI (multiple PRs)
 - Pin out bad versions of dask (:pull:`1663`)
+- Ensure correct boundary scalar precision with numpy 2 (:pull:`1673`)
 
 v1.8.19 (2nd July 2024)
 =======================

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -377,6 +377,7 @@ PRIMEM
 prog
 Proj
 provence
+PRs
 psql
 pts
 pwd


### PR DESCRIPTION
### Reason for this pull request

Ensure boundary scalar precision isn't lost when using numpy>2.0. 
See #1655 



 - [x] Closes #1655
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1673.org.readthedocs.build/en/1673/

<!-- readthedocs-preview datacube-core end -->