### PR TITLE
#1677 Allow flexibility in NaN strings

### DIFF
--- a/datacube/model/schema/dataset-type-schema.yaml
+++ b/datacube/model/schema/dataset-type-schema.yaml
@@ -98,7 +98,7 @@ definitions:
             nodata:
               oneOf:
                 - type: number
-                - enum: [NaN, Inf, -Inf]
+                - enum: [nan, NAN, NaN, Inf, -Inf]
             scale_factor:
               description: 'Defines mapping to some "real" space like so: real_value = pixel_value*scale_factor + add_offset'
               type: number

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -12,6 +12,7 @@ v1.8.next
 - Update docker image and CI (multiple PRs)
 - Pin out bad versions of dask (:pull:`1663`)
 - Ensure correct boundary scalar precision with numpy 2 (:pull:`1673`)
+- Add more string representations of nan (:pull:`1678`)
 
 v1.8.19 (2nd July 2024)
 =======================


### PR DESCRIPTION
### Reason for this pull request

Closes #1677 

### Proposed changes

- Allow x2 most common other string representations of `nan`



 - [x] Closes #1677
 - [x] Tests added / passed, manually, looks like YAML schema validation tests need updating
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1678.org.readthedocs.build/en/1678/

<!-- readthedocs-preview datacube-core end -->