### PR TITLE
Fix docs lineage

### DIFF
--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -549,6 +549,8 @@ def without_lineage_sources(doc: Dict[str, Any],
     if 'sources' in doc_view.fields:
         if doc_view.sources is not None:
             doc_view.sources = {}
+    elif 'lineage' in doc:
+        doc["lineage"] = {}
 
     return doc
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -20,6 +20,7 @@ v1.9.next
 * Rename `DatasetType` to `Product` in all the tests (:pull:`1671`)
 * Documentation updates for 1.9 release (:pull:`1664`, :pull:`1699`)
 * Suppress annoying config warning when configuring by environment variable (:pull:`1680`)
+* Fix metadata issues with new Lineage API. (:pull:`1677`)
 
 v1.9.0-rc11 (28th October 2024)
 ===============================

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -19,8 +19,9 @@ v1.9.next
 * Fix broken documentation build (:pull:`1668`)
 * Rename `DatasetType` to `Product` in all the tests (:pull:`1671`)
 * Documentation updates for 1.9 release (:pull:`1664`, :pull:`1699`)
-* Suppress annoying config warning when configuring by environment variable (:pull:`1680`)
 * Fix metadata issues with new Lineage API. (:pull:`1677`)
+* Fix metadata issues with new Lineage API. (:pull:`1679`)
+* Suppress annoying config warning when configuring by environment variable (:pull:`1680`)
 
 v1.9.0-rc11 (28th October 2024)
 ===============================

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ tests_require = [
     'pytest-httpserver',
     'moto<5.0',  # 5.0 will require changes to some tests.
     'psycopg2',
+    'netcdf4'
 ]
 
 types_require = [

--- a/tests/test_utils_docs.py
+++ b/tests/test_utils_docs.py
@@ -140,7 +140,11 @@ def test_without_lineage_sources():
         )
     }, dataset_search_fields={})
 
-    assert without_lineage_sources(mk_sample(10), no_sources_type)["lineage"] == {}
+    test_doc = mk_sample(10)
+    assert without_lineage_sources(test_doc, no_sources_type)["lineage"] == {}
+    test_doc["lineage"] = {"a": "a", "b": "b"}
+    assert without_lineage_sources(test_doc, no_sources_type)["lineage"] == {}
+
 
 
 def test_parse_yaml():

--- a/tests/test_utils_docs.py
+++ b/tests/test_utils_docs.py
@@ -140,7 +140,7 @@ def test_without_lineage_sources():
         )
     }, dataset_search_fields={})
 
-    assert without_lineage_sources(mk_sample(10), no_sources_type) == mk_sample(10)
+    assert without_lineage_sources(mk_sample(10), no_sources_type)["lineage"] == {}
 
 
 def test_parse_yaml():

--- a/tests/test_utils_docs.py
+++ b/tests/test_utils_docs.py
@@ -146,7 +146,6 @@ def test_without_lineage_sources():
     assert without_lineage_sources(test_doc, no_sources_type)["lineage"] == {}
 
 
-
 def test_parse_yaml():
     assert parse_yaml('a: 10') == {'a': 10}
 


### PR DESCRIPTION
### Reason for this pull request

The `without_lineage_sources` method didn't work correctly with the new Lineage API

### Proposed changes

- New lineage-style datasets now return lineage-free metadata correctly.


 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1679.org.readthedocs.build/en/1679/

<!-- readthedocs-preview datacube-core end -->