### PR TITLE
Cleanup config default warning

### DIFF
--- a/datacube/cfg/cfg.py
+++ b/datacube/cfg/cfg.py
@@ -9,10 +9,12 @@ The default search path and default config also live here.
 """
 
 import os
+import logging
 import warnings
 from enum import Enum
 from os import PathLike
 from os.path import expanduser
+from typing import Protocol, Callable
 
 from datacube.cfg.exceptions import ConfigException
 from datacube.cfg.utils import ConfigDict, smells_like_ini
@@ -33,8 +35,12 @@ default:
    db_connection_timeout: 60
 """
 
+_LOG = logging.getLogger(__name__)
 
-def find_config(paths_in: None | str | PathLike | list[str | PathLike]) -> str:
+
+IsDefaultCallback = Callable[[], None]
+
+def find_config(paths_in: None | str | PathLike | list[str | PathLike], defCallback: IsDefaultCallback | None = None) -> str:
     """
     Given a file system path, or a list of file system paths, return the contents of the first file
     in the list that can be read as a string.
@@ -82,7 +88,9 @@ def find_config(paths_in: None | str | PathLike | list[str | PathLike]) -> str:
             continue
 
     if using_default_paths:
-        warnings.warn("No configuration file found - using default configuration")
+        if defCallback is not None:
+            defCallback()
+        _LOG.info("No configuration file found - using default configuration and environment variables")
         return _DEFAULT_CONF
 
     raise ConfigException("No configuration file found in the provided locations")

--- a/datacube/cfg/utils.py
+++ b/datacube/cfg/utils.py
@@ -4,13 +4,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import re
-from typing import Any, TypeAlias
+from typing import Any, TypeAlias, Callable
 
 from .exceptions import ConfigException
 
 
 # A raw configuration dictionary. A dictionary of dictionaries
 ConfigDict: TypeAlias = dict[str, dict[str, Any]]
+SemaphoreCallback = Callable[[], None]
+
 
 
 def check_valid_env_name(name: str) -> None:

--- a/datacube/cfg/utils.py
+++ b/datacube/cfg/utils.py
@@ -14,7 +14,6 @@ ConfigDict: TypeAlias = dict[str, dict[str, Any]]
 SemaphoreCallback = Callable[[], None]
 
 
-
 def check_valid_env_name(name: str) -> None:
     """
     Enforce a valid ODC environment name.

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -19,6 +19,7 @@ v1.9.next
 * Fix broken documentation build (:pull:`1668`)
 * Rename `DatasetType` to `Product` in all the tests (:pull:`1671`)
 * Documentation updates for 1.9 release (:pull:`1664`, :pull:`1699`)
+* Suppress annoying config warning when configuring by environment variable (:pull:`1680`)
 
 v1.9.0-rc11 (28th October 2024)
 ===============================


### PR DESCRIPTION
### Reason for this pull request

If the default config (final fallback) is use, a warning was raised.

This was annoying in cases where config was being done solely by environment variable.


### Proposed changes

- Warning is suppressed for environments that read anything from environment variable.

 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1680.org.readthedocs.build/en/1680/

<!-- readthedocs-preview datacube-core end -->