### PR TITLE
Test warnings

### DIFF
--- a/datacube/drivers/netcdf/writer.py
+++ b/datacube/drivers/netcdf/writer.py
@@ -8,7 +8,7 @@ Create netCDF4 Storage Units and write data to them
 
 import logging
 import numbers
-from datetime import datetime
+from datetime import datetime, UTC
 from collections import namedtuple
 import numpy
 
@@ -68,7 +68,7 @@ def create_netcdf(netcdf_path, **kwargs):
     nco.setncattr('Conventions', 'CF-1.6, ACDD-1.3')
     nco.history = ("NetCDF-CF file created by "
                    "datacube version '{}' at {:%Y%m%d}."
-                   .format(__version__, datetime.utcnow()))
+                   .format(__version__, datetime.now(UTC)))
     return nco
 
 

--- a/datacube/drivers/netcdf/writer.py
+++ b/datacube/drivers/netcdf/writer.py
@@ -8,7 +8,7 @@ Create netCDF4 Storage Units and write data to them
 
 import logging
 import numbers
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from collections import namedtuple
 import numpy
 
@@ -20,6 +20,8 @@ from odc.geo.geom import box
 from odc.geo.math import data_resolution_and_offset
 
 from datacube import __version__
+
+UTC = timezone.utc
 
 Variable = namedtuple('Variable', ('dtype', 'nodata', 'dims', 'units'))
 _LOG = logging.getLogger(__name__)

--- a/datacube/index/abstract.py
+++ b/datacube/index/abstract.py
@@ -1092,17 +1092,25 @@ class DatasetTuple(NamedTuple):
     uri_: str | list[str]
 
     @property
-    def is_legacy(self):
+    def uri_is_string(self):
         if isinstance(self.uri_, str):
+            return True
+        return False
+
+    @property
+    def is_legacy(self):
+        if self.uri_is_string:
             return False
-        return True
+        return len(self.uri_) > 1
 
     @property
     def uri(self) -> str:
-        if self.is_legacy:
+        if self.uri_is_string:
+            return cast(str, self.uri_)
+        elif self.is_legacy:
             return self.uris[0]
         else:
-            return cast(str, self.uri_)
+            return cast(list[str], self.uri_)[0]
 
     @property
     @deprecat(
@@ -1110,10 +1118,10 @@ class DatasetTuple(NamedTuple):
         version='1.9.0',
         category=ODC2DeprecationWarning)
     def uris(self) -> Sequence[str]:
-        if self.is_legacy:
-            return cast(list[str], self.uri_)
-        else:
+        if self.uri_is_string:
             return [cast(str, self.uri_)]
+        else:
+            return cast(list[str], self.uri_)
 
 
 class AbstractDatasetResource(ABC):

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -170,7 +170,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                 transaction.update_search_index(dsids=[dataset.id])
                 # 1c. Store locations
                 if dataset.uri is not None:
-                    if len(dataset.uris) > 1:
+                    if dataset.has_multiple_uris():
                         raise ValueError('Postgis driver does not support multiple locations for a dataset.')
                     self._ensure_new_locations(dataset, transaction=transaction)
             if archive_less_mature is not None:
@@ -302,7 +302,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                                                                                          dataset.product.name,
                                                                                          dataset.id))
 
-        if len(dataset.uris) > 1:
+        if dataset.has_multiple_uris():
             raise ValueError('Postgis driver does not support multiple locations for a dataset.')
 
         # TODO: figure out (un)safe changes from metadata type?

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -152,6 +152,16 @@ class Dataset:
             return self.uri
         return pick_uri(self._uris, schema)
 
+    def has_multiple_uris(self) -> bool:
+        """
+        This is a 1.9-2.0 transitional method and will be removed in 2.0.
+
+        Returns true if the dataset has multiple locations.
+
+        Allows checking for multiple locations without tripping a deprecation warning.
+        """
+        return len(self._uris) > 1
+
     @property
     @deprecat(
         reason="The 'type' attribute has been deprecated. Please use the 'product' attribute instead.",

--- a/datacube/testutils/__init__.py
+++ b/datacube/testutils/__init__.py
@@ -14,6 +14,8 @@ import json
 import uuid
 import numpy as np
 import xarray as xr
+import warnings
+import contextlib
 from datetime import datetime
 from collections.abc import Sequence, Mapping
 import pathlib
@@ -254,13 +256,14 @@ def mk_sample_dataset(bands,
             "uris": uri
         }
 
-    return Dataset(product, {
-        'id': id,
-        'format': {'name': format},
-        'image': {'bands': image_bands},
-        'time': timestamp,
-        **geobox_to_gridspatial(geobox),
-    }, **kwargs)
+    with suppress_deprecations():
+        return Dataset(product, {
+            'id': id,
+            'format': {'name': format},
+            'image': {'bands': image_bands},
+            'time': timestamp,
+            **geobox_to_gridspatial(geobox),
+        }, **kwargs)
 
 
 def make_graph_abcde(node):
@@ -501,3 +504,13 @@ def sanitise_doc(d):
         return [sanitise_doc(i) for i in d]
     else:
         return d
+
+
+@contextlib.contextmanager
+def suppress_deprecations():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        try:
+            yield
+        finally:
+            pass

--- a/datacube/testutils/io.py
+++ b/datacube/testutils/io.py
@@ -5,6 +5,7 @@
 import numpy as np
 import toolz
 
+from . import suppress_deprecations
 from ..model import Dataset
 from ..storage import reproject_and_fuse, BandInfo
 from ..storage._rio import RasterioDataSource, RasterDatasetDataSource
@@ -88,14 +89,15 @@ def native_geobox(ds, measurements=None, basis=None):
 
     :return: GeoBox describing native storage coordinates.
     """
-    gs = ds.product.grid_spec
-    if gs is not None:
-        # Dataset is from ingested product, figure out GeoBox of the tile this dataset covers
-        bb = [gbox for _, gbox in gs.tiles(ds.bounds)]
-        if len(bb) != 1:
-            # Ingested product but dataset overlaps several/none tiles -- no good
-            raise ValueError('Broken GridSpec detected')
-        return bb[0]
+    with suppress_deprecations():
+        gs = ds.product.grid_spec
+        if gs is not None:
+            # Dataset is from ingested product, figure out GeoBox of the tile this dataset covers
+            bb = [gbox for _, gbox in gs.tiles(ds.bounds)]
+            if len(bb) != 1:
+                # Ingested product but dataset overlaps several/none tiles -- no good
+                raise ValueError('Broken GridSpec detected')
+            return bb[0]
 
     if measurements is None and basis is None:
         measurements = list(ds.product.measurements)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -22,7 +22,7 @@ v1.9.next
 * Fix metadata issues with new Lineage API. (:pull:`1677`)
 * Fix metadata issues with new Lineage API. (:pull:`1679`)
 * Suppress annoying config warning when configuring by environment variable (:pull:`1680`)
-* Suppress internal deprecation warnings from tests against deprecated code (:pull:`1681`)
+* Suppress internal deprecation warnings when running tests against deprecated code (:pull:`1681`)
 
 v1.9.0-rc11 (28th October 2024)
 ===============================

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -22,6 +22,7 @@ v1.9.next
 * Fix metadata issues with new Lineage API. (:pull:`1677`)
 * Fix metadata issues with new Lineage API. (:pull:`1679`)
 * Suppress annoying config warning when configuring by environment variable (:pull:`1680`)
+* Suppress internal deprecation warnings from tests against deprecated code (:pull:`1681`)
 
 v1.9.0-rc11 (28th October 2024)
 ===============================

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -10,6 +10,7 @@ Integration tests: these depend on a local Postgres instance.
 import copy
 import datetime
 import sys
+from os import supports_effective_ids
 from pathlib import Path
 from uuid import UUID
 
@@ -20,6 +21,7 @@ from datacube.index.exceptions import MissingRecordError
 from datacube.index import Index
 from datacube.model import Dataset, Product, MetadataType
 from datacube.index.eo3 import prep_eo3
+from datacube.testutils import suppress_deprecations
 
 _telemetry_uuid = UUID('4ec8fe97-e8b9-11e4-87ff-1040f381a756')
 _telemetry_dataset = {
@@ -462,56 +464,71 @@ def test_index_dataset_with_location(index: Index, default_metadata_type: Metada
     # Ingesting again should have no effect.
     index.datasets.add(dataset)
     stored = index.datasets.get(dataset.id)
-    locations = index.datasets.get_locations(dataset.id)  # Test of deprecated method
+    with suppress_deprecations():
+        locations = index.datasets.get_locations(dataset.id)  # Test of deprecated method
     assert len(locations) == 1
     # Remove the location
-    was_removed = index.datasets.remove_location(dataset.id, first_file.as_uri())  # Test of deprecated method
+    with suppress_deprecations():
+        was_removed = index.datasets.remove_location(dataset.id, first_file.as_uri())  # Test of deprecated method
     assert was_removed
-    was_removed = index.datasets.remove_location(dataset.id, first_file.as_uri())  # Test of deprecated method
+    with suppress_deprecations():
+        was_removed = index.datasets.remove_location(dataset.id, first_file.as_uri())  # Test of deprecated method
     assert not was_removed
-    locations = index.datasets.get_locations(dataset.id)  # Test of deprecated method
+    with suppress_deprecations():
+        locations = index.datasets.get_locations(dataset.id)  # Test of deprecated method
     assert len(locations) == 0
     # Re-add the location
-    was_added = index.datasets.add_location(dataset.id, first_file.as_uri())  # Test of deprecated method
+    with suppress_deprecations():
+        was_added = index.datasets.add_location(dataset.id, first_file.as_uri())  # Test of deprecated method
     assert was_added
-    was_added = index.datasets.add_location(dataset.id, first_file.as_uri())  # Test of deprecated method
+    with suppress_deprecations():
+        was_added = index.datasets.add_location(dataset.id, first_file.as_uri())  # Test of deprecated method
     assert not was_added
-    locations = index.datasets.get_locations(dataset.id)  # Test of deprecated method
+    with suppress_deprecations():
+        locations = index.datasets.get_locations(dataset.id)  # Test of deprecated method
     assert len(locations) == 1
 
     # A rough date is ok: 1:01 beforehand just in case someone runs this during daylight savings time conversion :)
     # (any UTC conversion errors will be off by much more than this for PST/AEST)
     before_archival_dt = utc_now() - datetime.timedelta(hours=1, minutes=1)
 
-    was_archived = index.datasets.archive_location(dataset.id, first_file.as_uri())  # Test of deprecated method
+    with suppress_deprecations():
+        was_archived = index.datasets.archive_location(dataset.id, first_file.as_uri())  # Test of deprecated method
     assert was_archived
-    locations = index.datasets.get_locations(dataset.id)  # Test of deprecated method
+    with suppress_deprecations():
+        locations = index.datasets.get_locations(dataset.id)  # Test of deprecated method
     assert locations == []
-    locations = index.datasets.get_archived_locations(dataset.id)  # Test of deprecated method
+    with suppress_deprecations():
+        locations = index.datasets.get_archived_locations(dataset.id)  # Test of deprecated method
     assert locations == [first_file.as_uri()]
 
     # It should return the time archived.
-    location_times = index.datasets.get_archived_location_times(dataset.id)  # Test of deprecated method
+    with suppress_deprecations():
+        location_times = index.datasets.get_archived_location_times(dataset.id)  # Test of deprecated method
     assert len(location_times) == 1
     location, archived_time = location_times[0]
     assert location == first_file.as_uri()
     assert utc_now() > archived_time > before_archival_dt
 
-    was_restored = index.datasets.restore_location(dataset.id, first_file.as_uri())  # Test of deprecated method
+    with suppress_deprecations():
+        was_restored = index.datasets.restore_location(dataset.id, first_file.as_uri())  # Test of deprecated method
     assert was_restored
-    locations = index.datasets.get_locations(dataset.id)  # Test of deprecated method
+    with suppress_deprecations():
+        locations = index.datasets.get_locations(dataset.id)  # Test of deprecated method
     assert len(locations) == 1
 
     # Indexing with a new path should NOT add the second one.
     dataset._uris = [second_file.as_uri()]
     index.datasets.add(dataset)
     stored = index.datasets.get(dataset.id)
-    locations = index.datasets.get_locations(dataset.id)  # Test of deprecated method
+    with suppress_deprecations():
+        locations = index.datasets.get_locations(dataset.id)  # Test of deprecated method
     assert len(locations) == 1
 
     # Add location manually instead
-    index.datasets.add_location(dataset.id, second_file.as_uri())  # Test of deprecated method
-    stored = index.datasets.get(dataset.id)
+    with suppress_deprecations():
+        index.datasets.add_location(dataset.id, second_file.as_uri())  # Test of deprecated method
+        stored = index.datasets.get(dataset.id)
     assert len(stored._uris) == 2
 
     # Newest to oldest.
@@ -520,30 +537,39 @@ def test_index_dataset_with_location(index: Index, default_metadata_type: Metada
     assert stored.local_path == Path(second_file)
 
     # Can archive and restore the first file, and location order is preserved
-    was_archived = index.datasets.archive_location(dataset.id, first_file.as_uri())  # Test of deprecated method
+    with suppress_deprecations():
+        was_archived = index.datasets.archive_location(dataset.id, first_file.as_uri())  # Test of deprecated method
     assert was_archived
-    locations = index.datasets.get_locations(dataset.id)  # Test of deprecated method
+    with suppress_deprecations():
+        locations = index.datasets.get_locations(dataset.id)  # Test of deprecated method
     assert locations == [second_file.as_uri()]
-    was_restored = index.datasets.restore_location(dataset.id, first_file.as_uri())  # Test of deprecated method
+    with suppress_deprecations():
+        was_restored = index.datasets.restore_location(dataset.id, first_file.as_uri())  # Test of deprecated method
     assert was_restored
-    locations = index.datasets.get_locations(dataset.id)  # Test of deprecated method
+    with suppress_deprecations():
+        locations = index.datasets.get_locations(dataset.id)  # Test of deprecated method
     assert locations == [second_file.as_uri(), first_file.as_uri()]
 
     # Can archive and restore the second file, and location order is preserved
-    was_archived = index.datasets.archive_location(dataset.id, second_file.as_uri())  # Test of deprecated method
+    with suppress_deprecations():
+        was_archived = index.datasets.archive_location(dataset.id, second_file.as_uri())  # Test of deprecated method
     assert was_archived
-    locations = index.datasets.get_locations(dataset.id)  # Test of deprecated method
+    with suppress_deprecations():
+        locations = index.datasets.get_locations(dataset.id)  # Test of deprecated method
     assert locations == [first_file.as_uri()]
-    was_restored = index.datasets.restore_location(dataset.id, second_file.as_uri())  # Test of deprecated method
+    with suppress_deprecations():
+        was_restored = index.datasets.restore_location(dataset.id, second_file.as_uri())  # Test of deprecated method
     assert was_restored
-    locations = index.datasets.get_locations(dataset.id)  # Test of deprecated method
+    with suppress_deprecations():
+        locations = index.datasets.get_locations(dataset.id)  # Test of deprecated method
     assert locations == [second_file.as_uri(), first_file.as_uri()]
 
     # Indexing again without location should have no effect.
     dataset._uris = []
-    index.datasets.add(dataset)
-    stored = index.datasets.get(dataset.id)
-    locations = index.datasets.get_locations(dataset.id)  # Test of deprecated method
+    with suppress_deprecations():
+        index.datasets.add(dataset)
+        stored = index.datasets.get(dataset.id)
+        locations = index.datasets.get_locations(dataset.id)  # Test of deprecated method
     assert len(locations) == 2
     # Newest to oldest.
     assert locations == [second_file.as_uri(), first_file.as_uri()]
@@ -553,28 +579,30 @@ def test_index_dataset_with_location(index: Index, default_metadata_type: Metada
     # Check order of uris is preserved when indexing with more than one
     second_ds_doc = copy.deepcopy(_telemetry_dataset)
     second_ds_doc['id'] = '366f32d8-e1f8-11e6-94b4-185e0f80a589'
-    index.datasets.add(
-        Dataset(  # Test deprecated behaviour
-            product, second_ds_doc, uris=['file:///a', 'file:///b'], sources={}
+    with suppress_deprecations():
+        index.datasets.add(
+            Dataset(  # Test deprecated behaviour
+                product, second_ds_doc, uris=['file:///a', 'file:///b'], sources={}
+            )
         )
-    )
 
     # test order using get_locations function
-    assert index.datasets.get_locations(second_ds_doc['id']) == ['file:///a', 'file:///b']  # Test of deprecated method
+    with suppress_deprecations():
+        assert index.datasets.get_locations(second_ds_doc['id']) == ['file:///a', 'file:///b']  # Test of deprecated method
 
-    # test order using datasets.get(), it has custom query as it turns out
-    assert index.datasets.get(second_ds_doc['id'])._uris == ['file:///a', 'file:///b']
+        # test order using datasets.get(), it has custom query as it turns out
+        assert index.datasets.get(second_ds_doc['id'])._uris == ['file:///a', 'file:///b']
 
-    # test update, this should prepend file:///c, file:///d to the existing list
-    index.datasets.update(Dataset(  # Test of deprecated functionality
-        product, second_ds_doc, uris=['file:///a', 'file:///c', 'file:///d'], sources={}
-    ))
-    assert index.datasets.get_locations(second_ds_doc['id']) == [  # Test of deprecated method
-        'file:///c', 'file:///d', 'file:///a', 'file:///b'
-    ]
-    assert index.datasets.get(second_ds_doc['id']).uris == [  # Test of deprecated functionality
-        'file:///c', 'file:///d', 'file:///a', 'file:///b'
-    ]
+        # test update, this should prepend file:///c, file:///d to the existing list
+        index.datasets.update(Dataset(  # Test of deprecated functionality
+            product, second_ds_doc, uris=['file:///a', 'file:///c', 'file:///d'], sources={}
+        ))
+        assert index.datasets.get_locations(second_ds_doc['id']) == [  # Test of deprecated method
+            'file:///c', 'file:///d', 'file:///a', 'file:///b'
+        ]
+        assert index.datasets.get(second_ds_doc['id']).uris == [  # Test of deprecated functionality
+            'file:///c', 'file:///d', 'file:///a', 'file:///b'
+        ]
 
     # Ability to get datasets for a location
     # Add a second dataset with a different location (to catch lack of joins, filtering etc)
@@ -582,7 +610,8 @@ def test_index_dataset_with_location(index: Index, default_metadata_type: Metada
     second_ds_doc['id'] = '366f32d8-e1f8-11e6-94b4-185e0f80a5c0'
     index.datasets.add(Dataset(product, second_ds_doc, uri=second_file.as_uri(), sources={}))
     for mode in ('exact', 'prefix', None):
-        dataset_ids = [d.id for d in index.datasets.get_datasets_for_location(first_file.as_uri(), mode=mode)]
+        with suppress_deprecations():
+            dataset_ids = [d.id for d in index.datasets.get_datasets_for_location(first_file.as_uri(), mode=mode)]
         assert dataset_ids == [dataset.id]
 
     assert list(index.datasets.get_datasets_for_location(first_file.as_uri() + "#part=100")) == []
@@ -592,8 +621,7 @@ def test_index_dataset_with_location(index: Index, default_metadata_type: Metada
 
 
 def utc_now():
-    # utcnow() doesn't include a tzinfo.
-    return datetime.datetime.utcnow().replace(tzinfo=tz.tzutc())
+    return datetime.datetime.now(datetime.UTC)
 
 
 def test_bulk_reads_transaction(index, extended_eo3_metadata_type_doc,

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -10,12 +10,10 @@ Integration tests: these depend on a local Postgres instance.
 import copy
 import datetime
 import sys
-from os import supports_effective_ids
 from pathlib import Path
 from uuid import UUID
 
 import pytest
-from dateutil import tz
 
 from datacube.index.exceptions import MissingRecordError
 from datacube.index import Index
@@ -588,7 +586,8 @@ def test_index_dataset_with_location(index: Index, default_metadata_type: Metada
 
     # test order using get_locations function
     with suppress_deprecations():
-        assert index.datasets.get_locations(second_ds_doc['id']) == ['file:///a', 'file:///b']  # Test of deprecated method
+        # Test of deprecated method
+        assert index.datasets.get_locations(second_ds_doc['id']) == ['file:///a', 'file:///b']
 
         # test order using datasets.get(), it has custom query as it turns out
         assert index.datasets.get(second_ds_doc['id'])._uris == ['file:///a', 'file:///b']

--- a/integration_tests/index/test_location.py
+++ b/integration_tests/index/test_location.py
@@ -5,71 +5,74 @@
 
 import pytest
 from datacube.model import Dataset
+from datacube.testutils import suppress_deprecations
 
 
 @pytest.mark.parametrize('datacube_env_name', ('datacube',))
 def test_legacy_location_behaviour(index, ls8_eo3_dataset):
-    locations = index.datasets.get_locations(ls8_eo3_dataset.id)  # Test of deprecated method
-    assert locations == [ls8_eo3_dataset.uri]
-
-    update = Dataset(  # Test of deprecated behaviour
-        ls8_eo3_dataset.product,
-        ls8_eo3_dataset.metadata_doc,
-        uris=locations + ["file:/tmp/foo"])
-    index.datasets.update(update)
-    locations = index.datasets.get_locations(ls8_eo3_dataset.id)  # Test of deprecated method
-    assert index.datasets.get_location(ls8_eo3_dataset.id) == locations[0]
-    assert locations == ["file:/tmp/foo", ls8_eo3_dataset.uri]
-    index.datasets.add_location(ls8_eo3_dataset.id, "s3:/bucket/hole/straw.axe")
-    locations = index.datasets.get_locations(ls8_eo3_dataset.id)  # Test of deprecated method
-    assert locations == ["s3:/bucket/hole/straw.axe", "file:/tmp/foo", ls8_eo3_dataset.uri,]
-    index.datasets.archive_location(ls8_eo3_dataset.id, "file:/tmp/foo")
-    locations = index.datasets.get_locations(ls8_eo3_dataset.id)  # Test of deprecated method
-    assert locations == ["s3:/bucket/hole/straw.axe", ls8_eo3_dataset.uri,]
-    assert "file:/tmp/foo" in index.datasets.get_archived_locations(ls8_eo3_dataset.id)
-    assert "file:/tmp/foo" == index.datasets.get_archived_location_times(ls8_eo3_dataset.id)[0][0]
-    index.datasets.restore_location(ls8_eo3_dataset.id, "file:/tmp/foo")
-    locations = index.datasets.get_locations(ls8_eo3_dataset.id)  # Test of deprecated method
-    assert locations == ["s3:/bucket/hole/straw.axe", "file:/tmp/foo", ls8_eo3_dataset.uri,]
-    index.datasets.remove_location(ls8_eo3_dataset.id, "file:/tmp/foo")
-    locations = index.datasets.get_locations(ls8_eo3_dataset.id)  # Test of deprecated method
-    assert locations == ["s3:/bucket/hole/straw.axe", ls8_eo3_dataset.uri,]
-    index.datasets.remove_location(ls8_eo3_dataset.id, "s3:/bucket/hole/straw.axe")
-    index.datasets.remove_location(ls8_eo3_dataset.id, ls8_eo3_dataset.uri)
-    ls8_eo3_dataset = index.datasets.get(ls8_eo3_dataset.id)
-    assert ls8_eo3_dataset.uri is None
-    assert index.datasets.get_location(ls8_eo3_dataset.id) is None
+    with suppress_deprecations():
+        locations = index.datasets.get_locations(ls8_eo3_dataset.id)  # Test of deprecated method
+        assert locations == [ls8_eo3_dataset.uri]
+        update = Dataset(  # Test of deprecated behaviour
+            ls8_eo3_dataset.product,
+            ls8_eo3_dataset.metadata_doc,
+            uris=locations + ["file:/tmp/foo"])
+        index.datasets.update(update)
+        locations = index.datasets.get_locations(ls8_eo3_dataset.id)  # Test of deprecated method
+        assert index.datasets.get_location(ls8_eo3_dataset.id) == locations[0]
+        assert locations == ["file:/tmp/foo", ls8_eo3_dataset.uri]
+        index.datasets.add_location(ls8_eo3_dataset.id, "s3:/bucket/hole/straw.axe")
+        locations = index.datasets.get_locations(ls8_eo3_dataset.id)  # Test of deprecated method
+        assert locations == ["s3:/bucket/hole/straw.axe", "file:/tmp/foo", ls8_eo3_dataset.uri,]
+        index.datasets.archive_location(ls8_eo3_dataset.id, "file:/tmp/foo")
+        locations = index.datasets.get_locations(ls8_eo3_dataset.id)  # Test of deprecated method
+        assert locations == ["s3:/bucket/hole/straw.axe", ls8_eo3_dataset.uri,]
+        assert "file:/tmp/foo" in index.datasets.get_archived_locations(ls8_eo3_dataset.id)
+        assert "file:/tmp/foo" == index.datasets.get_archived_location_times(ls8_eo3_dataset.id)[0][0]
+        index.datasets.restore_location(ls8_eo3_dataset.id, "file:/tmp/foo")
+        locations = index.datasets.get_locations(ls8_eo3_dataset.id)  # Test of deprecated method
+        assert locations == ["s3:/bucket/hole/straw.axe", "file:/tmp/foo", ls8_eo3_dataset.uri,]
+        index.datasets.remove_location(ls8_eo3_dataset.id, "file:/tmp/foo")
+        locations = index.datasets.get_locations(ls8_eo3_dataset.id)  # Test of deprecated method
+        assert locations == ["s3:/bucket/hole/straw.axe", ls8_eo3_dataset.uri,]
+        index.datasets.remove_location(ls8_eo3_dataset.id, "s3:/bucket/hole/straw.axe")
+        index.datasets.remove_location(ls8_eo3_dataset.id, ls8_eo3_dataset.uri)
+        ls8_eo3_dataset = index.datasets.get(ls8_eo3_dataset.id)
+        assert ls8_eo3_dataset.uri is None
+        assert index.datasets.get_location(ls8_eo3_dataset.id) is None
 
 
 @pytest.mark.parametrize('datacube_env_name', ('experimental',))
 def test_postgis_no_multiple_locations(index, ls8_eo3_dataset):
-    locations = index.datasets.get_locations(ls8_eo3_dataset.id)  # Test of deprecated method
-    assert locations == [ls8_eo3_dataset.uri]
+    with suppress_deprecations():
+        locations = index.datasets.get_locations(ls8_eo3_dataset.id)  # Test of deprecated method
+        assert locations == [ls8_eo3_dataset.uri]
 
-    update = Dataset(
-        ls8_eo3_dataset.product,
-        ls8_eo3_dataset.metadata_doc,
-        uris=locations + ["file:/tmp/foo"])
-    with pytest.raises(ValueError):
-        index.datasets.update(update)
-    assert index.datasets.get_location(ls8_eo3_dataset.id) == ls8_eo3_dataset.uri
+        update = Dataset(
+            ls8_eo3_dataset.product,
+            ls8_eo3_dataset.metadata_doc,
+            uris=locations + ["file:/tmp/foo"])
+        with pytest.raises(ValueError):
+            index.datasets.update(update)
+        assert index.datasets.get_location(ls8_eo3_dataset.id) == ls8_eo3_dataset.uri
 
-    index.datasets.remove_location(ls8_eo3_dataset.id, "file:/tmp/foo")
-    assert index.datasets.get_location(ls8_eo3_dataset.id) == ls8_eo3_dataset.uri
+        index.datasets.remove_location(ls8_eo3_dataset.id, "file:/tmp/foo")
+        assert index.datasets.get_location(ls8_eo3_dataset.id) == ls8_eo3_dataset.uri
 
-    index.datasets.remove_location(ls8_eo3_dataset.id, ls8_eo3_dataset.uri)
+        index.datasets.remove_location(ls8_eo3_dataset.id, ls8_eo3_dataset.uri)
     ls8_eo3_dataset = index.datasets.get(ls8_eo3_dataset.id)
     assert ls8_eo3_dataset.uri is None
     assert index.datasets.get_location(ls8_eo3_dataset.id) is None
 
-    index.datasets.add_location(ls8_eo3_dataset.id, "file:/tmp/foo")
-    location = index.datasets.get_location(ls8_eo3_dataset.id)
-    assert location == "file:/tmp/foo"
+    with suppress_deprecations():
+        index.datasets.add_location(ls8_eo3_dataset.id, "file:/tmp/foo")
+        location = index.datasets.get_location(ls8_eo3_dataset.id)
+        assert location == "file:/tmp/foo"
 
-    with pytest.raises(ValueError):
-        index.datasets.add_location(ls8_eo3_dataset.id, "s3:/bucket/hole/straw.axe")
+        with pytest.raises(ValueError):
+            index.datasets.add_location(ls8_eo3_dataset.id, "s3:/bucket/hole/straw.axe")
 
-    assert index.datasets.get_archived_locations(ls8_eo3_dataset.id) == []
+        assert index.datasets.get_archived_locations(ls8_eo3_dataset.id) == []
 
 
 def test_dataset_tuple_uris(ls8_eo3_product):
@@ -77,9 +80,10 @@ def test_dataset_tuple_uris(ls8_eo3_product):
     dst1 = DatasetTuple(ls8_eo3_product, {"dummy": True}, "file:///uri1")
     dst2 = DatasetTuple(ls8_eo3_product, {"dummy": True}, ["file:///uri1", "https://host.domain/uri1"])
 
-    assert dst1.uri == dst2.uri
-    assert dst1.uri == dst2.uri
-    assert dst1.uris == [dst1.uri]
-    assert dst2.uri in dst2.uris
+    with suppress_deprecations():
+        assert dst1.uri == dst2.uri
+        assert dst1.uri == dst2.uri
+        assert dst1.uris == [dst1.uri]
+        assert dst2.uri in dst2.uris
     assert not dst1.is_legacy
     assert dst2.is_legacy

--- a/integration_tests/index/test_memory_index.py
+++ b/integration_tests/index/test_memory_index.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 import pytest
 
 from datacube.cfg import ODCEnvironment
-from datacube.testutils import gen_dataset_test_dag
+from datacube.testutils import gen_dataset_test_dag, suppress_deprecations
 
 from datacube.utils import InvalidDocException, read_documents, SimpleDocNav
 
@@ -227,41 +227,42 @@ def test_mem_ds_locations(mem_eo3_data: tuple):
     dc, ls8_id, wo_id = mem_eo3_data
     before_test = datetime.datetime.now()
     ls8ds = dc.index.datasets.get(ls8_id)
-    dc.index.datasets.add_location(ls8_id, "file:///test_loc_1")  # Test of deprecated method
-    assert ls8ds.uri == dc.index.datasets.get_location(ls8_id)
-    assert "file:///test_loc_1" in dc.index.datasets.get_locations(ls8_id)  # Test of deprecated method
-    assert list(dc.index.datasets.get_archived_locations(ls8_id)) == []  # Test of deprecated method
-    dc.index.datasets.archive_location(ls8_id, "file:///test_loc_1")  # Test of deprecated method
-    assert "file:///test_loc_1" not in dc.index.datasets.get_locations(ls8_id)  # Test of deprecated method
-    assert "file:///test_loc_1" in dc.index.datasets.get_archived_locations(ls8_id)  # Test of deprecated method
-    found = False
-    for loc, dt in dc.index.datasets.get_archived_location_times(ls8_id):  # Test of deprecated method
-        if loc == "file:///test_loc_1":
-            found = True
-            assert dt >= before_test
-            break
-    assert found
-    assert dc.index.datasets.restore_location(ls8_id, "file:///test_loc_1")  # Test of deprecated method
-    assert "file:///test_loc_1" in dc.index.datasets.get_locations(ls8_id)  # Test of deprecated method
-    assert list(dc.index.datasets.get_archived_locations(ls8_id)) == []  # Test of deprecated method
-    assert list(dc.index.datasets.get_datasets_for_location("file:///test_loc_1", "exact"))[0].id == ls8_id
-    assert dc.index.datasets.remove_location(ls8_id, "file:///test_loc_1")  # Test of deprecated method
-    assert "file:///test_loc_1" not in dc.index.datasets.get_locations(ls8_id)  # Test of deprecated method
-    assert "file:///test_loc_1" not in dc.index.datasets.get_archived_locations(ls8_id)  # Test of deprecated method
-    assert dc.index.datasets.add_location(ls8_id, "file:///test_loc_2")  # Test of deprecated method
+    with suppress_deprecations():
+        dc.index.datasets.add_location(ls8_id, "file:///test_loc_1")  # Test of deprecated method
+        assert ls8ds.uri == dc.index.datasets.get_location(ls8_id)
+        assert "file:///test_loc_1" in dc.index.datasets.get_locations(ls8_id)  # Test of deprecated method
+        assert list(dc.index.datasets.get_archived_locations(ls8_id)) == []  # Test of deprecated method
+        dc.index.datasets.archive_location(ls8_id, "file:///test_loc_1")  # Test of deprecated method
+        assert "file:///test_loc_1" not in dc.index.datasets.get_locations(ls8_id)  # Test of deprecated method
+        assert "file:///test_loc_1" in dc.index.datasets.get_archived_locations(ls8_id)  # Test of deprecated method
+        found = False
+        for loc, dt in dc.index.datasets.get_archived_location_times(ls8_id):  # Test of deprecated method
+            if loc == "file:///test_loc_1":
+                found = True
+                assert dt >= before_test
+                break
+        assert found
+        assert dc.index.datasets.restore_location(ls8_id, "file:///test_loc_1")  # Test of deprecated method
+        assert "file:///test_loc_1" in dc.index.datasets.get_locations(ls8_id)  # Test of deprecated method
+        assert list(dc.index.datasets.get_archived_locations(ls8_id)) == []  # Test of deprecated method
+        assert list(dc.index.datasets.get_datasets_for_location("file:///test_loc_1", "exact"))[0].id == ls8_id
+        assert dc.index.datasets.remove_location(ls8_id, "file:///test_loc_1")  # Test of deprecated method
+        assert "file:///test_loc_1" not in dc.index.datasets.get_locations(ls8_id)  # Test of deprecated method
+        assert "file:///test_loc_1" not in dc.index.datasets.get_archived_locations(ls8_id)  # Test of deprecated method
+        assert dc.index.datasets.add_location(ls8_id, "file:///test_loc_2")  # Test of deprecated method
 
-    assert "file:///test_loc_2" in dc.index.datasets.get_locations(ls8_id)  # Test of deprecated method
-    ds = dc.index.datasets.get(ls8_id)
-    assert ds.uri in ds.uris  # Test of deprecated property
+        assert "file:///test_loc_2" in dc.index.datasets.get_locations(ls8_id)  # Test of deprecated method
+        ds = dc.index.datasets.get(ls8_id)
+        assert ds.uri in ds.uris  # Test of deprecated property
 
-    assert dc.index.datasets.archive_location(ls8_id, "file:///test_loc_2")  # Test of deprecated method
-    assert dc.index.datasets.remove_location(ls8_id, "file:///test_loc_2")  # Test of deprecated method
-    assert "file:///test_loc_2" not in list(dc.index.datasets.get_locations(ls8_id))  # Test of deprecated method
-    assert "file:///test_loc_2" not in list(
-        dc.index.datasets.get_archived_locations(ls8_id)  # Test of deprecated method
-    )
-    assert not dc.index.datasets.archive_location(ls8_id, "file:////not_a_valid_loc")  # Test of deprecated method
-    assert not dc.index.datasets.remove_location(ls8_id, "file:////not_a_valid_loc")  # Test of deprecated method
+        assert dc.index.datasets.archive_location(ls8_id, "file:///test_loc_2")  # Test of deprecated method
+        assert dc.index.datasets.remove_location(ls8_id, "file:///test_loc_2")  # Test of deprecated method
+        assert "file:///test_loc_2" not in list(dc.index.datasets.get_locations(ls8_id))  # Test of deprecated method
+        assert "file:///test_loc_2" not in list(
+            dc.index.datasets.get_archived_locations(ls8_id)  # Test of deprecated method
+        )
+        assert not dc.index.datasets.archive_location(ls8_id, "file:////not_a_valid_loc")  # Test of deprecated method
+        assert not dc.index.datasets.remove_location(ls8_id, "file:////not_a_valid_loc")  # Test of deprecated method
     assert dc.index.datasets.remove_location(ls8_id, ls8ds.uri)
     ls8ds = dc.index.datasets.get(ls8_id)
     assert ls8ds.uri is None

--- a/integration_tests/index/test_null_index.py
+++ b/integration_tests/index/test_null_index.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 from datacube import Datacube
 from datacube.cfg import ODCEnvironment
+from datacube.testutils import suppress_deprecations
 
 test_uuid = UUID('4ec8fe97-e8b9-11e4-87ff-1040f381a756')
 
@@ -108,23 +109,24 @@ def test_null_dataset_resource(null_config: ODCEnvironment):
         assert dc.index.datasets.get_location(test_uuid) is None
         assert dc.index.datasets.get_datasets_for_location("http://a.uri/test") == []
 
-        assert empty(dc.index.datasets.get_field_names())  # DEPRECATED WRAPPER METHOD
-        assert dc.index.datasets.get_locations(test_uuid) == []  # Test deprecated method
-        assert dc.index.datasets.get_archived_locations(test_uuid) == []  # Test deprecated method
-        assert dc.index.datasets.get_archived_location_times(test_uuid) == []  # Test deprecated method
+        with suppress_deprecations():
+            assert empty(dc.index.datasets.get_field_names())  # DEPRECATED WRAPPER METHOD
+            assert dc.index.datasets.get_locations(test_uuid) == []  # Test deprecated method
+            assert dc.index.datasets.get_archived_locations(test_uuid) == []  # Test deprecated method
+            assert dc.index.datasets.get_archived_location_times(test_uuid) == []  # Test deprecated method
 
-        with pytest.raises(NotImplementedError) as e:
-            dc.index.datasets.add_location(test_uuid, "http://a.uri/test")  # Test deprecated method
-        with pytest.raises(NotImplementedError) as e:
-            dc.index.datasets.remove_location(test_uuid, "http://a.uri/test")  # Test deprecated method
-        with pytest.raises(NotImplementedError) as e:
-            dc.index.datasets.archive_location(test_uuid, "http://a.uri/test")  # Test deprecated method
-        with pytest.raises(NotImplementedError) as e:
-            dc.index.datasets.restore_location(test_uuid, "http://a.uri/test")  # Test deprecated method
+            with pytest.raises(NotImplementedError) as e:
+                dc.index.datasets.add_location(test_uuid, "http://a.uri/test")  # Test deprecated method
+            with pytest.raises(NotImplementedError) as e:
+                dc.index.datasets.remove_location(test_uuid, "http://a.uri/test")  # Test deprecated method
+            with pytest.raises(NotImplementedError) as e:
+                dc.index.datasets.archive_location(test_uuid, "http://a.uri/test")  # Test deprecated method
+            with pytest.raises(NotImplementedError) as e:
+                dc.index.datasets.restore_location(test_uuid, "http://a.uri/test")  # Test deprecated method
         with pytest.raises(KeyError) as e:
             dc.index.datasets.temporal_extent(ids=[test_uuid])
         assert dc.index.datasets.spatial_extent(ids=[test_uuid]) is None
-        with pytest.raises(KeyError) as e:
+        with (suppress_deprecations(), pytest.raises(KeyError) as e):
             dc.index.datasets.get_product_time_bounds("product1")  # Test deprecated method
 
         assert dc.index.datasets.search_product_duplicates(MagicMock()) == []
@@ -136,8 +138,9 @@ def test_null_dataset_resource(null_config: ODCEnvironment):
         assert dc.index.datasets.count_by_product(foo="bar", baz=12) == []
         assert dc.index.datasets.count_by_product_through_time("1 month", foo="bar", baz=12) == []
         assert dc.index.datasets.count_product_through_time("1 month", foo="bar", baz=12) == []
-        assert dc.index.datasets.search_summaries(foo="bar", baz=12) == []  # Coverage test of deprecated method
-        assert dc.index.datasets.search_eager(foo="bar", baz=12) == []  # Coverage test of deprecated base class method
+        with suppress_deprecations():
+            assert dc.index.datasets.search_summaries(foo="bar", baz=12) == []  # Coverage test of deprecated method
+            assert dc.index.datasets.search_eager(foo="bar", baz=12) == []  # Coverage test of deprecated base class method
         assert dc.index.datasets.search_returning_datasets_light(("foo", "baz"), foo="bar", baz=12) == []
 
 

--- a/integration_tests/index/test_null_index.py
+++ b/integration_tests/index/test_null_index.py
@@ -139,8 +139,10 @@ def test_null_dataset_resource(null_config: ODCEnvironment):
         assert dc.index.datasets.count_by_product_through_time("1 month", foo="bar", baz=12) == []
         assert dc.index.datasets.count_product_through_time("1 month", foo="bar", baz=12) == []
         with suppress_deprecations():
-            assert dc.index.datasets.search_summaries(foo="bar", baz=12) == []  # Coverage test of deprecated method
-            assert dc.index.datasets.search_eager(foo="bar", baz=12) == []  # Coverage test of deprecated base class method
+            # Coverage test of deprecated method
+            assert dc.index.datasets.search_summaries(foo="bar", baz=12) == []
+            # Coverage test of deprecated base class method
+            assert dc.index.datasets.search_eager(foo="bar", baz=12) == []
         assert dc.index.datasets.search_returning_datasets_light(("foo", "baz"), foo="bar", baz=12) == []
 
 

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -22,6 +22,7 @@ from datacube.model import Product
 from datacube.model import Range
 
 from datacube import Datacube
+from datacube.testutils import suppress_deprecations
 from .search_utils import _cli_csv_search, _csv_search_raw, _load_product_query
 from datacube.utils.dates import tz_as_utc
 
@@ -289,7 +290,8 @@ def test_search_by_product_eo3(index: Index,
     [dataset] = products[base_eo3_product_doc["name"]]
     assert dataset.id == wo_eo3_dataset.id
     assert dataset.is_eo3
-    assert dataset.type == dataset.product  # DEPRECATED MEMBER
+    with suppress_deprecations():
+        assert dataset.type == dataset.product  # DEPRECATED MEMBER
 
 
 def test_search_limit_eo3(index, ls8_eo3_dataset, ls8_eo3_dataset2, wo_eo3_dataset):
@@ -564,8 +566,9 @@ def test_search_returning_uri(index, eo3_ls8_dataset_doc,
     dataset = ls8_eo3_dataset
     uri = eo3_ls8_dataset_doc[1]
 
-    # If returning a field like uri, there will be one result per dataset.
-    index.datasets.remove_location(dataset.id, uri)  # deprecated method
+    with suppress_deprecations():
+        # If returning a field like uri, there will be one result per dataset.
+        index.datasets.remove_location(dataset.id, uri)  # deprecated method
     results = list(index.datasets.search_returning(
         ('id', 'uri'),
         platform='landsat-8',
@@ -584,25 +587,26 @@ def test_search_returning_uris_legacy(index,
     uri3 = eo3_ls8_dataset2_doc[1]
 
     # If returning a field like uri, there will be one result per location.
-    # No locations
-    index.datasets.archive_location(dataset.id, uri)
-    index.datasets.remove_location(dataset.id, uri)
-    results = list(index.datasets.search_returning(
-        ('id', 'uri'),
-        platform='landsat-8',
-        instrument='OLI_TIRS',
-    ))
-    assert len(results) == 0
+    with suppress_deprecations():
+        # No locations
+        index.datasets.archive_location(dataset.id, uri)
+        index.datasets.remove_location(dataset.id, uri)
+        results = list(index.datasets.search_returning(
+            ('id', 'uri'),
+            platform='landsat-8',
+            instrument='OLI_TIRS',
+        ))
+        assert len(results) == 0
 
-    # Add a second location and we should get two results
-    index.datasets.add_location(dataset.id, uri)
-    uri2 = 'file:///tmp/test2'
-    index.datasets.add_location(dataset.id, uri2)
-    results = set(index.datasets.search_returning(
-        ('id', 'uri'),
-        platform='landsat-8',
-        instrument='OLI_TIRS',
-    ))
+        # Add a second location and we should get two results
+        index.datasets.add_location(dataset.id, uri)
+        uri2 = 'file:///tmp/test2'
+        index.datasets.add_location(dataset.id, uri2)
+        results = set(index.datasets.search_returning(
+            ('id', 'uri'),
+            platform='landsat-8',
+            instrument='OLI_TIRS',
+        ))
     assert len(results) == 2
     assert results == {
         (dataset.id, uri),

--- a/integration_tests/test_index_datasets_search.py
+++ b/integration_tests/test_index_datasets_search.py
@@ -6,6 +6,7 @@ import datetime
 
 import pytest
 
+from datacube.testutils import suppress_deprecations
 from integration_tests.utils import ensure_datasets_are_indexed
 
 
@@ -35,7 +36,8 @@ def test_index_get_product_time_bounds(index, clirunner, example_ls5_dataset_pat
                                                          product='ls5_nbar_scene'))
 
     # get time bounds
-    time_bounds = index.datasets.get_product_time_bounds(product='ls5_nbar_scene')  # Test of deprecated method
+    with suppress_deprecations():
+        time_bounds = index.datasets.get_product_time_bounds(product='ls5_nbar_scene')  # Test of deprecated method
     left = sorted(dataset_times, key=lambda dataset: dataset.time.lower)[0].time.lower
     right = sorted(dataset_times, key=lambda dataset: dataset.time.upper)[-1].time.upper
 

--- a/tests/api/test_core.py
+++ b/tests/api/test_core.py
@@ -15,7 +15,7 @@ from datacube.api.query import GroupBy
 from datacube.api.core import _calculate_chunk_sizes, output_geobox
 from datacube import Datacube
 from datacube.testutils.geom import AlbersGS
-from datacube.testutils import mk_sample_dataset
+from datacube.testutils import mk_sample_dataset, suppress_deprecations
 
 
 def test_grouping_datasets():
@@ -126,7 +126,8 @@ def test_index_validation():
 
 def test_output_geobox():
     from odc.geo.geobox import GeoBox as ODCGeoGeoBox, CRS as ODCGeoCRS
-    from datacube.utils.geometry import GeoBox as LegacyGeoGeoBox, CRS as LegacyCRS
+    with suppress_deprecations():
+        from datacube.utils.geometry import GeoBox as LegacyGeoGeoBox, CRS as LegacyCRS
     from odc.geo.xr import xr_zeros
 
     odc_gbox = ODCGeoGeoBox.from_bbox(

--- a/tests/drivers/test_rio_reader.py
+++ b/tests/drivers/test_rio_reader.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """ Tests for new RIO reader driver
 """
-from datetime import datetime
+from datetime import datetime, UTC
 from concurrent.futures import ThreadPoolExecutor, Future
 import numpy as np
 import rasterio
@@ -76,7 +76,7 @@ def test_rd_internals_bidx(data_folder):
                  base,
                  path="multi_doc.nc",
                  format=NetCDF,
-                 timestamp=datetime.utcfromtimestamp(1),
+                 timestamp=datetime.fromtimestamp(1, UTC),
                  layer='a')
     assert bi.uri.endswith('multi_doc.nc')
 

--- a/tests/drivers/test_rio_reader.py
+++ b/tests/drivers/test_rio_reader.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """ Tests for new RIO reader driver
 """
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from concurrent.futures import ThreadPoolExecutor, Future
 import numpy as np
 import rasterio
@@ -23,6 +23,8 @@ from datacube.testutils.geom import SAMPLE_WKT_WITHOUT_AUTHORITY, epsg3857
 from datacube.testutils.iodriver import (
     NetCDF, GeoTIFF, mk_band, mk_rio_driver, open_reader
 )
+
+UTC = timezone.utc
 
 
 def test_rio_rd_entry():

--- a/tests/storage/test_base.py
+++ b/tests/storage/test_base.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 from datacube.storage import BandInfo
-from datacube.testutils import mk_sample_dataset
+from datacube.testutils import mk_sample_dataset, suppress_deprecations
 from datacube.storage._base import _get_band_and_layer, measurement_paths
 
 
@@ -77,14 +77,15 @@ def test_band_info():
     assert band.uri_scheme is ''  # noqa: F632
 
     # Test legacy multi-location behaviour
-    ds = mk_sample_dataset(bands,
-                           uri=["file:///tmp/dataset.yml", "https://splat.foo/alternate/dataset.yml"],
-                           format='GeoTIFF')
-    binfo = BandInfo(ds, 'b')
-    assert binfo.uri == 'file:///tmp/b.tiff'
-    binfo = BandInfo(ds, 'b', uri_scheme="https")
-    assert binfo.uri == "https://splat.foo/alternate/b.tiff"
-    assert measurement_paths(ds)["b"] == "file:///tmp/b.tiff"
+    with suppress_deprecations():
+        ds = mk_sample_dataset(bands,
+                               uri=["file:///tmp/dataset.yml", "https://splat.foo/alternate/dataset.yml"],
+                               format='GeoTIFF')
+        binfo = BandInfo(ds, 'b')
+        assert binfo.uri == 'file:///tmp/b.tiff'
+        binfo = BandInfo(ds, 'b', uri_scheme="https")
+        assert binfo.uri == "https://splat.foo/alternate/b.tiff"
+        assert measurement_paths(ds)["b"] == "file:///tmp/b.tiff"
 
 
 def test_band_info_with_url_mangling():

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -2,8 +2,6 @@
 #
 # Copyright (c) 2015-2024 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-import warnings
-
 import pytest
 import yaml
 
@@ -14,7 +12,7 @@ from datacube.drivers import index_drivers, index_driver_by_name
 from datacube.drivers.indexes import IndexDriverCache
 from datacube.storage import BandInfo
 from datacube.storage._rio import RasterDatasetDataSource
-from datacube.testutils import mk_sample_dataset
+from datacube.testutils import mk_sample_dataset, suppress_deprecations
 from datacube.model import MetadataType
 
 
@@ -94,18 +92,14 @@ dataset:
             offset: [a,b,c,custom]
     ''')
 
-    # Suppress expected deprecation warnings
-    warnings.simplefilter('ignore')
-
     for name in index_drivers():
         driver = index_driver_by_name(name)
-        metadata = driver.metadata_type_from_doc(metadata_doc)  # deprecated method
-        assert isinstance(metadata, MetadataType)
-        assert metadata.id is None
-        assert metadata.name == 'minimal'
-        assert 'some_custom_field' in metadata.dataset_fields
-
-    warnings.resetwarnings()
+        with suppress_deprecations():
+            metadata = driver.metadata_type_from_doc(metadata_doc)  # deprecated method
+            assert isinstance(metadata, MetadataType)
+            assert metadata.id is None
+            assert metadata.name == 'minimal'
+            assert 'some_custom_field' in metadata.dataset_fields
 
 
 def test_reader_cache_throws_on_missing_fallback():

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -2,6 +2,8 @@
 #
 # Copyright (c) 2015-2024 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+import warnings
+
 import pytest
 import yaml
 
@@ -92,13 +94,18 @@ dataset:
             offset: [a,b,c,custom]
     ''')
 
+    # Suppress expected deprecation warnings
+    warnings.simplefilter('ignore')
+
     for name in index_drivers():
         driver = index_driver_by_name(name)
-        metadata = driver.metadata_type_from_doc(metadata_doc)  # Coverage test of deprecated method
+        metadata = driver.metadata_type_from_doc(metadata_doc)  # deprecated method
         assert isinstance(metadata, MetadataType)
         assert metadata.id is None
         assert metadata.name == 'minimal'
         assert 'some_custom_field' in metadata.dataset_fields
+
+    warnings.resetwarnings()
 
 
 def test_reader_cache_throws_on_missing_fallback():

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,6 +2,8 @@
 #
 # Copyright (c) 2015-2024 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+import warnings
+
 import pytest
 import numpy
 from copy import deepcopy
@@ -17,6 +19,9 @@ from datacube.api.core import output_geobox
 
 
 def test_gridspec():
+    # Suppress expected deprecation warnings
+    warnings.simplefilter("ignore")
+
     gs = GridSpec(  # Coverage test of deprecated class
         crs=CRS('EPSG:4326'), tile_size=(1, 1),
         resolution=(-0.1, 0.1), origin=(10, 10)
@@ -41,10 +46,15 @@ def test_gridspec():
     assert (gs == gs)
     assert (gs == {}) is False
 
+    warnings.resetwarnings()
+
 
 def test_gridspec_upperleft():
     """ Test to ensure grid indexes can be counted correctly from bottom left or top left
     """
+    # Suppress expected deprecation warnings
+    warnings.simplefilter("ignore")
+
     tile_bbox = BoundingBox(left=1934400.0, top=2414800.0, right=2084400.000, bottom=2264800.000, crs=CRS('EPSG:5070'))
     bbox = BoundingBox(left=1934615, top=2379460, right=1937615, bottom=2376460, crs=CRS('EPSG:5070'))
     # Upper left - validated against WELD product tile calculator
@@ -60,6 +70,8 @@ def test_gridspec_upperleft():
     cells = {index: geobox for index, geobox in list(gs.tiles(bbox))}
     assert set(cells.keys()) == {(30, 15)}  # WELD grid spec has 21 vertical cells -- 21 - 6 = 15
     assert cells[(30, 15)].extent.boundingbox == tile_bbox
+
+    warnings.resetwarnings()
 
 
 def test_dataset_basics():

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,8 +2,6 @@
 #
 # Copyright (c) 2015-2024 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-import warnings
-
 import pytest
 import numpy
 from copy import deepcopy
@@ -14,18 +12,17 @@ from odc.geo import CRS, BoundingBox
 from odc.geo.geom import polygon
 from datacube.utils.documents import InvalidDocException
 from datacube.storage import measurement_paths
+from datacube.testutils import suppress_deprecations
 from datacube.testutils.geom import AlbersGS
 from datacube.api.core import output_geobox
 
 
 def test_gridspec():
-    # Suppress expected deprecation warnings
-    warnings.simplefilter("ignore")
-
-    gs = GridSpec(  # Coverage test of deprecated class
-        crs=CRS('EPSG:4326'), tile_size=(1, 1),
-        resolution=(-0.1, 0.1), origin=(10, 10)
-    )
+    with suppress_deprecations():
+        gs = GridSpec(  # Coverage test of deprecated class
+            crs=CRS('EPSG:4326'), tile_size=(1, 1),
+            resolution=(-0.1, 0.1), origin=(10, 10)
+        )
     poly = polygon([(10, 12.2), (10.8, 13), (13, 10.8), (12.2, 10), (10, 12.2)], crs=CRS('EPSG:4326'))
     cells = {index: geobox for index, geobox in list(gs.tiles_from_geopolygon(poly))}
     assert set(cells.keys()) == {(0, 1), (0, 2), (1, 0), (1, 1), (1, 2), (2, 0), (2, 1)}
@@ -46,32 +43,27 @@ def test_gridspec():
     assert (gs == gs)
     assert (gs == {}) is False
 
-    warnings.resetwarnings()
-
 
 def test_gridspec_upperleft():
     """ Test to ensure grid indexes can be counted correctly from bottom left or top left
     """
-    # Suppress expected deprecation warnings
-    warnings.simplefilter("ignore")
-
     tile_bbox = BoundingBox(left=1934400.0, top=2414800.0, right=2084400.000, bottom=2264800.000, crs=CRS('EPSG:5070'))
     bbox = BoundingBox(left=1934615, top=2379460, right=1937615, bottom=2376460, crs=CRS('EPSG:5070'))
     # Upper left - validated against WELD product tile calculator
     # http://globalmonitoring.sdstate.edu/projects/weld/tilecalc.php
-    gs = GridSpec(crs=CRS('EPSG:5070'), tile_size=(-150000, 150000), resolution=(-30, 30),
-                  origin=(3314800.0, -2565600.0))  # Coverage test  of deprecated class
+    with suppress_deprecations():
+        gs = GridSpec(crs=CRS('EPSG:5070'), tile_size=(-150000, 150000), resolution=(-30, 30),
+                      origin=(3314800.0, -2565600.0))  # Coverage test  of deprecated class
     cells = {index: geobox for index, geobox in list(gs.tiles(bbox))}
     assert set(cells.keys()) == {(30, 6)}
     assert cells[(30, 6)].extent.boundingbox == tile_bbox
 
-    gs = GridSpec(crs=CRS('EPSG:5070'), tile_size=(150000, 150000), resolution=(-30, 30),
-                  origin=(14800.0, -2565600.0))
+    with suppress_deprecations():
+        gs = GridSpec(crs=CRS('EPSG:5070'), tile_size=(150000, 150000), resolution=(-30, 30),
+                      origin=(14800.0, -2565600.0))
     cells = {index: geobox for index, geobox in list(gs.tiles(bbox))}
     assert set(cells.keys()) == {(30, 15)}  # WELD grid spec has 21 vertical cells -- 21 - 6 = 15
     assert cells[(30, 15)].extent.boundingbox == tile_bbox
-
-    warnings.resetwarnings()
 
 
 def test_dataset_basics():
@@ -133,17 +125,20 @@ def test_product_basics():
 
 def test_product_dimensions():
     product = mk_sample_product('test_product')
-    assert product.grid_spec is None
+    with suppress_deprecations():
+        assert product.grid_spec is None
     assert product.dimensions == ('time', 'y', 'x')
 
     product = mk_sample_product('test_product', with_grid_spec=True)
-    assert product.grid_spec is not None
+    with suppress_deprecations():
+        assert product.grid_spec is not None
     assert product.dimensions == ('time', 'y', 'x')
 
     partial_storage = product.definition['storage']
     partial_storage.pop('tile_size')
     product = mk_sample_product('tt', storage=partial_storage)
-    assert product.grid_spec is None
+    with suppress_deprecations():
+        assert product.grid_spec is None
 
 
 def test_product_nodata_nan():
@@ -231,14 +226,16 @@ def test_product_load_hints():
 
     # check GridSpec leakage doesn't happen for fully defined gridspec
     product = mk_sample_product('test', with_grid_spec=True)
-    assert product.grid_spec is not None
+    with suppress_deprecations():
+        assert product.grid_spec is not None
     assert product.load_hints() == {}
 
     # check for fallback into partially defined `storage:`
     product = mk_sample_product('test', storage=dict(
         crs='EPSG:3857',
         resolution={'x': 10, 'y': -10}))
-    assert product.grid_spec is None
+    with suppress_deprecations():
+        assert product.grid_spec is None
     assert product.default_resolution.yx == (-10, 10)
     assert product.default_crs == CRS('EPSG:3857')
 
@@ -246,7 +243,8 @@ def test_product_load_hints():
     # no resolution -- no hints
     product = mk_sample_product('test', storage=dict(
         crs='EPSG:3857'))
-    assert product.grid_spec is None
+    with suppress_deprecations():
+        assert product.grid_spec is None
     assert product.load_hints() == {}
 
     # check misspelled load hints

--- a/tests/test_utils_cog.py
+++ b/tests/test_utils_cog.py
@@ -2,6 +2,8 @@
 #
 # Copyright (c) 2015-2024 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+import warnings
+
 import pytest
 import math
 from pathlib import Path
@@ -55,6 +57,9 @@ def gen_test_data(prefix, dask=False, shape=None, dtype="int16", nodata=-999):
 def test_cog_file(tmpdir, opts):
     pp = Path(str(tmpdir))
     xx, ds = gen_test_data(pp)
+
+    # Suppress expected deprecation warnings
+    warnings.simplefilter("ignore")
 
     # write to file
     ff = write_cog(  # Coverage test of deprecated function.
@@ -123,11 +128,16 @@ def test_cog_file(tmpdir, opts):
     aa = rio_slurp_xarray(pp / "cog_float.tif")
     assert aa.attrs["nodata"] == "nan" or math.isnan(aa.attrs["nodata"])
 
+    warnings.resetwarnings()
+
 
 def test_cog_file_dask(tmpdir):
     pp = Path(str(tmpdir))
     xx, ds = gen_test_data(pp, dask=True)
     assert dask.is_dask_collection(xx)
+
+    # Suppress expected deprecation warnings
+    warnings.simplefilter("ignore")
 
     path = pp / "cog.tif"
     ff = write_cog(xx, path, overview_levels=[2, 4])  # Test of deprecated method
@@ -135,6 +145,8 @@ def test_cog_file_dask(tmpdir):
     assert path.exists() is False
     assert ff.compute() == path
     assert path.exists()
+
+    warnings.resetwarnings()
 
     yy = rio_slurp_xarray(pp / "cog.tif")
     np.testing.assert_array_equal(yy.values, xx.values)
@@ -146,6 +158,9 @@ def test_cog_file_dask(tmpdir):
 def test_cog_mem(tmpdir, shape):
     pp = Path(str(tmpdir))
     xx, ds = gen_test_data(pp, shape=shape)
+
+    # Suppress expected deprecation warnings
+    warnings.simplefilter("ignore")
 
     # write to memory 1
     bb = write_cog(xx, ":mem:")  # Test of deprecated function
@@ -183,10 +198,15 @@ def test_cog_mem(tmpdir, shape):
     assert yy.odc.geobox == xx.odc.geobox
     assert yy.nodata == xx.nodata
 
+    warnings.resetwarnings()
+
 
 def test_cog_mem_dask(tmpdir):
     pp = Path(str(tmpdir))
     xx, ds = gen_test_data(pp, dask=True)
+
+    # Suppress expected deprecation warnings
+    warnings.simplefilter("ignore")
 
     # write to memory 1
     bb = write_cog(xx, ":mem:")  # Test of deprecated method
@@ -212,6 +232,8 @@ def test_cog_mem_dask(tmpdir):
     with open(str(path), "wb") as f:
         f.write(bb)
 
+    warnings.resetwarnings()
+
     yy = rio_slurp_xarray(path)
     np.testing.assert_array_equal(yy.values, xx.values)
     assert yy.odc.geobox == xx.odc.geobox
@@ -227,6 +249,9 @@ def test_cog_rgba(tmpdir, use_windowed_writes):
     assert rgba.odc.geobox == xx.odc.geobox
     assert rgba.shape[:2] == rgba.odc.geobox.shape
 
+    # Suppress expected deprecation warnings
+    warnings.simplefilter("ignore")
+
     ff = write_cog(rgba, pp / "cog.tif", use_windowed_writes=use_windowed_writes)  # Test of deprecated function
     yy = rio_slurp_xarray(ff)
 
@@ -241,3 +266,5 @@ def test_cog_rgba(tmpdir, use_windowed_writes):
             ":mem:",
             use_windowed_writes=use_windowed_writes,
         )
+
+    warnings.resetwarnings()

--- a/tests/test_utils_other.py
+++ b/tests/test_utils_other.py
@@ -10,6 +10,7 @@ Test utility functions from :module:`datacube.utils`
 import os
 import pathlib
 import string
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -127,6 +128,9 @@ def test_uri_resolve(base):
 def test_pick_uri():
     f, s, h = ('file://a', 's3://b', 'http://c')
 
+    # Suppress expected deprecation warnings
+    warnings.simplefilter("ignore")
+
     assert pick_uri([f, s, h]) is f  # Test of deprecated function
     assert pick_uri([s, h, f]) is f  # Test of deprecated function
     assert pick_uri([s, h]) is s  # Test of deprecated function
@@ -143,6 +147,8 @@ def test_pick_uri():
 
     with pytest.raises(ValueError):
         pick_uri([s, h], 'file:')  # Test of deprecated function
+
+    warnings.resetwarnings()
 
 
 @given(integers(min_value=10, max_value=30))

--- a/tests/test_utils_other.py
+++ b/tests/test_utils_other.py
@@ -10,7 +10,6 @@ Test utility functions from :module:`datacube.utils`
 import os
 import pathlib
 import string
-import warnings
 from pathlib import Path
 
 import numpy as np
@@ -36,7 +35,7 @@ from datacube.utils.uris import (uri_to_local_path, mk_part_uri, get_part_from_u
                                  pick_uri, uri_resolve, is_vsipath,
                                  normalise_path, default_base_dir)
 from datacube.utils.io import check_write_path
-from datacube.testutils import mk_sample_product
+from datacube.testutils import mk_sample_product, suppress_deprecations
 
 
 def test_stats_dates():
@@ -128,27 +127,23 @@ def test_uri_resolve(base):
 def test_pick_uri():
     f, s, h = ('file://a', 's3://b', 'http://c')
 
-    # Suppress expected deprecation warnings
-    warnings.simplefilter("ignore")
+    with suppress_deprecations():
+        assert pick_uri([f, s, h]) is f  # Test of deprecated function
+        assert pick_uri([s, h, f]) is f  # Test of deprecated function
+        assert pick_uri([s, h]) is s  # Test of deprecated function
+        assert pick_uri([h, s]) is h  # Test of deprecated function
+        assert pick_uri([f, s, h], 'http:') is h  # Test of deprecated function
+        assert pick_uri([f, s, h], 's3:') is s  # Test of deprecated function
+        assert pick_uri([f, s, h], 'file:') is f  # Test of deprecated function
 
-    assert pick_uri([f, s, h]) is f  # Test of deprecated function
-    assert pick_uri([s, h, f]) is f  # Test of deprecated function
-    assert pick_uri([s, h]) is s  # Test of deprecated function
-    assert pick_uri([h, s]) is h  # Test of deprecated function
-    assert pick_uri([f, s, h], 'http:') is h  # Test of deprecated function
-    assert pick_uri([f, s, h], 's3:') is s  # Test of deprecated function
-    assert pick_uri([f, s, h], 'file:') is f  # Test of deprecated function
+        with pytest.raises(ValueError):
+            pick_uri([])  # Test of deprecated function
 
-    with pytest.raises(ValueError):
-        pick_uri([])  # Test of deprecated function
+        with pytest.raises(ValueError):
+            pick_uri([f, s, h], 'ftp:')  # Test of deprecated function
 
-    with pytest.raises(ValueError):
-        pick_uri([f, s, h], 'ftp:')  # Test of deprecated function
-
-    with pytest.raises(ValueError):
-        pick_uri([s, h], 'file:')  # Test of deprecated function
-
-    warnings.resetwarnings()
+        with pytest.raises(ValueError):
+            pick_uri([s, h], 'file:')  # Test of deprecated function
 
 
 @given(integers(min_value=10, max_value=30))


### PR DESCRIPTION
### Reason for this pull request

Tests of deprecated code were causing an avalanche of internal deprecation warnings when running tests.


### Proposed changes

- add testutil context manager to suppress deprecations warnings
- deploy in tests and integration_tests


 - [x] Closes #1674
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
