### PR TITLE
Account for lineage location in postgis datasets

### DIFF
--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -437,7 +437,9 @@ class Doc2Dataset:
                     doc.doc,
                     auto_skip=auto_skip,
                     remap_lineage=not self.index.supports_external_lineage
-                )
+                ),
+                sources_path=('lineage',) if self.index.supports_external_lineage
+                else ('lineage', 'source_datasets')
             )
 
         dataset, err = self._ds_resolve(doc, uri, source_tree)

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -111,7 +111,7 @@ class Dataset:
         #: The datasets that this dataset is derived from (if requested on load).
         self.sources = sources
 
-        if self.sources is not None:
+        if self.sources is not None and self.metadata.sources is not None:
             assert set(self.metadata.sources.keys()) == set(self.sources.keys())
 
         self.source_tree = source_tree

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -106,7 +106,10 @@ def load_datasets_for_update(doc_stream, index):
         if existing is None:
             return None, None, "No such dataset in the database: {}".format(uuid)
 
-        ds = SimpleDocNav(prep_eo3(ds.doc, auto_skip=True))
+        ds = SimpleDocNav(
+            prep_eo3(ds.doc, auto_skip=True),
+            sources_path=('lineage',) if index.supports_external_lineage else ('lineage', 'source_datasets')
+        )
 
         # TODO: what about lineage?
         return Dataset(existing.product,

--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -439,7 +439,7 @@ class SimpleDocNav(object):
             self._sources = {k: SimpleDocNav(v) if isinstance(v, collections.abc.Mapping) else v
                              for k, v in get_doc_offset(self._sources_path, self._doc, {}).items()}
             # if we have sources but they are at (lineage) rather than (lineage, source_datasets)
-            if not self._sources and self._doc.get('lineage'):
+            if get_doc_offset(self._sources_path, self._doc) is None and self._doc.get('lineage'):
                 self._sources = self._doc['lineage']
         return self._sources
 

--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -403,13 +403,13 @@ class SimpleDocNav(object):
 
     """
 
-    def __init__(self, doc):
+    def __init__(self, doc, sources_path=None):
         if not isinstance(doc, collections.abc.Mapping):
             raise ValueError("")
 
         self._doc = doc
         self._doc_without = None
-        self._sources_path = ('lineage', 'source_datasets')
+        self._sources_path = sources_path if sources_path else ('lineage', 'source_datasets')
         self._sources = None
         self._doc_uuid = None
 
@@ -438,9 +438,6 @@ class SimpleDocNav(object):
             # sources aren't expected to be embedded documents anymore
             self._sources = {k: SimpleDocNav(v) if isinstance(v, collections.abc.Mapping) else v
                              for k, v in get_doc_offset(self._sources_path, self._doc, {}).items()}
-            # if we have sources but they are at (lineage) rather than (lineage, source_datasets)
-            if get_doc_offset(self._sources_path, self._doc) is None and self._doc.get('lineage'):
-                self._sources = self._doc['lineage']
         return self._sources
 
     @property

--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -20,8 +20,6 @@ from typing import Dict, Any, Mapping
 from copy import deepcopy
 from uuid import UUID
 
-from deprecat import deprecat
-
 import numpy
 import toolz  # type: ignore[import]
 import yaml
@@ -440,6 +438,9 @@ class SimpleDocNav(object):
             # sources aren't expected to be embedded documents anymore
             self._sources = {k: SimpleDocNav(v) if isinstance(v, collections.abc.Mapping) else v
                              for k, v in get_doc_offset(self._sources_path, self._doc, {}).items()}
+            # if we have sources but they are at (lineage) rather than (lineage, source_datasets)
+            if not self._sources and self._doc.get('lineage'):
+                self._sources = self._doc['lineage']
         return self._sources
 
     @property
@@ -531,7 +532,6 @@ class DocReader:
         return {**self.system_fields, **self.search_fields}
 
 
-@deprecat(deprecated_args={'inplace': {'version': '1.9.0', 'reason': 'not being used'}})
 def without_lineage_sources(doc: Dict[str, Any],
                             spec,
                             inplace: bool = False) -> Dict[str, Any]:

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -9,6 +9,7 @@ v1.9.next
 =========
 
 - Update and cross-reference 1.8 to 1.9 migration notes (:pull:`1686`)
+- Fix SimpleDocNav lineage handling with PostGIS index (:pull:`1687`)
 
 v1.9.0-rc12 (9th December 2024)
 ===============================

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -398,10 +398,8 @@ def ds_no_region(index, extended_eo3_metadata_type, ls8_eo3_product, final_datas
 
 
 @pytest.fixture
-def ds_with_lineage(index, wo_eo3_product, eo3_wo_dataset_doc, ls8_eo3_dataset):
+def ds_with_lineage(index, wo_eo3_product, eo3_wo_dataset_doc):
     doc, path = eo3_wo_dataset_doc
-    # rewrite lineage to correct format
-    doc["lineage"] = {"source_datasets": {"ard": [ls8_eo3_dataset.id]}}
     return doc_to_ds_no_add(
         index,
         wo_eo3_product.name,

--- a/integration_tests/test_cli_output.py
+++ b/integration_tests/test_cli_output.py
@@ -153,11 +153,11 @@ def test_cli_dataset_subcommand(index, clirunner,
     assert runner.exit_code == 0
 
 
-def test_readd_and_update_metadata_product_dataset_command(index, clirunner,
-                                                           ext_eo3_mdt_path,
-                                                           eo3_product_paths,
-                                                           eo3_dataset_paths,
-                                                           eo3_dataset_update_path):
+def test_read_and_update_metadata_product_dataset_command(index, clirunner,
+                                                          ext_eo3_mdt_path,
+                                                          eo3_product_paths,
+                                                          eo3_dataset_paths,
+                                                          eo3_dataset_update_path):
     add = clirunner(['metadata', 'add', ext_eo3_mdt_path])
     rerun_add = clirunner(['metadata', 'add', ext_eo3_mdt_path])
     assert "WARNING Metadata Type" in rerun_add.output


### PR DESCRIPTION
### Reason for this pull request

`SimpleDocNav` assumes document lineage will have been rewritten to be at `('lineage', 'source_datasets')`, which doesn't happen in the postgis driver, causing lineage information to not be captured correctly.


### Proposed changes

- Have `SimpleDocNav` check if there is lineage information present at `('lineage')` if there is nothing at `('lineage', 'source_datasets')`



 - [ ] Closes #xxxx
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1687.org.readthedocs.build/en/1687/

<!-- readthedocs-preview datacube-core end -->