### PR TITLE
Fix docs lineage more

### DIFF
--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -546,6 +546,10 @@ def without_lineage_sources(doc: Dict[str, Any],
     if 'sources' in doc_view.fields:
         if doc_view.sources is not None:
             doc_view.sources = {}
+        # lineage has not been remapped
+        elif 'lineage' in doc:
+            doc["lineage"] = {}
+    # 'sources' path isn't defined
     elif 'lineage' in doc:
         doc["lineage"] = {}
 

--- a/tests/test_utils_docs.py
+++ b/tests/test_utils_docs.py
@@ -127,6 +127,14 @@ def test_without_lineage_sources():
     assert mk_sample(10) != mk_sample({})
     assert without_lineage_sources(mk_sample(10), spec) == mk_sample({})
 
+    # check behaviour when `sources` is defined for the type but lineage has not been remapped
+    test_doc = dict(lineage={'a': ['a'], 'b': ['b']},
+                    aa='aa',
+                    bb=dict(bb='bb'))
+    assert without_lineage_sources(test_doc, spec) == dict(lineage={},
+                                                           aa='aa',
+                                                           bb=dict(bb='bb'))
+
     # check behaviour when `sources` is not defined for the type
     no_sources_type = MetadataType({
         'name': 'eo',

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -16,6 +16,8 @@ agdcv
 AIO
 aio
 albers
+algo
+Algo
 Analytics
 analytics
 antimeridian
@@ -86,6 +88,7 @@ configparser
 ConfigException
 confval
 coord
+corteva
 cov
 cp
 createdb
@@ -124,6 +127,7 @@ datasetType
 DatasetTypeResource
 DataSource
 datasource
+data's
 datetime
 dbs
 dea
@@ -135,6 +139,7 @@ dev
 df
 digitalearth
 digitalearthafrica
+DigitalEarthPacific
 Dingley
 distutils
 DocReader
@@ -149,6 +154,7 @@ dt
 dtr
 dtype
 EarthData
+earthobservation
 ec
 eg
 EnterpriseDB
@@ -166,6 +172,7 @@ eosphere
 EP
 EPSG
 epsg
+erP
 ESPA
 ESRI
 executor
@@ -256,6 +263,7 @@ isel
 isinstance
 jfEZEOkxRXgNsAsHEC
 jpg
+json
 JSON
 jsonify
 jsonschema
@@ -285,6 +293,7 @@ libudunits
 libyaml
 linux
 literalinclude
+LocalConfig
 localhost
 logoColor
 lon
@@ -315,8 +324,10 @@ MultiIndex
 multiline
 multipoint
 multipolygon
+multispectral
 mx
 mydb
+myenv
 mypassword
 mypy
 myuser
@@ -351,11 +362,13 @@ npm
 nrt
 ns
 numpy
+numref
 nx
 ny
 ODC
 odc
 ODCConfig
+ODCEnvironment
 odcintegration
 ODCv
 OGC
@@ -372,6 +385,7 @@ osr
 OSX
 ows
 pandoc
+parallelisable
 param
 params
 passwd
@@ -447,6 +461,7 @@ Resampling
 resampling
 rightarrow
 rio
+rioxarray
 Roadmap
 roadmap
 ROI
@@ -458,7 +473,8 @@ rtype
 runtime
 rws
 sameuser
-scaleable
+scalable
+Scalable
 schemas
 scipy
 scm
@@ -469,9 +485,13 @@ SimpleDocNav
 singledispatch
 spatio
 SpatioTemporal
+spc
 SPDX
 spindex
 SQLAlchemy
+srid
+SRID
+SRIDs
 SRTM
 srtm
 STAC
@@ -479,6 +499,7 @@ stac
 stacker
 stacspec
 stdlib
+Stereographic
 str
 stylesheet
 subcommands
@@ -489,6 +510,7 @@ swir
 swissdatacube
 TCP
 Terria
+TerriaJS
 th
 TIF
 tif
@@ -531,6 +553,7 @@ uuid
 UUIDs
 usp
 ValueError
+vam
 VDI
 vdi
 venv
@@ -544,19 +567,24 @@ VSR
 VSRDataSource
 VSRs
 WCS
+wfp
 wget
 WGS
 WIP
 WKT
 WMS
+WMTS
 WPS
 wSgIIApLG
 www
 XArray
+Xarrays
 xarray
+xarrays
 xBddeS
 xr
 YAML
 yaml
 yml
 yourscript
+zarr


### PR DESCRIPTION
Sequel to #1679 
Make sure to account for corner case where sources path is defined but lineage has not been remapped to be present there.


 - [ ] Closes #xxxx
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1690.org.readthedocs.build/en/1690/

<!-- readthedocs-preview datacube-core end -->