### PR TITLE
Update release process for post-1.9.0 release.

### DIFF
--- a/docs/about/release_process.rst
+++ b/docs/about/release_process.rst
@@ -1,8 +1,8 @@
 Release Process
 ***************
 
-#. Decide to do a release, and check with regular contributors on `Discord <https://discord.com/invite/4hhBQVas5U>`_ that
-   they don't have anything pending.
+#. Decide to do a release, and check with regular contributors on `Discord <https://discord.com/invite/4hhBQVas5U>`_
+   that they don't have anything pending.
 
 #. Ensure version pins in setup.py and conda-environment.yml are in sync and up to date.
 
@@ -15,10 +15,16 @@ Release Process
 #. Wait for the **conda-forge** bot to notice the new PyPI version and create a PR against
    `the conda-forge datacube feedstock <https://github.com/conda-forge/datacube-feedstock/pulls>`_
 
-#. Merge the `PR created by the conda-forge <https://github.com/conda-forge/datacube-feedstock/pulls>`_ bot to create a
+#. Fix any errors and merge the
+   `PR created by the conda-forge <https://github.com/conda-forge/datacube-feedstock/pulls>`_ bot to create a
    new `conda-forge release <https://anaconda.org/conda-forge/datacube>`_.
 
-#. Manually update the ``stable`` branch via a PR from ``develop``.
+#. Manually update the ``stable`` branch:
+
+   - git checkout <release tag>
+   - git push --force origin stable
+
+#. Post release announcements on Slack, Discord, and social media platforms.
 
 #. Kick back, relax, and enjoy a tasty beverage.
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,8 +8,9 @@ What's New
 v1.9.next
 =========
 
-- API autodocs cleanup (:pull:`1688`)
 - Further metadata fix for new lineage API (:pull:`1690`)
+- Update release process ready for post-1.9.0 release (:pull:`1691`)
+- API autodocs cleanup (:pull:`1688`)
 
 v1.9.0-rc13 (16th December 2024)
 ===============================

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,9 +8,9 @@ What's New
 v1.9.next
 =========
 
+- API autodocs cleanup (:pull:`1688`)
 - Further metadata fix for new lineage API (:pull:`1690`)
 - Update release process ready for post-1.9.0 release (:pull:`1691`)
-- API autodocs cleanup (:pull:`1688`)
 
 v1.9.0-rc13 (16th December 2024)
 ===============================


### PR DESCRIPTION
### Reason for this pull request

Release process document was a bit incomplete.  Main issue was merging to stable via PR, which can result in stable and develop diverging, and means 2 PRs per release which seems excessive.

Paired with a similar update to the 1.8 branch. (#1692)

### Proposed changes

Manually sync stable to release tag.

 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1691.org.readthedocs.build/en/1691/

<!-- readthedocs-preview datacube-core end -->