### PR TITLE
Update 1.8 release process for post 1.9.0 release.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   DOCKER_USER: gadockersvc
-  DOCKER_IMAGE: opendatacube/datacube-tests:latest
+  DOCKER_IMAGE: opendatacube/datacube-tests:latest1.8
 
 
 jobs:
@@ -69,7 +69,7 @@ jobs:
       id: login
       if: |
         github.event_name == 'push'
-        && github.ref == 'refs/heads/develop'
+        && github.ref == 'refs/heads/develop-1.8'
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUBUSER }}
@@ -106,7 +106,7 @@ jobs:
     - name: DockerHub Push
       if: |
         github.event_name == 'push'
-        && github.ref == 'refs/heads/develop'
+        && github.ref == 'refs/heads/develop-1.8'
         && steps.changes.outputs.docker == 'true'
       uses: docker/build-push-action@v6
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,10 +47,10 @@ jobs:
           docker:
             - 'docker/**'
 
-    - name: Pull Docker
-      if: steps.changes.outputs.docker == 'false'
-      run: |
-        docker pull "${{ env.DOCKER_IMAGE }}"
+    # - name: Pull Docker
+    #   if: steps.changes.outputs.docker == 'false'
+    #   run: |
+    #     docker pull "${{ env.DOCKER_IMAGE }}"
 
     - name: Set up Docker Buildx
       if: steps.changes.outputs.docker == 'true'

--- a/docs/about/release_process.rst
+++ b/docs/about/release_process.rst
@@ -1,14 +1,19 @@
-Release Process
-***************
+1.8 Release Process
+*******************
+
+Process for 1.8.x releases after the release of datacube 1.9.0
 
 #. Decide to do a release, and check with regular contributors on `Discord <https://discord.com/invite/4hhBQVas5U>`_ that
    they don't have anything pending.
 
 #. Ensure version pins in setup.py and conda-environment.yml are in sync and up to date.
 
-#. Update the release notes in the ``develop`` branch via a PR.
+#. Update the release notes in the ``develop-1.8`` branch via a PR.
 
 #. Create a new **Tag** and **Release** using the `GitHub Releases Web UI`_
+
+   - release from develop-1.8 branch
+   - be sure to uncheck "set as latest release".
 
 #. Wait for the `GitHub Action`_ to run and publish the new release to PyPI_
 
@@ -18,7 +23,12 @@ Release Process
 #. Merge the `PR created by the conda-forge <https://github.com/conda-forge/datacube-feedstock/pulls>`_ bot to create a
    new `conda-forge release <https://anaconda.org/conda-forge/datacube>`_.
 
-#. Manually update the ``stable`` branch via a PR from ``develop``.
+#. Manually update the ``stable-1.8`` branch:
+
+   - git checkout <release tag>
+   - git push --force origin stable
+
+#. Post release announcements on Slack, Discord, and social media platforms.
 
 #. Kick back, relax, and enjoy a tasty beverage.
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,8 @@ What's New
 v1.8.next
 =========
 
+- Update 1.8.x release process ready for post-1.9 release world (:pull:`1692`)
+
 v1.8.20 (9th December 2024)
 ===========================
 - Update docker image and CI (:pull:`1624`, :pull:`1625`, :pull:`1626`, :pull:`1639`, :pull:`1641`, :pull:`1642`)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -140,7 +140,7 @@ html_theme_options = {
 html_context = {
     "github_user": "opendatacube",
     "github_repo": "datacube-core",
-    "github_version": "develop",
+    "github_version": "develop-1.8",
     "doc_path": "docs",
 }
 


### PR DESCRIPTION
### Reason for this pull request

Release process for 1.8.x series changes after 1.9.0 release:

- will release off  `develop-1.8` instead of `develop`.
- keeps sync with `stable-1.8` instead of `stable`.

Plus changes from #1691

**Merge after 1.9.0 release**

 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1692.org.readthedocs.build/en/1692/

<!-- readthedocs-preview datacube-core end -->