### PR TITLE
For 1.9. release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,9 +15,7 @@ on:
 
 env:
   DOCKER_USER: gadockersvc
-  DOCKER_IMAGE: opendatacube/datacube-tests:latest1.9
-  # NB Restore standard image name when merge into develop
-  # DOCKER_IMAGE: opendatacube/datacube-tests:latest
+  DOCKER_IMAGE: opendatacube/datacube-tests:latest
 
 
 jobs:

--- a/docs/about/develop-1.9.rst
+++ b/docs/about/develop-1.9.rst
@@ -1,9 +1,0 @@
-Process for porting 1.8 updates into 1.9
-
-For admins only:
-
-1. cherry-pick the merged PR commits from develop into develop-1.9
-2. Regenerate constraints.txt if constraints.in has been touched and commit.
-3. force-push to develop-1.9 (before 1.9.0 release only)
-
-After 1.9.0 release, go through a full PR process.

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -12,7 +12,7 @@ v1.9.0 (23rd December 2024)
 ===========================
 
 1.9.0 is first major release of the Open Data Cube in several years.  The focus has been on retiring technical
-debt and unused features and preparing major architectural changes in subsequent releases.
+debt and unused features and preparing for major architectural changes in subsequent releases.
 
 As there are some backwards incompatibilities in this release, we recommend that you read the migration notes
 at ``docs/installation/MIGRATION-1.8-to-1.9`` before upgrading.

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,10 +8,44 @@ What's New
 v1.9.next
 =========
 
+v1.9.0 (23rd December 2024)
+===========================
+
+1.9.0 is first major release of the Open Data Cube in several years.  The focus has been on retiring technical
+debt and unused features and preparing major architectural changes in subsequent releases.
+
+As there are some backwards incompatibilities in this release, we recommend that you read the migration notes
+at ``docs/installation/MIGRATION-1.8-to-1.9`` before upgrading.
+
+Major changes from recent 1.8.x releases include:
+
+- A new index driver that uses PostGIS spatial indexes to provide faster and more accurate geospatial search
+  and provide better support for storing data that covers regions where traditional lat/long seach is
+  inadequate (i.e. covering polar regions or crossing the anti-meridian).
+
+  The new postgis index driver implements a new API for working with dataset lineage, and only supports
+  a single location per dataset. It is otherwise largely backwards compatible with the legacy postgres index driver.
+
+  The legacy "postgres" index driver is still available, but will be removed in a future release.
+- A new configuration layer that provides more predictable and consistent behaviour and will be easier to
+  extend in future.
+
+  Given the nature and scope of the changes, the new configuration layer is not fully backwards compatible
+  with the old implementation, but the vast majority of use cases should only require minor adjustments
+  to existing configuration and code at most.
+- The old ``datacube.utils.geometry`` library is now deprecated.  ``odc-geo`` is used internally throughout,
+  and we recommend updating all your code to use odc-geo rather than the deprecated internal library.
+- The long-deprecated executor and ingestion workflows have been removed.
+
+
+Changes since 1.9.0-rc13
+------------------------
+
 - API autodocs cleanup (:pull:`1688`)
 - Further metadata fix for new lineage API (:pull:`1690`)
 - Update release process ready for post-1.9.0 release (:pull:`1691`)
 - Removed all references to the postgis driver as "experimental" in tests and documentation (:pull:`1693`)
+- Update whats_new.rst etc. for 1.9.0 release (:pull:`1694`)
 
 v1.9.0-rc13 (16th December 2024)
 ===============================

--- a/docs/installation/extending-odc.rst
+++ b/docs/installation/extending-odc.rst
@@ -164,12 +164,9 @@ Index Plug-ins
     `datacube.plugins.index <https://github.com/opendatacube/datacube-core/blob/9c0ea8923fa5d29dc2a813141ad64daea74c4902/setup.py#L112>`__
 
 A connection to an ``Index`` is required to find data in the Data Cube.
-Already implemented in the ``develop`` branch was the concept of
-``environments`` which are a named set of configuration parameters used
-to connect to an ``Index``. This PR extends this with an
-``index_driver`` parameter, which specifies the name of the Index Driver
-to use. If this parameter is missing, it falls back to using the default
-PostgreSQL Index.
+
+ODC Configuration environments have an ``index_driver`` parameter, which specifies the name of the Index Driver
+to use. See :doc:`database/configuration`.
 
 A set of abstract base classes are defined in :py:mod:`datacube.index.abstract`. An index plugin
 is expected to supply implementations of all these abstract base classes. If any abstract


### PR DESCRIPTION
### Reason for this pull request

Datacube 1.9.0 will be released on Monday 23rd December


### Proposed changes

- Update whats_new.rst read gfor release.
- Fix some documentation and github actions ready for release.


 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1694.org.readthedocs.build/en/1694/

<!-- readthedocs-preview datacube-core end -->