### PR TITLE
Dra/extend valid db port range

### DIFF
--- a/datacube/cfg/opt.py
+++ b/datacube/cfg/opt.py
@@ -234,7 +234,7 @@ class PostgresURLOptionHandler(ODCOptionHandler):
                 ODCOptionHandler("db_hostname", self.env, legacy_env_aliases=['DB_HOSTNAME'],
                                  default=_DEFAULT_HOSTNAME),
                 IntOptionHandler("db_port", self.env, default=5432, legacy_env_aliases=['DB_PORT'],
-                                 minval=1, maxval=49151),
+                                 minval=1, maxval=65535),
                 ODCOptionHandler("db_database", self.env, legacy_env_aliases=['DB_DATABASE'],
                                  default=_DEFAULT_DATABASE),
             )


### PR DESCRIPTION
~~**Merge #1699 before this PR!**~~ **Done, thanks.**

The `db_port` configuration value was capped at 49,591, which is the maximum "registered port" available. Dynamic TCP ports go all the way up to 65,535. 

The dynamic docker database tests in odc-tools and datacube-explorer use dyamically allocated 
port numbers from Docker, to allow temporary concurrent PostGIS servers.

<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1697.org.readthedocs.build/en/1697/

<!-- readthedocs-preview datacube-core end -->