### PR TITLE
Fix: Use canonical RTD url everywhere

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,6 @@ and consider major enhancements, and there are a number of [current and past enh
 
 In case you haven't found them yet, please checkout the following resources:
 
-* [Documentation](https://datacube-core.readthedocs.io/en/latest/)
+* [Documentation](https://opendatacube.readthedocs.io/en/latest/)
 * [Discord](https://discord.com/invite/4hhBQVas5U)
 * [GIS Stack Exchange](https://gis.stackexchange.com/questions/tagged/open-data-cube).

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Open Data Cube Core
 
 .. image:: https://readthedocs.org/projects/datacube-core/badge/?version=latest
     :alt: Documentation Status
-    :target: http://datacube-core.readthedocs.org/en/latest/
+    :target: https://opendatacube.readthedocs.org/en/latest/
 
 .. image:: https://img.shields.io/discord/1212501566326571070?label=Discord&logo=discord&logoColor=white&color=7289DA)](https://discord.gg/4hhBQVas5U
     :alt: Discord
@@ -28,7 +28,7 @@ systems.
 Documentation
 =============
 
-See the `user guide <http://datacube-core.readthedocs.io/en/latest/>`__ for
+See the `user guide <https://opendatacube.readthedocs.io/en/latest/>`__ for
 installation and usage of the datacube, and for documentation of the API.
 
 `Join our Discord <https://discord.com/invite/4hhBQVas5U>`__ if you need help
@@ -39,7 +39,7 @@ reading and following our `Code of Conduct <code-of-conduct.md>`__.
 
 This is a ``1.9.x`` series release of the Open Data Cube.  If you are migrating from a ``1.8.x``
 series release, please refer to the
-`1.8.x to 1.9.x Migration Notes <https://datacube-core.readthedocs.io/en/latest/MIGRATION-1.8-to-1.9.html>`_.
+`1.8.x to 1.9.x Migration Notes <https://opendatacube.readthedocs.io/en/latest/MIGRATION-1.8-to-1.9.html>`_.
 
 Requirements
 ============
@@ -105,7 +105,7 @@ Run unit tests with:
       ``~/.datacube_integration.conf`` and edit to customise.
 
    - For instructions on setting up a password-less Postgres database, see
-      the `developer setup instructions <https://datacube-core.readthedocs.io/en/latest/installation/setup/ubuntu.html#postgres-database-configuration>`__.
+      the `developer setup instructions <https://opendatacube.readthedocs.io/en/latest/installation/setup/ubuntu.html#postgres-database-configuration>`__.
 
 
 Alternatively one can use the ``opendatacube/datacube-tests`` docker image to run

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ reading and following our `Code of Conduct <code-of-conduct.md>`__.
 
 This is a ``1.9.x`` series release of the Open Data Cube.  If you are migrating from a ``1.8.x``
 series release, please refer to the
-`1.8.x to 1.9.x Migration Notes <https://opendatacube.readthedocs.io/en/latest/MIGRATION-1.8-to-1.9.html>`_.
+`1.8.x to 1.9.x Migration Notes <https://opendatacube.readthedocs.io/en/latest/installation/MIGRATION-1.8-to-1.9.html>`_.
 
 Requirements
 ============
@@ -105,7 +105,7 @@ Run unit tests with:
       ``~/.datacube_integration.conf`` and edit to customise.
 
    - For instructions on setting up a password-less Postgres database, see
-      the `developer setup instructions <https://opendatacube.readthedocs.io/en/latest/installation/setup/ubuntu.html#postgres-database-configuration>`__.
+      the `developer setup instructions <https://opendatacube.readthedocs.io/en/latest/installation/setup/ubuntu.html#postgres-testing-database-configuration>`__.
 
 
 Alternatively one can use the ``opendatacube/datacube-tests`` docker image to run

--- a/datacube/__init__.py
+++ b/datacube/__init__.py
@@ -8,7 +8,7 @@ Datacube
 
 Provides access to multi-dimensional data, with a focus on Earth observations data such as LANDSAT.
 
-To use this module, see the `Developer Guide <https://opendatacube.readthedocs.io/en/stable/dev/developer.html>`_.
+To use this module, see the `Developer Guide <https://opendatacube.readthedocs.io/en/latest/installation/index.html>`_.
 
 The main class to access the datacube is :class:`datacube.Datacube`.
 

--- a/datacube/__init__.py
+++ b/datacube/__init__.py
@@ -8,16 +8,9 @@ Datacube
 
 Provides access to multi-dimensional data, with a focus on Earth observations data such as LANDSAT.
 
-To use this module, see the `Developer Guide <http://datacube-core.readthedocs.io/en/stable/dev/developer.html>`_.
+To use this module, see the `Developer Guide <https://opendatacube.readthedocs.io/en/stable/dev/developer.html>`_.
 
 The main class to access the datacube is :class:`datacube.Datacube`.
-
-To initialise this class, you will need a config pointing to a database, such as a file with the following::
-
-    [datacube]
-    db_hostname: 130.56.244.227
-    db_database: democube
-    db_username: cube_user
 
 """
 


### PR DESCRIPTION
### Reason for this pull request

There are two readthedocs hosted datacube-core documentation sites. The old one at `datacube-core.` and the new one at `opendatacube.`.

I think the new one is nicer, so update all the old references to point to it.

<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1702.org.readthedocs.build/en/1702/

<!-- readthedocs-preview datacube-core end -->