### PR TITLE
Fix failing configuration test when running as root (and fix potential crash on misconfigured config paths)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,74 +15,33 @@ on:
       - '!docker/**'
       - '!docs/**'
       - '!contrib/**'
+  workflow_dispatch:
+
+permissions: {}
 
 jobs:
-  pylint:
+  lint:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
-    name: Pylint
+        python-version: ["3.12"]
+        lintcommand:
+          - "pylint -j 2 --report no datacube"
+          - "mypy datacube"
+          - "pycodestyle tests integration_tests examples --max-line-length 120"
+    name: Linting
     steps:
       - name: checkout git
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Setup conda
-        uses: s-weigand/setup-conda@v1
-        with:
-          update-conda: true
-          python-version: ${{ matrix.python-version }}
-          conda-channels: anaconda, conda-forge
-      - name: run pylint
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: run linter
         run: |
-          sudo apt-get remove python3-openssl
-          pip install --upgrade -e '.[test]'
-          pip install pylint>3.2
-          pylint -j 2 --reports no datacube
-          
-
-  mypy:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10"]
-    name: MyPy
-    steps:
-      - name: checkout git
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Setup conda
-        uses: s-weigand/setup-conda@v1
-        with:
-          update-conda: true
-          python-version: ${{ matrix.python-version }}
-          conda-channels: anaconda, conda-forge
-      - name: run mypy
-        run: |
-          sudo apt-get remove python3-openssl
-          pip install --upgrade -e '.[types]'
-          mypy datacube
-
-
-  pycodestyle:
-    name: pycodestyle
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10"]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup conda
-        uses: s-weigand/setup-conda@v1
-        with:
-          update-conda: true
-          python-version: ${{ matrix.python-version }}
-          conda-channels: anaconda, conda-forge
-      - name: Run pycodestyle
-        run: |
-          sudo apt-get remove python3-openssl
-          pip install --upgrade -e '.[test]'
-          pycodestyle tests integration_tests examples --max-line-length 120
+          uv run --no-project --with '.[test,types]' ${LINT_COMMAND}
+        env:
+          LINT_COMMAND: ${{matrix.lintcommand}}
+          UV_PYTHON: ${{ matrix.python-version }}
+          UV_PYTHON_PREFERENCE: managed

--- a/datacube/cfg/cfg.py
+++ b/datacube/cfg/cfg.py
@@ -79,9 +79,7 @@ def find_config(paths_in: None | str | PathLike | list[str | PathLike],
         try:
             with open(path, "r") as fp:
                 return fp.read()
-        except PermissionError:
-            continue
-        except FileNotFoundError:
+        except OSError:
             continue
 
     if using_default_paths:

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -343,15 +343,15 @@ def test_ini_from_paths(path_to_ini_config, path_to_yaml_config, path_to_differe
     with pytest.raises(ConfigException):
         cfg = ODCConfig(paths=[
             "/non/existent/path.yml",
-            "/etc/shadow",  # A path that exists that we can't read
-            "/another/nonexistent/path.yml"
+            "/another/nonexistent/path.yml",
+            "/etc",
         ])
 
     with monkeypatch.context() as mp:
         mp.setattr("datacube.cfg.cfg._DEFAULT_CONFIG_SEARCH_PATH", [
             "/non/existent/path.yml",
-            "/etc/shadow",  # A path that exists that we can't read
             "/another/nonexistent/path.yml",
+            "/etc",
             path_to_yaml_config,
         ])
         cfg = ODCConfig()
@@ -360,7 +360,7 @@ def test_ini_from_paths(path_to_ini_config, path_to_yaml_config, path_to_differe
     with monkeypatch.context() as mp:
         mp.setattr("datacube.cfg.cfg._DEFAULT_CONFIG_SEARCH_PATH", [
             "/non/existent/path.yml",
-            "/etc/shadow",  # A path that exists that we can't read
+            "/etc",
             "/another/nonexistent/path.yml",
         ])
         cfg = ODCConfig()


### PR DESCRIPTION
The config file tests were failing if run as root. They assumed that `/etc/shadow` would not be readable. Although running as root is generally a terrible idea, doing so within a container is common and sometimes hard to work around.

Also

The config file loader would crash if provided with a directory as one of the config files to attempt to load.



 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1705.org.readthedocs.build/en/1705/

<!-- readthedocs-preview datacube-core end -->