### PR TITLE
Fix dask 2024.11+ incompatibility

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,74 +15,33 @@ on:
       - '!docker/**'
       - '!docs/**'
       - '!contrib/**'
+  workflow_dispatch:
+
+permissions: {}
 
 jobs:
-  pylint:
+  lint:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
-    name: Pylint
+        python-version: ["3.12"]
+        lintcommand:
+          - "pylint -j 2 --report no datacube"
+          - "mypy datacube"
+          - "pycodestyle tests integration_tests examples --max-line-length 120"
+    name: Linting
     steps:
       - name: checkout git
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Setup conda
-        uses: s-weigand/setup-conda@v1
-        with:
-          update-conda: true
-          python-version: ${{ matrix.python-version }}
-          conda-channels: anaconda, conda-forge
-      - name: run pylint
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: run linter
         run: |
-          sudo apt-get remove python3-openssl
-          pip install --upgrade -e '.[test]'
-          pip install pylint>3.2
-          pylint -j 2 --reports no datacube
-          
-
-  mypy:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10"]
-    name: MyPy
-    steps:
-      - name: checkout git
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Setup conda
-        uses: s-weigand/setup-conda@v1
-        with:
-          update-conda: true
-          python-version: ${{ matrix.python-version }}
-          conda-channels: anaconda, conda-forge
-      - name: run mypy
-        run: |
-          sudo apt-get remove python3-openssl
-          pip install --upgrade -e '.[types]'
-          mypy datacube
-
-
-  pycodestyle:
-    name: pycodestyle
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10"]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup conda
-        uses: s-weigand/setup-conda@v1
-        with:
-          update-conda: true
-          python-version: ${{ matrix.python-version }}
-          conda-channels: anaconda, conda-forge
-      - name: Run pycodestyle
-        run: |
-          sudo apt-get remove python3-openssl
-          pip install --upgrade -e '.[test]'
-          pycodestyle tests integration_tests examples --max-line-length 120
+          uv run --no-project --with '.[test,types]' ${LINT_COMMAND}
+        env:
+          LINT_COMMAND: ${{matrix.lintcommand}}
+          UV_PYTHON: ${{ matrix.python-version }}
+          UV_PYTHON_PREFERENCE: managed

--- a/setup.py
+++ b/setup.py
@@ -122,8 +122,8 @@ setup(
         'cachetools',
         'click>=5.0',
         'cloudpickle>=0.4',
-        'dask[array]<2024.11.0',  # Dask versions from 2024.11 cause problems with numpy2
-        'distributed<2024.11.0',
+        'dask[array]!=2024.11.*,!=2024.12.0',  # Dask versions >=2024.11 and < 2024.12.1 don't serialise Measurements
+        'distributed!=2024.11.*,!=2024.12.0',
         'jsonschema>=4.18',  # New reference resolution API
         'numpy>=1.26.0',
         'lark',

--- a/setup.py
+++ b/setup.py
@@ -122,8 +122,8 @@ setup(
         'cachetools',
         'click>=5.0',
         'cloudpickle>=0.4',
-        'dask[array]!=2024.11.*,!=2024.12.0',  # Dask versions >=2024.11 and < 2024.12.1 don't serialise Measurements
-        'distributed!=2024.11.*,!=2024.12.0',
+        'dask[array]',
+        'distributed',
         'jsonschema>=4.18',  # New reference resolution API
         'numpy>=1.26.0',
         'lark',


### PR DESCRIPTION
Using ODC with Dask 2024.11+ made it impossible to load data, with failures looking like `.nodata` attribute found, or other similarly unhelpful messages.

This was happening because the `datacube.model.Measurement` class, which contains important values like .dtype and .nodata, wasn't being correctly serialised/deserialised in those dask versions. Dask switched to using custom types for building the Dask Graph, but in the process added a special case for `dict`, which is fine, and for `dict-subclasses` which is more questionable. This converted all the ODC Measurement classes into `dict`s, which couldn't be used in the same way.

I think it should be changed in dask, but haven't started that conversationn yet. For now, I've changed the Measurement class to no longer subclass `dict`, and instead implemented all the dunder methods to make it behave as a dict, while not actually being one.


### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1706.org.readthedocs.build/en/1706/

<!-- readthedocs-preview datacube-core end -->