### PR TITLE
Hardcode to ns precision times in xarray

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,74 +15,33 @@ on:
       - '!docker/**'
       - '!docs/**'
       - '!contrib/**'
+  workflow_dispatch:
+
+permissions: {}
 
 jobs:
-  pylint:
+  lint:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
-    name: Pylint
+        python-version: ["3.12"]
+        lintcommand:
+          - "pylint -j 2 --report no datacube"
+          - "mypy datacube"
+          - "pycodestyle tests integration_tests examples --max-line-length 120"
+    name: Linting
     steps:
       - name: checkout git
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Setup conda
-        uses: s-weigand/setup-conda@v1
-        with:
-          update-conda: true
-          python-version: ${{ matrix.python-version }}
-          conda-channels: anaconda, conda-forge
-      - name: run pylint
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: run linter
         run: |
-          sudo apt-get remove python3-openssl
-          pip install --upgrade -e '.[test]'
-          pip install pylint>3.2
-          pylint -j 2 --reports no datacube
-          
-
-  mypy:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10"]
-    name: MyPy
-    steps:
-      - name: checkout git
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Setup conda
-        uses: s-weigand/setup-conda@v1
-        with:
-          update-conda: true
-          python-version: ${{ matrix.python-version }}
-          conda-channels: anaconda, conda-forge
-      - name: run mypy
-        run: |
-          sudo apt-get remove python3-openssl
-          pip install --upgrade -e '.[types]'
-          mypy datacube
-
-
-  pycodestyle:
-    name: pycodestyle
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10"]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup conda
-        uses: s-weigand/setup-conda@v1
-        with:
-          update-conda: true
-          python-version: ${{ matrix.python-version }}
-          conda-channels: anaconda, conda-forge
-      - name: Run pycodestyle
-        run: |
-          sudo apt-get remove python3-openssl
-          pip install --upgrade -e '.[test]'
-          pycodestyle tests integration_tests examples --max-line-length 120
+          uv run --no-project --with '.[test,types]' ${LINT_COMMAND}
+        env:
+          LINT_COMMAND: ${{matrix.lintcommand}}
+          UV_PYTHON: ${{ matrix.python-version }}
+          UV_PYTHON_PREFERENCE: managed

--- a/datacube/utils/dates.py
+++ b/datacube/utils/dates.py
@@ -99,7 +99,7 @@ def mk_time_coord(dts, name='time', units=None):
     attrs = {'units': units} if units is not None else {}
 
     dts = [normalise_dt(dt) for dt in dts]
-    data = np.asarray(dts, dtype='datetime64')
+    data = np.asarray(dts, dtype='datetime64[ns]')
     return xr.DataArray(data,
                         name=name,
                         coords={name: data},


### PR DESCRIPTION
xarray 2025+ added support for timecoordinates not being stored to nanosecond precision. This is lovely, and we probably should support it, but it broke our tests. I'm hard coding back to nanoseconds for now, in case there's other downstream implications or assumptions that might break.

I'm not sure, but the only reason I can see to support lower precision times is to save memory. And in typical EO data, the time values are vanishingly small compared to any observation data.

### Reason for this pull request

...


### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1707.org.readthedocs.build/en/1707/

<!-- readthedocs-preview datacube-core end -->