### PR TITLE
Fix tests for antimeridian 0.4+

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,74 +15,33 @@ on:
       - '!docker/**'
       - '!docs/**'
       - '!contrib/**'
+  workflow_dispatch:
+
+permissions: {}
 
 jobs:
-  pylint:
+  lint:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
-    name: Pylint
+        python-version: ["3.12"]
+        lintcommand:
+          - "pylint -j 2 --report no datacube"
+          - "mypy datacube"
+          - "pycodestyle tests integration_tests examples --max-line-length 120"
+    name: Linting
     steps:
       - name: checkout git
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Setup conda
-        uses: s-weigand/setup-conda@v1
-        with:
-          update-conda: true
-          python-version: ${{ matrix.python-version }}
-          conda-channels: anaconda, conda-forge
-      - name: run pylint
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: run linter
         run: |
-          sudo apt-get remove python3-openssl
-          pip install --upgrade -e '.[test]'
-          pip install pylint>3.2
-          pylint -j 2 --reports no datacube
-          
-
-  mypy:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10"]
-    name: MyPy
-    steps:
-      - name: checkout git
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Setup conda
-        uses: s-weigand/setup-conda@v1
-        with:
-          update-conda: true
-          python-version: ${{ matrix.python-version }}
-          conda-channels: anaconda, conda-forge
-      - name: run mypy
-        run: |
-          sudo apt-get remove python3-openssl
-          pip install --upgrade -e '.[types]'
-          mypy datacube
-
-
-  pycodestyle:
-    name: pycodestyle
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10"]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup conda
-        uses: s-weigand/setup-conda@v1
-        with:
-          update-conda: true
-          python-version: ${{ matrix.python-version }}
-          conda-channels: anaconda, conda-forge
-      - name: Run pycodestyle
-        run: |
-          sudo apt-get remove python3-openssl
-          pip install --upgrade -e '.[test]'
-          pycodestyle tests integration_tests examples --max-line-length 120
+          uv run --no-project --with '.[test,types]' ${LINT_COMMAND}
+        env:
+          LINT_COMMAND: ${{matrix.lintcommand}}
+          UV_PYTHON: ${{ matrix.python-version }}
+          UV_PYTHON_PREFERENCE: managed

--- a/integration_tests/index/test_postgis_index.py
+++ b/integration_tests/index/test_postgis_index.py
@@ -160,22 +160,9 @@ def test_spatial_index_crs_sanitise():
 
     sanitised = sanitise_extent(am_4326_ccw, epsg4326)
     assert sanitised.type == "MultiPolygon"
-    assert sanitised.json["coordinates"] == [
-        ((
-            (180.0, 25.0),
-            (178.0, 25.0),
-            (178.0, 23.0),
-            (180.0, 23.0),
-            (180.0, 25.0),
-        ),),
-        ((
-            (-180.0, 23.0),
-            (-178.0, 23.0),
-            (-178.0, 25.0),
-            (-180.0, 25.0),
-            (-180.0, 23.0),
-        ),),
-    ]
+    # We used to check for the exact new geometry here, but antimeridian 0.4
+    # changed the algorithm to use great circle instead of 2d for the splitting.
+    assert len(list(sanitised.geoms)) == 2
 
     assert sanitise_extent(pm_4326_ccw, epsg3857) == pm_4326_ccw.to_crs(epsg3857)
     assert sanitise_extent(pm_3857, epsg3857).geom.almost_equals(pm_3857.geom)


### PR DESCRIPTION
In the release of the antimeridian 0.4 package, the default method for splitting geometries at the meridian changed from a simple 2d method to a much nicer great-circle method. This changes the output coordinates from the operation. Both achieve the job of making the geometry valid, but the new method looks better.

Unfortunately, because there were hard coded coordinates in our tests of what happens with strange geometries, the tests started failing.

I've just removed the hard coded coordinates, but left in the check that the geometry has been split.

See https://github.com/gadomski/antimeridian/releases/tag/v0.4.0 for antimeridian release notes.


 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1708.org.readthedocs.build/en/1708/

<!-- readthedocs-preview datacube-core end -->