### PR TITLE
In GHA Always Build Test Docker (And don't rely on DockerHub/credentials)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,6 @@ name: build
 
 on:
   pull_request:
-    paths:
-      - '**'
-
   push:
     branches:
       - develop
@@ -16,9 +13,7 @@ on:
   workflow_dispatch:
 
 env:
-  DOCKER_USER: gadockersvc
-  DOCKER_IMAGE: opendatacube/datacube-tests:latest
-
+  DOCKER_IMAGE: ghrc.io/opendatacube/datacube-core:tests
 
 jobs:
   main:
@@ -29,52 +24,8 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Config
-      id: cfg
-      run: |
-        push_test_pypi=no
-        push_pypi=no
-
-        if [[ "${GITHUB_REF}" =~ refs/tags/.* ]]; then
-          echo "push_test_pypi=yes" >> $GITHUB_OUTPUT
-          echo "push_pypi=yes" >> $GITHUB_OUTPUT
-        fi
-
-    - uses: dorny/paths-filter@v3
-      id: changes
-      if: |
-        github.event_name == 'push'
-      with:
-        filters: |
-          docker:
-            - 'docker/**'
-    - name: Pull Docker
-      if: steps.changes.outputs.docker == 'false'
-      run: |
-        docker pull "${{ env.DOCKER_IMAGE }}"
-
     - name: Set up Docker Buildx
-      if: steps.changes.outputs.docker == 'true'
       uses: docker/setup-buildx-action@v3
-
-    - name: Cache Docker layers
-      if: steps.changes.outputs.docker == 'true'
-      uses: pat-s/always-upload-cache@v3.0.11
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-
-
-    - name: DockerHub Login
-      id: login
-      if: |
-        github.event_name == 'push'
-        && github.ref == 'refs/heads/develop'
-      uses: docker/login-action@v3
-      with:
-        username: ${{ env.DOCKER_USER }}
-        password: ${{ secrets.GADOCKERSVC_PASSWORD }}
 
     - name: Build Docker
       uses: docker/build-push-action@v6
@@ -83,14 +34,13 @@ jobs:
         context: .
         tags: ${{ env.DOCKER_IMAGE }}
         load: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
     - name: Verify and Run Tests
       run: |
-        echo "Verify that twine is installed"
-        docker run --rm ${{ env.DOCKER_IMAGE }} twine --version
-
         echo "Run tests"
-        cat <<EOF | docker run --rm -i -v $(pwd):/code ${{ env.DOCKER_IMAGE }} bash -
+        cat <<EOF | docker run --rm -v $(pwd):/code ${{ env.DOCKER_IMAGE }} bash -
           pip install -e /code/tests/drivers/fail_drivers --no-deps
           pip install -e /code/examples/io_plugin --no-deps
           pytest -r a \
@@ -103,18 +53,6 @@ jobs:
             integration_tests
         EOF
 
-    - name: DockerHub Push
-      if: |
-        github.event_name == 'push'
-        && github.ref == 'refs/heads/develop'
-        && steps.changes.outputs.docker == 'true'
-      uses: docker/build-push-action@v6
-      with:
-        file: docker/Dockerfile
-        context: .
-        push: true
-        tags: ${{env.DOCKER_IMAGE}}
-
     - name: Build Packages
       run: |
         cat <<EOF | docker run --rm -i  \
@@ -126,34 +64,9 @@ jobs:
         twine check ./dist/*
         EOF
 
-    - name: Publish to Test PyPi
-      if: |
-        steps.cfg.outputs.push_test_pypi == 'yes'
-      run: |
-        if [ -n "${TWINE_PASSWORD}" ]; then
-          docker run --rm  \
-            -v $(pwd):/code \
-            -e SKIP_DB=yes \
-            ${{ env.DOCKER_IMAGE }} \
-            twine upload \
-              --verbose \
-              --non-interactive \
-              --disable-progress-bar \
-              --username=__token__ \
-              --password=${TWINE_PASSWORD} \
-              --repository-url=${TWINE_REPOSITORY_URL} \
-              --skip-existing dist/* || true
-        else
-           echo "Skipping upload as 'TestPyPiToken' is not set"
-        fi
-      env:
-        TWINE_PASSWORD: ${{ secrets.TestPyPiToken }}
-        TWINE_REPOSITORY_URL: 'https://test.pypi.org/legacy/'
-
     - name: Publish to PyPi
       if: |
-        github.event_name == 'push'
-        && steps.cfg.outputs.push_pypi == 'yes'
+        github.repository_owner == 'opendatacube' && github.event.action == 'published'
       run: |
         if [ -n "${TWINE_PASSWORD}" ]; then
           docker run --rm  \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,8 +14,6 @@ ARG V_PGIS=16-postgis-3
 
 USER root
 RUN apt-get update -y \
-    && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
-    && DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-change-held-packages --fix-missing --no-install-recommends \
         git \
         libpq-dev libudunits2-dev libproj-dev \


### PR DESCRIPTION
Stop depending on DockerHub secrets, and on the strange periodic update of the "test" docker image. It doesn't take that long to build, just do it always.

I've enabled the GHA Cache backend for buildx, so the image build steps shouldn't re-run unnececessarily anyway.

### Reason for this pull request
- All the build + test GitHub actions runs were failing because, missing DockerHub secrets! 

We don't even publish images to DockerHub from this repo anymore. 🤦🏻 


### Proposed changes

<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1711.org.readthedocs.build/en/1711/

<!-- readthedocs-preview datacube-core end -->