### PR TITLE
Improve automated release process with OIDC and uv

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,9 @@ on:
       - '**'
       - '!docs/**'
       - '!contrib/**'
-
+  release:
+    types:
+      - published
   workflow_dispatch:
 
 env:
@@ -40,9 +42,12 @@ jobs:
     - name: Verify and Run Tests
       run: |
         echo "Run tests"
-        cat <<EOF | docker run --rm -v $(pwd):/code ${{ env.DOCKER_IMAGE }} bash -
+        cat <<EOF | docker run --rm -i -v $(pwd):/code ${{ env.DOCKER_IMAGE }} bash -
+          set -euo pipefail
+
           pip install -e /code/tests/drivers/fail_drivers --no-deps
           pip install -e /code/examples/io_plugin --no-deps
+
           pytest -r a \
             --cov datacube \
             --cov-report=xml \
@@ -53,39 +58,18 @@ jobs:
             integration_tests
         EOF
 
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+
     - name: Build Packages
       run: |
-        cat <<EOF | docker run --rm -i  \
-                  -v $(pwd):/code \
-                  -e SKIP_DB=yes \
-                  ${{ env.DOCKER_IMAGE }} bash -
-        python setup.py bdist_wheel sdist
-        ls -lh ./dist/
-        twine check ./dist/*
-        EOF
+        uv build
+        uv tool run twine check dist/*
 
-    - name: Publish to PyPi
-      if: |
-        github.repository_owner == 'opendatacube' && github.event.action == 'published'
-      run: |
-        if [ -n "${TWINE_PASSWORD}" ]; then
-          docker run --rm  \
-            -v $(pwd):/code \
-            -e SKIP_DB=yes \
-            ${{ env.DOCKER_IMAGE }} \
-            twine upload \
-              --verbose \
-              --non-interactive \
-              --disable-progress-bar \
-              --username=__token__ \
-              --password=${TWINE_PASSWORD} \
-              --skip-existing dist/*
-        else
-           echo "Skipping upload as 'PyPiToken' is not set"
-        fi
-
-      env:
-        TWINE_PASSWORD: ${{ secrets.PyPiToken }}
+    # Uses to OIDC identification between GitHub and PyPI
+    - name: Upload package to PyPI on GitHub Release
+      if: "github.repository_owner == 'opendatacube' && github.event.action == 'published'"
+      uses: pypa/gh-action-pypi-publish@release/v1
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5


### PR DESCRIPTION
Build packages directly on the GHA runner, instead of inside the docker container in the GHA runner.

Use uv to build the packages, instead of directly running setup.py which is no longer recommneded.

Use the PyPA GHA Action to upload the package, authenticating with OIDC.

No longer requires a stored authentication key for publishing.




<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1713.org.readthedocs.build/en/1713/

<!-- readthedocs-preview datacube-core end -->