### PR TITLE
Allow GHA to Authenticate with OIDC to PyPI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,9 @@ env:
 jobs:
   main:
     runs-on: ubuntu-latest
+    # Permit authenticating to PyPI
+    permissions:
+      id-token: write
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
### Reason for this pull request
Missed a key part of OIDC Authentication from GHA.


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1715.org.readthedocs.build/en/1715/

<!-- readthedocs-preview datacube-core end -->