### PR TITLE
Fix postgis filtered count bug

### DIFF
--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -863,10 +863,14 @@ class PostgisDbAPI:
             where_expressions = and_(*raw_expressions)
 
         query = select(func.count(Dataset.id))
+
         if geom:
             SpatialIndex, spatialquery = self.geospatial_query(geom)
             where_expressions = and_(where_expressions, spatialquery)
             query = query.join(SpatialIndex)
+
+        for join in self._join_tables(expressions=expressions):
+            query = query.join(*join)
 
         select_query = query.where(where_expressions)
         return self._connection.scalar(select_query)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -5,6 +5,13 @@
 What's New
 **********
 
+v1.9.next
+=========
+
+- Fix bug in postgis implementation of datasets.count() (with search filters).  Wasn't handling
+  table joins properly so was cartesian-joining with search tables resulting in wildly inaccurate
+  results and very slow queries on large databases. :pull:`1717`
+
 v1.9.1 (25th February 2025)
 ===========================
 
@@ -39,7 +46,7 @@ Maintenance
 
 - Update pre-commit hooks. :pull:`1701`, :pull:`1699`, :pull:`1710`
 - Update copyright dates for 2025.
-- Remove our GitHub Actions dependency on DockerHub (and credentials). :pull:`1711` 
+- Remove our GitHub Actions dependency on DockerHub (and credentials). :pull:`1711`
 - Update the release process to be a bit simpler, and use OIDC for authentication with
   PyPI. :pull:`1713`
 

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -464,6 +464,14 @@ def test_search_returning_eo3(index: Index,
     assert region_code == '090086'
     assert maturity == 'final'
 
+    count_by_date = index.datasets.count(
+        product='ga_ls8c_ard_3',
+        time=Range(
+            begin=datetime.datetime(2016, 5, 12, 18, tzinfo=datetime.timezone.utc),
+            end=datetime.datetime(2016, 5, 13, 2, tzinfo=datetime.timezone.utc)
+        )
+    )
+    assert count_by_date == 1
     results = list(index.datasets.search_returning(
         ('id', 'metadata_doc',),
         platform='landsat-8',

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -64,6 +64,7 @@ brazil
 Bugfix
 Bugfixes
 bY
+cartesian
 cbk
 cd
 CEOS


### PR DESCRIPTION
### Reason for this pull request

The postgis implementation of `dc.index.datasets.count()` does not handle joins properly, so when search tables are pulled into the query by user filter expressions, they queried as cartesian joins, resulting in wildly inaccurate results and extremely inefficient query time on large databases.

This has serious consequences for OWS.


### Proposed changes

- Handle joins properly in the postgis implementation of `dc.index.datasets.count()`.


 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1717.org.readthedocs.build/en/1717/

<!-- readthedocs-preview datacube-core end -->