### PR TITLE
Suppress cartesian join warnings

### DIFF
--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -815,7 +815,7 @@ class PostgisDbAPI:
         t1 = query.alias("t1")
         t2 = query.alias("t2")
 
-        t1fields = [getattr(t1.c, f.name) for f in fields]
+        t1fields = [getattr(t1.c, f.name) for f in fields]  # type: ignore[union-attr]
         time_overlap = select(
             t1.c.id,
             t1.c.time.intersection(t2.c.time).label('time_intersect'),
@@ -827,7 +827,7 @@ class PostgisDbAPI:
             )
         )
 
-        tovlap_fields = [getattr(time_overlap.c, f.name) for f in fields]
+        tovlap_fields = [getattr(time_overlap.c, f.name) for f in fields]  # type: ignore[union-attr]
         query = select(
             func.array_agg(func.distinct(time_overlap.c.id)).label("ids"),
             *tovlap_fields,  # type: ignore[arg-type]

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -817,6 +817,7 @@ class PostgresDbAPI(object):
         t1 = candidates_table.alias("t1")
         t2 = candidates_table.alias("t2")
 
+        fields = [getattr(t1.c, f.name) for f in fields]
         overlapping = select(
             t1.c.id,
             text("t1.time * t2.time as time_intersect"),
@@ -828,6 +829,7 @@ class PostgresDbAPI(object):
             )
         )
 
+        fields = [getattr(overlapping.c, f.name) for f in fields]
         final_query = select(
             func.array_agg(func.distinct(overlapping.c.id)).label("ids"),
             *fields,

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -11,6 +11,7 @@ v1.9.next
 - Fix bug in postgis implementation of datasets.count() (with search filters).  Wasn't handling
   table joins properly so was cartesian-joining with search tables resulting in wildly inaccurate
   results and very slow queries on large databases. :pull:`1717`
+- Suppress SQLAlchemy cartesian product warnings in datasets.find_duplicates_with_time :pull:`1719`
 
 v1.9.1 (25th February 2025)
 ===========================


### PR DESCRIPTION
### Reason for this pull request

We were getting SQLAlchemy cartesian join warnings from `datasets.find_duplicates_with_time` (both index drivers) as per #1718.

I'm not 100% sure whether there's a bug - it seems to me that if the results were wrong, the tests would fail as they are.


### Proposed changes

- Play strictly by SA's subquery model.

Not sure this fixes anything, but it removed the warnings and the tests still pass.

 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1719.org.readthedocs.build/en/1719/

<!-- readthedocs-preview datacube-core end -->