### PR TITLE
Update datetime handling to remove deprecated `utcnow()` usage

### DIFF
--- a/datacube/model/utils.py
+++ b/datacube/model/utils.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-import datetime
 import os
 import platform
 import sys
 import uuid
 import toolz
+from datetime import datetime, timezone
 
 import numpy
 import xarray
@@ -90,7 +90,7 @@ def geobox_info(extent, valid_data=None):
 def new_dataset_info():
     return {
         'id': str(uuid.uuid4()),
-        'creation_dt': datetime.datetime.utcnow().isoformat(),
+        'creation_dt': datetime.now(timezone.utc).replace(tzinfo=None).isoformat(),
     }
 
 


### PR DESCRIPTION
### Reason for this pull request
This PR addresses the deprecation warning related to `datetime.utcnow()` in Python 3.12/3.13 by replacing it with `datetime.now(timezone.utc)`.

### Proposed changes
- Replaced `datetime.utcnow().isoformat()` with `datetime.now(timezone.utc).replace(tzinfo=None).isoformat()` to maintain a consistent UTC format and solve the deprecation warning.

Note: I added `.replace(tzinfo=None)` to match the current format and ensure compatibility with existing code that expects timezone-unaware timestamps. This preserves the previous behavior of `datetime.utcnow().isoformat()`, which did not include an explicit UTC offset (+00:00). If you prefer to keep the timezone info, I can remove `.replace(tzinfo=None)`.

 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1721.org.readthedocs.build/en/1721/

<!-- readthedocs-preview datacube-core end -->