### PR TITLE
Fix PR links in docs (They're all broken)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,7 +89,7 @@ autodoc_default_options = {"autosummary": True, "inherited-members": True}
 
 extlinks = {
     "issue": ("https://github.com/opendatacube/datacube-core/issues/%s", "issue %s"),
-    "pull": ("https://github.com/opendatacube/datacube-core/pulls/%s", "PR %s"),
+    "pull": ("https://github.com/opendatacube/datacube-core/pull/%s", "PR %s"),
 }
 
 intersphinx_mapping = {


### PR DESCRIPTION
GitHub is now only working for `/pull/<number>` whereas it used to accept `/pulls/<number>`


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1722.org.readthedocs.build/en/1722/

<!-- readthedocs-preview datacube-core end -->