### PR TITLE
Fixing broken docs links

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -292,7 +292,7 @@ class Datacube:
         Load data as an ``xarray.Dataset`` object.
         Each measurement will be a data variable in the :class:`xarray.Dataset`.
 
-        See the `xarray documentation <http://xarray.pydata.org/en/stable/data-structures.html>`_ for usage of the
+        See the `xarray documentation <https://xarray.pydata.org/en/stable/data-structures.html>`_ for usage of the
         :class:`xarray.Dataset` and :class:`xarray.DataArray` objects.
 
         **Product and Measurements**
@@ -459,7 +459,7 @@ class Datacube:
             If the data should be lazily loaded using :class:`dask.array.Array`,
             specify the chunking size in each output dimension.
 
-            See the documentation on using `xarray with dask <http://xarray.pydata.org/en/stable/dask.html>`_
+            See the documentation on using `xarray with dask <https://xarray.pydata.org/en/stable/dask.html>`_
             for more information.
 
         :param xarray.Dataset like:
@@ -1044,7 +1044,7 @@ class Datacube:
             Unspecified dimensions will be auto-guessed, currently this means use chunk size of 1 for non-spatial
             dimensions and use whole dimension (no chunking unless specified) for spatial dimensions.
 
-            See the documentation on using `xarray with dask <http://xarray.pydata.org/en/stable/dask.html>`_
+            See the documentation on using `xarray with dask <https://xarray.pydata.org/en/stable/dask.html>`_
             for more information.
 
         :param progress_cbk: Int, Int -> None

--- a/docs/about-core-concepts/architecture-guide.rst
+++ b/docs/about-core-concepts/architecture-guide.rst
@@ -29,7 +29,7 @@ components that make up an implementation, as well as the ecosystem around it.
 
 .. _`Cloud Optimised GeoTIFFs`: https://www.cogeo.org/
 .. _`SpatioTemporal Asset Catalog`: https://stacspec.org/
-.. _`Sentinel-2 Indexing notes`: https://github.com/opendatacube/datacube-dataset-config/blob/master/sentinel-2-l2a-cogs.md
+.. _`Sentinel-2 Indexing notes`: https://github.com/opendatacube/datacube-dataset-config/blob/main/sentinel-2-l2a-cogs.md
 .. _`Datacube Explorer`: https://github.com/opendatacube/datacube-explorer
 
 

--- a/docs/about-core-concepts/extensions.rst
+++ b/docs/about-core-concepts/extensions.rst
@@ -128,5 +128,5 @@ producing datasets that are packaged completely.
 .. _odc-stats: https://github.com/opendatacube/odc-stats
 .. _datacube-alchemist: https://github.com/opendatacube/datacube-alchemist
 .. _`DEA Maps`: https://maps.dea.ga.gov.au
-.. _`Digital Earth Africa Maps`: http://maps.digitalearth.africa
-.. _`Digital Earth Australia Explorer`: https://explorer.sandbox.dea.ga.gov.au
+.. _`Digital Earth Africa Maps`: https://maps.digitalearth.africa
+.. _`Digital Earth Australia Explorer`: https://explorer.sandbox.dea.ga.gov.au/products

--- a/docs/about/glossary.rst
+++ b/docs/about/glossary.rst
@@ -35,14 +35,14 @@ This page lists definitions for terms used in the Open Data Cube and this manual
    Digital Earth Australia
 
       Geoscience Australia's deployment of ODC, hosted at the :term:`NCI`. See
-      the `DEA user guide <http://geoscienceaustralia.github.io/digitalearthau/>`_ for
+      the `DEA user guide <https://geoscienceaustralia.github.io/digitalearthau/>`_ for
       details on how to access the platform.
 
    GA
    Geoscience Australia
       The primary public sector geoscience organisation in Australia.
       It supports ODC through the development of Digital Earth Australia. For more
-      information see http://www.ga.gov.au/dea/.
+      information see https://www.ga.gov.au/scientific-topics/dea.
 
    grid spec
    Grid Specification
@@ -53,7 +53,7 @@ This page lists definitions for terms used in the Open Data Cube and this manual
 
       Australia's national research computing facility. It provides computing
       facilities for use by Australian researchers, industry and government. For
-      more information see http://nci.org.au/.
+      more information see https://nci.org.au/.
 
    HPC
    High Performance Computing
@@ -91,12 +91,6 @@ This page lists definitions for terms used in the Open Data Cube and this manual
    United States Geological Survey
       The USA government organisation which operates both the Landsat and MODIS satellites,
       which are available as free an open earth observation data.
-
-   VDI
-   Virtual Desktop Infrastructure
-      A virtual desktop environment at NCI that provides a linux desktop
-      environment for scientific computing. For more see
-      http://vdi.nci.org.au/help.
 
    WMS
    Web Map Service

--- a/docs/data-access-analysis/advanced-topics/data-loading.rst
+++ b/docs/data-access-analysis/advanced-topics/data-loading.rst
@@ -363,5 +363,5 @@ Storage Classes
 
 
 .. _rasterio: https://rasterio.readthedocs.io/en/latest/
-.. _xarray: https://xarray.pydata.org/
-.. _dask: https://dask.pydata.org/
+.. _xarray: https://docs.xarray.dev/en/stable/
+.. _dask: https://docs.dask.org/en/stable/

--- a/docs/data-access-analysis/tools-exploring-data/using-jupyter.rst
+++ b/docs/data-access-analysis/tools-exploring-data/using-jupyter.rst
@@ -48,4 +48,4 @@ DEA and DE Africa Tools code
 Both `Digital Earth Australia Notebooks`_ and `Digital Earth Africa Notebooks`_ provide pip-installable Python modules containing useful tools for analysing Open Data Cube data, including functions for loading and plotting satellite imagery, calculating band indices, analysing spatial datasets, and machine learning. These tools can be accessed here:
 
 * ``DEA Tools``: https://github.com/GeoscienceAustralia/dea-notebooks/tree/stable/Tools
-* ``DE Africa Tools``: https://github.com/digitalearthafrica/deafrica-sandbox-notebooks/tree/master/Tools
+* ``DE Africa Tools``: https://github.com/digitalearthafrica/deafrica-sandbox-notebooks/tree/main/Tools

--- a/docs/installation/MIGRATION-1.8-to-1.9.rst
+++ b/docs/installation/MIGRATION-1.8-to-1.9.rst
@@ -149,7 +149,7 @@ Major Changes between 1.8.x and 1.9.x
 8. Multiple locations per dataset is now deprecated, and is not supported by the ``postgis`` index driver.
 
 .. _`odc-geo`: https://github.com/opendatacube/odc-geo
-.. _`odc-loader`: https://github.com/opendatacube/odc-load
+.. _`odc-loader`: https://github.com/opendatacube/odc-loader
 
 The New Postgis Index Driver
 ----------------------------

--- a/docs/installation/dataset-documents.rst
+++ b/docs/installation/dataset-documents.rst
@@ -123,7 +123,7 @@ eo3 `formal specification`_.
 
 
 A command-line tool to validate eo3 documents called ``eo3-validate`` is available
-in the `eodatasets3 library <https://github.com/GeoscienceAustralia/eo-datasets>`_,
+in the `eodatasets3 library <https://github.com/opendatacube/eo-datasets>`_,
 as well as optional tools to write these files more easily.
 
 A command-line tool also exists for dynamically converting STAC items to EO3 datasets

--- a/docs/installation/indexing-data/indexing-from-s3.rst
+++ b/docs/installation/indexing-data/indexing-from-s3.rst
@@ -10,7 +10,7 @@ Configuring AWS CLI Credentials
 
 Install the AWS CLI package and configure it with your Amazon AWS credentials.
 For a more detailed tutorial on AWS CLI configurations, visit the
-`official AWS docs <https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html>`_.
+`official AWS docs <https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html>`_.
 The only two fields required to be configured are the ``Access Key``, and
 ``Secret Access Key``. These keys can be found on your AWS login
 security page. Try not to lose your ``Secret Access Key`` as you will

--- a/docs/installation/indexing-data/step-guide.rst
+++ b/docs/installation/indexing-data/step-guide.rst
@@ -35,7 +35,7 @@ Product Definition.
 
 More detailed information on the structure of a product definition document can be found :ref:`here <product-doc>`
 
-Some example Product definitions are supplied `here <https://github.com/opendatacube/datacube-dataset-config/tree/master/products>`_.
+Some example Product definitions are supplied `here <https://github.com/opendatacube/datacube-dataset-config/tree/main/products>`_.
 Other examples include the `Digital Earth Africa product definitions <https://github.com/digitalearthafrica/config/tree/master/products>`_.
 
 
@@ -68,7 +68,7 @@ for searching, querying and accessing the data.
 The data from Geoscience Australia already comes with relevant files (named ``ga-metadata.yaml``), so
 no further steps are required for indexing them.
 
-For third party datasets, see the examples detailed `here <https://github.com/opendatacube/datacube-dataset-config#documented-examples>`__.
+For third party datasets, see the examples detailed `here <https://github.com/opendatacube/datacube-dataset-config?tab=readme-ov-file#documented-examples>`__.
 For common distribution formats, data can be indexed using one of the tools from `odc-apps-dc-tools <https://github.com/opendatacube/odc-tools/tree/develop/apps/dc_tools>`__.
 In other cases, the metadata may need to be mapped to an ODC-compatible format. You can find examples of data preparation scripts `here <https://github.com/opendatacube/datacube-dataset-config/tree/main/old-prep-scripts>`__.
 

--- a/docs/installation/setup/common_install.rst
+++ b/docs/installation/setup/common_install.rst
@@ -12,8 +12,8 @@ Conda environment setup
 
 Conda environments are recommended for use in isolating your ODC development environment from your system installation and other Python environments.
 
-We recommend you use Mambaforge to set up your conda virtual environment, as all the required packages are obtained from the conda-forge channel.
-Download and install it from `the Miniforge GitHub <https://github.com/conda-forge/miniforge#mambaforge>`_.
+We recommend you use Miniforge to set up your conda virtual environment, as all the required packages are obtained from the conda-forge channel.
+Download and install it from `the Miniforge GitHub <https://github.com/conda-forge/miniforge>`_.
 
 Download the latest version of the Open Data Cube from the `repository <https://github.com/opendatacube/datacube-core>`_::
 


### PR DESCRIPTION
### Reason for this pull request

Update links that are broken or use http instead of https

 - [ ] Closes #1703 
 - [ ] Tests added / passed


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1725.org.readthedocs.build/en/1725/

<!-- readthedocs-preview datacube-core end -->