### PR TITLE
Stop (un-)filtering warnings

### DIFF
--- a/datacube/__init__.py
+++ b/datacube/__init__.py
@@ -20,11 +20,7 @@ except ImportError:
     __version__ = 'Unknown/Not Installed'
 
 from .api import Datacube
-import warnings
 from .utils import xarray_geoextensions
-
-# Ensure deprecation warnings from datacube modules are shown
-warnings.filterwarnings('always', category=DeprecationWarning, module=r'^datacube\.')
 
 __all__ = (
     "Datacube",


### PR DESCRIPTION
### Reason for this pull request

Filtering warnings breaks
"python3 -W ignore file.py"
for end-users, so libraries
should avoid that.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1734.org.readthedocs.build/en/1734/

<!-- readthedocs-preview datacube-core end -->