### PR TITLE
dataset: remove sequence unpacking

### DIFF
--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -262,8 +262,11 @@ def update_cmd(index, keys_that_can_change, dry_run, location_policy, dataset_pa
             _LOG.warning("Refusing to %s old location, there are several", action_name)
             return None
 
-        new_uri, = new_ds.uris
-        old_uri, = existing_ds.uris
+        if new_ds.has_multiple_uris():
+            raise ValueError("More than one uri in new dataset")
+
+        new_uri = new_ds.uri
+        old_uri = existing_ds.uri
 
         if new_uri == old_uri:
             return None


### PR DESCRIPTION
### Reason for this pull request

Replace the sequence unpacking
of new_ds.uris with an explicit
check and raising a ValueError,
and then use uri as accessor
after that.

Just read uri directly for
existing_ds, the code already
guarantees that this is a single
item list.

No functional change from these
two changes.

Refs #1716


### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1738.org.readthedocs.build/en/1738/

<!-- readthedocs-preview datacube-core end -->