### PR TITLE
Fix odc-geo warning

### DIFF
--- a/datacube/utils/geometry/__init__.py
+++ b/datacube/utils/geometry/__init__.py
@@ -8,8 +8,7 @@ from warnings import warn
 
 warn(
     'datacube.utils.geometry is now deprecated. Please use the odc-geo library instead.',
-    DeprecationWarning,
-    stacklevel=2)
+    DeprecationWarning)
 
 from ._base import (  # noqa
     Coordinate,


### PR DESCRIPTION
### Reason for this pull request

This warning is reported from:

/usr/lib/python3.12/importlib/__init__.py:90: DeprecationWarning:

which is confusing, so remove
the stacklevel.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1739.org.readthedocs.build/en/1739/

<!-- readthedocs-preview datacube-core end -->