### PR TITLE
_rio: prevent mypy note

### DIFF
--- a/datacube/storage/_rio.py
+++ b/datacube/storage/_rio.py
@@ -193,7 +193,7 @@ class RasterDatasetDataSource(RasterioDataSource):
         raise DeprecationWarning("Stacked netcdf without explicit time index is not supported anymore")
 
     def get_transform(self, shape: RasterShape) -> Affine:
-        return self._band_info.transform * Affine.scale(   # type: ignore[type-var, return-value]
+        return self._band_info.transform * Affine.scale(   # type: ignore[operator, type-var, return-value]
             1 / shape[1],
             1 / shape[0]
         )


### PR DESCRIPTION
### Reason for this pull request

Without ignoring the operator, there is a note about the left argument having type `Affine | None` from `mypy`. Add the operator to the ignore so introducing new type checker warnings stands out.




<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1742.org.readthedocs.build/en/1742/

<!-- readthedocs-preview datacube-core end -->