### PR TITLE
Update MyPy version

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -814,7 +814,10 @@ class Datacube:
             tuple(c.size for k, c in coords.items() if k in dims_default) + geobox.shape
         )
         coords_default: OrderedDict[str, xarray.DataArray] = OrderedDict(
-            **coords, **xr_coords(geobox, spatial_ref)
+            **coords
+        )
+        coords_default.update(
+            [(str(k), v) for k, v in xr_coords(geobox, spatial_ref).items()]
         )
 
         arrays = []

--- a/datacube/virtual/impl.py
+++ b/datacube/virtual/impl.py
@@ -826,7 +826,9 @@ class Reproject(VirtualProduct):
         result = xarray.Dataset()
         result.coords['time'] = grouped.box.coords['time']
 
-        coords: Mapping[Hashable, xarray.DataArray] = OrderedDict(**xr_coords(geobox, spatial_ref))
+        coords: Mapping[Hashable, xarray.DataArray] = OrderedDict(
+            [(str(k), v) for k, v in xr_coords(geobox, spatial_ref).items()]
+        )
         result.coords.update(coords)
 
         for measurement in measurements:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ tests_require = [
 ]
 
 types_require = [
-    "mypy<1.14",
+    "mypy",
     "types-affine",
     "types-cachetools",
     "types-jsonschema",


### PR DESCRIPTION
### Reason for this pull request

Modern MyPy gives an incomprehensible error message for these two `OrderedDicts`. `Pyright` gives
a more readable error:

    Argument expression after ** must be a mapping with a "str" key type

so convert the keys of the dictionary from `xr_coords` to strings.

The list of tuples with the type correct keys cannot come after the unpacked dictionary argument to `OrderedDict`, so
add them through the `update` method instead.

This changes the behavior of the code since there will no longer be a `TypeError` exception when the keys overlap between the two dictionaries.

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1743.org.readthedocs.build/en/1743/

<!-- readthedocs-preview datacube-core end -->