### PR TITLE
core: fix GridSpec deprecation warning

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -2,11 +2,12 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 import logging
 import uuid
 import collections.abc
 from itertools import groupby
-from typing import Any, Iterable, cast, Callable, Hashable, Mapping, Sequence
+from typing import Any, Iterable, cast, Callable, Hashable, Mapping, Sequence, TYPE_CHECKING
 import datetime
 
 import deprecat
@@ -28,9 +29,11 @@ from datacube.model import (
     ExtraDimensionSlices,
     Dataset,
     Measurement,
-    GridSpec,
 )
 from datacube.model.utils import xr_apply
+
+if TYPE_CHECKING:
+    from datacube.model import GridSpec
 
 from .query import Query, query_group_by, GroupBy
 from ..index import index_connect, Index, extract_geom_from_query


### PR DESCRIPTION
### Reason for this pull request

GridSpec is only used for type
checking, so only import it for
type checking to avoid triggering
deprecation warnings.

Refs #1716

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1745.org.readthedocs.build/en/1745/

<!-- readthedocs-preview datacube-core end -->