### PR TITLE
Stop building Python 2 wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,6 @@
 [aliases]
 test=pytest
 
-[bdist_wheel]
-universal=1
-
 [flake8]
 max-line-length = 120
 ignore =


### PR DESCRIPTION
### Reason for this pull request

This warning appears in the CI logs:

With Python 2.7 end-of-life, support for building universal wheels (i.e., wheels that support both Python 2 and Python 3) is being obviated.
Please discontinue using this option, or if you still need it, file an issue with pypa/setuptools describing your use case. By 2025-Aug-30, you need to update your project and remove deprecated calls or your builds will no longer be supported.

and since the package already requires
Python 3.10, stop building universal wheels.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1752.org.readthedocs.build/en/1752/

<!-- readthedocs-preview datacube-core end -->