### PR TITLE
CI: retry more in setup-miniconda

### DIFF
--- a/.github/workflows/test-conda-build.yml
+++ b/.github/workflows/test-conda-build.yml
@@ -33,6 +33,14 @@ jobs:
             hashFiles('conda-environment.yml') }}
 
       - uses: conda-incubator/setup-miniconda@v3
+        continue-on-error: true
+        id: conda1
+        with:
+          environment-file: conda-environment.yml
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version}}
+      - uses: conda-incubator/setup-miniconda@v3
+        if: steps.conda1.outcome == 'failure'
         with:
           environment-file: conda-environment.yml
           auto-update-conda: true


### PR DESCRIPTION
### Reason for this pull request

The action seems to fail intermittently with:

```
CondaHTTPError: HTTP 000 CONNECTION FAILED for url <https://conda.anaconda.org/conda-forge/linux-64/repodata.json>
Elapsed: -

An HTTP error occurred when trying to retrieve this URL. HTTP errors are often intermittent, and a simple retry will get you on your way.
```

So, permit the action to fail the first time, and then run the action again if that happens.


<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1753.org.readthedocs.build/en/1753/

<!-- readthedocs-preview datacube-core end -->