### PR TITLE
pytest: ignore boto deprecation warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,6 @@
 addopts = --doctest-modules
 testpaths = datacube tests integration_tests
 norecursedirs = .* build dist .git tmp*
-filterwarnings = ignore::FutureWarning
+filterwarnings =
+    ignore::FutureWarning
+    ignore:datetime.datetime.utcnow*:DeprecationWarning:botocore.*


### PR DESCRIPTION
### Reason for this pull request

Botocore interacts with a large code base
so it cannot fix the utcnow deprecation
warning easily. Since there is nothing
to do about the warning, ignore it.

Refs #1716

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1754.org.readthedocs.build/en/1754/

<!-- readthedocs-preview datacube-core end -->