### PR TITLE
Reinstate grid workflow

### DIFF
--- a/datacube/api/grid_workflow.py
+++ b/datacube/api/grid_workflow.py
@@ -70,9 +70,8 @@ class Tile:
         self.geobox: GeoBox = geobox
 
     @property
-    def dims(self) -> tuple[Hashable, ...]:
+    def dims(self) -> tuple[str, ...]:
         """Names of the dimensions, eg ``('time', 'y', 'x')``
-        :return: tuple(str)
         """
         return self.sources.dims + self.geobox.dimensions
 
@@ -96,13 +95,12 @@ class Tile:
         return Tile(sources, geobox)
 
     # TODO(csiro) Split on time range
-    def split(self, dim: str, step: int = 1):
+    def split(self, dim: str, step: int = 1) -> tuple(key, Tile):
         """
         Splits along a non-spatial dimension into Tile objects with a length of 1 or more in the `dim` dimension.
 
         :param dim: Name of the non-spatial dimension to split
         :param step: step size to split
-        :return: tuple(key, Tile)
         """
         axis = self.dims.index(dim)
         indexer = [slice(None)] * len(self.dims)
@@ -111,19 +109,19 @@ class Tile:
             indexer[axis] = slice(i, min(size, i + step))
             yield self.sources[dim].values[i], self[tuple(indexer)]
 
-    def split_by_time(self, freq: str = "A", time_dim: str = "time", **kwargs):
+    def split_by_time(self, freq: str = "A", time_dim: str = "time", **kwargs) -> Generator[tuple(str, Tile)]:
         """
         Splits along the `time` dimension, into periods, using pandas offsets, such as:
         :
             'A': Annual
             'Q': Quarter
             'M': Month
-        See: http://pandas.pydata.org/pandas-docs/stable/timeseries.html?highlight=rollback#timeseries-offset-aliases
+        See: https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#dateoffset-objects
 
         :param freq: time series frequency
         :param time_dim: name of the time dimension
         :param kwargs: other keyword arguments passed to ``pandas.period_range``
-        :return: Generator[tuple(str, Tile)] generator of the key string (eg '1994') and the slice of Tile
+        :return:  generator of the key string (eg '1994') and the slice of Tile
         """
         # extract first and last timestamps from the time axis, note this will
         # work with 1 element arrays as well
@@ -156,7 +154,7 @@ class GridWorkflow:
     def __init__(
         self,
         index: Index,
-        grid_spec: GridWorkflow | None = None,
+        grid_spec: GridSpec | None = None,
         product: Product | str | None = None,
     ):
         """

--- a/datacube/api/grid_workflow.py
+++ b/datacube/api/grid_workflow.py
@@ -1,6 +1,6 @@
 # This file is part of the Open Data Cube, see https://opendatacube.org for more information
 #
-# Copyright (c) 2015-2024 ODC Contributors
+# Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 import logging
@@ -23,13 +23,22 @@ if typing.TYPE_CHECKING:
 
 def _fast_slice(array: xr.DataArray, indexers):
     data = array.values[indexers]
-    dims = [dim for dim, indexer in zip(array.dims, indexers) if isinstance(indexer, slice)]
-    coords = OrderedDict((dim,
-                          xr.Variable((dim,),
-                                          array.coords[dim].values[indexer],
-                                          attrs=array.coords[dim].attrs,
-                                          fastpath=True))
-                         for dim, indexer in zip(array.dims, indexers) if isinstance(indexer, slice))
+    dims = [
+        dim for dim, indexer in zip(array.dims, indexers) if isinstance(indexer, slice)
+    ]
+    coords = OrderedDict(
+        (
+            dim,
+            xr.Variable(
+                (dim,),
+                array.coords[dim].values[indexer],
+                attrs=array.coords[dim].attrs,
+                fastpath=True,
+            ),
+        )
+        for dim, indexer in zip(array.dims, indexers)
+        if isinstance(indexer, slice)
+    )
     return xr.DataArray(data, dims=dims, coords=coords, attrs=array.attrs)
 
 
@@ -61,14 +70,14 @@ class Tile:
         self.geobox: GeoBox = geobox
 
     @property
-    def dims(self) -> tuple[str]:
+    def dims(self) -> tuple[Hashable, ...]:
         """Names of the dimensions, eg ``('time', 'y', 'x')``
         :return: tuple(str)
         """
         return self.sources.dims + self.geobox.dimensions
 
     @property
-    def shape(self) -> tuple[int]:
+    def shape(self) -> tuple[int, ...]:
         """Lengths of each dimension, eg ``(285, 4000, 4000)``
         :return: tuple(int)
         """
@@ -82,7 +91,7 @@ class Tile:
         return self.sources.values[0][0].product
 
     def __getitem__(self, chunk):
-        sources = _fast_slice(self.sources, chunk[:len(self.sources.shape)])
+        sources = _fast_slice(self.sources, chunk[: len(self.sources.shape)])
         geobox = self.geobox[chunk[len(self.sources.shape):]]
         return Tile(sources, geobox)
 
@@ -102,7 +111,7 @@ class Tile:
             indexer[axis] = slice(i, min(size, i + step))
             yield self.sources[dim].values[i], self[tuple(indexer)]
 
-    def split_by_time(self, freq:str = 'A', time_dim:str = 'time', **kwargs):
+    def split_by_time(self, freq: str = "A", time_dim: str = "time", **kwargs):
         """
         Splits along the `time` dimension, into periods, using pandas offsets, such as:
         :
@@ -120,11 +129,10 @@ class Tile:
         # work with 1 element arrays as well
         start_range, end_range = self.sources[time_dim].data[[0, -1]]
 
-        for p in pd.period_range(start=start_range,
-                                 end=end_range,
-                                 freq=freq,
-                                 **kwargs):
-            sources_slice = self.sources.loc[{time_dim: slice(p.start_time, p.end_time)}]
+        for p in pd.period_range(start=start_range, end=end_range, freq=freq, **kwargs):
+            sources_slice = self.sources.loc[
+                {time_dim: slice(p.start_time, p.end_time)}
+            ]
             yield str(p), Tile(sources=sources_slice, geobox=self.geobox)
 
     def __str__(self):
@@ -145,7 +153,12 @@ class GridWorkflow:
     and can be serialized for use with the `distributed` package.
     """
 
-    def __init__(self, index: Index, grid_spec: GridWorkflow | None = None, product: Product | str | None = None):
+    def __init__(
+        self,
+        index: Index,
+        grid_spec: GridWorkflow | None = None,
+        product: Product | str | None = None,
+    ):
         """
         Create a grid workflow tool.
 
@@ -160,19 +173,25 @@ class GridWorkflow:
             if product is None:
                 raise ValueError("Have to supply either grid_spec or product")
 
-            product = self.index.products.get_by_name(product)
+            if isinstance(product, str):
+                product = self.index.products.get_by_name(product)
+
             if product is None:
                 raise ValueError(f"No such product: {product}")
 
             if product.grid_spec is None:
-                raise ValueError(f"Supplied product `{product}` does not have a gridspec")
+                raise ValueError(
+                    f"Supplied product `{product}` does not have a gridspec"
+                )
 
             grid_spec = product.grid_spec
         self.grid_spec = grid_spec
 
         assert self.grid_spec is not None
 
-    def cell_observations(self, cell_index=None, geopolygon=None, tile_buffer=None, **indexers):
+    def cell_observations(
+        self, cell_index=None, geopolygon=None, tile_buffer=None, **indexers
+    ):
         """
         List datasets, grouped by cell.
 
@@ -196,11 +215,13 @@ class GridWorkflow:
         # TODO: split this method into 3: cell/polygon/unconstrained querying
 
         if tile_buffer is not None and geopolygon is not None:
-            raise ValueError('Cannot process tile_buffering and geopolygon together.')
+            raise ValueError("Cannot process tile_buffering and geopolygon together.")
         cells = {}
 
         def add_dataset_to_cells(tile_index, tile_geobox, dataset_):
-            cells.setdefault(tile_index, {'datasets': [], 'geobox': tile_geobox})['datasets'].append(dataset_)
+            cells.setdefault(tile_index, {"datasets": [], "geobox": tile_geobox})[
+                "datasets"
+            ].append(dataset_)
 
         if cell_index:
             assert len(cell_index) == 2
@@ -220,8 +241,11 @@ class GridWorkflow:
             if query.geopolygon:
                 # Get a rough region of tiles
                 query_tiles = set(
-                    tile_index for tile_index, tile_geobox in
-                    self.grid_spec.tiles_from_geopolygon(query.geopolygon, geobox_cache=geobox_cache))
+                    tile_index
+                    for tile_index, tile_geobox in self.grid_spec.tiles_from_geopolygon(
+                        query.geopolygon, geobox_cache=geobox_cache
+                    )
+                )
 
                 for dataset in datasets:
                     # Go through our datasets and see which tiles each dataset produces, and whether they intersect
@@ -230,15 +254,24 @@ class GridWorkflow:
                     bbox = dataset_extent.boundingbox
                     bbox = bbox.buffered(*tile_buffer) if tile_buffer else bbox
 
-                    for tile_index, tile_geobox in self.grid_spec.tiles(bbox, geobox_cache=geobox_cache):
-                        if tile_index in query_tiles and intersects(tile_geobox.extent, dataset_extent):
+                    for tile_index, tile_geobox in self.grid_spec.tiles(
+                        bbox, geobox_cache=geobox_cache
+                    ):
+                        if tile_index in query_tiles and intersects(
+                            tile_geobox.extent, dataset_extent
+                        ):
                             add_dataset_to_cells(tile_index, tile_geobox, dataset)
 
             else:
                 for dataset in datasets:
-                    dataset_extent = dataset.extent.buffer(*tile_buffer) if tile_buffer else dataset.extent
-                    for tile_index, tile_geobox in self.grid_spec.tiles_from_geopolygon(dataset_extent,
-                                                                                        geobox_cache=geobox_cache):
+                    dataset_extent = (
+                        dataset.extent.buffer(*tile_buffer)
+                        if tile_buffer
+                        else dataset.extent
+                    )
+                    for tile_index, tile_geobox in self.grid_spec.tiles_from_geopolygon(
+                        dataset_extent, geobox_cache=geobox_cache
+                    ):
                         if tile_buffer:
                             tile_geobox = tile_geobox.buffered(*tile_buffer)
                         add_dataset_to_cells(tile_index, tile_geobox, dataset)
@@ -248,7 +281,7 @@ class GridWorkflow:
     def _find_datasets(self, geopolygon, indexers):
         query = Query(index=self.index, geopolygon=geopolygon, **indexers)
         if not query.product:
-            raise RuntimeError('must specify a product')
+            raise RuntimeError("must specify a product")
         datasets = self.index.datasets.search_eager(**query.search_terms)
         return datasets, query
 
@@ -270,8 +303,8 @@ class GridWorkflow:
         """
         cells = {}
         for cell_index, observation in observations.items():
-            sources = Datacube.group_datasets(observation['datasets'], group_by)
-            cells[cell_index] = Tile(sources, observation['geobox'])
+            sources = Datacube.group_datasets(observation["datasets"], group_by)
+            cells[cell_index] = Tile(sources, observation["geobox"])
         return cells
 
     @staticmethod
@@ -292,14 +325,14 @@ class GridWorkflow:
         """
         tiles = {}
         for cell_index, observation in observations.items():
-            dss = observation['datasets']
-            geobox = observation['geobox']
+            dss = observation["datasets"]
+            geobox = observation["geobox"]
 
             sources = Datacube.group_datasets(dss, group_by)
             coord = sources[sources.dims[0]]
             for i in range(coord.size):
                 tile_index = cell_index + (coord.values[i],)
-                tiles[tile_index] = Tile(sources[i:i+1], geobox)
+                tiles[tile_index] = Tile(sources[i:i + 1], geobox)
 
         return tiles
 
@@ -344,7 +377,14 @@ class GridWorkflow:
         return self.tile_sources(observations, query_group_by(**query))
 
     @staticmethod
-    def load(tile, measurements=None, dask_chunks=None, fuse_func=None, resampling=None, skip_broken_datasets=False):
+    def load(
+        tile,
+        measurements=None,
+        dask_chunks=None,
+        fuse_func=None,
+        resampling=None,
+        skip_broken_datasets=False,
+    ):
         """
         Load data for a cell/tile.
 
@@ -388,22 +428,29 @@ class GridWorkflow:
         """
         measurement_dicts = tile.product.lookup_measurements(measurements)
 
-        dataset = Datacube.load_data(tile.sources, tile.geobox,
-                                     measurement_dicts, resampling=resampling,
-                                     dask_chunks=dask_chunks, fuse_func=fuse_func,
-                                     skip_broken_datasets=skip_broken_datasets)
+        dataset = Datacube.load_data(
+            tile.sources,
+            tile.geobox,
+            measurement_dicts,
+            resampling=resampling,
+            dask_chunks=dask_chunks,
+            fuse_func=fuse_func,
+            skip_broken_datasets=skip_broken_datasets,
+        )
 
         return dataset
 
     def update_tile_lineage(self, tile: Tile):
         for i in range(tile.sources.size):
             sources = tile.sources.values[i]
-            tile.sources.values[i] = tuple(self.index.datasets.get(dataset.id, include_sources=True)
-                                           for dataset in sources)
+            tile.sources.values[i] = tuple(
+                self.index.datasets.get(dataset.id, include_sources=True)
+                for dataset in sources
+            )
         return tile
 
     def __str__(self):
-        return "GridWorkflow<index={!r},\n\tgridspec={!r}>".format(self.index, self.grid_spec)
+        return f"GridWorkflow<index={self.index!r},\n\tgridspec={self.grid_spec!r}>"
 
     def __repr__(self):
         return self.__str__()

--- a/datacube/api/grid_workflow.py
+++ b/datacube/api/grid_workflow.py
@@ -3,25 +3,31 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-from collections.abc import Generator, Hashable
+
 import logging
 import typing
-from typing_extensions import override
-from odc.geo.gridspec import GridSpec
-import xarray as xr
 from collections import OrderedDict
-import pandas as pd
+from collections.abc import Generator, Hashable
 
-from odc.geo.geom import intersects
-from .query import Query, query_group_by
+import numpy as np
+import pandas as pd
+import xarray as xr
+from odc.geo.geom import Geometry, intersects
+from odc.geo.gridspec import GridSpec
+from typing_extensions import override
+
+from datacube.model import Dataset, QueryField
+
 from .core import Datacube
+from .query import GroupBy, Query, query_group_by
 
 _LOG = logging.getLogger(__name__)
 
 if typing.TYPE_CHECKING:
     from odc.geo.geobox import GeoBox
-    from datacube.model import Product
+
     from datacube.index import Index
+    from datacube.model import Product
 
 
 def _fast_slice(array: xr.DataArray, indexers):
@@ -62,7 +68,7 @@ class Tile:
     the entire `Tile` at once.
     """
 
-    def __init__(self, sources: xr.DataArray, geobox):
+    def __init__(self, sources: xr.DataArray, geobox: GeoBox):
         """Create a Tile representing a dataset that can be loaded.
 
         :param xr.DataArray sources: An array of non-spatial dimensions of the request, holding lists of
@@ -81,14 +87,12 @@ class Tile:
     @property
     def shape(self) -> tuple[int, ...]:
         """Lengths of each dimension, eg ``(285, 4000, 4000)``
-        :return: tuple(int)
         """
         return self.sources.shape + self.geobox.shape
 
     @property
     def product(self) -> Product:
         """
-        :rtype: datacube.model.DatasetType
         """
         return self.sources.values[0][0].product
 
@@ -171,7 +175,7 @@ class GridWorkflow:
         :param GridSpec grid_spec: The grid projection and resolution
         :param str product: The name of an existing product, if no grid_spec is supplied.
         """
-        self.index = index
+        self.index: Index = index
         if grid_spec is None:
             if product is None:
                 raise ValueError("Have to supply either grid_spec or product")
@@ -188,26 +192,29 @@ class GridWorkflow:
                 )
 
             grid_spec = product.grid_spec
-        self.grid_spec = grid_spec
+        self.grid_spec: GridSpec = grid_spec
 
         assert self.grid_spec is not None
 
     def cell_observations(
-        self, cell_index=None, geopolygon=None, tile_buffer=None, **indexers
-    ):
+        self,
+        cell_index: tuple[int, int]|None = None,
+        geopolygon: Geometry|None =None,
+        tile_buffer: tuple[float, float]|None = None,
+        **indexers: QueryField
+    ) -> dict[tuple[int, int], list[Dataset]]:
         """
         List datasets, grouped by cell.
 
-        :param datacube.utils.Geometry geopolygon:
+        :param geopolygon:
             Only return observations with data inside polygon.
-        :param (float,float) tile_buffer:
+        :param tile_buffer:
             buffer tiles by (y, x) in CRS units
-        :param (int,int) cell_index:
+        :param  cell_index:
             The cell index. E.g. (14, -40)
         :param indexers:
             Query to match the datasets, see :py:class:`datacube.api.query.Query`
         :return: Datsets grouped by cell index
-        :rtype: dict[(int,int), list[:py:class:`datacube.model.Dataset`]]
 
         .. seealso::
             :meth:`datacube.Datacube.find_datasets`
@@ -289,7 +296,7 @@ class GridWorkflow:
         return datasets, query
 
     @staticmethod
-    def group_into_cells(observations, group_by):
+    def group_into_cells(observations, group_by) -> dict[tuple[int, int], Tile]:
         """
         Group observations into a stack of source tiles.
 
@@ -297,7 +304,6 @@ class GridWorkflow:
         :param group_by: grouping method, as returned by :py:meth:`datacube.api.query.query_group_by`
         :type group_by: :py:class:`datacube.api.query.GroupBy`
         :return: tiles grouped by cell index
-        :rtype: dict[(int,int), :class:`.Tile`]
 
         .. seealso::
             :meth:`load`
@@ -311,7 +317,7 @@ class GridWorkflow:
         return cells
 
     @staticmethod
-    def tile_sources(observations, group_by):
+    def tile_sources(observations, group_by: GroupBy):
         """
         Split observations into tiles and group into source tiles
 
@@ -339,7 +345,7 @@ class GridWorkflow:
 
         return tiles
 
-    def list_cells(self, cell_index=None, **query):
+    def list_cells(self, cell_index: tuple[int, int]|None =None, **query) -> dict[tuple[int, int], Tile]:
         """
         List cells that match the query.
 
@@ -353,14 +359,13 @@ class GridWorkflow:
             gw.list_cells(product='ls5_nbar_albers',
                           time=('2001-1-1 00:00:00', '2001-3-31 23:59:59'))
 
-        :param (int,int) cell_index: The cell index. E.g. (14, -40)
+        :param cell_index: The cell index. E.g. (14, -40)
         :param query: see :py:class:`datacube.api.query.Query`
-        :rtype: dict[(int, int), :class:`.Tile`]
         """
         observations = self.cell_observations(cell_index, **query)
         return self.group_into_cells(observations, query_group_by(**query))
 
-    def list_tiles(self, cell_index=None, **query):
+    def list_tiles(self, cell_index: tuple[int, int]|None=None, **query) -> dict[tuple[int, int, np.datetime64], Tile]:
         """
         List tiles of data, sorted by cell.
         ::
@@ -370,9 +375,8 @@ class GridWorkflow:
 
         The values can be passed to :meth:`load`
 
-        :param (int,int) cell_index: The cell index (optional). E.g. (14, -40)
+        :param cell_index: The cell index (optional). E.g. (14, -40)
         :param query: see :py:class:`datacube.api.query.Query`
-        :rtype: dict[(int, int, numpy.datetime64), :class:`.Tile`]
 
         .. seealso:: :meth:`load`
         """

--- a/datacube/api/grid_workflow.py
+++ b/datacube/api/grid_workflow.py
@@ -17,6 +17,7 @@ from odc.geo.gridspec import GridSpec
 from typing_extensions import override
 
 from datacube.model import Dataset, QueryField
+from datacube.utils import DatacubeException
 
 from .core import Datacube
 from .query import GroupBy, Query, query_group_by
@@ -28,6 +29,9 @@ if typing.TYPE_CHECKING:
 
     from datacube.index import Index
     from datacube.model import Product
+
+class GridWorkflowException(DatacubeException):
+    """An ODC Exception raised while building or running Grid Workflows"""
 
 
 def _fast_slice(array: xr.DataArray, indexers):
@@ -176,25 +180,29 @@ class GridWorkflow:
         :param str product: The name of an existing product, if no grid_spec is supplied.
         """
         self.index: Index = index
-        if grid_spec is None:
+
+        # If available, use the provided grid_spec
+        if grid_spec is not None:
+            self.grid_spec: GridSpec = grid_spec
+        else:
+            # Otherwise, attempt to get the grid_spec by the provided product
+            # which may or may not have one.
             if product is None:
-                raise ValueError("Have to supply either grid_spec or product")
+                raise GridWorkflowException("Have to supply either grid_spec or product")
 
             if isinstance(product, str):
                 product = self.index.products.get_by_name(product)
 
             if product is None:
-                raise ValueError(f"No such product: {product}")
+                raise GridWorkflowException("No such product", product)
 
             if product.grid_spec is None:
-                raise ValueError(
-                    f"Supplied product `{product}` does not have a gridspec"
+                raise GridWorkflowException(
+                    "Supplied product does not have a gridspec", product
                 )
 
-            grid_spec = product.grid_spec
-        self.grid_spec: GridSpec = grid_spec
+            self.grid_spec = product.grid_spec
 
-        assert self.grid_spec is not None
 
     def cell_observations(
         self,
@@ -202,7 +210,7 @@ class GridWorkflow:
         geopolygon: Geometry|None =None,
         tile_buffer: tuple[float, float]|None = None,
         **indexers: QueryField
-    ) -> dict[tuple[int, int], list[Dataset]]:
+    ) -> dict[tuple[int, int], dict[str, Dataset|GeoBox]]:
         """
         List datasets, grouped by cell.
 
@@ -214,7 +222,8 @@ class GridWorkflow:
             The cell index. E.g. (14, -40)
         :param indexers:
             Query to match the datasets, see :py:class:`datacube.api.query.Query`
-        :return: Datsets grouped by cell index
+        :return: A dictionary of cell index (int, int) mapping to a dict containing two keys,
+          "datasets", with a list of datasets, and "geobox", containing the geobox for the cell.
 
         .. seealso::
             :meth:`datacube.Datacube.find_datasets`
@@ -225,8 +234,8 @@ class GridWorkflow:
         # TODO: split this method into 3: cell/polygon/unconstrained querying
 
         if tile_buffer is not None and geopolygon is not None:
-            raise ValueError("Cannot process tile_buffering and geopolygon together.")
-        cells = {}
+            raise GridWorkflowException("Cannot process tile_buffering and geopolygon together.")
+        cells: dict[tuple[int, int], dict[str, Dataset|GeoBox]] = {}
 
         def add_dataset_to_cells(tile_index, tile_geobox, dataset_):
             cells.setdefault(tile_index, {"datasets": [], "geobox": tile_geobox})[
@@ -234,8 +243,6 @@ class GridWorkflow:
             ].append(dataset_)
 
         if cell_index:
-            assert len(cell_index) == 2
-            cell_index = tuple(cell_index)
             geobox = self.grid_spec.tile_geobox(cell_index)
             geobox = geobox.buffered(*tile_buffer) if tile_buffer else geobox
 
@@ -246,7 +253,7 @@ class GridWorkflow:
             return cells
         else:
             datasets, query = self._find_datasets(geopolygon, indexers)
-            geobox_cache = {}
+            geobox_cache: dict[tuple[int, int], GeoBox] = {}
 
             if query.geopolygon:
                 # Get a rough region of tiles

--- a/datacube/api/grid_workflow.py
+++ b/datacube/api/grid_workflow.py
@@ -3,8 +3,11 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+from collections.abc import Generator, Hashable
 import logging
 import typing
+from typing_extensions import override
+from odc.geo.gridspec import GridSpec
 import xarray as xr
 from collections import OrderedDict
 import pandas as pd
@@ -70,7 +73,7 @@ class Tile:
         self.geobox: GeoBox = geobox
 
     @property
-    def dims(self) -> tuple[str, ...]:
+    def dims(self) -> tuple[Hashable, ...]:
         """Names of the dimensions, eg ``('time', 'y', 'x')``
         """
         return self.sources.dims + self.geobox.dimensions
@@ -95,7 +98,7 @@ class Tile:
         return Tile(sources, geobox)
 
     # TODO(csiro) Split on time range
-    def split(self, dim: str, step: int = 1) -> tuple(key, Tile):
+    def split(self, dim: str, step: int = 1) -> Generator[tuple[str, Tile]]:
         """
         Splits along a non-spatial dimension into Tile objects with a length of 1 or more in the `dim` dimension.
 
@@ -109,7 +112,7 @@ class Tile:
             indexer[axis] = slice(i, min(size, i + step))
             yield self.sources[dim].values[i], self[tuple(indexer)]
 
-    def split_by_time(self, freq: str = "A", time_dim: str = "time", **kwargs) -> Generator[tuple(str, Tile)]:
+    def split_by_time(self, freq: str = "A", time_dim: str = "time", **kwargs) -> Generator[tuple[str, Tile]]:
         """
         Splits along the `time` dimension, into periods, using pandas offsets, such as:
         :
@@ -133,9 +136,11 @@ class Tile:
             ]
             yield str(p), Tile(sources=sources_slice, geobox=self.geobox)
 
+    @override
     def __str__(self):
         return f"Tile<sources={self.sources!r},\n\tgeobox={self.geobox!r}>"
 
+    @override
     def __repr__(self):
         return self.__str__()
 
@@ -447,8 +452,10 @@ class GridWorkflow:
             )
         return tile
 
+    @override
     def __str__(self):
         return f"GridWorkflow<index={self.index!r},\n\tgridspec={self.grid_spec!r}>"
 
+    @override
     def __repr__(self):
         return self.__str__()

--- a/datacube/api/grid_workflow.py
+++ b/datacube/api/grid_workflow.py
@@ -236,9 +236,11 @@ class GridWorkflow:
 
             else:
                 for dataset in datasets:
-                    for tile_index, tile_geobox in self.grid_spec.tiles_from_geopolygon(dataset.extent,
-                                                                                        tile_buffer=tile_buffer,
+                    dataset_extent = dataset.extent.buffer(*tile_buffer) if tile_buffer else dataset.extent
+                    for tile_index, tile_geobox in self.grid_spec.tiles_from_geopolygon(dataset_extent,
                                                                                         geobox_cache=geobox_cache):
+                        if tile_buffer:
+                            tile_geobox = tile_geobox.buffered(*tile_buffer)
                         add_dataset_to_cells(tile_index, tile_geobox, dataset)
 
             return cells

--- a/datacube/api/grid_workflow.py
+++ b/datacube/api/grid_workflow.py
@@ -1,0 +1,407 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2024 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+import logging
+import typing
+import xarray as xr
+from collections import OrderedDict
+import pandas as pd
+
+from odc.geo.geom import intersects
+from .query import Query, query_group_by
+from .core import Datacube
+
+_LOG = logging.getLogger(__name__)
+
+if typing.TYPE_CHECKING:
+    from odc.geo.geobox import GeoBox
+    from datacube.model import Product
+    from datacube.index import Index
+
+
+def _fast_slice(array: xr.DataArray, indexers):
+    data = array.values[indexers]
+    dims = [dim for dim, indexer in zip(array.dims, indexers) if isinstance(indexer, slice)]
+    coords = OrderedDict((dim,
+                          xr.Variable((dim,),
+                                          array.coords[dim].values[indexer],
+                                          attrs=array.coords[dim].attrs,
+                                          fastpath=True))
+                         for dim, indexer in zip(array.dims, indexers) if isinstance(indexer, slice))
+    return xr.DataArray(data, dims=dims, coords=coords, attrs=array.attrs)
+
+
+class Tile:
+    """
+    The Tile object holds a lightweight representation of a datacube result.
+
+    It is produced by :meth:`.GridWorkflow.list_cells` or :meth:`.GridWorkflow.list_tiles`.
+
+    The Tile object can be passed to :meth:`GridWorkflow.load` to be loaded into memory as
+    an :class:`xr.Dataset`.
+
+    A portion of a tile can be created by using index notation. eg:
+
+        tile[0:1, 0:1000, 0:1000]
+
+    This can be used to load small portions of data into memory, instead of having to access
+    the entire `Tile` at once.
+    """
+
+    def __init__(self, sources: xr.DataArray, geobox):
+        """Create a Tile representing a dataset that can be loaded.
+
+        :param xr.DataArray sources: An array of non-spatial dimensions of the request, holding lists of
+            datacube.storage.DatasetSource objects.
+        :param model.GeoBox geobox: The spatial footprint of the Tile
+        """
+        self.sources: xr.DataArray = sources
+        self.geobox: GeoBox = geobox
+
+    @property
+    def dims(self) -> tuple[str]:
+        """Names of the dimensions, eg ``('time', 'y', 'x')``
+        :return: tuple(str)
+        """
+        return self.sources.dims + self.geobox.dimensions
+
+    @property
+    def shape(self) -> tuple[int]:
+        """Lengths of each dimension, eg ``(285, 4000, 4000)``
+        :return: tuple(int)
+        """
+        return self.sources.shape + self.geobox.shape
+
+    @property
+    def product(self) -> Product:
+        """
+        :rtype: datacube.model.DatasetType
+        """
+        return self.sources.values[0][0].product
+
+    def __getitem__(self, chunk):
+        sources = _fast_slice(self.sources, chunk[:len(self.sources.shape)])
+        geobox = self.geobox[chunk[len(self.sources.shape):]]
+        return Tile(sources, geobox)
+
+    # TODO(csiro) Split on time range
+    def split(self, dim: str, step: int = 1):
+        """
+        Splits along a non-spatial dimension into Tile objects with a length of 1 or more in the `dim` dimension.
+
+        :param dim: Name of the non-spatial dimension to split
+        :param step: step size to split
+        :return: tuple(key, Tile)
+        """
+        axis = self.dims.index(dim)
+        indexer = [slice(None)] * len(self.dims)
+        size = self.sources[dim].size
+        for i in range(0, size, step):
+            indexer[axis] = slice(i, min(size, i + step))
+            yield self.sources[dim].values[i], self[tuple(indexer)]
+
+    def split_by_time(self, freq:str = 'A', time_dim:str = 'time', **kwargs):
+        """
+        Splits along the `time` dimension, into periods, using pandas offsets, such as:
+        :
+            'A': Annual
+            'Q': Quarter
+            'M': Month
+        See: http://pandas.pydata.org/pandas-docs/stable/timeseries.html?highlight=rollback#timeseries-offset-aliases
+
+        :param freq: time series frequency
+        :param time_dim: name of the time dimension
+        :param kwargs: other keyword arguments passed to ``pandas.period_range``
+        :return: Generator[tuple(str, Tile)] generator of the key string (eg '1994') and the slice of Tile
+        """
+        # extract first and last timestamps from the time axis, note this will
+        # work with 1 element arrays as well
+        start_range, end_range = self.sources[time_dim].data[[0, -1]]
+
+        for p in pd.period_range(start=start_range,
+                                 end=end_range,
+                                 freq=freq,
+                                 **kwargs):
+            sources_slice = self.sources.loc[{time_dim: slice(p.start_time, p.end_time)}]
+            yield str(p), Tile(sources=sources_slice, geobox=self.geobox)
+
+    def __str__(self):
+        return f"Tile<sources={self.sources!r},\n\tgeobox={self.geobox!r}>"
+
+    def __repr__(self):
+        return self.__str__()
+
+
+class GridWorkflow:
+    """
+    GridWorkflow deals with cell- and tile-based processing using a grid defining a projection and resolution.
+
+    Use GridWorkflow to specify your desired output grid.  The methods :meth:`list_cells` and :meth:`list_tiles`
+    query the index and return a dictionary of cell or tile keys, each mapping to a :class:`Tile` object.
+
+    The :class:`.Tile` object can then be used to load the data without needing the index,
+    and can be serialized for use with the `distributed` package.
+    """
+
+    def __init__(self, index: Index, grid_spec: GridWorkflow | None = None, product: Product | str | None = None):
+        """
+        Create a grid workflow tool.
+
+        Either grid_spec or product must be supplied.
+
+        :param datacube.index.Index index: The database index to use.
+        :param GridSpec grid_spec: The grid projection and resolution
+        :param str product: The name of an existing product, if no grid_spec is supplied.
+        """
+        self.index = index
+        if grid_spec is None:
+            if product is None:
+                raise ValueError("Have to supply either grid_spec or product")
+
+            product = self.index.products.get_by_name(product)
+            if product is None:
+                raise ValueError(f"No such product: {product}")
+
+            if product.grid_spec is None:
+                raise ValueError(f"Supplied product `{product}` does not have a gridspec")
+
+            grid_spec = product.grid_spec
+        self.grid_spec = grid_spec
+
+        assert self.grid_spec is not None
+
+    def cell_observations(self, cell_index=None, geopolygon=None, tile_buffer=None, **indexers):
+        """
+        List datasets, grouped by cell.
+
+        :param datacube.utils.Geometry geopolygon:
+            Only return observations with data inside polygon.
+        :param (float,float) tile_buffer:
+            buffer tiles by (y, x) in CRS units
+        :param (int,int) cell_index:
+            The cell index. E.g. (14, -40)
+        :param indexers:
+            Query to match the datasets, see :py:class:`datacube.api.query.Query`
+        :return: Datsets grouped by cell index
+        :rtype: dict[(int,int), list[:py:class:`datacube.model.Dataset`]]
+
+        .. seealso::
+            :meth:`datacube.Datacube.find_datasets`
+
+            :class:`datacube.api.query.Query`
+        """
+        # pylint: disable=too-many-locals
+        # TODO: split this method into 3: cell/polygon/unconstrained querying
+
+        if tile_buffer is not None and geopolygon is not None:
+            raise ValueError('Cannot process tile_buffering and geopolygon together.')
+        cells = {}
+
+        def add_dataset_to_cells(tile_index, tile_geobox, dataset_):
+            cells.setdefault(tile_index, {'datasets': [], 'geobox': tile_geobox})['datasets'].append(dataset_)
+
+        if cell_index:
+            assert len(cell_index) == 2
+            cell_index = tuple(cell_index)
+            geobox = self.grid_spec.tile_geobox(cell_index)
+            geobox = geobox.buffered(*tile_buffer) if tile_buffer else geobox
+
+            datasets, query = self._find_datasets(geobox.extent, indexers)
+            for dataset in datasets:
+                if intersects(geobox.extent, dataset.extent.to_crs(self.grid_spec.crs)):
+                    add_dataset_to_cells(cell_index, geobox, dataset)
+            return cells
+        else:
+            datasets, query = self._find_datasets(geopolygon, indexers)
+            geobox_cache = {}
+
+            if query.geopolygon:
+                # Get a rough region of tiles
+                query_tiles = set(
+                    tile_index for tile_index, tile_geobox in
+                    self.grid_spec.tiles_from_geopolygon(query.geopolygon, geobox_cache=geobox_cache))
+
+                for dataset in datasets:
+                    # Go through our datasets and see which tiles each dataset produces, and whether they intersect
+                    # our query geopolygon.
+                    dataset_extent = dataset.extent.to_crs(self.grid_spec.crs)
+                    bbox = dataset_extent.boundingbox
+                    bbox = bbox.buffered(*tile_buffer) if tile_buffer else bbox
+
+                    for tile_index, tile_geobox in self.grid_spec.tiles(bbox, geobox_cache=geobox_cache):
+                        if tile_index in query_tiles and intersects(tile_geobox.extent, dataset_extent):
+                            add_dataset_to_cells(tile_index, tile_geobox, dataset)
+
+            else:
+                for dataset in datasets:
+                    for tile_index, tile_geobox in self.grid_spec.tiles_from_geopolygon(dataset.extent,
+                                                                                        tile_buffer=tile_buffer,
+                                                                                        geobox_cache=geobox_cache):
+                        add_dataset_to_cells(tile_index, tile_geobox, dataset)
+
+            return cells
+
+    def _find_datasets(self, geopolygon, indexers):
+        query = Query(index=self.index, geopolygon=geopolygon, **indexers)
+        if not query.product:
+            raise RuntimeError('must specify a product')
+        datasets = self.index.datasets.search_eager(**query.search_terms)
+        return datasets, query
+
+    @staticmethod
+    def group_into_cells(observations, group_by):
+        """
+        Group observations into a stack of source tiles.
+
+        :param observations: datasets grouped by cell index, like from :py:meth:`cell_observations`
+        :param group_by: grouping method, as returned by :py:meth:`datacube.api.query.query_group_by`
+        :type group_by: :py:class:`datacube.api.query.GroupBy`
+        :return: tiles grouped by cell index
+        :rtype: dict[(int,int), :class:`.Tile`]
+
+        .. seealso::
+            :meth:`load`
+
+            :meth:`datacube.Datacube.group_datasets`
+        """
+        cells = {}
+        for cell_index, observation in observations.items():
+            sources = Datacube.group_datasets(observation['datasets'], group_by)
+            cells[cell_index] = Tile(sources, observation['geobox'])
+        return cells
+
+    @staticmethod
+    def tile_sources(observations, group_by):
+        """
+        Split observations into tiles and group into source tiles
+
+        :param observations: datasets grouped by cell index, like from :meth:`cell_observations`
+        :param group_by: grouping method, as returned by :py:meth:`datacube.api.query.query_group_by`
+        :type group_by: :py:class:`datacube.api.query.GroupBy`
+        :return: tiles grouped by cell index and time
+        :rtype: dict[tuple(int, int, numpy.datetime64), :py:class:`.Tile`]
+
+        .. seealso::
+            :meth:`load`
+
+            :meth:`datacube.Datacube.group_datasets`
+        """
+        tiles = {}
+        for cell_index, observation in observations.items():
+            dss = observation['datasets']
+            geobox = observation['geobox']
+
+            sources = Datacube.group_datasets(dss, group_by)
+            coord = sources[sources.dims[0]]
+            for i in range(coord.size):
+                tile_index = cell_index + (coord.values[i],)
+                tiles[tile_index] = Tile(sources[i:i+1], geobox)
+
+        return tiles
+
+    def list_cells(self, cell_index=None, **query):
+        """
+        List cells that match the query.
+
+        Returns a dictionary of cell indexes to :class:`.Tile` objects.
+
+        Cells are included if they contain any datasets that match the query using the same format as
+        :meth:`datacube.Datacube.load`.
+
+        E.g.::
+
+            gw.list_cells(product='ls5_nbar_albers',
+                          time=('2001-1-1 00:00:00', '2001-3-31 23:59:59'))
+
+        :param (int,int) cell_index: The cell index. E.g. (14, -40)
+        :param query: see :py:class:`datacube.api.query.Query`
+        :rtype: dict[(int, int), :class:`.Tile`]
+        """
+        observations = self.cell_observations(cell_index, **query)
+        return self.group_into_cells(observations, query_group_by(**query))
+
+    def list_tiles(self, cell_index=None, **query):
+        """
+        List tiles of data, sorted by cell.
+        ::
+
+            tiles = gw.list_tiles(product='ls5_nbar_albers',
+                                  time=('2001-1-1 00:00:00', '2001-3-31 23:59:59'))
+
+        The values can be passed to :meth:`load`
+
+        :param (int,int) cell_index: The cell index (optional). E.g. (14, -40)
+        :param query: see :py:class:`datacube.api.query.Query`
+        :rtype: dict[(int, int, numpy.datetime64), :class:`.Tile`]
+
+        .. seealso:: :meth:`load`
+        """
+        observations = self.cell_observations(cell_index, **query)
+        return self.tile_sources(observations, query_group_by(**query))
+
+    @staticmethod
+    def load(tile, measurements=None, dask_chunks=None, fuse_func=None, resampling=None, skip_broken_datasets=False):
+        """
+        Load data for a cell/tile.
+
+        The data to be loaded is defined by the output of :meth:`list_tiles`.
+
+        This is a static function and does not use the index. This can be useful when running as a worker in a
+        distributed environment and you wish to minimize database connections.
+
+        See the documentation on using `xr with dask <http://xr.pydata.org/en/stable/dask.html>`_
+        for more information.
+
+        :param `.Tile` tile: The tile to load.
+
+        :param list(str) measurements: The names of measurements to load
+
+        :param dict dask_chunks: If the data should be loaded as needed using :py:class:`dask.array.Array`,
+            specify the chunk size in each output direction.
+
+            See the documentation on using `xr with dask <http://xr.pydata.org/en/stable/dask.html>`_
+            for more information.
+
+        :param fuse_func: Function to fuse together a tile that has been pre-grouped by calling
+            :meth:`list_cells` with a ``group_by`` parameter.
+
+        :param str|dict resampling:
+
+            The resampling method to use if re-projection is required, could be
+            configured per band using a dictionary (:meth: `load_data`)
+
+            Valid values are: ``'nearest', 'cubic', 'bilinear', 'cubic_spline', 'lanczos', 'average'``
+
+            Defaults to ``'nearest'``.
+
+        :param bool skip_broken_datasets: If True, ignore broken datasets and continue processing with the data
+             that can be loaded. If False, an exception will be raised on a broken dataset. Defaults to False.
+
+        :rtype: :py:class:`xr.Dataset`
+
+        .. seealso::
+            :meth:`list_tiles` :meth:`list_cells`
+        """
+        measurement_dicts = tile.product.lookup_measurements(measurements)
+
+        dataset = Datacube.load_data(tile.sources, tile.geobox,
+                                     measurement_dicts, resampling=resampling,
+                                     dask_chunks=dask_chunks, fuse_func=fuse_func,
+                                     skip_broken_datasets=skip_broken_datasets)
+
+        return dataset
+
+    def update_tile_lineage(self, tile: Tile):
+        for i in range(tile.sources.size):
+            sources = tile.sources.values[i]
+            tile.sources.values[i] = tuple(self.index.datasets.get(dataset.id, include_sources=True)
+                                           for dataset in sources)
+        return tile
+
+    def __str__(self):
+        return "GridWorkflow<index={!r},\n\tgridspec={!r}>".format(self.index, self.grid_spec)
+
+    def __repr__(self):
+        return self.__str__()

--- a/datacube/testutils/__init__.py
+++ b/datacube/testutils/__init__.py
@@ -175,7 +175,7 @@ dataset:
 
 def mk_sample_product(name: str,
                       description: str='Sample',
-                      measurements: Sequence[str] = ('red', 'green', 'blue'),
+                      measurements: Sequence[str|tuple|dict] = ('red', 'green', 'blue'),
                       with_grid_spec: bool = False,
                       metadata_type=None,
                       storage=None,

--- a/datacube/testutils/__init__.py
+++ b/datacube/testutils/__init__.py
@@ -174,12 +174,12 @@ dataset:
 
 
 def mk_sample_product(name: str,
-                      description: str = 'Sample',
-                      measurements=('red', 'green', 'blue'),
+                      description: str='Sample',
+                      measurements: Sequence[str] = ('red', 'green', 'blue'),
                       with_grid_spec: bool = False,
                       metadata_type=None,
                       storage=None,
-                      load: bool | None = None):
+                      load: bool | None = None) -> Product:
 
     if storage is None and with_grid_spec is True:
         storage = {'crs': 'EPSG:3577',

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,38 @@ What's New
 Next Version
 ============
 
+v1.9.4 (?? May 2025)
+====================
+
+Improvements
+------------
+
+**Bring back GridWorkflow**
+
+GridWorkflow is back! It was accidentally removed with the deprecated ingestion tools as
+part of the ODC 1.9 release, since it's no longer needed internally. It is however an
+extremely useful public API for anyone running large scale data summaries and is
+used by `ODC Statistician`_.
+
+It has been updated to use the odc-geo_ geometry classes.
+
+See: :issue:`1749` and :pull:`1760`
+
+**Cleaning and Tidying**
+
+Massive cleaning effort across the codebase, spearheaded by @pjonsson, with a focus on:
+
+ - Improvements in type annotation
+ - Linting fixes
+ - Code formatting and import ordering
+ - Continuous integration improvements 
+
+.. _odc-geo: https://odc-geo.readthedocs.io/
+.. _ODC Statistician: https://github.com/opendatacube/odc-stats
+
+Other Changes
+-------------
+
 - Use odc-geo GridSpec if `tile_shape` in product storage information :pull:`1783`
 - SQL: fix package names type :pull:`1784`
 - Add some type signatures :pull:`1785`, :pull:`1788`, :pull:`1796`
@@ -38,6 +70,7 @@ Next Version
 - Sort imports with Ruff :pull:`1858`
 - Fix documentation parameter names :pull:`1857`
 - Add pandas types for development :pull:`1867`
+
 
 v1.9.3 (15th April 2025)
 ========================
@@ -458,12 +491,10 @@ v1.8.13 (6th June 2023)
 - Add pre-commit hook to verify license headers (:pull:`1438`)
 - Support open-ended date ranges in `datacube dataset search`, `dc.load`, and `dc.find_datasets` (:pull:`1439`, :pull:`1443`)
 - Pass Y and Y Scale factors through to rasterio.warp.reproject, to eliminate projection bug affecting
-  non-square Areas Of Interest (See `Issue #1448`_) (:pull:`1450`)
+  non-square Areas Of Interest (See :issue:`1448` and :pull:`1450`)
 - Add `archive_less_mature` option to `datacube dataset add` and `datacube dataset update` (:pull:`1451`)
 - Allow for +-1ms leniency in finding other maturity versions of a dataset (:pull:`1452`)
 - Update whats_new.rst for release (:pull:`1453`)
-
-.. _`Issue #1448`: https://github.com/opendatacube/datacube-core/issues/1448
 
 v1.8.12 (7th March 2023)
 ========================

--- a/docs/api/grid-processing/gridWorkflow.rst
+++ b/docs/api/grid-processing/gridWorkflow.rst
@@ -1,0 +1,9 @@
+============
+Grid Workflow
+============
+
+.. currentmodule:: datacube
+
+.. autoclass:: datacube.api.GridWorkflow
+
+    :members:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ postgis = 'datacube.index.postgis.index:index_driver_init'
 [tool.pytest.ini_options]
 addopts = "--doctest-modules"
 testpaths = ["datacube", "tests", "integration_tests"]
-norecursedirs = [".*", "build", "dist", ".git", "tmp*"]
+norecursedirs = [".*", "build", "dist", ".git", "tmp*", "docs", ".jj"]
 filterwarnings = [
     "ignore::FutureWarning",
     "ignore:datetime.datetime.utcnow*:DeprecationWarning:botocore.*",

--- a/tests/api/test_grid_workflow.py
+++ b/tests/api/test_grid_workflow.py
@@ -208,8 +208,8 @@ def test_gridworkflow_loading(sample_grid_workflow):
     fakedataset2.product = fakedataset.product
 
     with patch("datacube.api.core.Datacube.load_data") as loader:
-        data = GridWorkflow.load(tile)
-        data2 = GridWorkflow.load(padded_tile)
+        _ = GridWorkflow.load(tile)
+        _ = GridWorkflow.load(padded_tile)
 
     assert loader.call_count == 2
 
@@ -217,7 +217,7 @@ def test_gridworkflow_loading(sample_grid_workflow):
         args = list(args)
         assert args[0] is loadable.sources
         assert args[1] is loadable.geobox
-        assert list(args[2].values())[0] is measurement
+        assert next(iter(args[2].values())) is measurement
         assert "resampling" in kwargs
 
 
@@ -284,10 +284,10 @@ def test_gridworkflow_with_time_depth():
     query = dict(product="fake_product_name")
 
     cells = gw.list_cells(**query)
-    for cell_index, cell in cells.items():
+    for _, cell in cells.items():
 
         #  test Tile.split()
-        for label, tile in cell.split("time"):
+        for _, tile in cell.split("time"):
             assert tile.shape == (1, 10, 10)
 
         #  test Tile.split_by_time()

--- a/tests/api/test_grid_workflow.py
+++ b/tests/api/test_grid_workflow.py
@@ -1,14 +1,13 @@
 # This file is part of the Open Data Cube, see https://opendatacube.org for more information
 #
-# Copyright (c) 2015-2024 ODC Contributors
+# Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 import numpy
 from datacube.api.grid_workflow import GridWorkflow
 from odc.geo import CRS, Resolution
-from odc.geo import geom
 from odc.geo.gridspec import GridSpec
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from datacube.testutils import mk_sample_product
 import datetime
 import uuid
@@ -42,24 +41,25 @@ def fake_index():
     )
 
 
-def test_create_gridworkflow_init_failures(fake_index):
+def test_create_gridworkflow_creation_with_product(fake_index):
     index = fake_index
 
     # need product or grispec
     with pytest.raises(ValueError):
         GridWorkflow(index)
 
-    # test missing product
+    # Can't specify a product that doesn't exist.
     with pytest.raises(ValueError):
         GridWorkflow(index, product="no-such-product")
 
-    # test missing product
+    # Error out if a production without a GridSpec is specified
     assert fake_index.products.get_by_name("without_gs") is not None
     assert fake_index.products.get_by_name("without_gs").grid_spec is None
 
     with pytest.raises(ValueError):
         GridWorkflow(index, product="without_gs")
 
+    # Able to create a Grid Workflow with a Product that has a GridSpec
     product = fake_index.products.get_by_name("with_gs")
     assert product is not None
     assert product.grid_spec is not None
@@ -67,59 +67,52 @@ def test_create_gridworkflow_init_failures(fake_index):
     assert gw.grid_spec is product.grid_spec
 
 
-def test_gridworkflow():
-    """Test GridWorkflow with padding option."""
-
-    # ----- fake a datacube -----
-    # e.g. let there be a dataset that coincides with a grid cell
-
+@pytest.fixture
+def sample_grid_workflow():
     crs = CRS("EPSG:3577")
-
-    grid = 10  # spatial frequency in crs units
     pixel = 10  # square pixel linear dimension in crs units
-    # if cell(0,0) has lower left corner at grid origin,
-    # and cell indices increase toward upper right,
-    # then this will be cell(1,-2).
+    grid = 10  # size of a single tile in pixels
     gridspec = GridSpec(
         crs=crs, tile_shape=(grid, grid), resolution=Resolution(pixel)
-    )  # e.g. product gridspec
-
+    )
     fakedataset = MagicMock()
     fakedataset.extent = gridspec.tile_geobox((1, -2)).extent
-    fakedataset.center_time = t = datetime.datetime(2001, 2, 15)
+    fakedataset.center_time = datetime.datetime(2001, 2, 15)
     fakedataset.id = uuid.uuid4()
-
     fakeindex = PickleableMock()
     fakeindex._db = None
-    fakeindex.datasets.get_field_names.return_value = ["time"]  # permit query on time
+    fakeindex.datasets.get_field_names.return_value = ["time"]
     fakeindex.products.get_field_names.return_value = ["time"]
     fakeindex.datasets.search_eager.return_value = [fakedataset]
-
-    # ------ test without padding ----
-
     gw = GridWorkflow(fakeindex, gridspec)
+    gw.index = fakeindex  # Need to force the fake index
+    return gw, gridspec, fakedataset, fakeindex
 
-    # smoke test str/repr
+
+def test_gridworkflow_str_repr(sample_grid_workflow):
+    gw, _, _, _ = sample_grid_workflow
     assert len(str(gw)) > 0
     assert len(repr(gw)) > 0
 
-    # Need to force the fake index otherwise the driver manager will
-    # only take its _db
-    gw.index = fakeindex
+
+def test_gridworkflow_cell_observations(sample_grid_workflow):
+    gw, gridspec, _, _ = sample_grid_workflow
     query = dict(
         product="fake_product_name", time=("2001-1-1 00:00:00", "2001-3-31 23:59:59")
     )
-
-    # test backend : that it finds the expected cell/dataset
     assert list(gw.cell_observations(**query).keys()) == [(1, -2)]
-
-    # again but with geopolygon
     assert list(
         gw.cell_observations(
             **query, geopolygon=gridspec.tile_geobox((1, -2)).extent
         ).keys()
     ) == [(1, -2)]
 
+
+def test_gridworkflow_cell_observations_errors(sample_grid_workflow):
+    gw, gridspec, _, _ = sample_grid_workflow
+    query = dict(
+        product="fake_product_name", time=("2001-1-1 00:00:00", "2001-3-31 23:59:59")
+    )
     # It's invalid to supply tile_buffer and geopolygon at the same time
     with pytest.raises(ValueError) as e:
         list(
@@ -131,103 +124,128 @@ def test_gridworkflow():
         )
     assert str(e.value) == "Cannot process tile_buffering and geopolygon together."
 
-    # test frontend
+
+def test_gridworkflow_list_tiles_unpadded(sample_grid_workflow):
+    gw, _, _, _ = sample_grid_workflow
+    query = dict(
+        product="fake_product_name", time=("2001-1-1 00:00:00", "2001-3-31 23:59:59")
+    )
     assert len(gw.list_tiles(**query)) == 1
 
-    # ------ introduce padding --------
 
-    # TODO: WTF
+def test_gridworkflow_list_tiles_padded(sample_grid_workflow):
+    gw, _, _, _ = sample_grid_workflow
+    query = dict(
+        product="fake_product_name", time=("2001-1-1 00:00:00", "2001-3-31 23:59:59")
+    )
     assert len(gw.list_tiles(tile_buffer=(20, 20), **query)) == 9
 
-    # ------ add another dataset (to test grouping) -----
+
+def test_gridworkflow_list_tiles_multiple_datasets(sample_grid_workflow):
+    gw, gridspec, fakedataset, fakeindex = sample_grid_workflow
+    query = dict(
+        product="fake_product_name", time=("2001-1-1 00:00:00", "2001-3-31 23:59:59")
+    )
 
     # Add dataset to cell (2,-2)
     fakedataset2 = MagicMock()
     fakedataset2.extent = gridspec.tile_geobox((2, -2)).extent
-    fakedataset2.center_time = t
+    fakedataset2.center_time = fakedataset.center_time
     fakedataset2.id = uuid.uuid4()
-
     fakeindex.datasets.search_eager.return_value = [fakedataset, fakedataset2]
 
     # unpadded
     assert len(gw.list_tiles(**query)) == 2
-    np_time = numpy.datetime64(t, "ns")
+    np_time = numpy.datetime64(fakedataset.center_time, "ns")
     assert set(gw.list_tiles(**query).keys()) == {(1, -2, np_time), (2, -2, np_time)}
 
     # padded
-    assert (
-        len(gw.list_tiles(tile_buffer=(20, 20), **query)) == 12
-    )  # not 18=2*9 because of grouping
+    assert len(gw.list_tiles(tile_buffer=(20, 20), **query)) == 12
 
-    # -------- inspect particular returned tile objects --------
 
-    # check the array shape
+def test_gridworkflow_returned_tile_properties(sample_grid_workflow):
+    gw, gridspec, fakedataset, fakeindex = sample_grid_workflow
+    query = dict(
+        product="fake_product_name", time=("2001-1-1 00:00:00", "2001-3-31 23:59:59")
+    )
+    np_time = numpy.datetime64(fakedataset.center_time, "ns")
 
-    # TODO: Is this right? Do we need padding? wtfmate
-    tile = gw.list_tiles(**query)[1, -2, np_time]  # unpadded example
-    assert tile.shape == (1, grid, grid) # Time, Y, X
-    #
-    # # smoke test str/repr
+    # Add dataset to cell (2,-2)
+    fakedataset2 = MagicMock()
+    fakedataset2.extent = gridspec.tile_geobox((2, -2)).extent
+    fakedataset2.center_time = fakedataset.center_time
+    fakedataset2.id = uuid.uuid4()
+    fakeindex.datasets.search_eager.return_value = [fakedataset, fakedataset2]
+
+    tile = gw.list_tiles(**query)[1, -2, np_time]
+    assert tile.shape == (1, 10, 10)
     assert len(str(tile)) > 0
     assert len(repr(tile)) > 0
-    #
-    padded_tile = gw.list_tiles(tile_buffer=(20, 20), **query)[
-        1, -2, np_time
-    ]  # padded example
-    # # assert grid/pixel + 2*gw2.grid_spec.padding == 14  # GREG: understand this
-    assert padded_tile.shape == (1, 14, 14)
 
-    # count the sources
+    padded_tile = gw.list_tiles(tile_buffer=(20, 20), **query)[1, -2, np_time]
+    assert padded_tile.shape == (1, 14, 14)
 
     assert len(tile.sources.isel(time=0).item()) == 1
     assert len(padded_tile.sources.isel(time=0).item()) == 2
-    #
-    # # check the geocoding
-    #
+
     assert tile.geobox.alignment == padded_tile.geobox.alignment
     assert tile.geobox.affine * (0, 0) == padded_tile.geobox.affine * (2, 2)
     assert tile.geobox.affine * (10, 10) == padded_tile.geobox.affine * (10 + 2, 10 + 2)
 
-    # ------- check loading --------
-    # GridWorkflow accesses the load_data API
-    # to ultimately convert geobox,sources,measurements to xarray,
-    # so only thing to check here is the call interface.
+
+def test_gridworkflow_loading(sample_grid_workflow):
+    gw, _, fakedataset, _ = sample_grid_workflow
+    query = dict(
+        product="fake_product_name", time=("2001-1-1 00:00:00", "2001-3-31 23:59:59")
+    )
+    np_time = numpy.datetime64(fakedataset.center_time, "ns")
+    tile = gw.list_tiles(**query)[1, -2, np_time]
+    padded_tile = gw.list_tiles(tile_buffer=(20, 20), **query)[1, -2, np_time]
 
     measurement = dict(nodata=0, dtype=numpy.int32)
     fakedataset.product.lookup_measurements.return_value = {"dummy": measurement}
+    fakedataset2 = MagicMock()
     fakedataset2.product = fakedataset.product
 
-    from unittest.mock import patch
-
     with patch("datacube.api.core.Datacube.load_data") as loader:
-
         data = GridWorkflow.load(tile)
         data2 = GridWorkflow.load(padded_tile)
-    #     # Note, could also test Datacube.load for consistency (but may require more patching)
-    #
-    # assert data is data2 is loader.return_value
+
     assert loader.call_count == 2
-    #
-    # # Note, use of positional arguments here is not robust, could spec mock etc.
+
     for (args, kwargs), loadable in zip(loader.call_args_list, [tile, padded_tile]):
         args = list(args)
         assert args[0] is loadable.sources
         assert args[1] is loadable.geobox
         assert list(args[2].values())[0] is measurement
         assert "resampling" in kwargs
-    #
-    # # ------- check single cell index extract -------
+
+
+def test_gridworkflow_cell_index_extract(sample_grid_workflow):
+    gw, gridspec, fakedataset, fakeindex = sample_grid_workflow
+    query = dict(
+        product="fake_product_name", time=("2001-1-1 00:00:00", "2001-3-31 23:59:59")
+    )
+    np_time = numpy.datetime64(fakedataset.center_time, "ns")
+
+    # Add dataset to cell (2,-2)
+    fakedataset2 = MagicMock()
+    fakedataset2.extent = gridspec.tile_geobox((2, -2)).extent
+    fakedataset2.center_time = fakedataset.center_time
+    fakedataset2.id = uuid.uuid4()
+    fakeindex.datasets.search_eager.return_value = [fakedataset, fakedataset2]
+
     tile = gw.list_tiles(cell_index=(1, -2), **query)
     assert len(tile) == 1
     assert tile[1, -2, np_time].shape == (1, 10, 10)
     assert len(tile[1, -2, np_time].sources.values[0]) == 1
-    #
+
     padded_tile = gw.list_tiles(cell_index=(1, -2), tile_buffer=(20, 20), **query)
     assert len(padded_tile) == 1
     assert padded_tile[1, -2, np_time].shape == (1, 14, 14)
     assert len(padded_tile[1, -2, np_time].sources.values[0]) == 2
-    #
-    # # query without product is not allowed
+
+    # query without product is not allowed
     with pytest.raises(RuntimeError):
         gw.list_cells(cell_index=(1, -2), time=query["time"])
 

--- a/tests/api/test_grid_workflow.py
+++ b/tests/api/test_grid_workflow.py
@@ -14,13 +14,13 @@ import datetime
 import uuid
 
 
-class PickableMock(MagicMock):
+class PickleableMock(MagicMock):
     def __reduce__(self):
         return (MagicMock, ())
 
 
 def mk_fake_index(products, datasets):
-    fakeindex = PickableMock()
+    fakeindex = PickleableMock()
     fakeindex._db = None
 
     fakeindex.products.get_by_name = lambda name: products.get(name, None)
@@ -73,27 +73,26 @@ def test_gridworkflow():
     # ----- fake a datacube -----
     # e.g. let there be a dataset that coincides with a grid cell
 
-    fakecrs = CRS("EPSG:3577")
+    crs = CRS("EPSG:3577")
 
-    grid = 100  # spatial frequency in crs units
+    grid = 10  # spatial frequency in crs units
     pixel = 10  # square pixel linear dimension in crs units
     # if cell(0,0) has lower left corner at grid origin,
     # and cell indices increase toward upper right,
     # then this will be cell(1,-2).
     gridspec = GridSpec(
-        crs=fakecrs, tile_shape=(grid, grid), resolution=Resolution(pixel)
+        crs=crs, tile_shape=(grid, grid), resolution=Resolution(pixel)
     )  # e.g. product gridspec
 
     fakedataset = MagicMock()
-    fakedataset.extent = geom.box(
-        left=grid, bottom=-grid, right=2 * grid, top=-2 * grid, crs=fakecrs
-    )
+    fakedataset.extent = gridspec.tile_geobox((1, -2)).extent
     fakedataset.center_time = t = datetime.datetime(2001, 2, 15)
     fakedataset.id = uuid.uuid4()
 
-    fakeindex = PickableMock()
+    fakeindex = PickleableMock()
     fakeindex._db = None
     fakeindex.datasets.get_field_names.return_value = ["time"]  # permit query on time
+    fakeindex.products.get_field_names.return_value = ["time"]
     fakeindex.datasets.search_eager.return_value = [fakedataset]
 
     # ------ test without padding ----
@@ -121,6 +120,7 @@ def test_gridworkflow():
         ).keys()
     ) == [(1, -2)]
 
+    # It's invalid to supply tile_buffer and geopolygon at the same time
     with pytest.raises(ValueError) as e:
         list(
             gw.cell_observations(
@@ -136,27 +136,23 @@ def test_gridworkflow():
 
     # ------ introduce padding --------
 
+    # TODO: WTF
     assert len(gw.list_tiles(tile_buffer=(20, 20), **query)) == 9
 
     # ------ add another dataset (to test grouping) -----
 
-    # consider cell (2,-2)
+    # Add dataset to cell (2,-2)
     fakedataset2 = MagicMock()
-    fakedataset2.extent = geometry.box(
-        left=2 * grid, bottom=-grid, right=3 * grid, top=-2 * grid, crs=fakecrs
-    )
+    fakedataset2.extent = gridspec.tile_geobox((2, -2)).extent
     fakedataset2.center_time = t
     fakedataset2.id = uuid.uuid4()
 
-    def search_eager(lat=None, lon=None, **kwargs):
-        return [fakedataset, fakedataset2]
-
-    fakeindex.datasets.search_eager = search_eager
+    fakeindex.datasets.search_eager.return_value = [fakedataset, fakedataset2]
 
     # unpadded
     assert len(gw.list_tiles(**query)) == 2
-    ti = numpy.datetime64(t, "ns")
-    assert set(gw.list_tiles(**query).keys()) == {(1, -2, ti), (2, -2, ti)}
+    np_time = numpy.datetime64(t, "ns")
+    assert set(gw.list_tiles(**query).keys()) == {(1, -2, np_time), (2, -2, np_time)}
 
     # padded
     assert (
@@ -167,27 +163,27 @@ def test_gridworkflow():
 
     # check the array shape
 
-    tile = gw.list_tiles(**query)[1, -2, ti]  # unpadded example
-    assert grid / pixel == 10
-    assert tile.shape == (1, 10, 10)
-
-    # smoke test str/repr
+    # TODO: Is this right? Do we need padding? wtfmate
+    tile = gw.list_tiles(**query)[1, -2, np_time]  # unpadded example
+    assert tile.shape == (1, grid, grid) # Time, Y, X
+    #
+    # # smoke test str/repr
     assert len(str(tile)) > 0
     assert len(repr(tile)) > 0
-
+    #
     padded_tile = gw.list_tiles(tile_buffer=(20, 20), **query)[
-        1, -2, ti
+        1, -2, np_time
     ]  # padded example
-    # assert grid/pixel + 2*gw2.grid_spec.padding == 14  # GREG: understand this
+    # # assert grid/pixel + 2*gw2.grid_spec.padding == 14  # GREG: understand this
     assert padded_tile.shape == (1, 14, 14)
 
     # count the sources
 
     assert len(tile.sources.isel(time=0).item()) == 1
     assert len(padded_tile.sources.isel(time=0).item()) == 2
-
-    # check the geocoding
-
+    #
+    # # check the geocoding
+    #
     assert tile.geobox.alignment == padded_tile.geobox.alignment
     assert tile.geobox.affine * (0, 0) == padded_tile.geobox.affine * (2, 2)
     assert tile.geobox.affine * (10, 10) == padded_tile.geobox.affine * (10 + 2, 10 + 2)
@@ -207,31 +203,31 @@ def test_gridworkflow():
 
         data = GridWorkflow.load(tile)
         data2 = GridWorkflow.load(padded_tile)
-        # Note, could also test Datacube.load for consistency (but may require more patching)
-
-    assert data is data2 is loader.return_value
+    #     # Note, could also test Datacube.load for consistency (but may require more patching)
+    #
+    # assert data is data2 is loader.return_value
     assert loader.call_count == 2
-
-    # Note, use of positional arguments here is not robust, could spec mock etc.
+    #
+    # # Note, use of positional arguments here is not robust, could spec mock etc.
     for (args, kwargs), loadable in zip(loader.call_args_list, [tile, padded_tile]):
         args = list(args)
         assert args[0] is loadable.sources
         assert args[1] is loadable.geobox
         assert list(args[2].values())[0] is measurement
         assert "resampling" in kwargs
-
-    # ------- check single cell index extract -------
+    #
+    # # ------- check single cell index extract -------
     tile = gw.list_tiles(cell_index=(1, -2), **query)
     assert len(tile) == 1
-    assert tile[1, -2, ti].shape == (1, 10, 10)
-    assert len(tile[1, -2, ti].sources.values[0]) == 1
-
+    assert tile[1, -2, np_time].shape == (1, 10, 10)
+    assert len(tile[1, -2, np_time].sources.values[0]) == 1
+    #
     padded_tile = gw.list_tiles(cell_index=(1, -2), tile_buffer=(20, 20), **query)
     assert len(padded_tile) == 1
-    assert padded_tile[1, -2, ti].shape == (1, 14, 14)
-    assert len(padded_tile[1, -2, ti].sources.values[0]) == 2
-
-    # query without product is not allowed
+    assert padded_tile[1, -2, np_time].shape == (1, 14, 14)
+    assert len(padded_tile[1, -2, np_time].sources.values[0]) == 2
+    #
+    # # query without product is not allowed
     with pytest.raises(RuntimeError):
         gw.list_cells(cell_index=(1, -2), time=query["time"])
 
@@ -240,15 +236,15 @@ def test_gridworkflow_with_time_depth():
     """Test GridWorkflow with time series.
     Also test `Tile` methods `split` and `split_by_time`
     """
-    fakecrs = CRS("EPSG:4326")
+    crs = CRS("EPSG:4326")
 
-    grid = 100  # spatial frequency in crs units
+    # grid = 100  # spatial frequency in crs units
     pixel = 10  # square pixel linear dimension in crs units
     # if cell(0,0) has lower left corner at grid origin,
     # and cell indices increase toward upper right,
     # then this will be cell(1,-2).
     gridspec = GridSpec(
-        crs=fakecrs, tile_shape=(grid, grid), resolution=Resolution(pixel)
+        crs=crs, tile_shape=(10, 10), resolution=Resolution(pixel)
     )  # e.g. product gridspec
 
     def make_fake_datasets(num_datasets):
@@ -256,13 +252,11 @@ def test_gridworkflow_with_time_depth():
         delta = datetime.timedelta(days=16)
         for i in range(num_datasets):
             fakedataset = MagicMock()
-            fakedataset.extent = geometry.box(
-                left=grid, bottom=-grid, right=2 * grid, top=-2 * grid, crs=fakecrs
-            )
+            fakedataset.extent = gridspec.tile_geobox((1, -2)).extent
             fakedataset.center_time = start_time + (delta * i)
             yield fakedataset
 
-    fakeindex = PickableMock()
+    fakeindex = PickleableMock()
     fakeindex.datasets.get_field_names.return_value = ["time"]  # permit query on time
     fakeindex.datasets.search_eager.return_value = list(make_fake_datasets(100))
 

--- a/tests/api/test_grid_workflow.py
+++ b/tests/api/test_grid_workflow.py
@@ -2,15 +2,17 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-import pytest
-import numpy
-from datacube.api.grid_workflow import GridWorkflow
-from odc.geo import CRS, Resolution
-from odc.geo.gridspec import GridSpec
-from unittest.mock import MagicMock, patch
-from datacube.testutils import mk_sample_product
 import datetime
 import uuid
+from unittest.mock import MagicMock, patch
+
+import numpy
+import pytest
+from odc.geo import CRS, Resolution
+from odc.geo.gridspec import GridSpec
+
+from datacube.api.grid_workflow import GridWorkflow
+from datacube.testutils import mk_sample_product
 
 
 class PickleableMock(MagicMock):
@@ -30,7 +32,7 @@ def mk_fake_index(products, datasets):
     return fakeindex
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def fake_index():
     return mk_fake_index(
         products=dict(
@@ -256,16 +258,12 @@ def test_gridworkflow_with_time_depth():
     """
     crs = CRS("EPSG:4326")
 
-    # grid = 100  # spatial frequency in crs units
     pixel = 10  # square pixel linear dimension in crs units
-    # if cell(0,0) has lower left corner at grid origin,
-    # and cell indices increase toward upper right,
-    # then this will be cell(1,-2).
     gridspec = GridSpec(
         crs=crs, tile_shape=(10, 10), resolution=Resolution(pixel)
-    )  # e.g. product gridspec
+    )
 
-    def make_fake_datasets(num_datasets):
+    def make_fake_datasets(num_datasets: int):
         start_time = datetime.datetime(2001, 2, 15)
         delta = datetime.timedelta(days=16)
         for i in range(num_datasets):

--- a/tests/api/test_grid_workflow.py
+++ b/tests/api/test_grid_workflow.py
@@ -11,7 +11,7 @@ import pytest
 from odc.geo import CRS, Resolution
 from odc.geo.gridspec import GridSpec
 
-from datacube.api.grid_workflow import GridWorkflow
+from datacube.api.grid_workflow import GridWorkflow, GridWorkflowException
 from datacube.testutils import mk_sample_product
 
 
@@ -47,18 +47,18 @@ def test_create_gridworkflow_creation_with_product(fake_index):
     index = fake_index
 
     # need product or grispec
-    with pytest.raises(ValueError):
+    with pytest.raises(GridWorkflowException):
         GridWorkflow(index)
 
     # Can't specify a product that doesn't exist.
-    with pytest.raises(ValueError):
+    with pytest.raises(GridWorkflowException):
         GridWorkflow(index, product="no-such-product")
 
     # Error out if a production without a GridSpec is specified
     assert fake_index.products.get_by_name("without_gs") is not None
     assert fake_index.products.get_by_name("without_gs").grid_spec is None
 
-    with pytest.raises(ValueError):
+    with pytest.raises(GridWorkflowException):
         GridWorkflow(index, product="without_gs")
 
     # Able to create a Grid Workflow with a Product that has a GridSpec
@@ -116,7 +116,7 @@ def test_gridworkflow_cell_observations_errors(sample_grid_workflow):
         product="fake_product_name", time=("2001-1-1 00:00:00", "2001-3-31 23:59:59")
     )
     # It's invalid to supply tile_buffer and geopolygon at the same time
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(GridWorkflowException) as e:
         list(
             gw.cell_observations(
                 **query,

--- a/tests/api/test_grid_workflow.py
+++ b/tests/api/test_grid_workflow.py
@@ -1,0 +1,284 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2024 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import numpy
+from datacube.api.grid_workflow import GridWorkflow
+from odc.geo import CRS, Resolution
+from odc.geo import geom
+from odc.geo.gridspec import GridSpec
+from unittest.mock import MagicMock
+from datacube.testutils import mk_sample_product
+import datetime
+import uuid
+
+
+class PickableMock(MagicMock):
+    def __reduce__(self):
+        return (MagicMock, ())
+
+
+def mk_fake_index(products, datasets):
+    fakeindex = PickableMock()
+    fakeindex._db = None
+
+    fakeindex.products.get_by_name = lambda name: products.get(name, None)
+
+    fakeindex.datasets.get_field_names.return_value = ["time"]  # permit query on time
+    fakeindex.datasets.search_eager.return_value = datasets
+
+    return fakeindex
+
+
+@pytest.fixture(scope="session")
+def fake_index():
+    return mk_fake_index(
+        products=dict(
+            with_gs=mk_sample_product("with_gs", with_grid_spec=True),
+            without_gs=mk_sample_product("without_gs", with_grid_spec=False),
+        ),
+        datasets=[],
+    )
+
+
+def test_create_gridworkflow_init_failures(fake_index):
+    index = fake_index
+
+    # need product or grispec
+    with pytest.raises(ValueError):
+        GridWorkflow(index)
+
+    # test missing product
+    with pytest.raises(ValueError):
+        GridWorkflow(index, product="no-such-product")
+
+    # test missing product
+    assert fake_index.products.get_by_name("without_gs") is not None
+    assert fake_index.products.get_by_name("without_gs").grid_spec is None
+
+    with pytest.raises(ValueError):
+        GridWorkflow(index, product="without_gs")
+
+    product = fake_index.products.get_by_name("with_gs")
+    assert product is not None
+    assert product.grid_spec is not None
+    gw = GridWorkflow(index, product="with_gs")
+    assert gw.grid_spec is product.grid_spec
+
+
+def test_gridworkflow():
+    """Test GridWorkflow with padding option."""
+
+    # ----- fake a datacube -----
+    # e.g. let there be a dataset that coincides with a grid cell
+
+    fakecrs = CRS("EPSG:3577")
+
+    grid = 100  # spatial frequency in crs units
+    pixel = 10  # square pixel linear dimension in crs units
+    # if cell(0,0) has lower left corner at grid origin,
+    # and cell indices increase toward upper right,
+    # then this will be cell(1,-2).
+    gridspec = GridSpec(
+        crs=fakecrs, tile_shape=(grid, grid), resolution=Resolution(pixel)
+    )  # e.g. product gridspec
+
+    fakedataset = MagicMock()
+    fakedataset.extent = geom.box(
+        left=grid, bottom=-grid, right=2 * grid, top=-2 * grid, crs=fakecrs
+    )
+    fakedataset.center_time = t = datetime.datetime(2001, 2, 15)
+    fakedataset.id = uuid.uuid4()
+
+    fakeindex = PickableMock()
+    fakeindex._db = None
+    fakeindex.datasets.get_field_names.return_value = ["time"]  # permit query on time
+    fakeindex.datasets.search_eager.return_value = [fakedataset]
+
+    # ------ test without padding ----
+
+    gw = GridWorkflow(fakeindex, gridspec)
+
+    # smoke test str/repr
+    assert len(str(gw)) > 0
+    assert len(repr(gw)) > 0
+
+    # Need to force the fake index otherwise the driver manager will
+    # only take its _db
+    gw.index = fakeindex
+    query = dict(
+        product="fake_product_name", time=("2001-1-1 00:00:00", "2001-3-31 23:59:59")
+    )
+
+    # test backend : that it finds the expected cell/dataset
+    assert list(gw.cell_observations(**query).keys()) == [(1, -2)]
+
+    # again but with geopolygon
+    assert list(
+        gw.cell_observations(
+            **query, geopolygon=gridspec.tile_geobox((1, -2)).extent
+        ).keys()
+    ) == [(1, -2)]
+
+    with pytest.raises(ValueError) as e:
+        list(
+            gw.cell_observations(
+                **query,
+                tile_buffer=(1, 1),
+                geopolygon=gridspec.tile_geobox((1, -2)).extent
+            ).keys()
+        )
+    assert str(e.value) == "Cannot process tile_buffering and geopolygon together."
+
+    # test frontend
+    assert len(gw.list_tiles(**query)) == 1
+
+    # ------ introduce padding --------
+
+    assert len(gw.list_tiles(tile_buffer=(20, 20), **query)) == 9
+
+    # ------ add another dataset (to test grouping) -----
+
+    # consider cell (2,-2)
+    fakedataset2 = MagicMock()
+    fakedataset2.extent = geometry.box(
+        left=2 * grid, bottom=-grid, right=3 * grid, top=-2 * grid, crs=fakecrs
+    )
+    fakedataset2.center_time = t
+    fakedataset2.id = uuid.uuid4()
+
+    def search_eager(lat=None, lon=None, **kwargs):
+        return [fakedataset, fakedataset2]
+
+    fakeindex.datasets.search_eager = search_eager
+
+    # unpadded
+    assert len(gw.list_tiles(**query)) == 2
+    ti = numpy.datetime64(t, "ns")
+    assert set(gw.list_tiles(**query).keys()) == {(1, -2, ti), (2, -2, ti)}
+
+    # padded
+    assert (
+        len(gw.list_tiles(tile_buffer=(20, 20), **query)) == 12
+    )  # not 18=2*9 because of grouping
+
+    # -------- inspect particular returned tile objects --------
+
+    # check the array shape
+
+    tile = gw.list_tiles(**query)[1, -2, ti]  # unpadded example
+    assert grid / pixel == 10
+    assert tile.shape == (1, 10, 10)
+
+    # smoke test str/repr
+    assert len(str(tile)) > 0
+    assert len(repr(tile)) > 0
+
+    padded_tile = gw.list_tiles(tile_buffer=(20, 20), **query)[
+        1, -2, ti
+    ]  # padded example
+    # assert grid/pixel + 2*gw2.grid_spec.padding == 14  # GREG: understand this
+    assert padded_tile.shape == (1, 14, 14)
+
+    # count the sources
+
+    assert len(tile.sources.isel(time=0).item()) == 1
+    assert len(padded_tile.sources.isel(time=0).item()) == 2
+
+    # check the geocoding
+
+    assert tile.geobox.alignment == padded_tile.geobox.alignment
+    assert tile.geobox.affine * (0, 0) == padded_tile.geobox.affine * (2, 2)
+    assert tile.geobox.affine * (10, 10) == padded_tile.geobox.affine * (10 + 2, 10 + 2)
+
+    # ------- check loading --------
+    # GridWorkflow accesses the load_data API
+    # to ultimately convert geobox,sources,measurements to xarray,
+    # so only thing to check here is the call interface.
+
+    measurement = dict(nodata=0, dtype=numpy.int32)
+    fakedataset.product.lookup_measurements.return_value = {"dummy": measurement}
+    fakedataset2.product = fakedataset.product
+
+    from unittest.mock import patch
+
+    with patch("datacube.api.core.Datacube.load_data") as loader:
+
+        data = GridWorkflow.load(tile)
+        data2 = GridWorkflow.load(padded_tile)
+        # Note, could also test Datacube.load for consistency (but may require more patching)
+
+    assert data is data2 is loader.return_value
+    assert loader.call_count == 2
+
+    # Note, use of positional arguments here is not robust, could spec mock etc.
+    for (args, kwargs), loadable in zip(loader.call_args_list, [tile, padded_tile]):
+        args = list(args)
+        assert args[0] is loadable.sources
+        assert args[1] is loadable.geobox
+        assert list(args[2].values())[0] is measurement
+        assert "resampling" in kwargs
+
+    # ------- check single cell index extract -------
+    tile = gw.list_tiles(cell_index=(1, -2), **query)
+    assert len(tile) == 1
+    assert tile[1, -2, ti].shape == (1, 10, 10)
+    assert len(tile[1, -2, ti].sources.values[0]) == 1
+
+    padded_tile = gw.list_tiles(cell_index=(1, -2), tile_buffer=(20, 20), **query)
+    assert len(padded_tile) == 1
+    assert padded_tile[1, -2, ti].shape == (1, 14, 14)
+    assert len(padded_tile[1, -2, ti].sources.values[0]) == 2
+
+    # query without product is not allowed
+    with pytest.raises(RuntimeError):
+        gw.list_cells(cell_index=(1, -2), time=query["time"])
+
+
+def test_gridworkflow_with_time_depth():
+    """Test GridWorkflow with time series.
+    Also test `Tile` methods `split` and `split_by_time`
+    """
+    fakecrs = CRS("EPSG:4326")
+
+    grid = 100  # spatial frequency in crs units
+    pixel = 10  # square pixel linear dimension in crs units
+    # if cell(0,0) has lower left corner at grid origin,
+    # and cell indices increase toward upper right,
+    # then this will be cell(1,-2).
+    gridspec = GridSpec(
+        crs=fakecrs, tile_shape=(grid, grid), resolution=Resolution(pixel)
+    )  # e.g. product gridspec
+
+    def make_fake_datasets(num_datasets):
+        start_time = datetime.datetime(2001, 2, 15)
+        delta = datetime.timedelta(days=16)
+        for i in range(num_datasets):
+            fakedataset = MagicMock()
+            fakedataset.extent = geometry.box(
+                left=grid, bottom=-grid, right=2 * grid, top=-2 * grid, crs=fakecrs
+            )
+            fakedataset.center_time = start_time + (delta * i)
+            yield fakedataset
+
+    fakeindex = PickableMock()
+    fakeindex.datasets.get_field_names.return_value = ["time"]  # permit query on time
+    fakeindex.datasets.search_eager.return_value = list(make_fake_datasets(100))
+
+    # ------ test with time dimension ----
+
+    gw = GridWorkflow(fakeindex, gridspec)
+    query = dict(product="fake_product_name")
+
+    cells = gw.list_cells(**query)
+    for cell_index, cell in cells.items():
+
+        #  test Tile.split()
+        for label, tile in cell.split("time"):
+            assert tile.shape == (1, 10, 10)
+
+        #  test Tile.split_by_time()
+        for year, year_cell in cell.split_by_time(freq="A"):
+            for t in year_cell.sources.time.values:
+                assert str(t)[:4] == year


### PR DESCRIPTION
### Reason for this pull request

Somewhere along the path to ODC 1.9, GridWorkflow was inadvertently removed. Discussed in #1749

It is no longer required internally, but it is a useful external API.

This PR re-adds the feature, including tests and documentation, and updated to (mostly) use odc-geo geometry types.

 - [x] Closes #1749
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1760.org.readthedocs.build/en/1760/

<!-- readthedocs-preview datacube-core end -->