### PR TITLE
Explicitly use psycopg2

### DIFF
--- a/datacube/cfg/opt.py
+++ b/datacube/cfg/opt.py
@@ -229,7 +229,7 @@ class PostgresURLOptionHandler(ODCOptionHandler):
             return None
         components = urlparse(value)
         # Check URL scheme is postgresql:
-        if components.scheme != "postgresql":
+        if components.scheme != "postgresql" and not value.startswith("postgresql+psycopg2"):
             raise ConfigException("Database URL is not a postgresql connection URL")
         # Don't bother splitting up the url, we'd just have to put it back together again later
         return value
@@ -304,7 +304,7 @@ def psql_url_from_config(env: "ODCEnvironment"):
         return env.db_url
     if not env.db_database:
         raise ConfigException(f"No database name supplied for environment {env._name}")
-    url = "postgresql://"
+    url = "postgresql+psycopg2://"
     if env.db_username:
         if env.db_password:
             escaped_password = quote_plus(env.db_password)

--- a/integration_tests/test_environments.py
+++ b/integration_tests/test_environments.py
@@ -29,8 +29,8 @@ db_hostname: alt-db.opendatacube.test
 
     # Make sure the correct config is passed through the API
     # Parsed config:
-    db_url = f'postgresql://{cfg_env.db_username}@db.opendatacube.test:5432/datacube'
-    alt_db_url = f'postgresql://{alt_env.db_username}@alt-db.opendatacube.test:5432/datacube'
+    db_url = f'postgresql+psycopg2://{cfg_env.db_username}@db.opendatacube.test:5432/datacube'
+    alt_db_url = f'postgresql+psycopg2://{alt_env.db_username}@alt-db.opendatacube.test:5432/datacube'
 
     with Datacube(env=cfg_env, validate_connection=False) as dc:
         assert str(dc.index.url) == db_url

--- a/tests/cfg/simple_cfg.ini
+++ b/tests/cfg/simple_cfg.ini
@@ -16,7 +16,7 @@ db_connection_timeout: 20
 
 [new]
 index_driver: postgis
-db_url: postgresql://foo:bar@server.subdomain.domain/mytestdb
+db_url: postgresql+psycopg2://foo:bar@server.subdomain.domain/mytestdb
 db_iam_authentication: yes
 
 [postgis]
@@ -28,7 +28,7 @@ db_url: @nota?valid:url//foo&bar%%%%
 
 [new2]
 index_driver: postgis
-db_url: postgresql://foo:bar@server.subdomain.domain/mytestdb
+db_url: postgresql+psycopg2://foo:bar@server.subdomain.domain/mytestdb
 db_database: not_read
 db_port: ignored
 db_iam_authentication: yes

--- a/tests/cfg/simple_cfg.yaml
+++ b/tests/cfg/simple_cfg.yaml
@@ -13,7 +13,7 @@ legacy:
    db_connection_timeout: 20
 new:
    index_driver: postgis
-   db_url: postgresql://foo:bar@server.subdomain.domain/mytestdb
+   db_url: 'postgresql+psycopg2://foo:bar@server.subdomain.domain/mytestdb'
    db_iam_authentication: yes
 postgis:
    alias: new
@@ -22,7 +22,7 @@ memory:
    db_url: '@nota?valid:url//foo&bar%%%'
 new2:
    index_driver: postgis
-   db_url: postgresql://foo:bar@server.subdomain.domain/mytestdb
+   db_url: 'postgresql+psycopg2://foo:bar@server.subdomain.domain/mytestdb'
    db_database: not_read
    db_port: ignored
    db_iam_authentication: yes

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -91,14 +91,23 @@ def test_parse_text(simple_valid_ini, simple_valid_yaml):
         yaml_as_ini = parse_text(simple_valid_yaml, fmt=CfgFormat.INI)
 
 
-@pytest.fixture
-def single_env_config():
-    return """# Simple single environment config
+def mk_single_env_config(connector: str) -> str:
+    return f"""# Simple single environment config
 new:
    index_driver: postgis
-   db_url: postgresql://foo:bar@server.subdomain.domain/mytestdb
+   db_url: postgresql{connector}://foo:bar@server.subdomain.domain/mytestdb
    db_iam_authentication: yes
 """
+
+
+@pytest.fixture
+def single_env_config():
+    return mk_single_env_config("+psycopg2")
+
+
+@pytest.fixture
+def single_env_config_no_connector():
+    return mk_single_env_config("")
 
 
 @pytest.fixture
@@ -118,7 +127,7 @@ legacy:
    db_connection_timeout: 20
 new:
    index_driver: postgis
-   db_url: postgresql://foo:bar@server.subdomain.domain/mytestdb
+   db_url: postgresql+psycopg2://foo:bar@server.subdomain.domain/mytestdb
    db_iam_authentication: yes
 postgis:
    alias: new
@@ -127,7 +136,7 @@ memory:
    db_url: '@nota?valid:url//foo&bar%%%'
 new2:
    index_driver: postgis
-   db_url: postgresql://foo:bar@server.subdomain.domain/mytestdb
+   db_url: postgresql+psycopg2://foo:bar@server.subdomain.domain/mytestdb
    db_database: not_read
    db_port: ignored
    db_iam_authentication: yes
@@ -151,7 +160,7 @@ def simple_dict():
         },
         "new": {
             "index_driver": "postgis",
-            "db_url": "postgresql://foo:bar@server.subdomain.domain/mytestdb",
+            "db_url": "postgresql+psycopg2://foo:bar@server.subdomain.domain/mytestdb",
             "db_iam_authentication": "yes"
         },
         "postgis": {"alias": "new"},
@@ -161,7 +170,7 @@ def simple_dict():
         },
         "new2": {
             "index_driver": "postgis",
-            "db_url": "postgresql://foo:bar@server.subdomain.domain/mytestdb",
+            "db_url": "postgresql+psycopg2://foo:bar@server.subdomain.domain/mytestdb",
             "db_database": "not_read",
             "db_port": "ignored",
             "db_iam_authentication": "yes",
@@ -209,18 +218,21 @@ def test_invalid_option():
         handler = ODCOptionHandler("NO_CAPS", mockenv)
 
 
-def test_single_env(single_env_config):
+def test_single_env(single_env_config, single_env_config_no_connector):
     from datacube.cfg import ODCConfig
-    cfg = ODCConfig(text=single_env_config)
-
-    assert cfg['new'].index_driver == "postgis"
-    assert cfg['new'].db_url == "postgresql://foo:bar@server.subdomain.domain/mytestdb"
-    assert cfg['new'].db_username == "foo"
-    with pytest.raises(AttributeError):
-        assert cfg['new'].not_an_option
-    assert cfg['new']['db_iam_authentication']
-    assert cfg['new'].db_iam_timeout == 600
-    assert cfg['new']['db_connection_timeout'] == 60
+    db_urls = []
+    for cfg in [ODCConfig(text=single_env_config),
+                ODCConfig(text=single_env_config_no_connector)]:
+        assert cfg['new'].index_driver == "postgis"
+        db_urls.append(cfg['new'].db_url)
+        assert cfg['new'].db_username == "foo"
+        with pytest.raises(AttributeError):
+            assert cfg['new'].not_an_option
+        assert cfg['new']['db_iam_authentication']
+        assert cfg['new'].db_iam_timeout == 600
+        assert cfg['new']['db_connection_timeout'] == 60
+    assert db_urls == ["postgresql+psycopg2://foo:bar@server.subdomain.domain/mytestdb",
+                       "postgresql://foo:bar@server.subdomain.domain/mytestdb"]
 
 
 def assert_simple_aliases(cfg):
@@ -259,7 +271,7 @@ def assert_simple_options(cfg):
     with pytest.raises(KeyError):
         assert cfg['default']["db_iam_timeout"]
 
-    assert cfg['new2'].db_url == "postgresql://foo:bar@server.subdomain.domain/mytestdb"
+    assert cfg['new2'].db_url == "postgresql+psycopg2://foo:bar@server.subdomain.domain/mytestdb"
     assert cfg['new2'].db_username == "foo"
     with pytest.raises(AttributeError):
         assert cfg['new2'].not_an_option
@@ -463,15 +475,15 @@ def test_pgurl_from_config(simple_dict):
     cfg = ODCConfig(raw_dict=simple_dict)
     assert psql_url_from_config(
         cfg["legacy"]
-    ) == "postgresql://foo:bar@server.subdomain.domain:5433/mytestdb"
+    ) == "postgresql+psycopg2://foo:bar@server.subdomain.domain:5433/mytestdb"
     assert psql_url_from_config(
         cfg["new"]
-    ) == "postgresql://foo:bar@server.subdomain.domain/mytestdb"
+    ) == "postgresql+psycopg2://foo:bar@server.subdomain.domain/mytestdb"
     with pytest.raises(AttributeError):
         psql_url_from_config(
             cfg["memory"]
         )
-    assert cfg["new2"].db_url == "postgresql://foo:bar@server.subdomain.domain/mytestdb"
+    assert cfg["new2"].db_url == "postgresql+psycopg2://foo:bar@server.subdomain.domain/mytestdb"
     assert cfg["new2"].db_username == "foo"
     assert cfg["new2"].db_password == "bar"
     assert cfg["new2"].db_hostname == "server.subdomain.domain"
@@ -488,7 +500,7 @@ def test_pgurl_from_config(simple_dict):
     })
     assert psql_url_from_config(
         cfg["foo"]
-    ) == "postgresql://penelope@remotehost.local:5544/mydb"
+    ) == "postgresql+psycopg2://penelope@remotehost.local:5544/mydb"
     cfg = ODCConfig(raw_dict={
         "foo": {
             "db_hostname": "remotehost.local",
@@ -528,7 +540,7 @@ def test_raw_by_environment(simple_config, monkeypatch):
     from datacube.cfg import ODCConfig
     monkeypatch.setenv(
         'ODC_CONFIG',
-        '{"default":{"alias": "foo"},"foo":{"index_driver":"postgis","db_url":"postgresql:///mydb"}}'
+        '{"default":{"alias": "foo"},"foo":{"index_driver":"postgis","db_url":"postgresql+psycopg2:///mydb"}}'
     )
     cfg = ODCConfig()
     assert cfg[None]._name == 'foo'


### PR DESCRIPTION

### Reason for this pull request

Currently, "postgresql://" is just
a short form of "postgresql+psycopg2://",
so there is no functional difference
from this change.

Being explicit ensures datacube will
continue to function even when SQLAlchemy
changes the default from psycopg2 to
psycopg3. Being explicit about psycopg2
will also make it easier to add parallel
psycopg3 support to datacube in the future.


### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1763.org.readthedocs.build/en/1763/

<!-- readthedocs-preview datacube-core end -->