### PR TITLE
Simplify/cast some types

### DIFF
--- a/datacube/drivers/postgis/_schema.py
+++ b/datacube/drivers/postgis/_schema.py
@@ -189,7 +189,7 @@ class SpatialIndexRecord:
     @classmethod
     def from_spindex(cls, spindex: type[SpatialIndex]) -> "SpatialIndexRecord":
         return cls(  # type: ignore [call-arg]
-            srid=spindex.__tablename__[8:],  # type: ignore [attr-defined]
+            srid=int(spindex.__tablename__[8:]),  # type: ignore [attr-defined]
             table_name=spindex.__tablename__  # type: ignore [attr-defined]
         )
 

--- a/datacube/drivers/postgis/_spatial.py
+++ b/datacube/drivers/postgis/_spatial.py
@@ -145,7 +145,7 @@ def ensure_spindex(engine: Engine, sp_idx: type[SpatialIndex]) -> None:
     with Session(engine) as session:
         results = session.execute(
             select(SpatialIndexRecord.srid).where(
-                SpatialIndexRecord.srid == sp_idx.__tablename__[8:])  # type: ignore[attr-defined]
+                SpatialIndexRecord.srid == int(sp_idx.__tablename__[8:]))  # type: ignore[arg-type,attr-defined]
         )
         for result in results:
             # SpatialIndexRecord exists - actual index assumed to exist too.
@@ -174,7 +174,7 @@ def drop_spindex(engine: Engine, sp_idx: type[SpatialIndex]):
     with Session(engine) as session:
         results = session.execute(
             select(SpatialIndexRecord).where(
-                SpatialIndexRecord.srid == sp_idx.__tablename__[8:])  # type: ignore[attr-defined]
+                SpatialIndexRecord.srid == int(sp_idx.__tablename__[8:]))  # type: ignore[arg-type,attr-defined]
         )
         spidx_record = None
         for result in results:

--- a/datacube/index/abstract/_types.py
+++ b/datacube/index/abstract/_types.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from typing import NamedTuple, cast
+from typing import NamedTuple
 from collections.abc import Iterable, Sequence
 from uuid import UUID
 
@@ -67,18 +67,13 @@ class DatasetTuple(NamedTuple):
 
     @property
     def is_legacy(self):
-        if self.uri_is_string:
-            return False
-        return len(self.uri_) > 1
+        return not isinstance(self.uri_, str) and len(self.uri_) > 1
 
     @property
     def uri(self) -> str:
-        if self.uri_is_string:
-            return cast(str, self.uri_)
-        elif self.is_legacy:
-            return self.uris[0]
-        else:
-            return cast(list[str], self.uri_)[0]
+        if isinstance(self.uri_, str):
+            return self.uri_
+        return self.uri_[0]
 
     @property
     @deprecat(
@@ -86,10 +81,9 @@ class DatasetTuple(NamedTuple):
         version='1.9.0',
         category=ODC2DeprecationWarning)
     def uris(self) -> Sequence[str]:
-        if self.uri_is_string:
-            return [cast(str, self.uri_)]
-        else:
-            return cast(list[str], self.uri_)
+        if isinstance(self.uri_, str):
+            return [self.uri_]
+        return self.uri_
 
 
 # The special handling of grid_spatial, etc appears to NOT apply to EO3.


### PR DESCRIPTION
### Reason for this pull request

Remove some casts from `_types.py` and add some explicit casts in the postgis code so psycopg2 does not have to do auto-casting under the hood.

No functional differences from these changes, but they will make it easier to upgrade to psycopg3 in the future.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1764.org.readthedocs.build/en/1764/

<!-- readthedocs-preview datacube-core end -->