### PR TITLE
tests: suppress winding warnings

### DIFF
--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -7,6 +7,7 @@ Common methods for index integration tests.
 """
 import itertools
 import os
+import warnings
 from copy import copy, deepcopy
 from datetime import timedelta
 from pathlib import Path
@@ -15,6 +16,7 @@ from uuid import uuid4
 
 import pytest
 import yaml
+from antimeridian import FixWindingWarning
 from click.testing import CliRunner
 from hypothesis import HealthCheck, settings
 from sqlalchemy import text
@@ -264,7 +266,9 @@ def doc_to_ds(index, product_name, ds_doc, ds_path, src_tree=None, derived_tree=
         ds.source_tree = src_tree
     if derived_tree is not None:
         ds.derived_tree = derived_tree
-    index.datasets.add(ds, with_lineage=index.supports_lineage)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', FixWindingWarning)
+        index.datasets.add(ds, with_lineage=index.supports_lineage)
     return index.datasets.get(ds.id)
 
 

--- a/integration_tests/index/test_index_cloning.py
+++ b/integration_tests/index/test_index_cloning.py
@@ -2,8 +2,10 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+import pytest
 
 
+@pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")
 def test_index_clone(index_pair_populated_empty):
     pop_idx, empty_idx = index_pair_populated_empty
     assert list(empty_idx.products.get_all()) == []
@@ -14,6 +16,7 @@ def test_index_clone(index_pair_populated_empty):
     assert results["datasets"].skipped == 0
 
 
+@pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")
 def test_index_clone_small_batch(index_pair_populated_empty):
     pop_idx, empty_idx = index_pair_populated_empty
     assert list(empty_idx.products.get_all()) == []
@@ -24,6 +27,7 @@ def test_index_clone_small_batch(index_pair_populated_empty):
     assert results["datasets"].skipped == 0
 
 
+@pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")
 def test_index_clone_cli(cfg_env_pair, index_pair_populated_empty, clirunner):
     source_cfg, target_cfg = cfg_env_pair
     clirunner([
@@ -39,6 +43,7 @@ def test_index_clone_cli(cfg_env_pair, index_pair_populated_empty, clirunner):
     ], skip_env=True, expect_success=True)
 
 
+@pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")
 def test_index_clone_cli_small_batch(cfg_env_pair, index_pair_populated_empty, clirunner):
     source_cfg, target_cfg = cfg_env_pair
     clirunner([

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -92,6 +92,7 @@ def test_archive_datasets(index, ls8_eo3_dataset):
     assert not indexed_dataset.is_archived
 
 
+@pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")
 def test_archive_less_mature(index, final_dataset, nrt_dataset, ds_no_region):
     # case 1: add nrt then final; nrt should get archived
     index.datasets.add(nrt_dataset, with_lineage=False, archive_less_mature=True)
@@ -108,6 +109,7 @@ def test_archive_less_mature(index, final_dataset, nrt_dataset, ds_no_region):
         index.datasets.add(nrt_dataset, with_lineage=False, archive_less_mature=True)
 
 
+@pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")
 def test_cannot_search_for_less_mature(index, nrt_dataset, ds_no_region):
     # if a dataset is missing a property required for finding less mature datasets,
     # it should error
@@ -118,6 +120,7 @@ def test_cannot_search_for_less_mature(index, nrt_dataset, ds_no_region):
         index.datasets.add(ds_no_region, with_lineage=False, archive_less_mature=0)
 
 
+@pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")
 def test_archive_less_mature_approx_timestamp(index, ga_s2am_ard3_final, ga_s2am_ard3_interim):
     # test archive_less_mature where there's a slight difference in timestamps
     index.datasets.add(ga_s2am_ard3_interim, with_lineage=False)
@@ -127,6 +130,7 @@ def test_archive_less_mature_approx_timestamp(index, ga_s2am_ard3_final, ga_s2am
     assert not index.datasets.get(ga_s2am_ard3_final.id).is_archived
 
 
+@pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")
 def test_dont_archive_less_mature(index, final_dataset, nrt_dataset):
     # ensure datasets aren't archive if no archive_less_mature value is provided
     index.datasets.add(nrt_dataset, with_lineage=False)
@@ -136,6 +140,7 @@ def test_dont_archive_less_mature(index, final_dataset, nrt_dataset):
     assert not index.datasets.get(final_dataset.id).is_archived
 
 
+@pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")
 def test_archive_less_mature_bool(index, final_dataset, nrt_dataset):
     # if archive_less_mature value gets passed as a bool via an outdated script
     index.datasets.add(nrt_dataset, with_lineage=False)
@@ -258,6 +263,7 @@ def test_get_dataset(index: Index, ls8_eo3_dataset: Dataset) -> None:
                                     'f226a278-e422-11e6-b501-185e0f80a5c1']) == []
 
 
+@pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")
 def test_add_dataset_no_product_id(index: Index, extended_eo3_metadata_type, ls8_eo3_product, eo3_ls8_dataset_doc):
     product_no_id = Product(extended_eo3_metadata_type, ls8_eo3_product.definition)
     assert product_no_id.id is None
@@ -266,6 +272,7 @@ def test_add_dataset_no_product_id(index: Index, extended_eo3_metadata_type, ls8
     assert index.datasets.add(dataset, with_lineage=False)
 
 
+@pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")
 def test_transactions_api_ctx_mgr(index,
                                   extended_eo3_metadata_type_doc,
                                   ls8_eo3_product,
@@ -296,6 +303,7 @@ def test_transactions_api_ctx_mgr(index,
     assert index.datasets.get(ds2.id) is None
 
 
+@pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")
 def test_transactions_api_ctx_mgr_nested(index,
                                          extended_eo3_metadata_type_doc,
                                          ls8_eo3_product,
@@ -329,6 +337,7 @@ def test_transactions_api_ctx_mgr_nested(index,
     assert index.datasets.get(ds2.id) is None
 
 
+@pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")
 def test_transactions_api_manual(index,
                                  extended_eo3_metadata_type_doc,
                                  ls8_eo3_product,
@@ -355,6 +364,7 @@ def test_transactions_api_manual(index,
     assert index.datasets.get(ds2.id) is not None
 
 
+@pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")
 def test_transactions_api_hybrid(index,
                                  extended_eo3_metadata_type_doc,
                                  ls8_eo3_product,
@@ -434,6 +444,7 @@ def test_index_dataset_with_sources(index, default_metadata_type):
 
 
 @pytest.mark.parametrize('datacube_env_name', ('postgis',))
+@pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")
 def test_index_dataset_with_lineage(index, ds_with_lineage, ls8_eo3_dataset):
     assert ds_with_lineage.source_tree
     index.datasets.add(ds_with_lineage)

--- a/integration_tests/index/test_memory_index.py
+++ b/integration_tests/index/test_memory_index.py
@@ -729,6 +729,7 @@ def test_default_clone_bulk_ops_multiloc(
         assert len(mem_index_fresh.index.datasets.get(ls8_eo3_dataset.id)._uris) == 2
 
 
+@pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")
 def test_default_clone_bulk_ops_reverse(mem_eo3_data: tuple, index):
     mem_idx, ls8id, woid = mem_eo3_data
     index.clone(mem_idx.index)

--- a/integration_tests/index/test_postgis_index.py
+++ b/integration_tests/index/test_postgis_index.py
@@ -35,6 +35,7 @@ def test_create_drop_spatial_index(index: Index):
 
 
 @pytest.mark.parametrize('datacube_env_name', ('postgis',))
+@pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")
 def test_spatial_index_maintain(index: Index, ls8_eo3_product, eo3_ls8_dataset_doc):
     index.create_spatial_index(CRS("EPSG:3577"))
     assert set(index.spatial_indexes(refresh=True)) == {CRS("EPSG:3577"), CRS("EPSG:4326")}
@@ -50,6 +51,7 @@ def test_spatial_index_maintain(index: Index, ls8_eo3_product, eo3_ls8_dataset_d
 
 
 @pytest.mark.parametrize('datacube_env_name', ('postgis',))
+@pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")
 def test_spatial_index_populate(index: Index,
                                 ls8_eo3_product,
                                 wo_eo3_product,

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -6,6 +6,8 @@
 Module
 """
 import datetime
+import warnings
+from antimeridian import FixWindingWarning
 from typing import Any
 from collections import namedtuple
 
@@ -1001,8 +1003,10 @@ def test_find_duplicates_eo3(index,
 
 
 def test_find_duplicates_with_time(index, nrt_dataset, final_dataset, ls8_eo3_dataset):
-    index.datasets.add(nrt_dataset, with_lineage=False)
-    index.datasets.add(final_dataset, with_lineage=False)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', FixWindingWarning)
+        index.datasets.add(nrt_dataset, with_lineage=False)
+        index.datasets.add(final_dataset, with_lineage=False)
     assert not index.datasets.get(nrt_dataset.id).is_archived
     assert not index.datasets.get(final_dataset.id).is_archived
 

--- a/integration_tests/test_3d.py
+++ b/integration_tests/test_3d.py
@@ -239,6 +239,7 @@ def test_missing_extra_dimensions(clirunner, invalid_dataset_type_paths):
 
 
 @pytest.mark.usefixtures("default_metadata_type")
+@pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")
 def test_indexing(clirunner, index, product_def):
     """Test indexing features for 2D and 3D products.
 
@@ -301,6 +302,7 @@ def test_indexing(clirunner, index, product_def):
 
 
 @pytest.mark.usefixtures("default_metadata_type")
+@pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")
 def test_indexing_with_spectral_map(clirunner, index, dataset_types):
     """Test indexing features with spectral map."""
     product_id = GEDI_PRODUCT_IDS[0]
@@ -321,6 +323,7 @@ def test_indexing_with_spectral_map(clirunner, index, dataset_types):
 
 
 @pytest.mark.usefixtures("default_metadata_type")
+@pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")
 def test_end_to_end_multitime(clirunner, index, product_def, original_data):
     """Test simple indexing but for multiple measurements and wavelengths."""
     dc = Datacube(index=index)

--- a/integration_tests/test_cli_output.py
+++ b/integration_tests/test_cli_output.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+import pytest
 
 
 def test_cli_product_subcommand(index_empty, clirunner, dataset_add_configs):
@@ -60,6 +61,7 @@ def test_cli_metadata_subcommand(index_empty, clirunner, dataset_add_configs):
     assert runner.exit_code == 1
 
 
+@pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")
 def test_cli_dataset_subcommand(index, clirunner,
                                 extended_eo3_metadata_type,
                                 ls8_eo3_product, wo_eo3_product, africa_s2_eo3_product,
@@ -153,6 +155,7 @@ def test_cli_dataset_subcommand(index, clirunner,
     assert runner.exit_code == 0
 
 
+@pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")
 def test_read_and_update_metadata_product_dataset_command(index, clirunner,
                                                           ext_eo3_mdt_path,
                                                           eo3_product_paths,

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,4 @@ norecursedirs = .* build dist .git tmp*
 filterwarnings =
     ignore::FutureWarning
     ignore:datetime.datetime.utcnow*:DeprecationWarning:botocore.*
+    ignore:.*numpy.ndarray size changed.*:


### PR DESCRIPTION
### Reason for this pull request

Filter the clockwise winding warning from all tests that import the data sets with that issue.

Also ignore the numpy ndarray size warning until someone has time to look at the problem.

Refs #1716


### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1768.org.readthedocs.build/en/1768/

<!-- readthedocs-preview datacube-core end -->