### PR TITLE
small refactor: sse set instead of list for index drivers

### DIFF
--- a/datacube/cfg/opt.py
+++ b/datacube/cfg/opt.py
@@ -139,8 +139,9 @@ class IndexDriverOptionHandler(ODCOptionHandler):
     def validate_and_normalise(self, value: Any) -> Any:
         value = super().validate_and_normalise(value)
         from datacube.drivers.indexes import index_drivers
-        if value not in index_drivers():
-            raise ConfigException(f"Unknown index driver: {value} - Try one of {','.join(index_drivers())}")
+        drivers = index_drivers()
+        if value not in drivers:
+            raise ConfigException(f"Unknown index driver: {value} - Try one of {','.join(drivers)}")
         return value
 
     @override

--- a/datacube/cfg/opt.py
+++ b/datacube/cfg/opt.py
@@ -141,7 +141,7 @@ class IndexDriverOptionHandler(ODCOptionHandler):
         from datacube.drivers.indexes import index_drivers
         drivers = index_drivers()
         if value not in drivers:
-            raise ConfigException(f"Unknown index driver: {value} - Try one of {','.join(drivers)}")
+            raise ConfigException(f"Unknown index driver: {value} - Try one of {','.join(sorted(drivers))}")
         return value
 
     @override

--- a/datacube/drivers/indexes.py
+++ b/datacube/drivers/indexes.py
@@ -51,11 +51,11 @@ def index_cache() -> IndexDriverCache:
                            'datacube.plugins.index')
 
 
-def index_drivers() -> list[str]:
+def index_drivers() -> set[str]:
     """
-    Returns list driver names
+    Returns a set of driver names
     """
-    return index_cache().drivers()
+    return set(index_cache().drivers())
 
 
 def index_driver_by_name(name: str) -> AbstractIndexDriver | None:

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -27,6 +27,7 @@ Next Version
 - Update to Python 3.10 syntax :pull:`1756`, :pull:`1757`, :pull:`1758`, :pull:`1759`
 - Preparations for Psycopg3 support :pull:`1764`, :pull:`1765`, :pull:`1766`
 - Add override annotations :pull:`1767`
+- - Optimize index_drivers() to return a set :pull:`1774`
 
 v1.9.2 (26th February 2025)
 ===========================


### PR DESCRIPTION
### Reason for this pull request

While looking at the code, I realized `index_drivers()` is only used to return a list and check if a driver is in it. A `set` is better for this as it is faster with O(1) lookups (`list` is O(N)). I know that with few drivers, the speedup is tiny.

### Proposed changes

- Change `index_drivers()` to return a `set` instead of a `list` for O(1) lookups.
- Uses a variable in the `index_drivers()` result to avoid calling it twice and improve readability.


 - [ ] Closes #xxxx (as it is a small change, I dont open an Issue)
 - [x] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1774.org.readthedocs.build/en/1774/

<!-- readthedocs-preview datacube-core end -->