### PR TITLE
CI: update to latest Doctor-RST

### DIFF
--- a/.github/workflows/doc-qa.yaml
+++ b/.github/workflows/doc-qa.yaml
@@ -41,10 +41,10 @@ jobs:
           uses: actions/cache@v4
           with:
               path: .cache
-              key: ${{ runner.os }}-doctor-rst-${{ steps.extract_base_branch.outputs.branch }}
+              key: doctor-rst-${{ runner.os }}-${{ steps.extract_base_branch.outputs.branch }}
 
       -   name: "Run DOCtor-RST"
-          uses: docker://oskarstark/doctor-rst:1.64.0
+          uses: docker://oskarstark/doctor-rst:1.67.0
           with:
               args: --short --error-format=github --cache-file=/github/workspace/.cache/doctor-rst.cache
           env:

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -27,6 +27,7 @@ Next Version
 - Update to Python 3.10 syntax :pull:`1756`, :pull:`1757`, :pull:`1758`, :pull:`1759`
 - Preparations for Psycopg3 support :pull:`1764`, :pull:`1765`, :pull:`1766`
 - Add override annotations :pull:`1767`
+- CI: update doctor rst version :pull:`1775`
 
 v1.9.2 (26th February 2025)
 ===========================


### PR DESCRIPTION
### Reason for this pull request

Bump the version and align the cache
key with the Doctor-RST
documentation.

Edit: I initially thought the CI was missing some caching, but we only run it on a single OS so the additional `restore-keys` provide no benefit, so just align the cache key name with the upstream documentation.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1775.org.readthedocs.build/en/1775/

<!-- readthedocs-preview datacube-core end -->