### PR TITLE
Fix measurement pickling in Python 3.10

### DIFF
--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -525,6 +525,14 @@ class Measurement:
             self[key] = value
 
     @override
+    def __eq__(self, other):
+        return self._data == other._data
+
+    @override
+    def __hash__(self):
+        return hash(self._data)
+
+    @override
     def __repr__(self) -> str:
         return f"Measurement({repr(self._data)})"
 

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -545,6 +545,12 @@ class Measurement:
         """This returns attributes filtered for display in a dataarray."""
         return {key: value for key, value in self.items() if key not in self.ATTR_SKIP}
 
+    def __getstate__(self):
+        return self._data
+
+    def __setstate__(self, state):
+        self.__init__(**state)
+
 
 @schema_validated(SCHEMA_PATH / 'metadata-type-schema.yaml')
 class MetadataType:

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -27,6 +27,7 @@ Next Version
 - Update to Python 3.10 syntax :pull:`1756`, :pull:`1757`, :pull:`1758`, :pull:`1759`
 - Preparations for Psycopg3 support :pull:`1764`, :pull:`1765`, :pull:`1766`
 - Add override annotations :pull:`1767`
+- Fix error when run with Python 3.10 causing pickling errors :pull:`1776`
 
 v1.9.2 (26th February 2025)
 ===========================

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -294,6 +294,12 @@ def test_measurement():
     assert 'dtype' in str(e.value)
 
 
+def test_measurement_equality():
+    m1 = Measurement(name='t', dtype='uint8', nodata=255, units='1')
+    m2 = Measurement(name='t', dtype='uint8', nodata=255, units='1')
+    assert m1 == m2
+
+
 def test_output_geobox_load_hints():
     geobox0 = AlbersGS.tile_geobox((15, -40))
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 import numpy
+import pickle
 from copy import deepcopy
 from datacube.testutils import mk_sample_dataset, mk_sample_product
 from datacube.model import (Product, GridSpec, Measurement,
@@ -298,6 +299,27 @@ def test_measurement_equality():
     m1 = Measurement(name='t', dtype='uint8', nodata=255, units='1')
     m2 = Measurement(name='t', dtype='uint8', nodata=255, units='1')
     assert m1 == m2
+
+
+@pytest.mark.parametrize("protocol", range(pickle.HIGHEST_PROTOCOL))
+def test_measurement_pickling(protocol):
+    m = Measurement(name='t', dtype='uint8', nodata=255, units='1')
+
+    serialised_m = pickle.dumps(m, protocol=protocol)
+
+    restored_m = pickle.loads(serialised_m)
+
+    assert m == restored_m
+
+
+def test_measurement_cloudpickle():
+    import cloudpickle
+
+    m = Measurement(name='t', dtype='uint8', nodata=255, units='1')
+    serialised = cloudpickle.dumps(m)
+
+    deserialised = cloudpickle.loads(serialised)
+    assert m == deserialised
 
 
 def test_output_geobox_load_hints():


### PR DESCRIPTION
### Reason for this pull request

Strange errors when using dask and object serialisation in Python 3.10

    TypeError: 'NoneType' object is not callable

They didn't happen in Python 3.11+ due to the following change:

<img width="1239" alt="Screenshot 2025-04-10 at 3 47 26 pm" src="https://github.com/user-attachments/assets/ce561f39-85fa-4cee-9793-83ffd415b256" />

This Measurement class is an abomination and should be replaced with something simpler, that *doesn't* try to act like a dictionary and an object!

 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1776.org.readthedocs.build/en/1776/

<!-- readthedocs-preview datacube-core end -->