### PR TITLE
Update whats_new.rst for 1.9.3 release.

### DIFF
--- a/datacube/drivers/postgis/alembic/versions/18afe14f2816_updated_column.py
+++ b/datacube/drivers/postgis/alembic/versions/18afe14f2816_updated_column.py
@@ -51,7 +51,7 @@ def upgrade() -> None:
                                         nullable=False, comment="when last updated"), schema="odc")
     else:
         op.alter_column("product", "updated", schema="odc", type_=DateTime(timezone=True),
-                        server_default=func.now(), nullable=False, comment="when last updated") # noqa: E501
+                        server_default=func.now(), nullable=False, comment="when last updated")  # noqa: E501
 
 
 def downgrade() -> None:

--- a/datacube/drivers/postgis/alembic/versions/18afe14f2816_updated_column.py
+++ b/datacube/drivers/postgis/alembic/versions/18afe14f2816_updated_column.py
@@ -36,7 +36,7 @@ def upgrade() -> None:
                                         nullable=False, index=True, comment="when last updated"), schema="odc")
     else:
         op.alter_column("dataset", "updated", schema="odc", type_=DateTime(timezone=True),
-                        server_default=func.now(), nullable=False, comment="when last updated")  # type: ignore[arg-type] # noqa: E501
+                        server_default=func.now(), nullable=False, comment="when last updated")  # noqa: E501
     op.create_index("ix_dataset_updated", "dataset", ["updated"], schema="odc", if_not_exists=True)
 
     if not column_exists("metadata_type", "updated"):
@@ -44,14 +44,14 @@ def upgrade() -> None:
                                               nullable=False, comment="when last updated"), schema="odc")
     else:
         op.alter_column("metadata_type", "updated", schema="odc", type_=DateTime(timezone=True),
-                        server_default=func.now(), nullable=False, comment="when last updated")  # type: ignore[arg-type] # noqa: E501
+                        server_default=func.now(), nullable=False, comment="when last updated")  # noqa: E501
 
     if not column_exists("product", "updated"):
         op.add_column("product", Column("updated", DateTime(timezone=True), server_default=func.now(),
                                         nullable=False, comment="when last updated"), schema="odc")
     else:
         op.alter_column("product", "updated", schema="odc", type_=DateTime(timezone=True),
-                        server_default=func.now(), nullable=False, comment="when last updated")  # type: ignore[arg-type] # noqa: E501
+                        server_default=func.now(), nullable=False, comment="when last updated") # noqa: E501
 
 
 def downgrade() -> None:

--- a/docs/about/release_process.rst
+++ b/docs/about/release_process.rst
@@ -4,7 +4,7 @@ Release Process
 #. Decide to do a release, and check with regular contributors on `Discord <https://discord.com/invite/4hhBQVas5U>`_
    that they don't have anything pending.
 
-#. Ensure version pins in pyproject.toml and conda-environment.yml are in sync and up to date. Referesh uv.lock::
+#. Ensure version pins in pyproject.toml and conda-environment.yml are in sync and up to date. Refresh uv.lock::
 
    uv lock
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,31 +8,65 @@ What's New
 Next Version
 ============
 
-- docs: fix broken links :pull:`1725`
-- Update dependencies :pull:`1727`, :pull:`1731`
+v1.9.3 (15th April 2025)
+========================
+
+Contains a fix to a serious bug affecting dask usage, preparation for psycopg3, and a lot of other minor cleanup,
+tweaks and fixes.
+
+Includes contributions from @pjonsson, @omad, @caitlinadams, @SpacemanPaul and first PRs from new contributors
+@emmanuel-ferdman and @allrob23.
+
+Special thanks to @pjonsson who is single-handedly responsible for most of the PRs in this release, and to
+to all supporting organisations including Geoscience Australia, CSIRO and RI.SE.
+
+Bug Fix
+-------
+
+- Fix error when run with Python 3.10 causing pickling errors :pull:`1776`
+
+CI Fixes and Improvements:
+--------------------------
+
+- CI: fix docker image name :pull:`1730`
+- CI: fix codecov warning :pull:`1740`
+- CI: retry more in setup-miniconda :pull:`1753`
+- CI: cancel old PR jobs :pull:`1761`
+- CI: update doctor rst version :pull:`1775`
+- Stop building Python 2 wheels :pull:`1752`
+- pytest: only test documentation for relevant files :pull:`1751`
+- Fix some readthedocs warnings :pull:`1762`
+- Autoupdates :pull:`1723`, :pull:`1726`, :pull:`1729`, :pull:`1771`
+- Update mypy version :pull:`1743`
+
+Warnings Cleanups:
+------------------
+
 - config.py: emit ODC2DeprecationWarning :pull:`1733`
 - Stop filtering warnings :pull:`1734`
-- Fix ODC2DeprecationWarnings :pull:`1737`, :pull:`1738`, :pull:`1745`
-- CI: fix codecov warning :pull:`1740`
 - tests: ignore deliberate warnings :pull:`1741`, :pull:`1754`, :pull:`1768`
-- Update mypy version :pull:`1743`
 - Add a common table expression to fix a SQLAlchemy 2.0 sub-query warning :pull:`1747`
-- Convert examples and tests to pyproject.toml :pull:`1748`
-- pytest: only test documentation for relevant files :pull:`1751`
-- Stop building Python 2 wheels :pull:`1752`
-- CI: retry more in setup-miniconda :pull:`1753`
+- Fix ODC2DeprecationWarnings :pull:`1737`, :pull:`1738`, :pull:`1745`
+
+Typecheck Cleanups:
+-------------------
+
+- Type check cleanups :pull:`1744`, :pull:`1746`, :pull:`1742`, :pull:`1755`
 - Remove redundant casts :pull:`1758`
-- CI: cancel old PR jobs :pull:`1761`
-- Remove deprecation of Product.grid_spec :pull:`1770`
-- Fix some readthedocs warnings :pull:`1762`
+- Add override annotations :pull:`1767`
+
+Minor Fixes and Cleanup:
+------------------------
+
+- Documentation fixes and tweaks :pull:`1722`, :pull:`1725`
+- Update dependencies :pull:`1727`, :pull:`1731`, :pull:`1750`
+- Convert examples and tests to pyproject.toml :pull:`1748`
 - Update to Python 3.10 syntax :pull:`1756`, :pull:`1757`, :pull:`1758`, :pull:`1759`
 - Preparations for Psycopg3 support :pull:`1763`, :pull:`1764`, :pull:`1765`, :pull:`1766`
-- Add override annotations :pull:`1767`
 - Optimize index_drivers() to return a set :pull:`1774`
 - Various minor cleanups :pull:`1772`
 - api: add missing staticmethod :pull:`1773`
-- CI: update doctor rst version :pull:`1775`
-- Fix error when run with Python 3.10 causing pickling errors :pull:`1776`
+- whats_new.rst updates :pull:`1769`, :pull:`THIS`
 
 v1.9.2 (26th February 2025)
 ===========================

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -59,8 +59,8 @@ Minor Fixes and Cleanup:
 - api: add missing staticmethod :pull:`1773`
 - whats_new.rst updates :pull:`1769`, :pull:`1778`
 
-Typecheck Cleanups:
--------------------
+Typechecking Cleanups:
+----------------------
 
 - Type check cleanups :pull:`1744`, :pull:`1746`, :pull:`1742`, :pull:`1755`
 - Remove redundant casts :pull:`1758`

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -18,12 +18,53 @@ Includes contributions from @pjonsson, @omad, @caitlinadams, @SpacemanPaul and f
 @emmanuel-ferdman and @allrob23.
 
 Special thanks to @pjonsson who is single-handedly responsible for most of the PRs in this release, and to
-to all supporting organisations including Geoscience Australia, CSIRO and RI.SE.
+to all supporting organisations including Geoscience Australia, CSIRO and RISE.
 
-Bug Fix
--------
+Known Issue
+-----------
+
+There are still some issues with Dask loading in 1.9.  We are looking into them and anticipate a 1.9.4 release
+to fix them in the next few weeks.
+
+Full list of changes:
+---------------------
+
+Bug Fixes
+---------
 
 - Fix error when run with Python 3.10 causing pickling errors :pull:`1776`
+- Stop filtering warnings :pull:`1734`
+
+Warnings Cleanup:
+-----------------
+
+- Fix some readthedocs warnings :pull:`1762`
+- config.py: emit ODC2DeprecationWarning :pull:`1733`
+- tests: ignore deliberate warnings :pull:`1741`, :pull:`1754`, :pull:`1768`
+- Add a common table expression to fix a SQLAlchemy 2.0 sub-query warning :pull:`1747`
+- Fix ODC2DeprecationWarnings :pull:`1737`, :pull:`1738`, :pull:`1745`
+- Undeprecate Product.grid_spec :pull:`1770`
+
+Minor Fixes and Cleanup:
+------------------------
+
+- Replace setup.py with pyproject.toml :pull:`1670`
+- Documentation fixes and tweaks :pull:`1722`, :pull:`1725`
+- Update dependencies :pull:`1727`, :pull:`1731`, :pull:`1750`
+- Convert examples and tests to pyproject.toml :pull:`1748`
+- Update to Python 3.10 syntax :pull:`1756`, :pull:`1757`, :pull:`1758`, :pull:`1759`
+- Preparations for Psycopg3 support :pull:`1763`, :pull:`1764`, :pull:`1765`, :pull:`1766`
+- Optimize index_drivers() to return a set :pull:`1774`
+- Various minor cleanups :pull:`1772`
+- api: add missing staticmethod :pull:`1773`
+- whats_new.rst updates :pull:`1769`, :pull:`1778`
+
+Typecheck Cleanups:
+-------------------
+
+- Type check cleanups :pull:`1744`, :pull:`1746`, :pull:`1742`, :pull:`1755`
+- Remove redundant casts :pull:`1758`
+- Add override annotations :pull:`1767`
 
 CI Fixes and Improvements:
 --------------------------
@@ -35,38 +76,8 @@ CI Fixes and Improvements:
 - CI: update doctor rst version :pull:`1775`
 - Stop building Python 2 wheels :pull:`1752`
 - pytest: only test documentation for relevant files :pull:`1751`
-- Fix some readthedocs warnings :pull:`1762`
 - Autoupdates :pull:`1723`, :pull:`1726`, :pull:`1729`, :pull:`1771`
 - Update mypy version :pull:`1743`
-
-Warnings Cleanups:
-------------------
-
-- config.py: emit ODC2DeprecationWarning :pull:`1733`
-- Stop filtering warnings :pull:`1734`
-- tests: ignore deliberate warnings :pull:`1741`, :pull:`1754`, :pull:`1768`
-- Add a common table expression to fix a SQLAlchemy 2.0 sub-query warning :pull:`1747`
-- Fix ODC2DeprecationWarnings :pull:`1737`, :pull:`1738`, :pull:`1745`
-
-Typecheck Cleanups:
--------------------
-
-- Type check cleanups :pull:`1744`, :pull:`1746`, :pull:`1742`, :pull:`1755`
-- Remove redundant casts :pull:`1758`
-- Add override annotations :pull:`1767`
-
-Minor Fixes and Cleanup:
-------------------------
-
-- Documentation fixes and tweaks :pull:`1722`, :pull:`1725`
-- Update dependencies :pull:`1727`, :pull:`1731`, :pull:`1750`
-- Convert examples and tests to pyproject.toml :pull:`1748`
-- Update to Python 3.10 syntax :pull:`1756`, :pull:`1757`, :pull:`1758`, :pull:`1759`
-- Preparations for Psycopg3 support :pull:`1763`, :pull:`1764`, :pull:`1765`, :pull:`1766`
-- Optimize index_drivers() to return a set :pull:`1774`
-- Various minor cleanups :pull:`1772`
-- api: add missing staticmethod :pull:`1773`
-- whats_new.rst updates :pull:`1769`, :pull:`1778`
 
 v1.9.2 (26th February 2025)
 ===========================

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -66,7 +66,7 @@ Minor Fixes and Cleanup:
 - Optimize index_drivers() to return a set :pull:`1774`
 - Various minor cleanups :pull:`1772`
 - api: add missing staticmethod :pull:`1773`
-- whats_new.rst updates :pull:`1769`, :pull:`THIS`
+- whats_new.rst updates :pull:`1769`, :pull:`1778`
 
 v1.9.2 (26th February 2025)
 ===========================

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -558,6 +558,7 @@ ul
 unarchived
 unary
 Uncomment
+undeprecate
 ur
 URI
 uri

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -18,6 +18,7 @@ aio
 albers
 Algo
 algo
+allrob
 Analytics
 analytics
 antimeridian
@@ -42,6 +43,7 @@ automethod
 automodule
 autoselectionlabel
 autosummary
+autoupdates
 auxuser
 aws
 backend
@@ -64,6 +66,7 @@ brazil
 Bugfix
 Bugfixes
 bY
+caitlinadams
 cartesian
 cbk
 cd
@@ -163,6 +166,7 @@ EarthData
 earthobservation
 ec
 eg
+emmanuel
 EnterpriseDB
 entrypoint
 env
@@ -185,6 +189,7 @@ executor
 f'file
 fd
 feedstock
+ferdman
 Festivus
 fmask
 fmt
@@ -235,6 +240,7 @@ GridSpec
 GridWorkflow
 gridWorkflow
 GroupBy
+handedly
 HDF
 hdf
 hhBQVas
@@ -407,6 +413,7 @@ pgadmin
 pgintegration
 pgisintegration
 pixelquality
+pjonsson
 pkgs
 Pluggable
 pmap
@@ -496,6 +503,7 @@ serialiser
 setuptools
 SimpleDocNav
 singledispatch
+SpacemanPaul
 spatio
 SpatioTemporal
 spc

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -575,6 +575,7 @@ utils
 UUID
 uuid
 UUIDs
+uv
 ValueError
 vam
 VDI


### PR DESCRIPTION
### Reason for this pull request

Preparing for 1.9.3 release - probably early next week.


### Proposed changes

- Update whats_new.rst ready for 1.9.3 release.



 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1778.org.readthedocs.build/en/1778/

<!-- readthedocs-preview datacube-core end -->