### PR TITLE
Fix Dask Data Load error

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -1455,7 +1455,7 @@ def _make_dask_array(
             dss = tiled_dss.get(idx, None)
 
             if dss is None:
-                val3d = _mk_empty(gbt.chunk_shape(idx).xy)
+                val3d = _mk_empty(gbt.chunk_shape(idx).yx)
                 # 3D case
                 if "extra_dim" in measurement:
                     assert extra_dims is not None  # For type checker

--- a/datacube/testutils/__init__.py
+++ b/datacube/testutils/__init__.py
@@ -406,7 +406,7 @@ def gen_tiff_dataset(bands,
                      prefix='',
                      timestamp='2018-07-19',
                      base_folder_of_record=None,
-                     **kwargs):
+                     **kwargs) -> tuple[Dataset, GeoBox]:
     """
        each band:
          .name    - string

--- a/datacube/testutils/__init__.py
+++ b/datacube/testutils/__init__.py
@@ -5,6 +5,8 @@
 """
 Useful methods for tests (particularly: reading/writing and checking files)
 """
+import typing
+
 import atexit
 import math
 import os
@@ -13,6 +15,7 @@ import tempfile
 import json
 import uuid
 import numpy as np
+from numpy.typing import NDArray
 import xarray as xr
 import warnings
 import contextlib
@@ -33,6 +36,13 @@ from odc.geo import CRS, wh_
 from odc.geo.geobox import GeoBox
 
 _DEFAULT = object()
+
+
+class BandObject(typing.Protocol):
+    """A protocol defining an object with name, values, and nodata attributes."""
+    name: str
+    values: NDArray
+    nodata: typing.Any  # Maybe could be int | float | None
 
 
 def assert_file_structure(
@@ -219,7 +229,7 @@ def mk_sample_product(name,
     return Product(metadata_type, definition)
 
 
-def mk_sample_dataset(bands,
+def mk_sample_dataset(bands: list[dict],
                       uri: str | list[str] | None = 'file:///tmp',
                       product_name='sample',
                       format='GeoTiff',
@@ -401,7 +411,7 @@ def split_test_image(aa):
     return x, y
 
 
-def gen_tiff_dataset(bands,
+def gen_tiff_dataset(bands: list[BandObject],
                      base_folder,
                      prefix='',
                      timestamp='2018-07-19',
@@ -425,8 +435,7 @@ def gen_tiff_dataset(bands,
         bands = (bands,)
 
     # write arrays to disk and construct compatible measurement definitions
-    geobox = None
-    mm = []
+    measurement_defs = []
     for band in bands:
         name = band.name
         fname = prefix + name + '.tiff'
@@ -435,16 +444,16 @@ def gen_tiff_dataset(bands,
                            overwrite=True,
                            **kwargs)
 
-        geobox = meta.geobox
+        geobox: GeoBox = meta.geobox
 
-        mm.append(dict(name=name,
-                       path=fname,
-                       layer=1,
-                       nodata=band.nodata,
-                       dtype=meta.dtype))
+        measurement_defs.append(dict(name=name,
+                                     path=fname,
+                                     layer=1,
+                                     nodata=band.nodata,
+                                     dtype=meta.dtype))
 
     uri = Path(base_folder_of_record/'metadata.yaml').absolute().as_uri()
-    ds = mk_sample_dataset(mm,
+    ds = mk_sample_dataset(measurement_defs,
                            uri=uri,
                            timestamp=timestamp,
                            geobox=geobox)

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -79,6 +79,39 @@ def test_load_data(tmpdir):
     np.testing.assert_array_equal(aa, ds_data.aa.values[0])
 
 
+def test_load_data_dask(tmp_path):
+    spatial = dict(resolution=(15, -15),
+                   offset=(11230, 1381110),)
+
+    nodata = -999
+    aa = mk_test_image(128, 128, 'int16', nodata=nodata)
+
+    ds, geobox = gen_tiff_dataset([SimpleNamespace(name='aa', values=aa, nodata=nodata)],
+                                  tmp_path,
+                                  prefix='ds1-',
+                                  timestamp='2018-07-19',
+                                  **spatial)
+
+    sources = Datacube.group_datasets([ds], 'time')
+    mm = ds.product.measurements
+
+    import dask
+    dask.config.set(scheduler='synchronous')
+
+    ds_data = Datacube.load_data(sources, geobox, mm, dask_chunks={'x': 50, 'y': 67})  # spatial dims not equal!
+    ds_data.compute()
+    assert ds_data.aa.nodata == nodata
+    np.testing.assert_array_equal(aa, ds_data.aa.values[0])
+
+    # Include an empty value area outside the data area, large enough to include completely empty chunks
+    geobox = geobox.pad(100, 100)
+    ds_data = Datacube.load_data(sources, geobox, mm, dask_chunks={'x': 50, 'y': 67})  # spatial dims not equal!
+
+    ds_data.compute()
+    assert ds_data.aa.nodata == nodata
+    np.testing.assert_array_equal(aa, ds_data.aa.values[0, 100:228, 100:228])
+
+
 def test_load_data_with_url_mangling(tmpdir):
     actual_tmpdir = Path(str(tmpdir))
     recorded_tmpdir = Path(str(tmpdir / "not" / "actual" / "location"))


### PR DESCRIPTION
This PR adds a test and a fix for a data load error which causes the load to raise an unhandled exception. I believe it was introduced at some point in the lead up to ODC 1.9, probably when switching from the internal geometry classes to those in `odc-geo`.

 It happens whenever:
- Lazy loading using dask is requested by specifying `dask_chunks=`
- There's at least 1 completely empty AND non-square chunk.

The problem (and fix) is requesting the x and y shape of the chunk in the wrong order.

Fixes: #1779