### PR TITLE
sql: fix packagenames type

### DIFF
--- a/datacube/drivers/postgis/sql.py
+++ b/datacube/drivers/postgis/sql.py
@@ -83,9 +83,9 @@ class Float8Range(GenericFunction):
 
     name = 'float8range'
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self.packagenames = ['%s' % SCHEMA_NAME]
+        self.packagenames = ('%s' % SCHEMA_NAME,)
 
 
 class PGNAME(sqltypes.Text):

--- a/datacube/drivers/postgres/sql.py
+++ b/datacube/drivers/postgres/sql.py
@@ -109,9 +109,9 @@ class CommonTimestamp(GenericFunction):
 
     name = 'common_timestamp'
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self.packagenames = ['%s' % SCHEMA_NAME]
+        self.packagenames = ('%s' % SCHEMA_NAME,)
 
 
 # pylint: disable=too-many-ancestors
@@ -123,9 +123,9 @@ class Float8Range(GenericFunction):
 
     name = 'float8range'
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self.packagenames = ['%s' % SCHEMA_NAME]
+        self.packagenames = ('%s' % SCHEMA_NAME,)
 
 
 class PGNAME(sqltypes.Text):

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -9,7 +9,7 @@ Next Version
 ============
 
 - Use odc-geo GridSpec if `tile_shape` in product storage information :pull:`1783`
-
+- SQL: fix package names type :pull:`1784`
 
 v1.9.3 (15th April 2025)
 ========================

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -509,6 +509,7 @@ SpatioTemporal
 spc
 SPDX
 spindex
+SQL
 SQLAlchemy
 SRID
 srid


### PR DESCRIPTION
### Reason for this pull request

The type is `tuple[str, ...]` rather than `list[str]` according to mypy.


### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1784.org.readthedocs.build/en/1784/

<!-- readthedocs-preview datacube-core end -->