### PR TITLE
api: type annotate group_by_time

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -585,7 +585,7 @@ class Datacube:
             geopolygon=cast(Geometry | None, query.pop("geopolygon", None)),
             **query,
         )
-        group_by = query_group_by(**query)
+        group_by = query_group_by(**query)  # type: ignore[arg-type]
         grouped = self.group_datasets(datasets, group_by)
 
         measurement_dicts = datacube_product.lookup_measurements(measurements)

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -18,7 +18,7 @@ from pandas import to_datetime as pandas_to_datetime
 from typing_extensions import override
 import numpy as np
 from ..index import extract_geom_from_query, strip_all_spatial_fields_from_query
-from ..model import Range, Dataset
+from ..model import Range, Dataset, QueryField
 from ..utils.dates import normalise_dt, tz_aware
 from odc.geo import Geometry
 from odc.geo.geom import lonlat_bounds, mid_longitude
@@ -181,7 +181,7 @@ def _extract_time_from_ds(ds: Dataset) -> datetime.datetime:
     return normalise_dt(ds.center_time)
 
 
-def query_group_by(group_by='time', **kwargs) -> GroupBy:
+def query_group_by(group_by: str | GroupBy | None = 'time', **kwargs: QueryField) -> GroupBy:
     """
     Group by function for loading datasets
 

--- a/datacube/index/_spatial.py
+++ b/datacube/index/_spatial.py
@@ -29,7 +29,7 @@ def strip_all_spatial_fields_from_query(q: QueryDict) -> QueryDict:
     }
 
 
-def extract_geom_from_query(**q: QueryField | tuple) -> Geometry | None:
+def extract_geom_from_query(**q: QueryField) -> Geometry | None:
     """
     Utility method for index drivers supporting spatial indexes.
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -10,7 +10,7 @@ Next Version
 
 - Use odc-geo GridSpec if `tile_shape` in product storage information :pull:`1783`
 - SQL: fix package names type :pull:`1784`
-- Add some type signatures :pull:`1785`
+- Add some type signatures :pull:`1785`, :pull:`1788`
 - Use Ruff instead of flake8 :pull:`1789`
 - Update uv.lock with Dependabot :pull:`1790`
 - tests: use set instead of list :pull:`1792`


### PR DESCRIPTION
### Reason for this pull request

This uncovered that extract_geom_from_type
had the wrong type annotation, so update
that.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1788.org.readthedocs.build/en/1788/

<!-- readthedocs-preview datacube-core end -->