### PR TITLE
memory: fix MetadataTypeResource constructor

### DIFF
--- a/datacube/index/memory/_metadata_types.py
+++ b/datacube/index/memory/_metadata_types.py
@@ -18,12 +18,12 @@ _LOG = logging.getLogger(__name__)
 
 
 class MetadataTypeResource(AbstractMetadataTypeResource):
-    def __init__(self):
-        self.by_id = {}
-        self.by_name = {}
+    def __init__(self) -> None:
+        self.by_id: dict = {}
+        self.by_name: dict = {}
         self.next_id = 1
         for doc in default_metadata_type_docs():
-            self.add(self.from_doc(doc))
+            self.add(doc)
 
     @override
     def from_doc(self, definition: Mapping[str, Any]) -> MetadataType:

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -11,6 +11,7 @@ Next Version
 - Use odc-geo GridSpec if `tile_shape` in product storage information :pull:`1783`
 - SQL: fix package names type :pull:`1784`
 - Add some type signatures :pull:`1785`
+- memory: fix constructor :pull:`1794`
 
 v1.9.3 (15th April 2025)
 ========================


### PR DESCRIPTION
### Reason for this pull request

The `default_metadata_type_docs()` returns a list of `MetadataType`, which is what `self.add()` wants, so just add directly without any conversion.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1794.org.readthedocs.build/en/1794/

<!-- readthedocs-preview datacube-core end -->