### PR TITLE
dask: assign dictinary key

### DIFF
--- a/datacube/utils/dask.py
+++ b/datacube/utils/dask.py
@@ -10,6 +10,7 @@ from collections.abc import Iterable
 from random import randint
 import toolz
 import queue
+from dask.config import config as dask_config
 from dask.distributed import Client
 import dask
 import threading
@@ -97,11 +98,11 @@ def start_local_dask(n_workers: int = 1,
     """
 
     # if dashboard.link set to default value and running behind hub, make dashboard link go via proxy
-    if dask.config.get("distributed.dashboard.link") == '{scheme}://{host}:{port}/status':
+    if dask_config.get("distributed.dashboard.link") == '{scheme}://{host}:{port}/status':
         jup_prefix = os.environ.get('JUPYTERHUB_SERVICE_PREFIX')
         if jup_prefix is not None:
             jup_prefix = jup_prefix.rstrip('/')
-            dask.config.set({"distributed.dashboard.link": f"{jup_prefix}/proxy/{{port}}/status"})
+            dask_config["distributed.dashboard.link"] = f"{jup_prefix}/proxy/{{port}}/status"
 
     memory_limit = compute_memory_per_worker(n_workers=n_workers,
                                              memory_limit=memory_limit,

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -13,6 +13,7 @@ Next Version
 - Add some type signatures :pull:`1785`
 - tests: use set instead of list :pull:`1792`
 - users: import right index :pull:`1793`
+- dask: assign dictionary key :pull:`1798`
 
 v1.9.3 (15th April 2025)
 ========================


### PR DESCRIPTION
### Reason for this pull request

The config in dask is a dictionary
so there is no set method, assign
as a regular dictionary instead.

Also import the config from
the module where it is defined.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1798.org.readthedocs.build/en/1798/

<!-- readthedocs-preview datacube-core end -->