### PR TITLE
fields: type annotate offset parameter

### DIFF
--- a/datacube/index/memory/_fields.py
+++ b/datacube/index/memory/_fields.py
@@ -53,7 +53,7 @@ def get_dataset_fields(metadata_definition: Mapping[str, Any]) -> dict[str, Fiel
 def build_custom_fields(custom_offsets: Mapping[str, Offset]) -> dict[str, Field]:
     return {
         name: SimpleField(
-            offset,
+            list(offset),
             lambda x: x, 'any',
             name=name,
             description=f"Custom field: {name}"

--- a/datacube/model/fields.py
+++ b/datacube/model/fields.py
@@ -104,7 +104,7 @@ class Field:
 
 class SimpleField(Field):
     def __init__(self,
-                 offset,
+                 offset: list[str | int],
                  converter,
                  type_name,
                  name='',

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -18,6 +18,7 @@ Next Version
 - postgres: use one type for fields :pull:`1795`
 - Remove executable permission on files :pull:`1797`
 - Import names from defining module :pull:`1799`
+- fields: type annotate offset parameter :pull:`1809`
 - Dependabot: make one pull request for everything :pull:`1816`
 
 v1.9.3 (15th April 2025)


### PR DESCRIPTION
### Reason for this pull request

The examples for toolz.get_in() use
lists of strings and ints, so annotate
the offset parameter of SimpleField
as list[str | int].

This reveals that the memory index
passes a tuple in one place, so
convert that to a list.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1809.org.readthedocs.build/en/1809/

<!-- readthedocs-preview datacube-core end -->