### PR TITLE
virtual: fix pydoc formatting

### DIFF
--- a/datacube/virtual/transformations.py
+++ b/datacube/virtual/transformations.py
@@ -454,7 +454,7 @@ def year(time):
 
 
 def fiscal_year(time):
-    """"
+    """
     This function supports group-by financial years
     """
     def convert_to_quarters(x):

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -18,6 +18,7 @@ Next Version
 - postgres: use one type for fields :pull:`1795`
 - Remove executable permission on files :pull:`1797`
 - Import names from defining module :pull:`1799`
+- virtual: fix pydoc formatting :pull:`1810`
 - Dependabot: make one pull request for everything :pull:`1816`
 
 v1.9.3 (15th April 2025)

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -440,6 +440,7 @@ pwd
 px
 py
 pydata
+pydoc
 pyenv
 PyLint
 pylint


### PR DESCRIPTION
### Reason for this pull request

There is one quote sign too much
in the opening.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1810.org.readthedocs.build/en/1810/

<!-- readthedocs-preview datacube-core end -->