### PR TITLE
dependabot: group uv dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      uv-deps:
+        patterns:
+          - "*"

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -18,7 +18,7 @@ Next Version
 - postgres: use one type for fields :pull:`1795`
 - Remove executable permission on files :pull:`1797`
 - Import names from defining module :pull:`1799`
-
+- Dependabot: make one pull request for everything :pull:`1816`
 
 v1.9.3 (15th April 2025)
 ========================


### PR DESCRIPTION
### Reason for this pull request

There are interdependencies like
boto3 and botocore that must be
updated at the same time. Just
make a large group for everything
for now.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview datacube-core start -->
----
📚 Documentation preview 📚: https://datacube-core--1816.org.readthedocs.build/en/1816/

<!-- readthedocs-preview datacube-core end -->