### PR TITLE
dependabot: update boto* weekly instead

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,15 @@ updates:
       uv-deps:
         patterns:
           - "*"
+        exclude-patterns: # Packages updated almost every day.
+          - "boto3"
+          - "botocore"
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      uv-weekly-deps:
+        patterns:
+          - "boto3"
+          - "botocore"

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -27,6 +27,7 @@ Next Version
 - Various lint fixes :pull:`1824`
 - CI: use the right project slug :pull:`1823`
 - tests: update to moto 5.1.4 :pull:`1821`
+- Dependabot: update boto weekly instead :pull:`1837`
 
 v1.9.3 (15th April 2025)
 ========================


### PR DESCRIPTION
### Reason for this pull request

Their release schedule is almost daily,
so update them once a week.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1837.org.readthedocs.build/en/1837/

<!-- readthedocs-preview opendatacube end -->