### PR TITLE
Dependabot: fix boto group conflict

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,10 @@ updates:
           - "boto3"
           - "botocore"
   - package-ecosystem: "uv"
+    # Have two jobs with same eco-system/directory by setting target-branch
+    # for one of them:
+    # https://github.com/dependabot/dependabot-core/issues/1778#issuecomment-1988140219
+    target-branch: "develop"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -28,7 +28,7 @@ Next Version
 - CI: use the right project slug :pull:`1823`
 - tests: update to moto 5.1.4 :pull:`1821`
 - Python 3.10 updates :pull:`1839`
-- Dependabot: update boto weekly instead :pull:`1837`
+- Dependabot: update boto weekly instead :pull:`1837`, :pull:`1843`
 - Dockerfile: stop running chown :pull:`1835`
 - CI: add security scanner :pull:`1833`
 - postgis: update mapper dynamically :pull:`1831`


### PR DESCRIPTION
### Reason for this pull request

Dependabot only permits one configuration
per eco-system/directory pair, so specify
the target-branch on one of them to get
around that limitation.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1843.org.readthedocs.build/en/1843/

<!-- readthedocs-preview opendatacube end -->