### PR TITLE
pytest: configure in pyproject.toml

### DIFF
--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -32,6 +32,7 @@ Next Version
 - Dockerfile: stop running chown :pull:`1835`
 - CI: add security scanner :pull:`1833`
 - postgis: update mapper dynamically :pull:`1831`
+- pytest: configure in pyproject.toml :pull:`1844`
 
 v1.9.3 (15th April 2025)
 ========================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,16 @@ null = 'datacube.index.null.index:index_driver_init'
 memory = 'datacube.index.memory.index:index_driver_init'
 postgis = 'datacube.index.postgis.index:index_driver_init'
 
+[tool.pytest.ini_options]
+addopts = "--doctest-modules"
+testpaths = ["datacube", "tests", "integration_tests"]
+norecursedirs = [".*", "build", "dist", ".git", "tmp*"]
+filterwarnings = [
+    "ignore::FutureWarning",
+    "ignore:datetime.datetime.utcnow*:DeprecationWarning:botocore.*",
+    "ignore:.*numpy.ndarray size changed.*:"
+]
+
 [tool.ruff]
 extend-exclude = ["datacube/drivers/postgis/alembic/versions"]
 src = ["datacube", "docs", "examples", "tests", "integration_tests"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,8 +1,0 @@
-[pytest]
-addopts = --doctest-modules
-testpaths = datacube tests integration_tests
-norecursedirs = .* build dist .git tmp*
-filterwarnings =
-    ignore::FutureWarning
-    ignore:datetime.datetime.utcnow*:DeprecationWarning:botocore.*
-    ignore:.*numpy.ndarray size changed.*:


### PR DESCRIPTION
### Reason for this pull request

Put all the configuration in one
place so there's one place to
look for it. This also aligns
with how eo-datasets was just
configured.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1844.org.readthedocs.build/en/1844/

<!-- readthedocs-preview opendatacube end -->