### PR TITLE
Sort imports with Ruff

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -3,46 +3,47 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+
+import collections.abc
+import datetime
 import logging
 import uuid
-import collections.abc
+from collections.abc import Callable, Hashable, Iterable, Mapping, Sequence
 from itertools import groupby
-from typing import Any, cast, TYPE_CHECKING
-from typing_extensions import override
-from collections.abc import Iterable, Callable, Hashable, Mapping, Sequence
-import datetime
+from typing import TYPE_CHECKING, Any, cast
 
 import deprecat
 import numpy
 import xarray
 from dask import array as da
-
-from datacube.cfg import GeneralisedRawCfg, GeneralisedCfg, GeneralisedEnv, ODCConfig
-from datacube.storage import reproject_and_fuse, BandInfo
-from datacube.utils import ignore_exceptions_if
-from odc.geo import CRS, yx_, res_, resyx_, Resolution, XY
+from odc.geo import CRS, XY, Resolution, res_, resyx_, yx_
+from odc.geo.geobox import GeoBox, GeoboxTiles
+from odc.geo.geom import Geometry, bbox_union, box, intersects
 from odc.geo.warp import Resampling
 from odc.geo.xr import xr_coords
-from datacube.utils.dates import normalise_dt
-from odc.geo.geom import intersects, box, bbox_union, Geometry
-from odc.geo.geobox import GeoBox, GeoboxTiles
+from typing_extensions import override
+
+from datacube.cfg import GeneralisedCfg, GeneralisedEnv, GeneralisedRawCfg, ODCConfig
 from datacube.model import (
+    Dataset,
     ExtraDimensions,
     ExtraDimensionSlices,
-    Dataset,
     Measurement,
 )
 from datacube.model.utils import xr_apply
+from datacube.storage import BandInfo, reproject_and_fuse
+from datacube.utils import ignore_exceptions_if
+from datacube.utils.dates import normalise_dt
 
 if TYPE_CHECKING:
     from datacube.model import GridSpec
 
-from .query import Query, query_group_by, GroupBy
-from ..index import index_connect, Index, extract_geom_from_query
 from ..drivers import new_datasource
-from ..model import QueryField
+from ..index import Index, extract_geom_from_query, index_connect
 from ..migration import ODC2DeprecationWarning
-from ..storage._load import ProgressFunction, FuserFunction
+from ..model import QueryField
+from ..storage._load import FuserFunction, ProgressFunction
+from .query import GroupBy, Query, query_group_by
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -7,21 +7,22 @@ Storage Query and Access API module
 """
 
 
-import logging
-import datetime
 import collections
+import datetime
+import logging
 import math
 import warnings
-import pandas
 
-from pandas import to_datetime as pandas_to_datetime
-from typing_extensions import override
 import numpy as np
-from ..index import extract_geom_from_query, strip_all_spatial_fields_from_query
-from ..model import Range, Dataset, QueryField
-from ..utils.dates import normalise_dt, tz_aware
+import pandas
 from odc.geo import Geometry
 from odc.geo.geom import lonlat_bounds, mid_longitude
+from pandas import to_datetime as pandas_to_datetime
+from typing_extensions import override
+
+from ..index import extract_geom_from_query, strip_all_spatial_fields_from_query
+from ..model import Dataset, QueryField, Range
+from ..utils.dates import normalise_dt, tz_aware
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/cfg/__init__.py
+++ b/datacube/cfg/__init__.py
@@ -4,13 +4,25 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+from .api import (
+    GeneralisedCfg,
+    GeneralisedEnv,
+    GeneralisedPath,
+    GeneralisedRawCfg,
+    ODCConfig,
+    ODCEnvironment,
+)
+from .cfg import CfgFormat, find_config, parse_text
 from .exceptions import ConfigException
+from .opt import (
+    IAMAuthenticationOptionHandler,
+    IntOptionHandler,
+    ODCOptionHandler,
+    PostgresURLOptionHandler,
+    config_options_for_psql_driver,
+    psql_url_from_config,
+)
 from .utils import ConfigDict, check_valid_env_name, check_valid_option, smells_like_ini
-from .cfg import find_config, CfgFormat, parse_text
-from .opt import ODCOptionHandler, IntOptionHandler, IAMAuthenticationOptionHandler, PostgresURLOptionHandler
-from .opt import config_options_for_psql_driver, psql_url_from_config
-from .api import GeneralisedPath, GeneralisedCfg, GeneralisedEnv, GeneralisedRawCfg, ODCConfig, ODCEnvironment
-
 
 __all__ = [
     "CfgFormat",

--- a/datacube/cfg/api.py
+++ b/datacube/cfg/api.py
@@ -8,22 +8,21 @@ Datacube configuration
 """
 import os
 import warnings
-
 from os import PathLike
 from threading import Lock
 from typing import Any, TypeAlias, Union, cast
 
+from ..migration import ODC2DeprecationWarning
 from .cfg import find_config, parse_text
 from .exceptions import ConfigException
 from .opt import (
-    ODCOptionHandler,
     AliasOptionHandler,
-    IndexDriverOptionHandler,
     BoolOptionHandler,
+    IndexDriverOptionHandler,
     IntOptionHandler,
+    ODCOptionHandler,
 )
 from .utils import ConfigDict, check_valid_env_name
-from ..migration import ODC2DeprecationWarning
 
 # TypeAliases for more concise type hints
 # (Unions required as typehint | operator doesn't work with string forward-references).

--- a/datacube/cfg/cfg.py
+++ b/datacube/cfg/cfg.py
@@ -15,7 +15,7 @@ from os import PathLike
 from os.path import expanduser
 
 from datacube.cfg.exceptions import ConfigException
-from datacube.cfg.utils import ConfigDict, smells_like_ini, SemaphoreCallback
+from datacube.cfg.utils import ConfigDict, SemaphoreCallback, smells_like_ini
 from datacube.migration import ODC2DeprecationWarning
 
 _DEFAULT_CONFIG_SEARCH_PATH: list[str] = [

--- a/datacube/cfg/opt.py
+++ b/datacube/cfg/opt.py
@@ -5,14 +5,14 @@
 
 import os
 import warnings
-from typing import Any, TYPE_CHECKING
-from typing_extensions import override
-from urllib.parse import urlparse
-from urllib.parse import quote_plus
+from typing import TYPE_CHECKING, Any
+from urllib.parse import quote_plus, urlparse
 
+from typing_extensions import override
+
+from ..migration import ODC2DeprecationWarning
 from .exceptions import ConfigException
 from .utils import check_valid_option
-from ..migration import ODC2DeprecationWarning
 
 if TYPE_CHECKING:
     from .api import ODCEnvironment

--- a/datacube/cfg/utils.py
+++ b/datacube/cfg/utils.py
@@ -4,11 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import re
-from typing import Any, TypeAlias
 from collections.abc import Callable
+from typing import Any, TypeAlias
 
 from .exceptions import ConfigException
-
 
 # A raw configuration dictionary. A dictionary of dictionaries
 ConfigDict: TypeAlias = dict[str, dict[str, Any]]

--- a/datacube/config.py
+++ b/datacube/config.py
@@ -6,6 +6,7 @@
 User configuration.
 """
 import warnings
+
 from datacube.migration import ODC2DeprecationWarning
 
 warnings.warn("The old datacube.config  is no longer supported.  Please use the new datacube.cfg library",

--- a/datacube/drivers/_types.py
+++ b/datacube/drivers/_types.py
@@ -4,18 +4,16 @@
 # SPDX-License-Identifier: Apache-2.0
 """ Defines abstract types for IO drivers.
 """
-from typing import (
-    Any,
-    TYPE_CHECKING
-)
-from collections.abc import Iterable
-
 from abc import ABCMeta, abstractmethod
+from collections.abc import Iterable
+from concurrent.futures import Future
+from typing import TYPE_CHECKING, Any
+
 import numpy as np
 from affine import Affine
-from concurrent.futures import Future
-from datacube.storage import BandInfo
 from odc.geo.crs import CRS
+
+from datacube.storage import BandInfo
 
 # pylint: disable=invalid-name,unsubscriptable-object,pointless-statement
 

--- a/datacube/drivers/datasource.py
+++ b/datacube/drivers/datasource.py
@@ -5,12 +5,12 @@
 """ Defines abstract types for IO reader drivers.
 """
 from abc import ABCMeta, abstractmethod
+from collections.abc import Iterator
 from contextlib import contextmanager
+from typing import TypeAlias
+
 import numpy as np
 from affine import Affine
-from typing import TypeAlias
-from collections.abc import Iterator
-
 
 RasterShape: TypeAlias = tuple[int, int]                 # pylint: disable=invalid-name
 RasterWindow: TypeAlias = tuple[slice, slice] | tuple[tuple[int, int], tuple[int, int]] # pylint: disable=invalid-name

--- a/datacube/drivers/driver_cache.py
+++ b/datacube/drivers/driver_cache.py
@@ -3,8 +3,8 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import logging
-from typing import Any
 from collections.abc import Iterable
+from typing import Any
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/drivers/indexes.py
+++ b/datacube/drivers/indexes.py
@@ -3,9 +3,9 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 
+from ..index.abstract import AbstractIndexDriver
 from ._tools import singleton_setup
 from .driver_cache import load_drivers
-from ..index.abstract import AbstractIndexDriver
 
 
 class IndexDriverCache:
@@ -14,9 +14,15 @@ class IndexDriverCache:
 
         if len(self._drivers) == 0:
             # Driver load has failed.  Something is very wrong, but try to manually load the main drivers anyway.
-            from datacube.index.postgres.index import index_driver_init as pg_index_driver_init
-            from datacube.index.postgis.index import index_driver_init as pgis_index_driver_init
-            from datacube.index.memory.index import index_driver_init as mem_index_driver_init
+            from datacube.index.memory.index import (
+                index_driver_init as mem_index_driver_init,
+            )
+            from datacube.index.postgis.index import (
+                index_driver_init as pgis_index_driver_init,
+            )
+            from datacube.index.postgres.index import (
+                index_driver_init as pg_index_driver_init,
+            )
             self._drivers = dict(postgres=pg_index_driver_init(),
                                  postgis=pgis_index_driver_init(),
                                  memory=mem_index_driver_init())

--- a/datacube/drivers/netcdf/__init__.py
+++ b/datacube/drivers/netcdf/__init__.py
@@ -2,8 +2,8 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from ._write import write_dataset_to_netcdf, create_netcdf_storage_unit
 from . import writer as netcdf_writer
+from ._write import create_netcdf_storage_unit, write_dataset_to_netcdf
 from .writer import Variable
 
 __all__ = [

--- a/datacube/drivers/netcdf/_write.py
+++ b/datacube/drivers/netcdf/_write.py
@@ -2,13 +2,13 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from pathlib import Path
 import logging
+from pathlib import Path
+
+from datacube.storage._hdf5 import HDF5_LOCK
+from datacube.utils import DatacubeException
 
 from . import writer as netcdf_writer
-from datacube.utils import DatacubeException
-from datacube.storage._hdf5 import HDF5_LOCK
-
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/drivers/netcdf/driver.py
+++ b/datacube/drivers/netcdf/driver.py
@@ -2,13 +2,13 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from urllib.parse import urlsplit
 from pathlib import Path
+from urllib.parse import urlsplit
 
 from datacube.storage._rio import RasterDatasetDataSource
 from datacube.utils.uris import normalise_path
-from ._write import write_dataset_to_netcdf
 
+from ._write import write_dataset_to_netcdf
 
 PROTOCOL = 'file'
 FORMAT = 'NetCDF'

--- a/datacube/drivers/netcdf/writer.py
+++ b/datacube/drivers/netcdf/writer.py
@@ -8,20 +8,19 @@ Create netCDF4 Storage Units and write data to them
 
 import logging
 import numbers
-from datetime import datetime, timezone
 from collections import namedtuple
-from os import PathLike
 from collections.abc import Sequence
+from datetime import datetime, timezone
+from os import PathLike
+
 import numpy
-
-from datacube.utils.masking import describe_flags_def
 from netCDF4 import Dataset
-
 from odc.geo import CRS
 from odc.geo.geom import box
 from odc.geo.math import data_resolution_and_offset
 
 from datacube import __version__
+from datacube.utils.masking import describe_flags_def
 
 UTC: timezone = timezone.utc
 

--- a/datacube/drivers/postgis/__init__.py
+++ b/datacube/drivers/postgis/__init__.py
@@ -8,7 +8,7 @@ Lower-level database access.
 This package tries to contain any SQLAlchemy and database-specific code.
 """
 
-from ._connections import PostGisDb
 from ._api import PostgisDbAPI
+from ._connections import PostGisDb
 
 __all__ = ['PostGisDb', 'PostgisDbAPI']

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -17,42 +17,60 @@ import datetime
 import json
 import logging
 import uuid
-from sqlalchemy import (
-    cast,
-    delete,
-    update,
-    select,
-    text,
-    and_,
-    or_,
-    func,
-    column,
-)
-from sqlalchemy.dialects.postgresql import insert
-from sqlalchemy.sql.expression import Select
-from sqlalchemy.dialects.postgresql import INTERVAL
-from sqlalchemy.exc import IntegrityError
-
+from collections.abc import Iterable, Iterator, Sequence
 from typing import Any
-from collections.abc import Iterator
-from typing_extensions import override
-from collections.abc import Iterable, Sequence
 from typing import cast as type_cast
 
+from odc.geo import CRS, Geometry
+from sqlalchemy import (
+    and_,
+    cast,
+    column,
+    delete,
+    func,
+    or_,
+    select,
+    text,
+    update,
+)
+from sqlalchemy.dialects.postgresql import INTERVAL, insert
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.sql.expression import Select
+from typing_extensions import override
+
+from datacube.index.abstract import DSID
 from datacube.index.fields import OrExpression
 from datacube.model import Range
-from odc.geo import CRS, Geometry
+from datacube.model.lineage import LineageDirection, LineageRelation
 from datacube.utils.uris import split_uri
-from datacube.index.abstract import DSID
-from datacube.model.lineage import LineageRelation, LineageDirection
-from . import _core
-from ._fields import parse_fields, PgField, PgExpression, DateRangeDocField
-from ._fields import NativeField, DateDocField, SimpleDocField, UnindexableValue
-from ._schema import MetadataType, Product, Dataset, DatasetLineage, \
-    search_field_index_map, search_field_indexes, DatasetHome
-from ._spatial import geom_alchemy, generate_dataset_spatial_values, extract_geometry_from_eo3_projection
-from .sql import escape_pg_identifier
+
 from ...utils.changes import Offset
+from . import _core
+from ._fields import (
+    DateDocField,
+    DateRangeDocField,
+    NativeField,
+    PgExpression,
+    PgField,
+    SimpleDocField,
+    UnindexableValue,
+    parse_fields,
+)
+from ._schema import (
+    Dataset,
+    DatasetHome,
+    DatasetLineage,
+    MetadataType,
+    Product,
+    search_field_index_map,
+    search_field_indexes,
+)
+from ._spatial import (
+    extract_geometry_from_eo3_projection,
+    generate_dataset_spatial_values,
+    geom_alchemy,
+)
+from .sql import escape_pg_identifier
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/drivers/postgis/_connections.py
+++ b/datacube/drivers/postgis/_connections.py
@@ -15,26 +15,30 @@ Postgis connection and setup
 import json
 import logging
 import re
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from contextlib import contextmanager
 from typing import Any
-from collections.abc import Iterator
-from typing_extensions import override
-from collections.abc import Callable, Iterable, Mapping
 
-from sqlalchemy import Connection, event, create_engine
+from odc.geo import CRS
+from sqlalchemy import Connection, create_engine, event
 from sqlalchemy.engine import Engine
 from sqlalchemy.engine.url import URL as EngineUrl  # noqa: N811
+from typing_extensions import override
 
 import datacube
 from datacube.index.exceptions import IndexSetupError
 from datacube.utils import jsonify_document
-from odc.geo import CRS
 
-from . import _api
-from . import _core
-from ._spatial import ensure_spindex, spindexes, spindex_for_crs, drop_spindex, crs_to_epsg
-from ._schema import SpatialIndex
 from ...cfg import ODCEnvironment, psql_url_from_config
+from . import _api, _core
+from ._schema import SpatialIndex
+from ._spatial import (
+    crs_to_epsg,
+    drop_spindex,
+    ensure_spindex,
+    spindex_for_crs,
+    spindexes,
+)
 
 _LIB_ID: str = 'odc-' + str(datacube.__version__)
 
@@ -291,7 +295,7 @@ def handle_dynamic_token_authentication(engine: Engine,
         # Handle IAM authentication
         # Importing here because the function `clock_gettime` is not available on Windows
         # which shouldn't be a problem, because boto3 auth is mostly used on AWS.
-        from time import clock_gettime, CLOCK_REALTIME
+        from time import CLOCK_REALTIME, clock_gettime
 
         now = clock_gettime(CLOCK_REALTIME)
         if now - last_token_time[0] > timeout:

--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -9,19 +9,22 @@ Core SQL schema settings.
 import logging
 import os
 
+from alembic import command, config
+from alembic.migration import MigrationContext
+from alembic.runtime.environment import EnvironmentContext
+from alembic.script import ScriptDirectory
 from sqlalchemy import MetaData, inspect, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.schema import CreateSchema
 from sqlalchemy.sql.ddl import DropSchema
-from alembic import command, config
-from alembic.migration import MigrationContext
-from alembic.script import ScriptDirectory
-from alembic.runtime.environment import EnvironmentContext
 
-from datacube.drivers.postgis.sql import (INSTALL_TRIGGER_SQL_TEMPLATE,
-                                          SCHEMA_NAME, TYPES_INIT_SQL,
-                                          UPDATE_TIMESTAMP_SQL,
-                                          escape_pg_identifier)
+from datacube.drivers.postgis.sql import (
+    INSTALL_TRIGGER_SQL_TEMPLATE,
+    SCHEMA_NAME,
+    TYPES_INIT_SQL,
+    UPDATE_TIMESTAMP_SQL,
+    escape_pg_identifier,
+)
 
 USER_ROLES = ('odc_user', 'odc_manage', 'odc_admin')
 
@@ -110,7 +113,7 @@ def ensure_db(engine, with_permissions: bool = True) -> bool:
             _LOG.info('Creating types.')
             for s in TYPES_INIT_SQL:
                 c.execute(text(s))
-            from ._schema import orm_registry, ALL_STATIC_TABLES
+            from ._schema import ALL_STATIC_TABLES, orm_registry
             _LOG.info('Creating tables.')
             _LOG.info("Dataset indexes: %s", repr(orm_registry.metadata.tables["odc.dataset"].indexes))
             orm_registry.metadata.create_all(c, tables=ALL_STATIC_TABLES)  # type: ignore[arg-type]

--- a/datacube/drivers/postgis/_fields.py
+++ b/datacube/drivers/postgis/_fields.py
@@ -6,30 +6,26 @@
 Build and index fields within documents.
 """
 import math
-
 from collections import namedtuple
-from datetime import timezone
-from datetime import datetime, date
+from collections.abc import Callable
+from datetime import date, datetime, timezone
 from decimal import Decimal
 from typing import Any, TypeAlias
-from typing_extensions import override
-from collections.abc import Callable
 
-from sqlalchemy.types import TIMESTAMP
-from sqlalchemy import cast, func, and_
+from sqlalchemy import and_, cast, func
 from sqlalchemy.dialects import postgresql as postgres
-from sqlalchemy.dialects.postgresql import NUMRANGE, TSTZRANGE, Range as PgRange
-from sqlalchemy.dialects.postgresql import INTERVAL
-from sqlalchemy.sql import ColumnElement, FromClause, ColumnExpressionArgument
+from sqlalchemy.dialects.postgresql import INTERVAL, NUMRANGE, TSTZRANGE
+from sqlalchemy.dialects.postgresql import Range as PgRange
 from sqlalchemy.orm import aliased
+from sqlalchemy.sql import ColumnElement, ColumnExpressionArgument, FromClause
+from sqlalchemy.types import TIMESTAMP
+from typing_extensions import override
 
 from datacube import utils
-from datacube.model.fields import Expression, Field
-from datacube.model import Range
-from datacube.utils import get_doc_offset
-
 from datacube.drivers.postgis._schema import Dataset, search_field_index_map
-from datacube.utils import cached_property
+from datacube.model import Range
+from datacube.model.fields import Expression, Field
+from datacube.utils import cached_property, get_doc_offset
 from datacube.utils.dates import tz_as_utc
 
 DatasetJoinArgs = tuple[FromClause] | tuple[FromClause, ColumnExpressionArgument]

--- a/datacube/drivers/postgis/_schema.py
+++ b/datacube/drivers/postgis/_schema.py
@@ -10,16 +10,30 @@ import logging
 from datetime import datetime
 from uuid import UUID
 
-from sqlalchemy.dialects.postgresql import NUMRANGE, TSTZRANGE
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, registry, relationship, column_property
-from sqlalchemy import ForeignKey, PrimaryKeyConstraint, CheckConstraint, SmallInteger, Text, Index, \
-    literal
-from sqlalchemy import String, DateTime
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    PrimaryKeyConstraint,
+    SmallInteger,
+    String,
+    Text,
+    literal,
+)
 from sqlalchemy.dialects import postgresql as postgres
+from sqlalchemy.dialects.postgresql import NUMRANGE, TSTZRANGE
+from sqlalchemy.orm import (
+    DeclarativeBase,
+    Mapped,
+    column_property,
+    mapped_column,
+    registry,
+    relationship,
+)
 from sqlalchemy.sql import func
 
-from . import sql
-from . import _core
+from . import _core, sql
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/drivers/postgis/_spatial.py
+++ b/datacube/drivers/postgis/_spatial.py
@@ -7,26 +7,23 @@ Tracking spatial indexes
 """
 
 import logging
-from threading import Lock
 from collections.abc import Mapping
-
-from sqlalchemy import ForeignKey, select, delete
-from sqlalchemy.dialects import postgresql as postgres
-from geoalchemy2 import Geometry
+from threading import Lock
 
 from antimeridian import fix_shape
-
-from sqlalchemy.engine import Engine
-from sqlalchemy import text
-from sqlalchemy.orm import Session, mapped_column
-
-from odc.geo import CRS, Geometry as Geom
+from geoalchemy2 import Geometry
+from odc.geo import CRS
+from odc.geo import Geometry as Geom
 from odc.geo.geom import multipolygon, polygon
+from sqlalchemy import ForeignKey, delete, select, text
+from sqlalchemy.dialects import postgresql as postgres
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, mapped_column
 from sqlalchemy.sql.ddl import DropTable
 
 from ._core import METADATA
+from ._schema import Base, Dataset, SpatialIndex, SpatialIndexRecord, orm_registry
 from .sql import SCHEMA_NAME
-from ._schema import Base, orm_registry, Dataset, SpatialIndex, SpatialIndexRecord
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/drivers/postgis/alembic/env.py
+++ b/datacube/drivers/postgis/alembic/env.py
@@ -2,6 +2,9 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from collections.abc import MutableMapping
+from typing import Literal
+
 from alembic import context
 
 from datacube.cfg import ODCConfig, ODCEnvironment
@@ -9,8 +12,6 @@ from datacube.drivers.postgis._connections import PostGisDb
 from datacube.drivers.postgis._schema import MetadataObj
 from datacube.drivers.postgis._spatial import is_spindex_table_name
 from datacube.drivers.postgis.sql import SCHEMA_NAME
-from typing import Literal
-from collections.abc import MutableMapping
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/datacube/drivers/postgis/sql.py
+++ b/datacube/drivers/postgis/sql.py
@@ -7,12 +7,12 @@ Custom types for postgres & sqlalchemy
 """
 
 from sqlalchemy import text
-from sqlalchemy.types import Double
 from sqlalchemy.dialects.postgresql.ranges import AbstractRange, Range
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql import sqltypes
-from sqlalchemy.sql.expression import Executable, ClauseElement
+from sqlalchemy.sql.expression import ClauseElement, Executable
 from sqlalchemy.sql.functions import GenericFunction
+from sqlalchemy.types import Double
 
 SCHEMA_NAME = 'odc'
 

--- a/datacube/drivers/postgres/__init__.py
+++ b/datacube/drivers/postgres/__init__.py
@@ -8,7 +8,7 @@ Lower-level database access.
 This package tries to contain any SQLAlchemy and database-specific code.
 """
 
-from ._connections import PostgresDb
 from ._api import PostgresDbAPI
+from ._connections import PostgresDb
 
 __all__ = ['PostgresDb', 'PostgresDbAPI']

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -16,41 +16,48 @@ Persistence API implementation for postgres.
 import datetime
 import logging
 import uuid  # noqa: F401
+from collections.abc import Iterable, Iterator
 from typing import Any
-from collections.abc import Iterator
-from typing_extensions import override
-from collections.abc import Iterable
 from typing import cast as type_cast
+
 from sqlalchemy import (
-    cast,
-    String,
     Label,
-    delete,
-    column,
-    values,
-    select,
-    text,
-    bindparam,
+    String,
     and_,
-    or_,
+    bindparam,
+    cast,
+    column,
+    delete,
+    distinct,
     func,
     literal,
-    distinct,
+    or_,
+    select,
+    text,
+    values,
 )
-from sqlalchemy.dialects.postgresql import INTERVAL
-from sqlalchemy.dialects.postgresql import JSONB, insert, UUID
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.dialects.postgresql import INTERVAL, JSONB, UUID, insert
 from sqlalchemy.engine import Row
+from sqlalchemy.exc import IntegrityError
+from typing_extensions import override
 
 from datacube.index.exceptions import MissingRecordError
-from datacube.index.fields import Field, Expression, OrExpression
+from datacube.index.fields import Expression, Field, OrExpression
 from datacube.model import Range
 from datacube.utils.uris import split_uri
+
 from . import _core
 from . import _dynamic as dynamic
-from ._fields import parse_fields, PgField, PgExpression, DateRangeDocField  # noqa: F401
-from ._fields import NativeField, DateDocField, SimpleDocField
-from ._schema import DATASET, DATASET_SOURCE, METADATA_TYPE, DATASET_LOCATION, PRODUCT
+from ._fields import (  # noqa: F401
+    DateDocField,
+    DateRangeDocField,
+    NativeField,
+    PgExpression,
+    PgField,
+    SimpleDocField,
+    parse_fields,
+)
+from ._schema import DATASET, DATASET_LOCATION, DATASET_SOURCE, METADATA_TYPE, PRODUCT
 from .sql import escape_pg_identifier
 
 PGCODE_FOREIGN_KEY_VIOLATION = '23503'

--- a/datacube/drivers/postgres/_connections.py
+++ b/datacube/drivers/postgres/_connections.py
@@ -15,22 +15,20 @@ Postgres connection and setup
 import json
 import logging
 import re
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
-from collections.abc import Callable
-from collections.abc import Iterator
-from typing_extensions import override
 
-from sqlalchemy import event, create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.engine import Engine
 from sqlalchemy.engine.url import URL as EngineUrl  # noqa: N811
+from typing_extensions import override
 
 import datacube
 from datacube.index.exceptions import IndexSetupError
 from datacube.utils import jsonify_document
 
-from . import _api
-from . import _core
 from ...cfg import ODCEnvironment, psql_url_from_config
+from . import _api, _core
 
 _LIB_ID: str = 'odc-' + str(datacube.__version__)
 
@@ -233,7 +231,7 @@ def handle_dynamic_token_authentication(engine: Engine,
         # Handle IAM authentication
         # Importing here because the function `clock_gettime` is not available on Windows
         # which shouldn't be a problem, because boto3 auth is mostly used on AWS.
-        from time import clock_gettime, CLOCK_REALTIME
+        from time import CLOCK_REALTIME, clock_gettime
 
         now = clock_gettime(CLOCK_REALTIME)
         if now - last_token_time[0] > timeout:

--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -8,19 +8,22 @@ Core SQL schema settings.
 
 import logging
 
-from datacube.drivers.postgres.sql import (INSTALL_TRIGGER_SQL_TEMPLATE,
-                                           SCHEMA_NAME, TYPES_INIT_SQL,
-                                           UPDATE_COLUMN_MIGRATE_SQL_TEMPLATE,
-                                           UPDATE_COLUMN_INDEX_SQL_TEMPLATE,
-                                           ADDED_COLUMN_MIGRATE_SQL_TEMPLATE,
-                                           ADDED_COLUMN_INDEX_SQL_TEMPLATE,
-                                           UPDATE_TIMESTAMP_SQL,
-                                           escape_pg_identifier,
-                                           pg_column_exists)
 from sqlalchemy import MetaData, inspect, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.schema import CreateSchema, DropSchema
 
+from datacube.drivers.postgres.sql import (
+    ADDED_COLUMN_INDEX_SQL_TEMPLATE,
+    ADDED_COLUMN_MIGRATE_SQL_TEMPLATE,
+    INSTALL_TRIGGER_SQL_TEMPLATE,
+    SCHEMA_NAME,
+    TYPES_INIT_SQL,
+    UPDATE_COLUMN_INDEX_SQL_TEMPLATE,
+    UPDATE_COLUMN_MIGRATE_SQL_TEMPLATE,
+    UPDATE_TIMESTAMP_SQL,
+    escape_pg_identifier,
+    pg_column_exists,
+)
 
 USER_ROLES = ('agdc_user', 'agdc_ingest', 'agdc_manage', 'agdc_admin')
 

--- a/datacube/drivers/postgres/_dynamic.py
+++ b/datacube/drivers/postgres/_dynamic.py
@@ -9,12 +9,11 @@ Methods for managing dynamic dataset field indexes and views.
 import logging
 from collections.abc import Sequence
 
-from sqlalchemy import Index, text
-from sqlalchemy import select
+from sqlalchemy import Index, select, text
 
 from ._core import schema_qualified
-from ._schema import DATASET, PRODUCT, METADATA_TYPE
-from .sql import pg_exists, CreateView
+from ._schema import DATASET, METADATA_TYPE, PRODUCT
+from .sql import CreateView, pg_exists
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/drivers/postgres/_fields.py
+++ b/datacube/drivers/postgres/_fields.py
@@ -6,26 +6,24 @@
 Build and index fields within documents.
 """
 from collections import namedtuple
-from datetime import datetime, date
+from collections.abc import Callable
+from datetime import date, datetime
 from decimal import Decimal
 from typing import Any
-from typing_extensions import override
-from collections.abc import Callable
 
-from sqlalchemy import cast, func, and_
+from sqlalchemy import and_, cast, func
 from sqlalchemy.dialects import postgresql as postgres
-from sqlalchemy.dialects.postgresql import INT4RANGE
-from sqlalchemy.dialects.postgresql import NUMRANGE, TSTZRANGE
-from sqlalchemy.dialects.postgresql import INTERVAL
+from sqlalchemy.dialects.postgresql import INT4RANGE, INTERVAL, NUMRANGE, TSTZRANGE
 from sqlalchemy.sql import ColumnElement
+from typing_extensions import override
 
 from datacube import utils
-from datacube.model.fields import Expression, Field
 from datacube.model import Range
+from datacube.model.fields import Expression, Field
 from datacube.utils import get_doc_offset
-from .sql import FLOAT8RANGE
-
 from datacube.utils.dates import tz_aware
+
+from .sql import FLOAT8RANGE
 
 
 class PgField(Field):

--- a/datacube/drivers/postgres/_schema.py
+++ b/datacube/drivers/postgres/_schema.py
@@ -8,13 +8,23 @@ Tables for indexing the datasets which were ingested into the AGDC.
 
 import logging
 
-from sqlalchemy import ForeignKey, UniqueConstraint, PrimaryKeyConstraint, CheckConstraint, SmallInteger, Index
-from sqlalchemy import Table, Column, Integer, String, DateTime
+from sqlalchemy import (
+    CheckConstraint,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    PrimaryKeyConstraint,
+    SmallInteger,
+    String,
+    Table,
+    UniqueConstraint,
+)
 from sqlalchemy.dialects import postgresql as postgres
 from sqlalchemy.sql import func
 
-from . import sql
-from . import _core
+from . import _core, sql
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/drivers/postgres/sql.py
+++ b/datacube/drivers/postgres/sql.py
@@ -7,12 +7,12 @@ Custom types for postgres & sqlalchemy
 """
 
 from sqlalchemy import TIMESTAMP, text
-from sqlalchemy.types import Double
 from sqlalchemy.dialects.postgresql.ranges import AbstractRange, Range
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql import sqltypes
-from sqlalchemy.sql.expression import Executable, ClauseElement
+from sqlalchemy.sql.expression import ClauseElement, Executable
 from sqlalchemy.sql.functions import GenericFunction
+from sqlalchemy.types import Double
 
 SCHEMA_NAME = 'agdc'
 

--- a/datacube/drivers/readers.py
+++ b/datacube/drivers/readers.py
@@ -3,10 +3,12 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 from collections.abc import Callable
-from .driver_cache import load_drivers
-from .datasource import DataSource
-from ._tools import singleton_setup
+
 from datacube.storage._base import BandInfo
+
+from ._tools import singleton_setup
+from .datasource import DataSource
+from .driver_cache import load_drivers
 
 DatasourceFactory = Callable[[BandInfo], DataSource]  # pylint: disable=invalid-name
 

--- a/datacube/drivers/rio/_reader.py
+++ b/datacube/drivers/rio/_reader.py
@@ -4,34 +4,33 @@
 # SPDX-License-Identifier: Apache-2.0
 """ reader
 """
-from typing import (
-    Any,
-    NamedTuple, TypeAlias, TypeVar
-)
-from typing_extensions import override
 from collections.abc import Iterable
-import numpy as np
-from affine import Affine
 from concurrent.futures import ThreadPoolExecutor
-import rasterio
-from rasterio.io import DatasetReader
-import rasterio.crs
+from typing import Any, NamedTuple, TypeAlias, TypeVar
 
-from datacube.storage import BandInfo
+import numpy as np
+import rasterio
+import rasterio.crs
+from affine import Affine
 from odc.geo import CRS
-from datacube.utils import (
-    uri_to_local_path,
-    get_part_from_uri,
-)
+from rasterio.io import DatasetReader
+from typing_extensions import override
+
 from datacube.drivers._types import (
-    ReaderDriverEntry,
-    ReaderDriver,
-    GeoRasterReader,
     FutureGeoRasterReader,
     FutureNdarray,
+    GeoRasterReader,
     RasterShape,
     RasterWindow,
+    ReaderDriver,
+    ReaderDriverEntry,
 )
+from datacube.storage import BandInfo
+from datacube.utils import (
+    get_part_from_uri,
+    uri_to_local_path,
+)
+
 
 class Overrides(NamedTuple):
     crs: CRS | None

--- a/datacube/index/__init__.py
+++ b/datacube/index/__init__.py
@@ -6,11 +6,12 @@
 Modules for interfacing with the index/database.
 """
 
-from ._api import index_connect
-from ._spatial import strip_all_spatial_fields_from_query, extract_geom_from_query
-from .fields import UnknownFieldError
-from .exceptions import DuplicateRecordError, MissingRecordError, IndexSetupError
 from datacube.index.abstract import AbstractIndex as Index
+
+from ._api import index_connect
+from ._spatial import extract_geom_from_query, strip_all_spatial_fields_from_query
+from .exceptions import DuplicateRecordError, IndexSetupError, MissingRecordError
+from .fields import UnknownFieldError
 
 __all__ = [
     'DuplicateRecordError',

--- a/datacube/index/_api.py
+++ b/datacube/index/_api.py
@@ -9,6 +9,7 @@ Access methods for indexing datasets & products.
 import logging
 
 from datacube.cfg import ODCConfig, ODCEnvironment
+
 from .abstract import AbstractIndex as Index
 
 _LOG: logging.Logger = logging.getLogger(__name__)

--- a/datacube/index/_spatial.py
+++ b/datacube/index/_spatial.py
@@ -3,9 +3,11 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 from typing import cast
+
 from odc.geo.crs import CRS
 from odc.geo.geom import Geometry, box
-from datacube.model import Range, QueryDict, QueryField
+
+from datacube.model import QueryDict, QueryField, Range
 from datacube.utils.documents import JsonDict
 
 H_SPATIAL_KEYS = ("lon", "longitude", "x")

--- a/datacube/index/abstract/__init__.py
+++ b/datacube/index/abstract/__init__.py
@@ -3,14 +3,18 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from ._types import BatchStatus, DSID, DatasetTuple, dsid_to_uuid, DatasetSpatialMixin
-from ._users import AbstractUserResource
-from ._metadata_types import AbstractMetadataTypeResource, default_metadata_type_docs, _DEFAULT_METADATA_TYPES_PATH
-from ._products import AbstractProductResource
-from ._lineage import AbstractLineageResource, NoLineageResource
 from ._datasets import AbstractDatasetResource
-from ._transactions import AbstractTransaction, UnhandledTransaction
 from ._index import AbstractIndex, AbstractIndexDriver
+from ._lineage import AbstractLineageResource, NoLineageResource
+from ._metadata_types import (
+    _DEFAULT_METADATA_TYPES_PATH,
+    AbstractMetadataTypeResource,
+    default_metadata_type_docs,
+)
+from ._products import AbstractProductResource
+from ._transactions import AbstractTransaction, UnhandledTransaction
+from ._types import DSID, BatchStatus, DatasetSpatialMixin, DatasetTuple, dsid_to_uuid
+from ._users import AbstractUserResource
 
 __all__ = [
     "DSID",

--- a/datacube/index/abstract/_datasets.py
+++ b/datacube/index/abstract/_datasets.py
@@ -5,22 +5,22 @@
 import datetime
 import logging
 from abc import ABC, abstractmethod
+from collections.abc import Iterable, Mapping, Sequence
 from datetime import timedelta
 from time import monotonic
 from typing import Any
-from collections.abc import Iterable, Mapping, Sequence
 from uuid import UUID
 
 from deprecat import deprecat
 from odc.geo import CRS, Geometry
 
 from datacube.migration import ODC2DeprecationWarning
-from datacube.model import Dataset, Product, Field, Range, QueryDict, QueryField
+from datacube.model import Dataset, Field, Product, QueryDict, QueryField, Range
 from datacube.utils import report_to_user
-from datacube.utils.changes import Offset, AllowPolicy, Change, DocumentMismatchError
+from datacube.utils.changes import AllowPolicy, Change, DocumentMismatchError, Offset
 from datacube.utils.documents import JsonDict
 
-from ._types import DSID, DatasetTuple, BatchStatus
+from ._types import DSID, BatchStatus, DatasetTuple
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/index/abstract/_index.py
+++ b/datacube/index/abstract/_index.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Mapping, Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from urllib.parse import ParseResult, urlparse
 
 from deprecat import deprecat
@@ -16,13 +16,13 @@ from datacube.model import Field, MetadataType
 from datacube.utils import cached_property, report_to_user
 from datacube.utils.generic import thread_local_cache
 
-from ._types import DSID, BatchStatus
-from ._users import AbstractUserResource
+from ._datasets import AbstractDatasetResource
+from ._lineage import AbstractLineageResource
 from ._metadata_types import AbstractMetadataTypeResource
 from ._products import AbstractProductResource
-from ._lineage import AbstractLineageResource
-from ._datasets import AbstractDatasetResource
 from ._transactions import AbstractTransaction
+from ._types import DSID, BatchStatus
+from ._users import AbstractUserResource
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/index/abstract/_lineage.py
+++ b/datacube/index/abstract/_lineage.py
@@ -4,12 +4,13 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 from abc import ABC, abstractmethod
+from collections.abc import Iterable, Mapping
 from time import monotonic
-from collections.abc import Mapping, Iterable
-from typing_extensions import override
 from uuid import UUID
 
-from datacube.model import LineageTree, LineageDirection, LineageRelation
+from typing_extensions import override
+
+from datacube.model import LineageDirection, LineageRelation, LineageTree
 from datacube.model.lineage import LineageRelations
 from datacube.utils import report_to_user
 

--- a/datacube/index/abstract/_metadata_types.py
+++ b/datacube/index/abstract/_metadata_types.py
@@ -4,14 +4,14 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from pathlib import Path
 from time import monotonic
 from typing import cast
-from collections.abc import Iterable
 
 from datacube.model import MetadataType
-from datacube.utils import read_documents, jsonify_document, InvalidDocException
-from datacube.utils.changes import DocumentMismatchError, check_doc_unchanged, Change
+from datacube.utils import InvalidDocException, jsonify_document, read_documents
+from datacube.utils.changes import Change, DocumentMismatchError, check_doc_unchanged
 from datacube.utils.documents import JsonDict
 
 from ._types import BatchStatus

--- a/datacube/index/abstract/_products.py
+++ b/datacube/index/abstract/_products.py
@@ -5,15 +5,15 @@
 import datetime
 import logging
 from abc import ABC, abstractmethod
+from collections.abc import Iterable, Iterator, Sequence
 from time import monotonic
-from typing import cast, TYPE_CHECKING
-from collections.abc import Iterable, Sequence, Iterator
+from typing import TYPE_CHECKING, cast
 
 from odc.geo import CRS, Geometry
 
-from datacube.model import MetadataType, Product, QueryField, QueryDict
-from datacube.utils import jsonify_document, InvalidDocException
-from datacube.utils.changes import DocumentMismatchError, check_doc_unchanged, Change
+from datacube.model import MetadataType, Product, QueryDict, QueryField
+from datacube.utils import InvalidDocException, jsonify_document
+from datacube.utils.changes import Change, DocumentMismatchError, check_doc_unchanged
 from datacube.utils.documents import JsonDict, JsonLike, UnknownMetadataType
 
 from ._types import BatchStatus

--- a/datacube/index/abstract/_transactions.py
+++ b/datacube/index/abstract/_transactions.py
@@ -5,6 +5,7 @@
 from abc import ABC, abstractmethod
 from threading import Lock
 from typing import Any
+
 from typing_extensions import override
 
 from datacube.index.exceptions import TransactionException

--- a/datacube/index/abstract/_types.py
+++ b/datacube/index/abstract/_types.py
@@ -2,14 +2,14 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from typing import NamedTuple
 from collections.abc import Iterable, Sequence
+from typing import NamedTuple
 from uuid import UUID
 
 from deprecat import deprecat
 
 from datacube.migration import ODC2DeprecationWarning
-from datacube.model import Product, Dataset
+from datacube.model import Dataset, Product
 from datacube.utils import cached_property
 from datacube.utils.documents import JsonDict
 

--- a/datacube/index/eo3.py
+++ b/datacube/index/eo3.py
@@ -5,21 +5,20 @@
 # TODO: typehints need attention
 """ Tools for working with EO3 metadata
 """
-from affine import Affine
+from collections.abc import Iterable
 from functools import reduce
 from typing import Any, cast
-from collections.abc import Iterable
 from uuid import UUID
 
+from affine import Affine
 from odc.geo import (
-    SomeCRS,
     CRS,
-    Geometry,
-    CoordList,
     BoundingBox,
+    CoordList,
+    Geometry,
+    SomeCRS,
 )
-
-from odc.geo.geom import polygon, lonlat_bounds
+from odc.geo.geom import lonlat_bounds, polygon
 
 EO3_SCHEMA = "https://schemas.opendatacube.org/dataset"
 

--- a/datacube/index/fields.py
+++ b/datacube/index/fields.py
@@ -7,10 +7,11 @@ Common datatypes for DB drivers.
 """
 
 from datetime import date, datetime, time
+
 from dateutil.tz import tz
 from typing_extensions import override
 
-from datacube.model import Range, Not
+from datacube.model import Not, Range
 from datacube.model.fields import Expression, Field
 
 __all__ = [

--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -5,21 +5,26 @@
 """
 High level indexing operations/utilities
 """
-import logging
-
 import json
-import toolz
+import logging
+from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequence
+from typing import Any, TypeAlias, cast
 from uuid import UUID
-from typing import TypeAlias, cast, Any
-from collections.abc import Callable, Iterable, Mapping, Sequence, MutableMapping
 
-from datacube.model import Dataset, LineageTree, Product
+import toolz
+
 from datacube.index.abstract import AbstractIndex
-from datacube.utils import changes, InvalidDocException, SimpleDocNav, jsonify_document
-from datacube.model.utils import BadMatch, dedup_lineage, remap_lineage_doc, flatten_datasets
+from datacube.model import Dataset, LineageDirection, LineageTree, Product
+from datacube.model.utils import (
+    BadMatch,
+    dedup_lineage,
+    flatten_datasets,
+    remap_lineage_doc,
+)
+from datacube.utils import InvalidDocException, SimpleDocNav, changes, jsonify_document
 from datacube.utils.changes import get_doc_changes
-from datacube.model import LineageDirection
-from .eo3 import prep_eo3, is_doc_eo3, is_doc_geo
+
+from .eo3 import is_doc_eo3, is_doc_geo, prep_eo3
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -6,31 +6,35 @@ import datetime
 import logging
 import re
 import warnings
-from itertools import chain
-
-from deprecat import deprecat
 from collections import namedtuple
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from itertools import chain
 from time import monotonic
 from typing import Any, cast
-from typing_extensions import override
-from collections.abc import Callable, Iterable, Mapping, Sequence
 from uuid import UUID
 
-from datacube.migration import ODC2DeprecationWarning
+from deprecat import deprecat
+from typing_extensions import override
+
 from datacube.index import fields
-from datacube.index.abstract import (AbstractDatasetResource, DSID, BatchStatus,
-                                     NoLineageResource,
-                                     dsid_to_uuid, DatasetSpatialMixin,
-                                     AbstractIndex)
-from datacube.model._base import QueryField
+from datacube.index.abstract import (
+    DSID,
+    AbstractDatasetResource,
+    AbstractIndex,
+    BatchStatus,
+    DatasetSpatialMixin,
+    NoLineageResource,
+    dsid_to_uuid,
+)
 from datacube.index.fields import Field
 from datacube.index.memory._fields import build_custom_fields, get_dataset_fields
+from datacube.migration import ODC2DeprecationWarning
 from datacube.model import Dataset, LineageRelation, Product, Range, ranges_overlap
-from datacube.utils import jsonify_document, _readable_offset
-from datacube.utils import changes
+from datacube.model._base import QueryField
+from datacube.utils import _readable_offset, changes, jsonify_document
 from datacube.utils.changes import AllowPolicy, Change, Offset, get_doc_changes
 from datacube.utils.dates import tz_aware
-from datacube.utils.documents import metadata_subset, JsonDict
+from datacube.utils.documents import JsonDict, metadata_subset
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/index/memory/_fields.py
+++ b/datacube/index/memory/_fields.py
@@ -2,9 +2,11 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any
 from collections.abc import Mapping
-from datacube.model.fields import SimpleField, Field, get_dataset_fields as generic_get_dataset_fields
+from typing import Any
+
+from datacube.model.fields import Field, SimpleField
+from datacube.model.fields import get_dataset_fields as generic_get_dataset_fields
 from datacube.utils.changes import Offset
 
 

--- a/datacube/index/memory/_metadata_types.py
+++ b/datacube/index/memory/_metadata_types.py
@@ -3,16 +3,26 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import logging
-from copy import deepcopy
-from typing import cast, Any
-from typing_extensions import override
 from collections.abc import Iterable, Mapping
+from copy import deepcopy
+from typing import Any, cast
 
-from datacube.index.abstract import AbstractMetadataTypeResource, default_metadata_type_docs
-from datacube.model import MetadataType
+from typing_extensions import override
+
+from datacube.index.abstract import (
+    AbstractMetadataTypeResource,
+    default_metadata_type_docs,
+)
 from datacube.index.memory._fields import get_dataset_fields
-from datacube.utils import jsonify_document, changes, _readable_offset
-from datacube.utils.changes import AllowPolicy, Change, Offset, check_doc_unchanged, get_doc_changes
+from datacube.model import MetadataType
+from datacube.utils import _readable_offset, changes, jsonify_document
+from datacube.utils.changes import (
+    AllowPolicy,
+    Change,
+    Offset,
+    check_doc_unchanged,
+    get_doc_changes,
+)
 from datacube.utils.documents import JsonDict
 
 _LOG: logging.Logger = logging.getLogger(__name__)

--- a/datacube/index/memory/_products.py
+++ b/datacube/index/memory/_products.py
@@ -4,19 +4,26 @@
 # SPDX-License-Identifier: Apache-2.0
 import datetime
 import logging
-
-from typing import cast
-from typing_extensions import override
 from collections.abc import Iterable, Sequence
+from typing import cast
 from uuid import UUID
 
+from typing_extensions import override
+
+from datacube.index.abstract import AbstractIndex, AbstractProductResource
 from datacube.index.fields import as_expression
-from datacube.index.abstract import AbstractProductResource, AbstractIndex
-from datacube.model._base import QueryField, QueryDict
 from datacube.model import Product
-from datacube.utils import changes, jsonify_document, _readable_offset
-from datacube.utils.changes import AllowPolicy, Change, Offset, check_doc_unchanged, get_doc_changes, classify_changes
-from datacube.utils.documents import metadata_subset, JsonDict
+from datacube.model._base import QueryDict, QueryField
+from datacube.utils import _readable_offset, changes, jsonify_document
+from datacube.utils.changes import (
+    AllowPolicy,
+    Change,
+    Offset,
+    check_doc_unchanged,
+    classify_changes,
+    get_doc_changes,
+)
+from datacube.utils.documents import JsonDict, metadata_subset
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/index/memory/_users.py
+++ b/datacube/index/memory/_users.py
@@ -3,7 +3,9 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 from collections.abc import Iterable
+
 from typing_extensions import override
+
 from datacube.index.abstract import AbstractUserResource
 
 

--- a/datacube/index/memory/index.py
+++ b/datacube/index/memory/index.py
@@ -6,19 +6,24 @@ import logging
 from collections.abc import Mapping
 from threading import Lock
 from typing import Any
-from typing_extensions import override
 
 from deprecat import deprecat
+from odc.geo import CRS
+from typing_extensions import override
+
 from datacube.cfg import ODCEnvironment
+from datacube.index.abstract import (
+    AbstractIndex,
+    AbstractIndexDriver,
+    UnhandledTransaction,
+)
 from datacube.index.memory._datasets import DatasetResource, LineageResource
 from datacube.index.memory._fields import get_dataset_fields
 from datacube.index.memory._metadata_types import MetadataTypeResource
 from datacube.index.memory._products import ProductResource
 from datacube.index.memory._users import UserResource
-from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, UnhandledTransaction
-from datacube.model import Field, MetadataType
 from datacube.migration import ODC2DeprecationWarning
-from odc.geo import CRS
+from datacube.model import Field, MetadataType
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/index/null/_datasets.py
+++ b/datacube/index/null/_datasets.py
@@ -4,13 +4,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime
+from collections.abc import Iterable, Sequence
+
 from deprecat import deprecat
 from typing_extensions import override
 
+from datacube.index.abstract import DSID, AbstractDatasetResource
 from datacube.migration import ODC2DeprecationWarning
-from datacube.index.abstract import AbstractDatasetResource, DSID
 from datacube.model import Dataset, Product
-from collections.abc import Iterable, Sequence
 
 
 class DatasetResource(AbstractDatasetResource):

--- a/datacube/index/null/_metadata_types.py
+++ b/datacube/index/null/_metadata_types.py
@@ -3,12 +3,14 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 from collections.abc import Iterable
+
 from typing_extensions import override
 
 from datacube.index.abstract import AbstractMetadataTypeResource
 from datacube.model import MetadataType
 from datacube.utils.changes import Change
 from datacube.utils.documents import JsonDict
+
 
 class MetadataTypeResource(AbstractMetadataTypeResource):
     @override

--- a/datacube/index/null/_products.py
+++ b/datacube/index/null/_products.py
@@ -2,15 +2,15 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-import logging
 import datetime
+import logging
+from collections.abc import Iterable
+
+from odc.geo import CRS, Geometry
 from typing_extensions import override
 
 from datacube.index.abstract import AbstractProductResource
 from datacube.model import Product
-from odc.geo import CRS, Geometry
-
-from collections.abc import Iterable
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/index/null/_users.py
+++ b/datacube/index/null/_users.py
@@ -3,7 +3,9 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 from collections.abc import Iterable
+
 from typing_extensions import override
+
 from datacube.index.abstract import AbstractUserResource
 
 

--- a/datacube/index/null/index.py
+++ b/datacube/index/null/index.py
@@ -7,17 +7,23 @@ from collections.abc import Mapping
 from typing import Any
 
 from deprecat import deprecat
+from odc.geo import CRS
+from typing_extensions import override
+
 from datacube.cfg import ODCEnvironment
+from datacube.index.abstract import (
+    AbstractIndex,
+    AbstractIndexDriver,
+    NoLineageResource,
+    UnhandledTransaction,
+)
 from datacube.index.null._datasets import DatasetResource
 from datacube.index.null._metadata_types import MetadataTypeResource
 from datacube.index.null._products import ProductResource
 from datacube.index.null._users import UserResource
-from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, UnhandledTransaction, NoLineageResource
+from datacube.migration import ODC2DeprecationWarning
 from datacube.model import Field, MetadataType
 from datacube.model.fields import get_dataset_fields
-from datacube.migration import ODC2DeprecationWarning
-from odc.geo import CRS
-from typing_extensions import override
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -10,31 +10,48 @@ import json
 import logging
 import warnings
 from collections import namedtuple
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from time import monotonic
 from typing import Any, NamedTuple, cast
-from collections.abc import Iterator
-from typing_extensions import override
-from collections.abc import Iterable, Mapping, Sequence
 from uuid import UUID
 
 from deprecat import deprecat
-
-from datacube.drivers.postgis._fields import SimpleDocField, PgField, PgExpression
-from datacube.drivers.postgis._schema import Dataset as SQLDataset, search_field_map
-from datacube.drivers.postgis._api import non_native_fields, extract_dataset_fields, mk_simple_offset_field
-from datacube.utils.uris import split_uri
-from datacube.drivers.postgis._spatial import generate_dataset_spatial_values, extract_geometry_from_eo3_projection
-from datacube.migration import ODC2DeprecationWarning
-from datacube.index.abstract import AbstractDatasetResource, DSID, BatchStatus, DatasetTuple, DatasetSpatialMixin
-from datacube.utils.documents import JsonDict
-from datacube.model._base import QueryField
-from datacube.index.postgis._transaction import IndexResourceAddIn
-from datacube.model import Dataset, Product, Range, LineageTree
-from datacube.model.fields import Field
-from datacube.utils import jsonify_document, _readable_offset, changes
-from datacube.utils.changes import get_doc_changes, Offset
 from odc.geo import CRS, Geometry
-from datacube.index import fields, extract_geom_from_query, strip_all_spatial_fields_from_query
+from typing_extensions import override
+
+from datacube.drivers.postgis._api import (
+    extract_dataset_fields,
+    mk_simple_offset_field,
+    non_native_fields,
+)
+from datacube.drivers.postgis._fields import PgExpression, PgField, SimpleDocField
+from datacube.drivers.postgis._schema import Dataset as SQLDataset
+from datacube.drivers.postgis._schema import search_field_map
+from datacube.drivers.postgis._spatial import (
+    extract_geometry_from_eo3_projection,
+    generate_dataset_spatial_values,
+)
+from datacube.index import (
+    extract_geom_from_query,
+    fields,
+    strip_all_spatial_fields_from_query,
+)
+from datacube.index.abstract import (
+    DSID,
+    AbstractDatasetResource,
+    BatchStatus,
+    DatasetSpatialMixin,
+    DatasetTuple,
+)
+from datacube.index.postgis._transaction import IndexResourceAddIn
+from datacube.migration import ODC2DeprecationWarning
+from datacube.model import Dataset, LineageTree, Product, Range
+from datacube.model._base import QueryField
+from datacube.model.fields import Field
+from datacube.utils import _readable_offset, changes, jsonify_document
+from datacube.utils.changes import Offset, get_doc_changes
+from datacube.utils.documents import JsonDict
+from datacube.utils.uris import split_uri
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/index/postgis/_lineage.py
+++ b/datacube/index/postgis/_lineage.py
@@ -2,15 +2,22 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from collections.abc import Iterable, Mapping
 from time import monotonic
-from collections.abc import Mapping, Iterable
-from typing_extensions import override
 from uuid import UUID
 
-from datacube.index.abstract import AbstractIndex, AbstractLineageResource, DSID, BatchStatus, dsid_to_uuid
-from datacube.index.postgis._transaction import IndexResourceAddIn
+from typing_extensions import override
+
 from datacube.drivers.postgis._connections import PostGisDb
-from datacube.model import LineageTree, LineageDirection, LineageRelation
+from datacube.index.abstract import (
+    DSID,
+    AbstractIndex,
+    AbstractLineageResource,
+    BatchStatus,
+    dsid_to_uuid,
+)
+from datacube.index.postgis._transaction import IndexResourceAddIn
+from datacube.model import LineageDirection, LineageRelation, LineageTree
 from datacube.model.lineage import LineageRelations
 
 

--- a/datacube/index/postgis/_metadata_types.py
+++ b/datacube/index/postgis/_metadata_types.py
@@ -3,17 +3,23 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import logging
-from time import monotonic
 from collections.abc import Iterable, Mapping
-from typing_extensions import override
+from time import monotonic
 
 from cachetools.func import lru_cache
+from typing_extensions import override
 
 from datacube.index.abstract import AbstractMetadataTypeResource, BatchStatus
 from datacube.index.postgis._transaction import IndexResourceAddIn
 from datacube.model import MetadataType
-from datacube.utils import jsonify_document, changes, _readable_offset
-from datacube.utils.changes import AllowPolicy, Change, Offset, check_doc_unchanged, get_doc_changes
+from datacube.utils import _readable_offset, changes, jsonify_document
+from datacube.utils.changes import (
+    AllowPolicy,
+    Change,
+    Offset,
+    check_doc_unchanged,
+    get_doc_changes,
+)
 from datacube.utils.documents import JsonDict
 
 _LOG: logging.Logger = logging.getLogger(__name__)

--- a/datacube/index/postgis/_products.py
+++ b/datacube/index/postgis/_products.py
@@ -3,27 +3,26 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+
 import datetime
 import logging
-
+from collections.abc import Iterable, Mapping, Sequence
 from time import monotonic
-from cachetools.func import lru_cache
+from typing import TYPE_CHECKING, cast
 
+from cachetools.func import lru_cache
 from odc.geo.crs import CRS
 from odc.geo.geom import Geometry
+from typing_extensions import override
+
 from datacube.drivers.postgis import PostGisDb
 from datacube.index import fields
 from datacube.index.abstract import AbstractProductResource, BatchStatus
-from datacube.utils.documents import JsonDict
 from datacube.index.postgis._transaction import IndexResourceAddIn
-from datacube.model import Product, MetadataType, QueryDict
-from datacube.utils import jsonify_document, changes, _readable_offset
+from datacube.model import MetadataType, Product, QueryDict
+from datacube.utils import _readable_offset, changes, jsonify_document
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes
-
-from typing import TYPE_CHECKING, cast
-from typing_extensions import override
-from collections.abc import Iterable, Mapping, Sequence
-
+from datacube.utils.documents import JsonDict
 
 if TYPE_CHECKING:
     from datacube.index.postgis.index import Index

--- a/datacube/index/postgis/_transaction.py
+++ b/datacube/index/postgis/_transaction.py
@@ -3,10 +3,11 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 
+from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any
+
 from typing_extensions import override
-from collections.abc import Iterator
 
 from datacube.drivers.postgis import PostGisDb
 from datacube.drivers.postgis._api import PostgisDbAPI

--- a/datacube/index/postgis/_users.py
+++ b/datacube/index/postgis/_users.py
@@ -3,13 +3,15 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+
 from collections.abc import Iterable
-from datacube.index.abstract import AbstractUserResource
-from datacube.index.postgis._transaction import IndexResourceAddIn
-from datacube.drivers.postgis import PostGisDb
 from typing import TYPE_CHECKING
+
 from typing_extensions import override
 
+from datacube.drivers.postgis import PostGisDb
+from datacube.index.abstract import AbstractUserResource
+from datacube.index.postgis._transaction import IndexResourceAddIn
 
 if TYPE_CHECKING:
     from datacube.index.postgis.index import Index

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -3,28 +3,32 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import logging
+from collections.abc import Iterable, Iterator, Sequence
 from contextlib import contextmanager
 from pathlib import Path
-from collections.abc import Iterable, Iterator, Sequence
-from typing_extensions import override
 
 from deprecat import deprecat
+from odc.geo import CRS
+from typing_extensions import override
+
 from datacube.cfg.api import ODCEnvironment, ODCOptionHandler
 from datacube.cfg.opt import config_options_for_psql_driver
 from datacube.drivers.postgis import PostGisDb, PostgisDbAPI
-from datacube.index.postgis._transaction import PostgisTransaction
-from datacube.index.postgis._datasets import DatasetResource
-from datacube.index.postgis._metadata_types import MetadataTypeResource
-from datacube.index.postgis._lineage import LineageResource
-from datacube.index.postgis._products import ProductResource
-from datacube.index.postgis._users import UserResource
 from datacube.index.abstract import (
-    AbstractIndex, AbstractIndexDriver, AbstractTransaction,
-    default_metadata_type_docs, DSID
+    DSID,
+    AbstractIndex,
+    AbstractIndexDriver,
+    AbstractTransaction,
+    default_metadata_type_docs,
 )
-from datacube.model import MetadataType
+from datacube.index.postgis._datasets import DatasetResource
+from datacube.index.postgis._lineage import LineageResource
+from datacube.index.postgis._metadata_types import MetadataTypeResource
+from datacube.index.postgis._products import ProductResource
+from datacube.index.postgis._transaction import PostgisTransaction
+from datacube.index.postgis._users import UserResource
 from datacube.migration import ODC2DeprecationWarning
-from odc.geo import CRS
+from datacube.model import MetadataType
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -10,28 +10,33 @@ import json
 import logging
 import warnings
 from collections import namedtuple
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from time import monotonic
 from typing import Any
-from collections.abc import Iterator
-from typing_extensions import override
-from collections.abc import Iterable, Mapping, Sequence
 from uuid import UUID
-from deprecat import deprecat
 
+from deprecat import deprecat
+from typing_extensions import override
+
+from datacube.drivers.postgres._api import split_uri
 from datacube.drivers.postgres._fields import SimpleDocField
 from datacube.drivers.postgres._schema import DATASET
-from datacube.index.abstract import (AbstractDatasetResource, DSID,
-                                     DatasetTuple, BatchStatus, DatasetSpatialMixin)
+from datacube.index import fields
+from datacube.index.abstract import (
+    DSID,
+    AbstractDatasetResource,
+    BatchStatus,
+    DatasetSpatialMixin,
+    DatasetTuple,
+)
 from datacube.index.postgres._transaction import IndexResourceAddIn
+from datacube.migration import ODC2DeprecationWarning
 from datacube.model import Dataset, Product
 from datacube.model._base import QueryField
-from datacube.model.fields import Field, Expression
+from datacube.model.fields import Expression, Field
 from datacube.model.utils import flatten_datasets
-from datacube.utils import jsonify_document, _readable_offset, changes
-from datacube.utils.changes import get_doc_changes, Offset
-from datacube.index import fields
-from datacube.drivers.postgres._api import split_uri
-from datacube.migration import ODC2DeprecationWarning
+from datacube.utils import _readable_offset, changes, jsonify_document
+from datacube.utils.changes import Offset, get_doc_changes
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/index/postgres/_lineage.py
+++ b/datacube/index/postgres/_lineage.py
@@ -2,8 +2,9 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from time import monotonic
 from collections.abc import Iterable
+from time import monotonic
+
 from typing_extensions import override
 
 from datacube.index.abstract import BatchStatus, NoLineageResource

--- a/datacube/index/postgres/_metadata_types.py
+++ b/datacube/index/postgres/_metadata_types.py
@@ -11,8 +11,14 @@ from typing_extensions import override
 from datacube.index.abstract import AbstractMetadataTypeResource
 from datacube.index.postgres._transaction import IndexResourceAddIn
 from datacube.model import MetadataType
-from datacube.utils import jsonify_document, changes, _readable_offset
-from datacube.utils.changes import AllowPolicy, Change, Offset, check_doc_unchanged, get_doc_changes
+from datacube.utils import _readable_offset, changes, jsonify_document
+from datacube.utils.changes import (
+    AllowPolicy,
+    Change,
+    Offset,
+    check_doc_unchanged,
+    get_doc_changes,
+)
 from datacube.utils.documents import JsonDict
 
 _LOG: logging.Logger = logging.getLogger(__name__)

--- a/datacube/index/postgres/_products.py
+++ b/datacube/index/postgres/_products.py
@@ -3,23 +3,23 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+
 import datetime
 import logging
+from collections.abc import Iterable, Mapping, Sequence
+from typing import TYPE_CHECKING, cast
 
 from cachetools.func import lru_cache
-from typing import TYPE_CHECKING, cast
 from typing_extensions import override
-from collections.abc import Iterable, Mapping, Sequence
 
 from datacube.drivers.postgres import PostgresDb
 from datacube.index import fields
 from datacube.index.abstract import AbstractProductResource
-from datacube.utils.documents import JsonDict
 from datacube.index.postgres._transaction import IndexResourceAddIn
 from datacube.model import MetadataType, Product
-from datacube.utils import jsonify_document, changes, _readable_offset
+from datacube.utils import _readable_offset, changes, jsonify_document
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes
-
+from datacube.utils.documents import JsonDict
 
 if TYPE_CHECKING:
     from datacube.index.postgres.index import Index

--- a/datacube/index/postgres/_transaction.py
+++ b/datacube/index/postgres/_transaction.py
@@ -3,10 +3,11 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 
+from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any
+
 from typing_extensions import override
-from collections.abc import Iterator
 
 from datacube.drivers.postgres import PostgresDb
 from datacube.drivers.postgres._api import PostgresDbAPI

--- a/datacube/index/postgres/_users.py
+++ b/datacube/index/postgres/_users.py
@@ -3,13 +3,15 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-from typing import TYPE_CHECKING
-from typing_extensions import override
+
 from collections.abc import Iterable
+from typing import TYPE_CHECKING
+
+from typing_extensions import override
+
+from datacube.drivers.postgres import PostgresDb
 from datacube.index.abstract import AbstractUserResource
 from datacube.index.postgres._transaction import IndexResourceAddIn
-from datacube.drivers.postgres import PostgresDb
-
 
 if TYPE_CHECKING:
     from datacube.index.postgres.index import Index

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -3,24 +3,29 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import logging
-from contextlib import contextmanager
 from collections.abc import Iterable, Iterator
-from typing_extensions import override
+from contextlib import contextmanager
 
 from deprecat import deprecat
-from datacube.cfg.opt import ODCOptionHandler, config_options_for_psql_driver
+from typing_extensions import override
+
 from datacube.cfg.api import ODCEnvironment
+from datacube.cfg.opt import ODCOptionHandler, config_options_for_psql_driver
 from datacube.drivers.postgres import PostgresDb, PostgresDbAPI
-from datacube.index.postgres._transaction import PostgresTransaction
+from datacube.index.abstract import (
+    AbstractIndex,
+    AbstractIndexDriver,
+    AbstractTransaction,
+    default_metadata_type_docs,
+)
 from datacube.index.postgres._datasets import DatasetResource
 from datacube.index.postgres._lineage import LineageResource
 from datacube.index.postgres._metadata_types import MetadataTypeResource
 from datacube.index.postgres._products import ProductResource
+from datacube.index.postgres._transaction import PostgresTransaction
 from datacube.index.postgres._users import UserResource
-from datacube.index.abstract import AbstractIndex, AbstractIndexDriver, AbstractTransaction, \
-    default_metadata_type_docs
-from datacube.model import MetadataType
 from datacube.migration import ODC2DeprecationWarning
+from datacube.model import MetadataType
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -6,25 +6,38 @@
 Core classes used across modules.
 """
 from __future__ import annotations
+
 import logging
 import math
 from collections import OrderedDict
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from datetime import datetime
 from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
 from uuid import UUID
 
 from affine import Affine
-from typing import Any
 from typing_extensions import override
-from collections.abc import Mapping, Iterator, Iterable, Sequence
 
-from urllib.parse import urlparse
-from datacube.utils import without_lineage_sources, parse_time, cached_property, uri_to_local_path, \
-    schema_validated, DocReader
-from .fields import Field, get_dataset_fields
-from ._base import Range, ranges_overlap, Not, QueryField, QueryDict  # noqa: F401
+from datacube.utils import (
+    DocReader,
+    cached_property,
+    parse_time,
+    schema_validated,
+    uri_to_local_path,
+    without_lineage_sources,
+)
+
+from ._base import Not, QueryDict, QueryField, Range, ranges_overlap  # noqa: F401
 from .eo3 import validate_eo3_compatible_type
-from .lineage import LineageDirection, LineageTree, LineageRelation, InconsistentLineageException
+from .fields import Field, get_dataset_fields
+from .lineage import (
+    InconsistentLineageException,
+    LineageDirection,
+    LineageRelation,
+    LineageTree,
+)
 
 __all__ = [
     "Dataset",
@@ -46,12 +59,13 @@ __all__ = [
     "ranges_overlap"
 ]
 
-from odc.geo import CRS, BoundingBox, Geometry, wh_, resyx_, res_, yx_
+from deprecat import deprecat
+from odc.geo import CRS, BoundingBox, Geometry, res_, resyx_, wh_, yx_
 from odc.geo.geobox import GeoBox
 from odc.geo.geom import intersects, polygon
 from odc.geo.gridspec import GridSpec as GeoGridSpec
+
 from datacube.migration import ODC2DeprecationWarning
-from deprecat import deprecat
 
 from ..utils.uris import pick_uri
 

--- a/datacube/model/eo3.py
+++ b/datacube/model/eo3.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from collections.abc import Sequence
 from typing import Any
+
 from datacube.utils.documents import InvalidDocException
 
 required_sys_field_values = [

--- a/datacube/model/fields.py
+++ b/datacube/model/fields.py
@@ -6,12 +6,15 @@
 
 This allows extraction of fields of interest from dataset metadata document.
 """
+import decimal
 from collections.abc import Callable, Mapping
 from typing import Any
-from typing_extensions import override
+
 import toolz
-import decimal
+from typing_extensions import override
+
 from datacube.utils import parse_time
+
 from ._base import Range
 
 # Allowed values for field 'type' (specified in a metadata type document)

--- a/datacube/model/lineage.py
+++ b/datacube/model/lineage.py
@@ -2,12 +2,13 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
+from typing import Any, Optional, cast
 from uuid import UUID
-from typing import Optional, Any, cast
+
 from typing_extensions import override
-from collections.abc import Mapping, Sequence, Iterable
 
 
 class LineageDirection(Enum):

--- a/datacube/model/utils.py
+++ b/datacube/model/utils.py
@@ -6,25 +6,22 @@ import os
 import platform
 import sys
 import uuid
-from collections.abc import Sequence
-from typing import Literal
-from collections.abc import Mapping
-
-import toolz
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
+from typing import Literal
 
 import numpy
+import toolz
 import xarray
 import yaml
+from odc.geo import CRS
+from odc.geo.geom import Geometry, point
 from pandas import to_datetime
 
 import datacube
 from datacube.model import Dataset
-from datacube.utils import SimpleDocNav, InvalidDocException
+from datacube.utils import InvalidDocException, SimpleDocNav
 from datacube.utils.py import sorted_items
-
-from odc.geo import CRS
-from odc.geo.geom import Geometry, point
 
 try:
     from yaml import CSafeDumper as SafeDumper

--- a/datacube/scripts/cli_app.py
+++ b/datacube/scripts/cli_app.py
@@ -7,14 +7,13 @@ Datacube command-line interface
 """
 
 
-from datacube.ui.click import cli
 import datacube.scripts.dataset
-import datacube.scripts.product
 import datacube.scripts.metadata
+import datacube.scripts.product
 import datacube.scripts.spindex
 import datacube.scripts.system
-import datacube.scripts.user      # noqa: F401
-
+import datacube.scripts.user  # noqa: F401
+from datacube.ui.click import cli
 
 if __name__ == '__main__':
     cli()

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -7,9 +7,9 @@ import datetime
 import logging
 import sys
 from collections import OrderedDict
-from textwrap import dedent
-from typing import cast, Any
 from collections.abc import Iterable, Iterator, Mapping, MutableMapping, Sequence
+from textwrap import dedent
+from typing import Any, cast
 from uuid import UUID
 
 import click
@@ -17,15 +17,15 @@ import yaml
 import yaml.resolver
 from click import echo
 
+from datacube.index import Index
+from datacube.index.eo3 import prep_eo3
 from datacube.index.exceptions import MissingRecordError
 from datacube.index.hl import Doc2Dataset, check_dataset_consistent
-from datacube.index.eo3 import prep_eo3
-from datacube.index import Index
 from datacube.model import Dataset
 from datacube.ui import click as ui
 from datacube.ui.click import cli, print_help_msg
 from datacube.ui.common import ui_path_doc_stream
-from datacube.utils import changes, SimpleDocNav
+from datacube.utils import SimpleDocNav, changes
 from datacube.utils.serialise import SafeDatacubeDumper
 from datacube.utils.uris import uri_resolve
 

--- a/datacube/scripts/metadata.py
+++ b/datacube/scripts/metadata.py
@@ -6,15 +6,14 @@ import json
 import logging
 import sys
 
-import yaml
-
 import click
+import yaml
 from click import echo, style
 
 from datacube.index import Index
 from datacube.ui import click as ui
-from datacube.ui.click import cli, print_help_msg, exit_on_empty_file
-from datacube.utils import read_documents, InvalidDocException
+from datacube.ui.click import cli, exit_on_empty_file, print_help_msg
+from datacube.utils import InvalidDocException, read_documents
 from datacube.utils.serialise import SafeDatacubeDumper
 
 _LOG: logging.Logger = logging.getLogger('datacube-md-type')

--- a/datacube/scripts/product.py
+++ b/datacube/scripts/product.py
@@ -5,10 +5,10 @@
 import csv
 import json
 import logging
+import signal
 import sys
 
 import click
-import signal
 import pandas as pd
 import yaml
 import yaml.resolver
@@ -16,8 +16,8 @@ from click import echo, style
 
 from datacube.index import Index
 from datacube.ui import click as ui
-from datacube.ui.click import cli, print_help_msg, exit_on_empty_file
-from datacube.utils import read_documents, InvalidDocException
+from datacube.ui.click import cli, exit_on_empty_file, print_help_msg
+from datacube.utils import InvalidDocException, read_documents
 from datacube.utils.serialise import SafeDatacubeDumper
 
 _LOG: logging.Logger = logging.getLogger('datacube-product')

--- a/datacube/scripts/search_tool.py
+++ b/datacube/scripts/search_tool.py
@@ -11,17 +11,15 @@ import datetime
 import shutil
 import sys
 from collections.abc import Callable, Collection
-from functools import partial
+from functools import partial, singledispatch
+from os import terminal_size as t_size
 from typing import Any
 
 import click
-from os import terminal_size as t_size
 from sqlalchemy.dialects.postgresql import Range
-from functools import singledispatch
 
 from datacube.ui import click as ui
 from datacube.ui.click import CLICK_SETTINGS
-
 from datacube.utils.dates import tz_as_utc
 
 PASS_INDEX = ui.pass_index('datacube-search')

--- a/datacube/scripts/spindex.py
+++ b/datacube/scripts/spindex.py
@@ -7,9 +7,9 @@ import sys
 from collections.abc import Sequence
 
 import click
-from pyproj.exceptions import CRSError
-from click import echo, confirm
+from click import confirm, echo
 from odc.geo import CRS
+from pyproj.exceptions import CRSError
 
 from datacube.index import Index
 from datacube.ui import click as ui

--- a/datacube/scripts/system.py
+++ b/datacube/scripts/system.py
@@ -10,8 +10,8 @@ from sqlalchemy.exc import OperationalError
 
 import datacube
 from datacube.cfg import ODCEnvironment, psql_url_from_config
-from datacube.index import index_connect
 from datacube.drivers.postgres._connections import IndexSetupError
+from datacube.index import index_connect
 from datacube.ui import click as ui
 from datacube.ui.click import cli, handle_exception
 

--- a/datacube/scripts/user.py
+++ b/datacube/scripts/user.py
@@ -2,23 +2,22 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+import csv
 import logging
+import sys
+from collections import OrderedDict
 from collections.abc import Iterable
 
 import click
-import csv
-import sys
 import yaml
 import yaml.resolver
 
-from collections import OrderedDict
-
 from datacube.cfg import ODCEnvironment
-from datacube.utils import gen_password
+from datacube.index.abstract import AbstractIndex
 from datacube.ui import click as ui
 from datacube.ui.click import cli
+from datacube.utils import gen_password
 from datacube.utils.serialise import SafeDatacubeDumper
-from datacube.index.abstract import AbstractIndex
 
 _LOG: logging.Logger = logging.getLogger('datacube-user')
 USER_ROLES = ('user', 'manage', 'admin')

--- a/datacube/storage/__init__.py
+++ b/datacube/storage/__init__.py
@@ -8,12 +8,7 @@ Modules for creating and accessing Data Store Units
 
 """
 
-from ..drivers.datasource import (
-    DataSource,
-    GeoRasterReader,
-    RasterShape,
-    RasterWindow)
-
+from ..drivers.datasource import DataSource, GeoRasterReader, RasterShape, RasterWindow
 from ._base import BandInfo, measurement_paths
 from ._load import reproject_and_fuse
 

--- a/datacube/storage/_base.py
+++ b/datacube/storage/_base.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any
 from collections.abc import Callable
+from typing import Any
 from urllib.parse import urlparse
 
 from datacube.model import Dataset
-from datacube.utils.uris import uri_resolve, pick_uri
+from datacube.utils.uris import pick_uri, uri_resolve
 
 
 def _get_band_and_layer(b: dict[str, Any]) -> tuple[int | None, str | None]:

--- a/datacube/storage/_hdf5.py
+++ b/datacube/storage/_hdf5.py
@@ -3,4 +3,5 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 from threading import RLock
+
 HDF5_LOCK = RLock()

--- a/datacube/storage/_load.py
+++ b/datacube/storage/_load.py
@@ -11,23 +11,23 @@ Important functions are:
 import logging
 import numbers
 from collections import OrderedDict
+from collections.abc import Callable, Hashable, Iterable, Iterator, Mapping
+from typing import Any, cast
+
 import numpy as np
+from odc.geo.geobox import GeoBox
+from odc.geo.roi import roi_is_empty
+from odc.geo.warp import Resampling
+from odc.geo.xr import xr_coords
 from xarray.core.coordinates import DataArrayCoordinates
 from xarray.core.dataarray import DataArray as XrDataArray
 from xarray.core.dataset import Dataset as XrDataset
-from typing import (
-    Any, cast
-)
-from collections.abc import Callable, Iterator, Iterable, Mapping, Hashable
 
+from datacube.drivers._types import ReaderDriver
+from datacube.model import Measurement
 from datacube.utils import ignore_exceptions_if
 from datacube.utils.math import invalid_mask
-from odc.geo.geobox import GeoBox
-from odc.geo.roi import roi_is_empty
-from odc.geo.xr import xr_coords
-from odc.geo.warp import Resampling
-from datacube.model import Measurement
-from datacube.drivers._types import ReaderDriver
+
 from ..drivers.datasource import DataSource
 from ._base import BandInfo
 

--- a/datacube/storage/_loader.py
+++ b/datacube/storage/_loader.py
@@ -11,9 +11,9 @@ separate file to reduce formatting issues.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import datetime
 from types import SimpleNamespace
-from collections.abc import Sequence
 
 import xarray as xr
 from odc.geo.geobox import GeoBox, GeoboxTiles

--- a/datacube/storage/_read.py
+++ b/datacube/storage/_read.py
@@ -4,29 +4,24 @@
 # SPDX-License-Identifier: Apache-2.0
 """ Dataset -> Raster
 """
-import numpy as np
 from typing import cast
 
-from ..utils.math import valid_mask
-
+import numpy as np
 from odc.geo import wh_
+from odc.geo.geobox import GeoBox, zoom_out
+from odc.geo.math import is_affine_st, is_almost_int
+from odc.geo.overlap import compute_reproject_roi
 from odc.geo.roi import (
-    roi_shape,
     roi_is_empty,
     roi_is_full,
     roi_pad,
+    roi_shape,
     w_,
 )
-from odc.geo.geobox import GeoBox, zoom_out
 from odc.geo.types import Nodata
-from odc.geo.warp import (
-    warp_affine,
-    rio_reproject,
-    is_resampling_nn,
-    Resampling
-)
-from odc.geo.overlap import compute_reproject_roi
-from odc.geo.math import is_affine_st, is_almost_int
+from odc.geo.warp import Resampling, is_resampling_nn, rio_reproject, warp_affine
+
+from ..utils.math import valid_mask
 
 
 def rdr_geobox(rdr) -> GeoBox:

--- a/datacube/storage/_rio.py
+++ b/datacube/storage/_rio.py
@@ -6,21 +6,24 @@
 Driver implementation for Rasterio based reader.
 """
 from __future__ import annotations
-import logging
+
 import contextlib
+import logging
+from collections.abc import Iterator
 from contextlib import contextmanager
 from threading import RLock
-import numpy as np
-from affine import Affine
-from typing_extensions import override
-import rasterio
 from urllib.parse import urlparse
-from collections.abc import Iterator
 
+import numpy as np
+import rasterio
+from affine import Affine
 from odc.geo import CRS
+from typing_extensions import override
+
+from datacube.utils import get_part_from_uri, is_vsipath, uri_to_local_path
 from datacube.utils.math import num2numpy
-from datacube.utils import uri_to_local_path, get_part_from_uri, is_vsipath
 from datacube.utils.rio import activate_from_config
+
 from ..drivers.datasource import DataSource, GeoRasterReader, RasterShape, RasterWindow
 from ._base import BandInfo
 from ._hdf5 import HDF5_LOCK

--- a/datacube/testutils/__init__.py
+++ b/datacube/testutils/__init__.py
@@ -5,35 +5,34 @@
 """
 Useful methods for tests (particularly: reading/writing and checking files)
 """
-import typing
-
 import atexit
+import contextlib
+import json
 import math
 import os
+import pathlib
 import shutil
 import tempfile
-import json
+import typing
 import uuid
-import numpy as np
-from numpy.typing import NDArray
-import xarray as xr
 import warnings
-import contextlib
+from collections.abc import Mapping, Sequence
 from datetime import datetime
-from collections.abc import Sequence, Mapping
 from typing import Any
-import pathlib
 
+import numpy as np
+import xarray as xr
 from affine import Affine
-from datacube import Datacube
-from datacube.model import Measurement
-from datacube.utils.dates import mk_time_coord
-from datacube.utils.documents import parse_yaml
-from datacube.model import Dataset, Product, MetadataType
-from datacube.ui.common import get_metadata_path
-from datacube.utils import read_documents, SimpleDocNav
+from numpy.typing import NDArray
 from odc.geo import CRS, wh_
 from odc.geo.geobox import GeoBox
+
+from datacube import Datacube
+from datacube.model import Dataset, Measurement, MetadataType, Product
+from datacube.ui.common import get_metadata_path
+from datacube.utils import SimpleDocNav, read_documents
+from datacube.utils.dates import mk_time_coord
+from datacube.utils.documents import parse_yaml
 
 _DEFAULT = object()
 
@@ -425,8 +424,9 @@ def gen_tiff_dataset(bands: list[BandObject],
 
     :returns:  (Dataset, GeoBox)
     """
-    from .io import write_gtiff
     from pathlib import Path
+
+    from .io import write_gtiff
 
     if base_folder_of_record is None:
         base_folder_of_record = base_folder

--- a/datacube/testutils/geom.py
+++ b/datacube/testutils/geom.py
@@ -2,15 +2,16 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+import warnings
+from collections.abc import Callable
+
 import numpy as np
 from affine import Affine
-from collections.abc import Callable
-import warnings
-
 from odc.geo import CRS
 from odc.geo.geobox import GeoBox
-from odc.geo.math import apply_affine
 from odc.geo.gridspec import GridSpec
+from odc.geo.math import apply_affine
+
 # from datacube.model import GridSpec
 
 # pylint: disable=invalid-name

--- a/datacube/testutils/io.py
+++ b/datacube/testutils/io.py
@@ -2,24 +2,25 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
 import numpy as np
 import toolz
 import xarray
-from pathlib import Path
-from typing import Any
+from odc.geo import wh_
+from odc.geo.geobox import GeoBox, zoom_to
+from odc.geo.warp import resampling_s2rio
+from odc.geo.xr import xr_coords
 from typing_extensions import override
 
-from . import suppress_deprecations
+from ..index.eo3 import EO3Grid, is_doc_eo3
 from ..model import Dataset
-from ..storage import reproject_and_fuse, BandInfo
-from ..storage._rio import RasterioDataSource, RasterDatasetDataSource
+from ..storage import BandInfo, reproject_and_fuse
 from ..storage._read import rdr_geobox
-from ..index.eo3 import is_doc_eo3, EO3Grid
-from types import SimpleNamespace
-from odc.geo.warp import resampling_s2rio
-from odc.geo.geobox import GeoBox, zoom_to
-from odc.geo import wh_
-from odc.geo.xr import xr_coords
+from ..storage._rio import RasterDatasetDataSource, RasterioDataSource
+from . import suppress_deprecations
 
 
 class RasterFileDataSource(RasterioDataSource):
@@ -199,9 +200,10 @@ def write_gtiff(fname: Path,
     """
     # pylint: disable=too-many-locals
 
-    from affine import Affine
-    import rasterio
     from pathlib import Path
+
+    import rasterio
+    from affine import Affine
 
     if pix.ndim == 2:
         h, w = pix.shape

--- a/datacube/testutils/iodriver.py
+++ b/datacube/testutils/iodriver.py
@@ -5,13 +5,14 @@
 """ Reader driver construction for tests
 """
 from pathlib import Path
-from datacube.testutils import mk_sample_dataset
+
+from datacube.drivers._types import ReaderDriver
 from datacube.drivers.rio._reader import (
     RDEntry,
 )
 from datacube.storage import BandInfo
+from datacube.testutils import mk_sample_dataset
 from datacube.testutils.threads import FakeThreadPoolExecutor
-from datacube.drivers._types import ReaderDriver
 
 NetCDF = 'NetCDF'    # pylint: disable=invalid-name
 GeoTIFF = 'GeoTIFF'  # pylint: disable=invalid-name

--- a/datacube/ui/__init__.py
+++ b/datacube/ui/__init__.py
@@ -5,9 +5,10 @@
 """
 User Interface Utilities
 """
-from .expression import parse_expressions
-from .common import get_metadata_path
 from datacube.utils import read_documents
+
+from .common import get_metadata_path
+from .expression import parse_expressions
 
 __all__ = [
     'get_metadata_path',

--- a/datacube/ui/click.py
+++ b/datacube/ui/click.py
@@ -5,24 +5,22 @@
 """
 Common functions for click-based cli scripts.
 """
+import copy
 import functools
 import logging
 import os
-import copy
 import sys
 from textwrap import dedent
-from typing_extensions import override
 
 import click
+from sqlalchemy.exc import OperationalError, ProgrammingError
+from typing_extensions import override
 
 from datacube import __version__
 from datacube.api.core import Datacube
-from datacube.cfg import ODCConfig, ODCEnvironment, ConfigException
-
+from datacube.cfg import ConfigException, ODCConfig, ODCEnvironment
 from datacube.index import index_connect
-
 from datacube.ui.expression import parse_expressions
-from sqlalchemy.exc import OperationalError, ProgrammingError
 
 _LOG_FORMAT_STRING = '%(asctime)s %(process)d %(name)s %(levelname)s %(message)s'
 CLICK_SETTINGS: dict[str, list[str]] = dict(help_option_names=['-h', '--help'])

--- a/datacube/ui/common.py
+++ b/datacube/ui/common.py
@@ -5,12 +5,18 @@
 """
 Common methods for UI code.
 """
-from pathlib import Path
 from collections.abc import Iterator
+from pathlib import Path
 
 from toolz.functoolz import identity
 
-from datacube.utils import read_documents, InvalidDocException, SimpleDocNav, is_supported_document_type, is_url
+from datacube.utils import (
+    InvalidDocException,
+    SimpleDocNav,
+    is_supported_document_type,
+    is_url,
+    read_documents,
+)
 
 
 def get_metadata_path(possible_path: str | Path) -> str:

--- a/datacube/ui/task_app.py
+++ b/datacube/ui/task_app.py
@@ -2,22 +2,21 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-import logging
-import os
-import time
-from collections.abc import Sequence
-
-import click
 import functools
 import itertools
-import re
-from pathlib import Path
-import pandas as pd
+import logging
+import os
 import pickle
+import re
+import time
+from collections.abc import Sequence
+from pathlib import Path
+
+import click
+import pandas as pd
 
 from datacube.ui import click as dc_ui
 from datacube.utils import read_documents
-
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/utils/__init__.py
+++ b/datacube/utils/__init__.py
@@ -6,38 +6,33 @@
 Utility functions
 """
 
+from ._misc import DatacubeException, gen_password, report_to_user
 from .dates import parse_time
+from .documents import (
+    DocReader,
+    InvalidDocException,
+    NoDatesSafeLoader,
+    SimpleDocNav,
+    _readable_offset,
+    get_doc_offset,
+    is_supported_document_type,
+    netcdf_extract_string,
+    read_documents,
+    read_strings_from_netcdf,
+    schema_validated,
+    validate_document,
+    without_lineage_sources,
+)
+from .io import check_write_path, slurp, write_user_secret_file
+from .math import (
+    iter_slices,
+    spatial_dims,
+    unsqueeze_data_array,
+    unsqueeze_dataset,
+)
 from .py import cached_property, ignore_exceptions_if, import_function
 from .serialise import jsonify_document
-from .uris import is_url, uri_to_local_path, get_part_from_uri, mk_part_uri, is_vsipath
-from .io import slurp, check_write_path, write_user_secret_file
-from .documents import (
-    InvalidDocException,
-    SimpleDocNav,
-    DocReader,
-    is_supported_document_type,
-    read_strings_from_netcdf,
-    read_documents,
-    validate_document,
-    NoDatesSafeLoader,
-    get_doc_offset,
-    netcdf_extract_string,
-    without_lineage_sources,
-    schema_validated,
-    _readable_offset,
-)
-from .math import (
-    unsqueeze_dataset,
-    unsqueeze_data_array,
-    spatial_dims,
-    iter_slices,
-)
-from ._misc import (
-    DatacubeException,
-    gen_password,
-    report_to_user
-)
-
+from .uris import get_part_from_uri, is_url, is_vsipath, mk_part_uri, uri_to_local_path
 
 __all__ = [
     "DatacubeException",

--- a/datacube/utils/_misc.py
+++ b/datacube/utils/_misc.py
@@ -5,9 +5,9 @@
 """
 Utility functions
 """
+import logging
 import os
 import sys
-import logging
 
 
 class DatacubeException(Exception):  # noqa: N818

--- a/datacube/utils/aws/__init__.py
+++ b/datacube/utils/aws/__init__.py
@@ -5,20 +5,21 @@
 """
 Helper methods for working with AWS
 """
+import functools
 import os
 import time
-import functools
+from typing import IO, Any, TypeAlias
+from urllib.parse import urlparse
+from urllib.request import urlopen
+
 import botocore
 import botocore.session
 from botocore.client import BaseClient
 from botocore.config import Config
 from botocore.credentials import Credentials, ReadOnlyCredentials
 from botocore.session import Session
-from urllib.request import urlopen
-from urllib.parse import urlparse
 from sqlalchemy.engine.url import URL
 
-from typing import Any, IO, TypeAlias
 from datacube.utils.generic import thread_local_cache
 
 ByteRange: TypeAlias = slice | tuple[int, int]       # pylint: disable=invalid-name

--- a/datacube/utils/changes.py
+++ b/datacube/utils/changes.py
@@ -5,12 +5,12 @@
 """
 Validation of document/dictionary changes.
 """
-import numpy
-
-from itertools import zip_longest
-from typing import TypeAlias, cast, Any
-from typing_extensions import override
 from collections.abc import Callable, Mapping, Sequence
+from itertools import zip_longest
+from typing import Any, TypeAlias, cast
+
+import numpy
+from typing_extensions import override
 
 # Type that can be checked for changes.
 # (MyPy approximation without recursive references)

--- a/datacube/utils/cog.py
+++ b/datacube/utils/cog.py
@@ -3,25 +3,25 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import warnings
-import toolz
-import rasterio
-from rasterio.shutil import copy as rio_copy
-import numpy as np
-import xarray as xr
-import dask
-from dask.base import is_dask_collection
-from dask.delayed import Delayed
 from pathlib import Path
 from typing import Any
+
+import dask
+import numpy as np
+import rasterio
+import toolz
+import xarray as xr
+from dask.base import is_dask_collection
+from dask.delayed import Delayed
+from deprecat import deprecat
+from odc.geo.geobox import GeoBox
+from odc.geo.math import align_up
+from odc.geo.warp import Resampling, resampling_s2rio
+from rasterio.shutil import copy as rio_copy
 
 from datacube.migration import ODC2DeprecationWarning
 
 from .io import check_write_path
-from odc.geo.geobox import GeoBox
-from odc.geo.math import align_up
-from odc.geo.warp import Resampling, resampling_s2rio
-
-from deprecat import deprecat
 
 __all__ = ["to_cog", "write_cog"]
 

--- a/datacube/utils/dask.py
+++ b/datacube/utils/dask.py
@@ -5,19 +5,19 @@
 """ Dask Distributed Tools
 
 """
-from pathlib import Path
-from typing import Any
-from collections.abc import Iterable
-from random import randint
-import toolz
-import queue
-from dask.distributed import Client
-import dask
-from dask.delayed import delayed
-import threading
 import logging
 import os
+import queue
+import threading
+from collections.abc import Iterable
+from pathlib import Path
+from random import randint
+from typing import Any
 
+import dask
+import toolz
+from dask.delayed import delayed
+from dask.distributed import Client
 
 __all__ = [
     "compute_tasks",
@@ -264,7 +264,8 @@ def _save_blob_to_s3(data: bytes | str,
                      **kw) -> tuple[str, bool]:
     from botocore.errorfactory import ClientError
     from botocore.exceptions import BotoCoreError
-    from .aws import s3_dump, s3_client
+
+    from .aws import s3_client, s3_dump
 
     try:
         s3 = s3_client(profile=profile,

--- a/datacube/utils/dates.py
+++ b/datacube/utils/dates.py
@@ -13,12 +13,11 @@ from datetime import datetime, tzinfo
 
 import dateutil
 import dateutil.parser
-from dateutil.relativedelta import relativedelta
-from dateutil.rrule import YEARLY, MONTHLY, DAILY, rrule
-from dateutil.tz import tzutc
 import numpy as np
 import xarray as xr
-
+from dateutil.relativedelta import relativedelta
+from dateutil.rrule import DAILY, MONTHLY, YEARLY, rrule
+from dateutil.tz import tzutc
 
 FREQS: dict[str, int] = {'y': YEARLY, 'm': MONTHLY, 'd': DAILY}
 DURATIONS = {'y': 'years', 'm': 'months', 'd': 'days'}

--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -5,26 +5,26 @@
 """
 Functions for working with YAML documents and configurations
 """
+import collections.abc
 import gzip
 import json
 import logging
 import math
 import sys
-import collections.abc
 from collections import OrderedDict
+from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
+from copy import deepcopy
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
-from typing import Any
-from typing_extensions import override
-from collections.abc import Iterator, Mapping
-from copy import deepcopy
 from uuid import UUID
 
 import numpy
 import toolz
 import yaml
+from typing_extensions import override
 
 try:
     from yaml import CSafeLoader as SafeLoader
@@ -32,8 +32,7 @@ except ImportError:
     from yaml import SafeLoader  # type: ignore
 
 from datacube.utils.generic import map_with_lookahead
-from datacube.utils.uris import mk_part_uri, as_url, uri_to_local_path
-
+from datacube.utils.uris import as_url, mk_part_uri, uri_to_local_path
 
 JsonAtom = None | bool | str | float | int
 JsonLike = JsonAtom | list["JsonLike"] | dict[str, "JsonLike"]

--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -2,32 +2,31 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+import array
 import functools
 import itertools
 import math
-import array
 import warnings
 from collections import OrderedDict
-from typing import Union, Optional, Any, NamedTuple, TypeAlias
-from typing_extensions import override
-from collections.abc import Iterable, Callable, Hashable, Iterator
-from collections.abc import Sequence
-from packaging.version import Version
+from collections.abc import Callable, Hashable, Iterable, Iterator, Sequence
+from typing import Any, NamedTuple, Optional, TypeAlias, Union
 
 import cachetools
 import numpy
+import rasterio
 import xarray as xr
 from affine import Affine
-import rasterio
-from shapely import geometry, ops, from_wkt
-from shapely.geometry import base
+from packaging.version import Version
 from pyproj import CRS as _CRS
 from pyproj.enums import WktVersion
-from pyproj.transformer import Transformer
 from pyproj.exceptions import CRSError
+from pyproj.transformer import Transformer
+from shapely import from_wkt, geometry, ops
+from shapely.geometry import base
+from typing_extensions import override
 
-from .tools import roi_normalise, roi_shape, is_affine_st
 from ..math import is_almost_int
+from .tools import is_affine_st, roi_normalise, roi_shape
 
 
 class Coordinate(NamedTuple):

--- a/datacube/utils/geometry/_warp.py
+++ b/datacube/utils/geometry/_warp.py
@@ -2,11 +2,13 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-import rasterio.warp
-import rasterio.crs
-import numpy as np
-from affine import Affine
 from typing import TypeAlias
+
+import numpy as np
+import rasterio.crs
+import rasterio.warp
+from affine import Affine
+
 from . import GeoBox
 
 Resampling: TypeAlias = str | int | rasterio.warp.Resampling  # pylint: disable=invalid-name

--- a/datacube/utils/geometry/gbox.py
+++ b/datacube/utils/geometry/gbox.py
@@ -6,15 +6,16 @@
 Geometric operations on GeoBox class
 """
 
-from collections.abc import Iterable
 import itertools
 import math
+from collections.abc import Iterable
 from typing import TypeAlias
-from affine import Affine
 
-from . import Geometry, GeoBox, BoundingBox
-from .tools import align_up
+from affine import Affine
 from odc.geo.math import clamp
+
+from . import BoundingBox, GeoBox, Geometry
+from .tools import align_up
 
 # pylint: disable=invalid-name
 MaybeInt: TypeAlias = int | None

--- a/datacube/utils/geometry/tools.py
+++ b/datacube/utils/geometry/tools.py
@@ -2,9 +2,10 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-import numpy as np
 import collections.abc
 from types import SimpleNamespace
+
+import numpy as np
 from affine import Affine
 
 # This is numeric code, short names make sense in this context, so disabling
@@ -393,7 +394,7 @@ def compute_axis_overlap(Ns: int, Nd: int, s: float, t: float) -> tuple[slice, s
     :returns: (slice in the source image,
                slice in the destination image)
     """
-    from math import floor, ceil
+    from math import ceil, floor
 
     needs_flip = s < 0
 

--- a/datacube/utils/masking.py
+++ b/datacube/utils/masking.py
@@ -16,7 +16,6 @@ from xarray import DataArray, Dataset
 
 from datacube.utils.math import valid_mask
 
-
 FLAGS_ATTR_NAME = 'flags_definition'
 
 

--- a/datacube/utils/math.py
+++ b/datacube/utils/math.py
@@ -3,17 +3,17 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 from collections.abc import Iterator
-from typing import Any
 from math import ceil
+from typing import Any
 
 import numpy
-import xarray as xr
 import odc.geo.math as geomath
+import xarray as xr
+from deprecat import deprecat
 from odc.geo import SomeResolution
 from odc.geo.xr import spatial_dims as xr_spatial_dims
 
 from datacube.migration import ODC2DeprecationWarning
-from deprecat import deprecat
 
 
 def unsqueeze_data_array(da: xr.DataArray,

--- a/datacube/utils/rio/__init__.py
+++ b/datacube/utils/rio/__init__.py
@@ -8,12 +8,12 @@ This will move into IO driver eventually.
 For now this provides tools to configure GDAL environment for performant reads from S3.
 """
 from ._rio import (
+    activate_from_config,
     activate_rio_env,
+    configure_s3_access,
     deactivate_rio_env,
     get_rio_env,
     set_default_rio_config,
-    activate_from_config,
-    configure_s3_access,
 )
 
 __all__ = [

--- a/datacube/utils/rio/_rio.py
+++ b/datacube/utils/rio/_rio.py
@@ -6,9 +6,11 @@
 """
 import threading
 from types import SimpleNamespace
+
 import rasterio
-from rasterio.session import AWSSession, DummySession
 import rasterio.env
+from rasterio.session import AWSSession, DummySession
+
 from datacube.utils.generic import thread_local_cache
 
 _CFG_LOCK = threading.Lock()

--- a/datacube/utils/serialise.py
+++ b/datacube/utils/serialise.py
@@ -8,16 +8,16 @@ Serialise function used in YAML output
 
 import math
 from collections import OrderedDict
-from datetime import datetime, date
+from datetime import date, datetime
 from decimal import Decimal
 from uuid import UUID
 
 import numpy
 import yaml
-
-from datacube.utils.documents import transform_object_tree
-from datacube.model._base import Range
 from odc.geo.crs import CRS
+
+from datacube.model._base import Range
+from datacube.utils.documents import transform_object_tree
 
 
 class SafeDatacubeDumper(yaml.SafeDumper):  # pylint: disable=too-many-ancestors

--- a/datacube/utils/uris.py
+++ b/datacube/utils/uris.py
@@ -3,14 +3,14 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import os
-
 import pathlib
 import re
-from deprecat import deprecat
 import urllib.parse
-from urllib.parse import urlparse, parse_qsl, urljoin
-from urllib.request import url2pathname
 from pathlib import Path
+from urllib.parse import parse_qsl, urljoin, urlparse
+from urllib.request import url2pathname
+
+from deprecat import deprecat
 
 from datacube.migration import ODC2DeprecationWarning
 

--- a/datacube/utils/xarray_geoextensions.py
+++ b/datacube/utils/xarray_geoextensions.py
@@ -14,11 +14,12 @@ This extension is reliant on an `xarray` object having a `.crs` property of type
 
 """
 import warnings
+
 import xarray
 from odc.geo import resxy_
+from odc.geo._xr_interop import _xarray_geobox as _xr_geobox
 from odc.geo.math import affine_from_axis
 from odc.geo.xr import spatial_dims
-from odc.geo._xr_interop import _xarray_geobox as _xr_geobox
 
 
 def _xarray_affine_impl(obj):

--- a/datacube/virtual/__init__.py
+++ b/datacube/virtual/__init__.py
@@ -2,20 +2,38 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, cast
-from collections.abc import Mapping
 import copy
-
-from .impl import VirtualProduct, Transformation, VirtualProductException
-from .impl import from_validated_recipe, virtual_product_kind
-from .transformations import MakeMask, ApplyMask, ToFloat, Rename, Select, Expressions
-from .transformations import XarrayReduction, year, month, week, day, earliest_time, fiscal_year
-from .catalog import Catalog
-from .utils import reject_keys
+from collections.abc import Mapping
+from typing import Any, cast
 
 from datacube.model import Measurement
 from datacube.utils import import_function
 from datacube.utils.documents import parse_yaml
+
+from .catalog import Catalog
+from .impl import (
+    Transformation,
+    VirtualProduct,
+    VirtualProductException,
+    from_validated_recipe,
+    virtual_product_kind,
+)
+from .transformations import (
+    ApplyMask,
+    Expressions,
+    MakeMask,
+    Rename,
+    Select,
+    ToFloat,
+    XarrayReduction,
+    day,
+    earliest_time,
+    fiscal_year,
+    month,
+    week,
+    year,
+)
+from .utils import reject_keys
 
 __all__ = ['Measurement', 'Transformation', 'construct']
 

--- a/datacube/virtual/catalog.py
+++ b/datacube/virtual/catalog.py
@@ -6,13 +6,12 @@
 Catalog of virtual products.
 """
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Iterator, Mapping
 from itertools import chain
 from typing import Any
-from collections.abc import Iterable, Iterator
-from typing_extensions import override
 
 import yaml
+from typing_extensions import override
 
 from datacube.model.utils import SafeDumper
 

--- a/datacube/virtual/expr.py
+++ b/datacube/virtual/expr.py
@@ -71,11 +71,30 @@ def formula_parser() -> lark.Lark:
 
 @lark.v_args(inline=True)
 class FormulaEvaluator(lark.Transformer):
-    from operator import not_, or_, and_, xor              # type: ignore[misc]
-    from operator import eq, ne, le, ge, lt, gt            # type: ignore[misc]
-    from operator import add, sub, mul, truediv, floordiv  # type: ignore[misc]
-    from operator import neg, pos, inv                     # type: ignore[misc]
-    from operator import mod, pow, lshift, rshift          # type: ignore[misc]  # noqa: A004
+    from operator import (  # type: ignore[misc]
+        add,
+        and_,
+        eq,
+        floordiv,
+        ge,
+        gt,
+        inv,
+        le,
+        lshift,
+        lt,
+        mod,
+        mul,
+        ne,
+        neg,
+        not_,
+        or_,
+        pos,
+        pow,  # noqa: A004
+        rshift,
+        sub,
+        truediv,
+        xor,
+    )
 
     float_literal = float
     int_literal = int
@@ -84,7 +103,7 @@ class FormulaEvaluator(lark.Transformer):
 @lark.v_args(inline=True)
 class MaskEvaluator(lark.Transformer):
     # the result of an expression is nodata whenever any of its subexpressions is nodata
-    from operator import or_     # type: ignore[misc]
+    from operator import or_  # type: ignore[misc]
 
     # pylint: disable=invalid-name
     and_ = _xor = or_

--- a/datacube/virtual/impl.py
+++ b/datacube/virtual/impl.py
@@ -8,38 +8,40 @@ to query and to load data, and combinators to combine multiple products into "vi
 products implementing the same interface.
 """
 
-from abc import ABC, abstractmethod
-from collections.abc import Mapping, Sequence
-
-from typing import Any, cast
-from collections.abc import Iterator
-from typing_extensions import override
-from collections.abc import Hashable
-from collections.abc import Mapping as TypeMapping
-
 import uuid
+from abc import ABC, abstractmethod
+from collections import OrderedDict
+from collections.abc import Hashable, Iterator, Mapping, Sequence
+from collections.abc import Mapping as TypeMapping
+from typing import Any, cast
+
+import dask.array
 import numpy
 import xarray
-import dask.array
-from dask.core import flatten
 import yaml
-from collections import OrderedDict
-
-from datacube import Datacube
-from datacube.api.core import output_geobox
-from datacube.api.query import Query, query_group_by
-from datacube.model import Measurement, Product
-from datacube.model.utils import xr_apply, xr_iter, SafeDumper
-from datacube.testutils.io import native_geobox
+from dask.core import flatten
 from odc.geo.geobox import GeoBox, GeoboxTiles, geobox_union_conservative
 from odc.geo.math import is_affine_st
-from odc.geo.warp import rio_reproject, resampling_s2rio
 from odc.geo.overlap import compute_reproject_roi
+from odc.geo.warp import resampling_s2rio, rio_reproject
 from odc.geo.xr import xr_coords
-from datacube.api.core import per_band_load_data_settings
+from typing_extensions import override
 
-from .utils import qualified_name, merge_dicts
-from .utils import select_unique, select_keys, reject_keys, merge_search_terms
+from datacube import Datacube
+from datacube.api.core import output_geobox, per_band_load_data_settings
+from datacube.api.query import Query, query_group_by
+from datacube.model import Measurement, Product
+from datacube.model.utils import SafeDumper, xr_apply, xr_iter
+from datacube.testutils.io import native_geobox
+
+from .utils import (
+    merge_dicts,
+    merge_search_terms,
+    qualified_name,
+    reject_keys,
+    select_keys,
+    select_unique,
+)
 
 
 class VirtualProductException(Exception):  # noqa: N818

--- a/datacube/virtual/transformations.py
+++ b/datacube/virtual/transformations.py
@@ -2,22 +2,27 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from collections.abc import Collection, Iterable, Mapping
 import warnings
+from collections.abc import Collection, Iterable, Mapping
 
 import numpy
-import xarray
 import pandas as pd
+import xarray
 from typing_extensions import override
 
 from datacube.utils.masking import make_mask as make_mask_prim
 from datacube.utils.masking import mask_invalid_data as mask_invalid_data_prim
-
 from datacube.utils.math import dtype_is_float
 
-from .impl import VirtualProductException, Transformation, Measurement
-from .expr import FormulaEvaluator, MaskEvaluator
-from .expr import formula_parser, evaluate_data, evaluate_nodata_mask, evaluate_type
+from .expr import (
+    FormulaEvaluator,
+    MaskEvaluator,
+    evaluate_data,
+    evaluate_nodata_mask,
+    evaluate_type,
+    formula_parser,
+)
+from .impl import Measurement, Transformation, VirtualProductException
 
 
 def selective_apply_dict(dictionary, apply_to=None, key_map=None, value_map=None):

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -35,6 +35,7 @@ Next Version
 - Dockerfile: use uv-generated constraints :pull:`1842`
 - pytest: configure in pyproject.toml :pull:`1844`
 - Remove executable permission :pull:`1846`
+- Sort imports with Ruff :pull:`1858`
 
 v1.9.3 (15th April 2025)
 ========================

--- a/docs/click_utils.py
+++ b/docs/click_utils.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from docutils.nodes import literal_block, section, title, make_id
-from sphinx.domains import Domain
-from docutils.parsers.rst import Directive
 import importlib
 
 import click
+from docutils.nodes import literal_block, make_id, section, title
+from docutils.parsers.rst import Directive
+from sphinx.domains import Domain
 
 
 class ClickHelpDirective(Directive):

--- a/examples/io_plugin/dcio_example/xarray_3d.py
+++ b/examples/io_plugin/dcio_example/xarray_3d.py
@@ -4,18 +4,19 @@
 # SPDX-License-Identifier: Apache-2.0
 """ xarray 3D driver plugin for 3D support testing
 """
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
-from collections.abc import Generator
 from urllib.parse import urlparse
 
 import numpy as np
 import xarray as xr
 from affine import Affine
+from odc.geo import CRS
+
 from datacube.storage import BandInfo
 from datacube.utils.math import num2numpy
-from odc.geo import CRS
 
 PROTOCOL = ["file", "xarray_3d"]
 FORMAT = "xarray_3d"

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -23,17 +23,21 @@ from sqlalchemy import text
 
 import datacube.scripts.cli_app
 import datacube.utils
-from datacube.drivers.postgres import _core as pgres_core
+from datacube.cfg import ODCConfig, ODCEnvironment, psql_url_from_config
+from datacube.drivers.postgis import PostGisDb
 from datacube.drivers.postgis import _core as pgis_core
+from datacube.drivers.postgres import PostgresDb
+from datacube.drivers.postgres import _core as pgres_core
 from datacube.index import index_connect
 from datacube.index.abstract import default_metadata_type_docs
-from integration_tests.utils import _make_geotiffs, _make_ls5_scene_datasets, load_yaml_file, \
-    GEOTIFF, load_test_products
-
-from datacube.cfg import ODCConfig, ODCEnvironment, psql_url_from_config
-from datacube.drivers.postgres import PostgresDb
-from datacube.drivers.postgis import PostGisDb
-from datacube.model import LineageTree, LineageDirection
+from datacube.model import LineageDirection, LineageTree
+from integration_tests.utils import (
+    GEOTIFF,
+    _make_geotiffs,
+    _make_ls5_scene_datasets,
+    load_test_products,
+    load_yaml_file,
+)
 
 _SINGLE_RUN_CONFIG_TEMPLATE = """
 

--- a/integration_tests/data_utils.py
+++ b/integration_tests/data_utils.py
@@ -17,8 +17,15 @@ from pathlib import Path
 import numpy as np
 import rasterio
 import yaml
-from hypothesis.strategies import sampled_from, datetimes, composite, floats, lists, text, uuids
-
+from hypothesis.strategies import (
+    composite,
+    datetimes,
+    floats,
+    lists,
+    sampled_from,
+    text,
+    uuids,
+)
 from odc.geo import CRS
 from odc.geo.geom import point
 

--- a/integration_tests/index/search_utils.py
+++ b/integration_tests/index/search_utils.py
@@ -7,7 +7,7 @@ import io
 from collections.abc import Iterable
 
 import datacube.scripts.search_tool
-from datacube.model import Product, Dataset
+from datacube.model import Dataset, Product
 
 
 def _load_product_query(

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -7,19 +7,25 @@ Module
 """
 
 import copy
+
 import pytest
 import yaml
 from sqlalchemy import text
 
-from datacube.drivers.postgres._fields import NumericRangeDocField as PgrNumericRangeDocField, PgField as PgrPgField
-from datacube.drivers.postgis._fields import NumericRangeDocField as PgsNumericRangeDocField, PgField as PgsPgField
+from datacube.drivers.postgis._fields import (
+    NumericRangeDocField as PgsNumericRangeDocField,
+)
+from datacube.drivers.postgis._fields import PgField as PgsPgField
+from datacube.drivers.postgres._fields import (
+    NumericRangeDocField as PgrNumericRangeDocField,
+)
+from datacube.drivers.postgres._fields import PgField as PgrPgField
 from datacube.index import Index
 from datacube.index.abstract import default_metadata_type_docs
-from datacube.model import MetadataType, Product
-from datacube.model import Range, Not, Dataset
+from datacube.model import Dataset, MetadataType, Not, Product, Range
+from datacube.testutils import sanitise_doc, suppress_deprecations
 from datacube.utils import changes
 from datacube.utils.documents import documents_equal
-from datacube.testutils import sanitise_doc, suppress_deprecations
 
 _DATASET_METADATA = {
     'id': 'f7018d80-8807-11e5-aeaa-1040f381a756',

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -14,10 +14,10 @@ from uuid import UUID
 
 import pytest
 
-from datacube.index.exceptions import MissingRecordError
 from datacube.index import Index
-from datacube.model import Dataset, Product, MetadataType
 from datacube.index.eo3 import prep_eo3
+from datacube.index.exceptions import MissingRecordError
+from datacube.model import Dataset, MetadataType, Product
 from datacube.testutils import suppress_deprecations
 
 _telemetry_uuid = UUID('4ec8fe97-e8b9-11e4-87ff-1040f381a756')

--- a/integration_tests/index/test_lineage.py
+++ b/integration_tests/index/test_lineage.py
@@ -6,7 +6,7 @@ from uuid import uuid4 as random_uuid
 
 import pytest
 
-from datacube.model import LineageDirection, LineageTree, InconsistentLineageException
+from datacube.model import InconsistentLineageException, LineageDirection, LineageTree
 from datacube.model.lineage import LineageRelations
 
 

--- a/integration_tests/index/test_location.py
+++ b/integration_tests/index/test_location.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+
 from datacube.model import Dataset
 from datacube.testutils import suppress_deprecations
 

--- a/integration_tests/index/test_memory_index.py
+++ b/integration_tests/index/test_memory_index.py
@@ -7,13 +7,11 @@ from uuid import uuid4
 
 import pytest
 
-from datacube.cfg import ODCEnvironment
-from datacube.testutils import gen_dataset_test_dag, suppress_deprecations
-
-from datacube.utils import InvalidDocException, read_documents, SimpleDocNav
-
 from datacube import Datacube
+from datacube.cfg import ODCEnvironment
 from datacube.model import Range
+from datacube.testutils import gen_dataset_test_dag, suppress_deprecations
+from datacube.utils import InvalidDocException, SimpleDocNav, read_documents
 
 
 def test_init_memory(in_memory_config: ODCEnvironment) -> None:

--- a/integration_tests/index/test_null_index.py
+++ b/integration_tests/index/test_null_index.py
@@ -2,9 +2,10 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-import pytest
 from unittest.mock import MagicMock
 from uuid import UUID
+
+import pytest
 
 from datacube import Datacube
 from datacube.cfg import ODCEnvironment

--- a/integration_tests/index/test_postgis_index.py
+++ b/integration_tests/index/test_postgis_index.py
@@ -3,11 +3,12 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import datetime
-import pytest
 
-from datacube.model import Range
-from datacube.index import Index
+import pytest
 from odc.geo import CRS
+
+from datacube.index import Index
+from datacube.model import Range
 
 
 @pytest.mark.parametrize('datacube_env_name', ('postgis',))
@@ -177,6 +178,7 @@ def spatial_index_crs_sanitise_helper() -> None:
 
 def test_spatial_index_crs_sanitise() -> None:
     import warnings
+
     from antimeridian import FixWindingWarning
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', FixWindingWarning)

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -7,26 +7,24 @@ Module
 """
 import datetime
 import warnings
-from antimeridian import FixWindingWarning
-from typing import Any
 from collections import namedtuple
+from typing import Any
 
 import pytest
 import yaml
+from antimeridian import FixWindingWarning
 from dateutil import tz
 
 import datacube.scripts.search_tool
+from datacube import Datacube
 from datacube.cfg import ODCEnvironment
 from datacube.cfg.opt import _DEFAULT_DB_USER
 from datacube.index import Index
-from datacube.model import Dataset
-from datacube.model import Product
-from datacube.model import Range
-
-from datacube import Datacube
+from datacube.model import Dataset, Product, Range
 from datacube.testutils import suppress_deprecations
-from .search_utils import _cli_csv_search, _csv_search_raw, _load_product_query
 from datacube.utils.dates import tz_as_utc
+
+from .search_utils import _cli_csv_search, _csv_search_raw, _load_product_query
 
 
 def test_search_by_metadata(index: Index, ls8_eo3_product, wo_eo3_product) -> None:

--- a/integration_tests/index/test_search_legacy.py
+++ b/integration_tests/index/test_search_legacy.py
@@ -9,8 +9,8 @@ import copy
 import datetime
 import uuid
 from decimal import Decimal
-from uuid import UUID
 from typing import Any
+from uuid import UUID
 
 import pytest
 import yaml
@@ -18,19 +18,15 @@ from dateutil import tz
 from odc.geo import CRS
 from sqlalchemy.dialects.postgresql.ranges import Range as SQLARange
 
+from datacube import Datacube
 from datacube.cfg import ODCEnvironment
 from datacube.cfg.opt import _DEFAULT_DB_USER
 from datacube.index import Index
-from datacube.model import Dataset
-from datacube.model import Product
-from datacube.model import MetadataType
-from datacube.model import Range
-
+from datacube.model import Dataset, MetadataType, Product, Range
 from datacube.testutils import load_dataset_definition, suppress_deprecations
-
-from datacube import Datacube
-from .search_utils import _load_product_query, _csv_search_raw, _cli_csv_search
 from datacube.utils.dates import tz_as_utc
+
+from .search_utils import _cli_csv_search, _csv_search_raw, _load_product_query
 
 # These tests use non-EO3 metadata, so will not work with the postgis driver.
 # Mark all with @pytest.mark.parametrize('datacube_env_name', ('datacube', ))

--- a/integration_tests/index/test_update_columns.py
+++ b/integration_tests/index/test_update_columns.py
@@ -9,9 +9,8 @@ Test creation of added/updated columns during
 import pytest
 from sqlalchemy import text
 
-from datacube.drivers.postgres.sql import SCHEMA_NAME
 from datacube.drivers.postgres import _schema
-
+from datacube.drivers.postgres.sql import SCHEMA_NAME
 
 COLUMN_PRESENCE = """
 select exists (select 1 from information_schema.columns

--- a/integration_tests/test_3d.py
+++ b/integration_tests/test_3d.py
@@ -15,13 +15,14 @@ try:
     from yaml import CSafeDumper as SafeDumper  # type: ignore
     from yaml import CSafeLoader as SafeLoader  # type: ignore
 except ImportError:
-    from yaml import SafeLoader, SafeDumper  # type: ignore
+    from yaml import SafeDumper, SafeLoader  # type: ignore
 
 import rasterio
 import xarray as xr
 from affine import Affine
-from datacube.api.core import Datacube
 from odc.geo.geobox import GeoBox
+
+from datacube.api.core import Datacube
 
 pytest.importorskip("dcio_example.xarray_3d")  # skip this test if 3d driver is not installed
 _LOG = logging.getLogger(__name__)

--- a/integration_tests/test_config_tool.py
+++ b/integration_tests/test_config_tool.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 import pytest
 
-
 EXAMPLE_DATASET_TYPE_DOCS = map(str, Path(__file__).parent.parent.
                                 joinpath('docs', 'config_samples', 'dataset_types').glob('**/*.yaml'))
 

--- a/integration_tests/test_dataset_add.py
+++ b/integration_tests/test_dataset_add.py
@@ -2,19 +2,24 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+import logging
 import math
 
 import pytest
 import toolz
 import yaml
-import logging
 
 from datacube.index import Index
 from datacube.index.hl import Doc2Dataset
 from datacube.model import MetadataType
-from datacube.testutils import gen_dataset_test_dag, load_dataset_definition, write_files, dataset_maker
-from datacube.utils import SimpleDocNav
 from datacube.scripts.dataset import _resolve_uri
+from datacube.testutils import (
+    dataset_maker,
+    gen_dataset_test_dag,
+    load_dataset_definition,
+    write_files,
+)
+from datacube.utils import SimpleDocNav
 
 logger = logging.getLogger(__name__)
 

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -8,6 +8,7 @@ import shutil
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
+
 import numpy as np
 import rasterio
 from click.testing import CliRunner

--- a/odc_search_profile.py
+++ b/odc_search_profile.py
@@ -1,11 +1,11 @@
 import sys
-
+from datetime import datetime, timezone
 from time import monotonic
+
+from odc.geo.geom import CRS, polygon
+
 from datacube import Datacube
 from datacube.model import Range
-from datetime import timezone
-from datetime import datetime
-from odc.geo.geom import CRS, polygon
 
 
 def benchmark(test, dc, label, n):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,6 @@ filterwarnings = [
 
 [tool.ruff]
 extend-exclude = ["datacube/drivers/postgis/alembic/versions"]
-src = ["datacube", "docs", "examples", "tests", "integration_tests"]
 
 [tool.ruff.lint]
 select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,6 +177,8 @@ extend-ignore-names = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
+# Generated file, exclude from linting.
+"datacube/_version.py" = ["UP"]
 # SQLAlchemy has overloaded ==, so use that (or is_) to compare with None.
 "datacube/drivers/postgis/_api.py" = ["E711"]
 "datacube/drivers/postgis/_schema.py" = ["E711"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,7 @@ select = [
     "B",  # flake8-bugbear
     "E",  # pycodestyle errors
     "EXE", # flake8-executable
+    "I",  # isort
     "N",  # pep8-naming
     "RUF", # Ruff-specific rules
     "UP", # pyupgrade

--- a/tests/api/test_core.py
+++ b/tests/api/test_core.py
@@ -2,20 +2,20 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from unittest.mock import MagicMock
-
-import xarray as xr
-import numpy as np
 import datetime
-from uuid import UUID
 from types import SimpleNamespace
-import pytest
+from unittest.mock import MagicMock
+from uuid import UUID
 
-from datacube.api.query import GroupBy
-from datacube.api.core import _calculate_chunk_sizes, output_geobox
+import numpy as np
+import pytest
+import xarray as xr
+
 from datacube import Datacube
-from datacube.testutils.geom import AlbersGS
+from datacube.api.core import _calculate_chunk_sizes, output_geobox
+from datacube.api.query import GroupBy
 from datacube.testutils import mk_sample_dataset, suppress_deprecations
+from datacube.testutils.geom import AlbersGS
 
 
 def test_grouping_datasets() -> None:
@@ -128,7 +128,8 @@ def test_output_geobox() -> None:
     from odc.geo.crs import CRS as ODCGeoCRS  # noqa: N811
     from odc.geo.geobox import GeoBox as ODCGeoGeoBox
     with suppress_deprecations():
-        from datacube.utils.geometry import GeoBox as LegacyGeoGeoBox, CRS as LegacyCRS  # noqa: N811
+        from datacube.utils.geometry import CRS as LegacyCRS  # noqa: N811
+        from datacube.utils.geometry import GeoBox as LegacyGeoGeoBox
     from odc.geo.xr import xr_zeros
 
     odc_gbox = ODCGeoGeoBox.from_bbox(

--- a/tests/api/test_masking.py
+++ b/tests/api/test_masking.py
@@ -2,17 +2,17 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-import yaml
-import pytest
-from xarray import DataArray, Dataset
 import numpy as np
+import pytest
+import yaml
+from xarray import DataArray, Dataset
 
 from datacube.utils.masking import (
-    list_flag_names,
     create_mask_value,
     describe_variable_flags,
-    mask_to_dict,
+    list_flag_names,
     mask_invalid_data,
+    mask_to_dict,
     valid_data_mask,
 )
 

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -3,16 +3,16 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import datetime
-import pandas
-import numpy as np
 from types import SimpleNamespace
 
+import numpy as np
+import pandas
 import pytest
+from odc.geo import CRS
 
-from datacube.api.query import Query, query_group_by, solar_day, GroupBy, solar_offset
+from datacube.api.query import GroupBy, Query, query_group_by, solar_day, solar_offset
 from datacube.model import Range
 from datacube.utils import parse_time
-from odc.geo import CRS
 
 
 @pytest.fixture
@@ -219,8 +219,9 @@ def test_solar_day() -> None:
 
 
 def test_solar_offset() -> None:
-    from odc.geo.geom import point
     from datetime import timedelta
+
+    from odc.geo.geom import point
 
     def _hr(t):
         return t.days*24 + t.seconds/3600

--- a/tests/api/test_virtual.py
+++ b/tests/api/test_virtual.py
@@ -2,26 +2,29 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from collections import OrderedDict
-from datetime import datetime
-from copy import deepcopy
 import warnings
-
-import pytest
+from collections import OrderedDict
+from copy import deepcopy
+from datetime import datetime
 from unittest import mock
-import numpy
-import xarray as xr
 
-from datacube.model import Product, MetadataType, Dataset
+import numpy
+import pytest
+import xarray as xr
 from odc.geo import CRS
 from odc.geo.gridspec import GridSpec
-from datacube.virtual import construct_from_yaml, catalog_from_yaml, VirtualProductException
-from datacube.virtual import DEFAULT_RESOLVER, Transformation
+
+from datacube.model import Dataset, MetadataType, Product
+from datacube.virtual import (
+    DEFAULT_RESOLVER,
+    Transformation,
+    VirtualProductException,
+    catalog_from_yaml,
+    construct_from_yaml,
+)
+from datacube.virtual.expr import FormulaEvaluator, evaluate_data, formula_parser
 from datacube.virtual.impl import Datacube
-
-from datacube.virtual.expr import formula_parser, FormulaEvaluator, evaluate_data
 from datacube.virtual.transformations import fiscal_year
-
 
 ##########################################
 # Set up some common test data and fixtures

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,13 +13,13 @@ import os
 
 import pytest
 from affine import Affine
-
-from datacube import Datacube
 from odc.geo import CRS, wh_
 from odc.geo.geobox import GeoBox
-from datacube.utils.documents import read_documents
-from datacube.model import Measurement, MetadataType, Product, Dataset
+
+from datacube import Datacube
 from datacube.index.eo3 import prep_eo3
+from datacube.model import Dataset, Measurement, MetadataType, Product
+from datacube.utils.documents import read_documents
 
 AWS_ENV_VARS = (
     "AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN"

--- a/tests/drivers/test_rio_reader.py
+++ b/tests/drivers/test_rio_reader.py
@@ -4,24 +4,29 @@
 # SPDX-License-Identifier: Apache-2.0
 """ Tests for new RIO reader driver
 """
+import warnings
+from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import datetime, timezone
-from concurrent.futures import ThreadPoolExecutor, Future
+
 import numpy as np
+import pytest
 import rasterio
 from affine import Affine
-import pytest
-import warnings
 
 from datacube.drivers.rio._reader import (
     RDEntry,
     _dc_crs,
-    _rio_uri,
     _rio_band_idx,
+    _rio_uri,
     _roi_to_window,
 )
 from datacube.testutils.geom import SAMPLE_WKT_WITHOUT_AUTHORITY, epsg3857
 from datacube.testutils.iodriver import (
-    NetCDF, GeoTIFF, mk_band, mk_rio_driver, open_reader
+    GeoTIFF,
+    NetCDF,
+    mk_band,
+    mk_rio_driver,
+    open_reader,
 )
 
 UTC = timezone.utc

--- a/tests/index/test_api_index_dataset.py
+++ b/tests/index/test_api_index_dataset.py
@@ -6,12 +6,11 @@ import datetime
 from collections import namedtuple
 from contextlib import contextmanager
 from copy import deepcopy
-
 from uuid import UUID
 
-from datacube.index.postgres._datasets import DatasetResource
 from datacube.index.exceptions import DuplicateRecordError
-from datacube.model import Product, MetadataType, Dataset
+from datacube.index.postgres._datasets import DatasetResource
+from datacube.model import Dataset, MetadataType, Product
 
 _nbar_uuid = UUID('f2f12372-8366-11e5-817e-1040f381a756')
 _ortho_uuid = UUID('5cf41d98-eda9-11e4-8a8e-1040f381a756')

--- a/tests/index/test_fields.py
+++ b/tests/index/test_fields.py
@@ -6,12 +6,18 @@
 Module
 """
 
-from datacube.drivers.postgres._fields import SimpleDocField, NumericRangeDocField, parse_fields, RangeDocField, \
-    IntDocField
-from datacube.utils.uris import split_uri
+import pytest
+
+from datacube.drivers.postgres._fields import (
+    IntDocField,
+    NumericRangeDocField,
+    RangeDocField,
+    SimpleDocField,
+    parse_fields,
+)
 from datacube.drivers.postgres._schema import DATASET
 from datacube.model import Range
-import pytest
+from datacube.utils.uris import split_uri
 
 
 def _assert_same(obj1, obj2) -> None:

--- a/tests/index/test_hl_index.py
+++ b/tests/index/test_hl_index.py
@@ -2,9 +2,9 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-import pytest
-
 from unittest.mock import MagicMock
+
+import pytest
 
 from datacube.index.hl import Doc2Dataset
 

--- a/tests/index/test_postgis_fields.py
+++ b/tests/index/test_postgis_fields.py
@@ -8,8 +8,13 @@ from decimal import Decimal
 
 import pytest
 
-from datacube.drivers.postgis._fields import NumericDocField, IntDocField, DoubleDocField, DateDocField, \
-    UnindexableValue
+from datacube.drivers.postgis._fields import (
+    DateDocField,
+    DoubleDocField,
+    IntDocField,
+    NumericDocField,
+    UnindexableValue,
+)
 from datacube.drivers.postgis._schema import Dataset
 
 

--- a/tests/index/test_query.py
+++ b/tests/index/test_query.py
@@ -8,8 +8,12 @@ Module
 
 from sqlalchemy.dialects.postgresql import Range as PgRange
 
-from datacube.drivers.postgres._fields import SimpleDocField, RangeBetweenExpression, EqualsExpression, \
-    NumericRangeDocField
+from datacube.drivers.postgres._fields import (
+    EqualsExpression,
+    NumericRangeDocField,
+    RangeBetweenExpression,
+    SimpleDocField,
+)
 from datacube.index.fields import to_expressions
 from datacube.model import Range
 

--- a/tests/storage/test_base.py
+++ b/tests/storage/test_base.py
@@ -3,9 +3,10 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import pytest
+
 from datacube.storage import BandInfo
-from datacube.testutils import mk_sample_dataset, suppress_deprecations
 from datacube.storage._base import _get_band_and_layer, measurement_paths
+from datacube.testutils import mk_sample_dataset, suppress_deprecations
 
 
 def test_band_layer() -> None:

--- a/tests/storage/test_netcdfwriter.py
+++ b/tests/storage/test_netcdfwriter.py
@@ -2,25 +2,32 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-import netCDF4
-import numpy
-import xarray as xr
-import pytest
-from hypothesis import given
-from hypothesis.strategies import text
 import string
 from uuid import uuid4
 
-from datacube.drivers.netcdf._write import _get_units
-from datacube.drivers.netcdf.writer import create_netcdf, create_coordinate, create_variable, netcdfy_data, \
-    create_grid_mapping_variable, flag_mask_meanings, Variable
-from datacube.drivers.netcdf import write_dataset_to_netcdf
-from datacube.drivers.netcdf.writer import DEFAULT_GRID_MAPPING
-from datacube.utils import DatacubeException, read_strings_from_netcdf
+import netCDF4
+import numpy
+import pytest
+import xarray as xr
+from hypothesis import given
+from hypothesis.strategies import text
 from odc.geo import CRS
 from odc.geo.geobox import Coordinate
-from datacube.testutils import mk_sample_xr_dataset
 
+from datacube.drivers.netcdf import write_dataset_to_netcdf
+from datacube.drivers.netcdf._write import _get_units
+from datacube.drivers.netcdf.writer import (
+    DEFAULT_GRID_MAPPING,
+    Variable,
+    create_coordinate,
+    create_grid_mapping_variable,
+    create_netcdf,
+    create_variable,
+    flag_mask_meanings,
+    netcdfy_data,
+)
+from datacube.testutils import mk_sample_xr_dataset
+from datacube.utils import DatacubeException, read_strings_from_netcdf
 
 crs_var = DEFAULT_GRID_MAPPING
 

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -3,26 +3,24 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 from contextlib import contextmanager
-
 from unittest import mock
+
 import numpy as np
 import pytest
 import rasterio.warp
 from affine import Affine, identity
+from odc.geo import wh_
+from odc.geo.geobox import GeoBox
 from rasterio.warp import Resampling
 
 from datacube.drivers.datasource import DataSource
-from datacube.model import Dataset, Product, MetadataType
-from datacube.testutils.io import RasterFileDataSource
-from datacube.storage import BandInfo
-from datacube.drivers.netcdf import create_netcdf_storage_unit, Variable
-from datacube.storage import reproject_and_fuse
-from datacube.storage._rio import RasterDatasetDataSource, _url2rasterio
+from datacube.drivers.netcdf import Variable, create_netcdf_storage_unit
+from datacube.model import Dataset, MetadataType, Product
+from datacube.storage import BandInfo, reproject_and_fuse
 from datacube.storage._read import read_time_slice
-from odc.geo.geobox import GeoBox
-from odc.geo import wh_
-
-from datacube.testutils.geom import epsg4326, epsg3577
+from datacube.storage._rio import RasterDatasetDataSource, _url2rasterio
+from datacube.testutils.geom import epsg3577, epsg4326
+from datacube.testutils.io import RasterFileDataSource
 
 
 def mk_gbox(shape=(2, 2), transform=identity, crs=epsg4326):
@@ -647,8 +645,9 @@ def test_netcdf_multi_part() -> None:
 
 
 def test_rasterio_nodata(tmpdir) -> None:
-    from datacube.testutils.io import dc_read, write_gtiff
     from pathlib import Path
+
+    from datacube.testutils.io import dc_read, write_gtiff
 
     roi = np.s_[10:20, 20:30]
     xx = np.zeros((64, 64), dtype='uint8')

--- a/tests/storage/test_storage_load.py
+++ b/tests/storage/test_storage_load.py
@@ -7,11 +7,8 @@
 
 import numpy as np
 
-from datacube.storage._load import (
-    xr_load, _default_fuser
-)
-
 from datacube.api.core import Datacube
+from datacube.storage._load import _default_fuser, xr_load
 from datacube.testutils import mk_sample_dataset
 from datacube.testutils.io import rio_slurp
 from datacube.testutils.iodriver import mk_rio_driver, tee_new_load_context

--- a/tests/storage/test_storage_read.py
+++ b/tests/storage/test_storage_read.py
@@ -3,32 +3,24 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import numpy as np
-
 import pytest
+from odc.geo import geobox as gbx
+from odc.geo.geobox import GeoBox
+from odc.geo.overlap import compute_reproject_roi
+from odc.geo.roi import roi_is_empty, roi_shape
 from rasterio.enums import Resampling
 
 from datacube.storage._read import (
+    pick_read_scale,
+    rdr_geobox,
     read_time_slice,
     read_time_slice_v2,
-    pick_read_scale,
-    rdr_geobox)
-
-from datacube.testutils.io import RasterFileDataSource
-from odc.geo.overlap import compute_reproject_roi
-from odc.geo.roi import roi_shape, roi_is_empty
-from odc.geo.geobox import GeoBox
-
-from odc.geo import geobox as gbx
-
-from datacube.testutils.io import (
-    rio_slurp
 )
-
 from datacube.testutils.geom import (
-    epsg3857,
     AlbersGS,
+    epsg3857,
 )
-
+from datacube.testutils.io import RasterFileDataSource, rio_slurp
 
 nearest_resampling_parametrize = pytest.mark.parametrize(
     "nearest_resampling", ['nearest', Resampling.nearest, Resampling.nearest.value]
@@ -44,9 +36,10 @@ def test_pick_read_scale() -> None:
 
 @nearest_resampling_parametrize
 def test_read_paste(nearest_resampling, tmpdir) -> None:
+    from pathlib import Path
+
     from datacube.testutils import mk_test_image
     from datacube.testutils.io import write_gtiff
-    from pathlib import Path
 
     pp = Path(str(tmpdir))
 
@@ -123,9 +116,10 @@ def test_read_paste(nearest_resampling, tmpdir) -> None:
 
 @nearest_resampling_parametrize
 def test_read_with_reproject(nearest_resampling, tmpdir) -> None:
+    from pathlib import Path
+
     from datacube.testutils import mk_test_image
     from datacube.testutils.io import write_gtiff
-    from pathlib import Path
 
     pp = Path(str(tmpdir))
 
@@ -183,10 +177,11 @@ def test_read_with_reproject(nearest_resampling, tmpdir) -> None:
 
 @nearest_resampling_parametrize
 def test_read_paste_v2(nearest_resampling, tmpdir) -> None:
+    from pathlib import Path
+
     from datacube.testutils import mk_test_image
     from datacube.testutils.io import write_gtiff
     from datacube.testutils.iodriver import open_reader
-    from pathlib import Path
 
     pp = Path(str(tmpdir))
 
@@ -269,10 +264,11 @@ def test_read_paste_v2(nearest_resampling, tmpdir) -> None:
 
 @nearest_resampling_parametrize
 def test_read_with_reproject_v2(nearest_resampling, tmpdir) -> None:
+    from pathlib import Path
+
     from datacube.testutils import mk_test_image
     from datacube.testutils.io import write_gtiff
     from datacube.testutils.iodriver import open_reader
-    from pathlib import Path
 
     pp = Path(str(tmpdir))
 

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -77,7 +77,7 @@ goo:
 
 
 def test_parse_text(simple_valid_ini, simple_valid_yaml) -> None:
-    from datacube.cfg import ConfigException, parse_text, CfgFormat
+    from datacube.cfg import CfgFormat, ConfigException, parse_text
     ini = parse_text(simple_valid_ini)
     yaml = parse_text(simple_valid_yaml)
     assert ini["foo"]["bar"] == yaml["foo"]["bar"]
@@ -180,7 +180,7 @@ def simple_dict():
 
 
 def test_invalid_env() -> None:
-    from datacube.cfg import ODCConfig, ConfigException
+    from datacube.cfg import ConfigException, ODCConfig
     with pytest.raises(ConfigException):
         ODCConfig(text="""
 default:
@@ -212,7 +212,7 @@ def test_oldstyle_cfg() -> None:
 
 
 def test_invalid_option() -> None:
-    from datacube.cfg import ODCOptionHandler, ConfigException
+    from datacube.cfg import ConfigException, ODCOptionHandler
     mockenv = MagicMock()
     with pytest.raises(ConfigException):
         ODCOptionHandler("NO_CAPS", mockenv)
@@ -248,7 +248,7 @@ def assert_simple_aliases(cfg) -> None:
 
 
 def test_aliases(simple_config) -> None:
-    from datacube.cfg import ODCConfig, ConfigException
+    from datacube.cfg import ConfigException, ODCConfig
     cfg = ODCConfig(text=simple_config)
     assert_simple_aliases(cfg)
     with pytest.raises(ConfigException) as e:
@@ -336,7 +336,7 @@ def test_ini_from_path(path_to_ini_config) -> None:
 
 
 def test_ini_from_paths(path_to_ini_config, path_to_yaml_config, path_to_different_config, monkeypatch) -> None:
-    from datacube.cfg import ODCConfig, ConfigException
+    from datacube.cfg import ConfigException, ODCConfig
     cfg = ODCConfig(paths=[
         "/non/existent/path.yml",
         path_to_yaml_config,
@@ -410,7 +410,7 @@ def test_envvar_overrides(path_to_yaml_config, monkeypatch) -> None:
 
 
 def test_intopt_validation() -> None:
-    from datacube.cfg import ODCConfig, ConfigException
+    from datacube.cfg import ConfigException, ODCConfig
     cfg = ODCConfig(text="""
 env1:
     db_hostname: localhost
@@ -442,7 +442,7 @@ env1:
 
 
 def test_invalid_idx_driver() -> None:
-    from datacube.cfg import ODCConfig, ConfigException
+    from datacube.cfg import ConfigException, ODCConfig
     cfg = ODCConfig(raw_dict={
         "default": {"alias": "foo"},
         "foo": {
@@ -458,7 +458,7 @@ def test_invalid_idx_driver() -> None:
 
 
 def test_invalid_pg_url() -> None:
-    from datacube.cfg import ODCConfig, ConfigException
+    from datacube.cfg import ConfigException, ODCConfig
     cfg = ODCConfig(raw_dict={
         "default": {"alias": "foo"},
         "foo": {
@@ -511,7 +511,7 @@ def test_pgurl_from_config(simple_dict) -> None:
 
 
 def test_multiple_sourcetypes(simple_config, path_to_ini_config, simple_dict) -> None:
-    from datacube.cfg import ODCConfig, ConfigException
+    from datacube.cfg import ConfigException, ODCConfig
     with pytest.raises(ConfigException) as e:
         ODCConfig(paths=path_to_ini_config, raw_dict=simple_dict, text=simple_config)
     assert "Can only supply one of" in str(e.value)
@@ -527,7 +527,7 @@ def test_multiple_sourcetypes(simple_config, path_to_ini_config, simple_dict) ->
 
 
 def test_get_environment(simple_config) -> None:
-    from datacube.cfg import ODCConfig, ConfigException
+    from datacube.cfg import ConfigException, ODCConfig
     cfg = ODCConfig(text=simple_config)
     with pytest.raises(ConfigException) as e:
         ODCConfig.get_environment(config=cfg, raw_config=simple_config)

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -2,18 +2,23 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from types import SimpleNamespace
+
 import pytest
 import yaml
 
-from types import SimpleNamespace
-
-from datacube.drivers import new_datasource, reader_drivers, writer_drivers
-from datacube.drivers import index_drivers, index_driver_by_name
+from datacube.drivers import (
+    index_driver_by_name,
+    index_drivers,
+    new_datasource,
+    reader_drivers,
+    writer_drivers,
+)
 from datacube.drivers.indexes import IndexDriverCache
+from datacube.model import MetadataType
 from datacube.storage import BandInfo
 from datacube.storage._rio import RasterDatasetDataSource
 from datacube.testutils import mk_sample_dataset, suppress_deprecations
-from datacube.model import MetadataType
 
 
 def test_new_datasource_fallback() -> None:
@@ -113,8 +118,9 @@ def test_reader_cache_throws_on_missing_fallback() -> None:
 
 
 def test_driver_singleton() -> None:
-    from datacube.drivers._tools import singleton_setup
     from unittest.mock import MagicMock
+
+    from datacube.drivers._tools import singleton_setup
 
     result = object()
     factory = MagicMock(return_value=result)

--- a/tests/test_dynamic_db_passwd.py
+++ b/tests/test_dynamic_db_passwd.py
@@ -3,11 +3,13 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import pytest
-from sqlalchemy.exc import OperationalError
 from sqlalchemy.engine.url import URL
+from sqlalchemy.exc import OperationalError
 
-from datacube.drivers.postgres._connections import PostgresDb, handle_dynamic_token_authentication
-
+from datacube.drivers.postgres._connections import (
+    PostgresDb,
+    handle_dynamic_token_authentication,
+)
 
 counter = [0]
 last_base = [None]

--- a/tests/test_eo3.py
+++ b/tests/test_eo3.py
@@ -2,18 +2,20 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from affine import Affine
 import pytest
-from datacube.utils.documents import parse_yaml, InvalidDocException
-from datacube.testutils import mk_sample_product
-from datacube.model import Dataset
+from affine import Affine
 
 from datacube.index.eo3 import (
     EO3Grid,
-    prep_eo3,
     add_eo3_parts,
-    is_doc_eo3, eo3_grid_spatial, is_doc_geo,
+    eo3_grid_spatial,
+    is_doc_eo3,
+    is_doc_geo,
+    prep_eo3,
 )
+from datacube.model import Dataset
+from datacube.testutils import mk_sample_product
+from datacube.utils.documents import InvalidDocException, parse_yaml
 
 SAMPLE_DOC = '''---
 $schema: https://schemas.opendatacube.org/dataset

--- a/tests/test_ext_lineage.py
+++ b/tests/test_ext_lineage.py
@@ -3,11 +3,12 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import os
-import pytest
 from uuid import uuid4 as random_uuid
 
-from datacube.model import LineageDirection, LineageTree, InconsistentLineageException
-from datacube.model.lineage import LineageRelations, LineageIDPair
+import pytest
+
+from datacube.model import InconsistentLineageException, LineageDirection, LineageTree
+from datacube.model.lineage import LineageIDPair, LineageRelations
 from datacube.utils import read_documents
 
 

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -2,19 +2,25 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from datacube import Datacube
-from datacube.api.query import query_group_by
-import numpy as np
+from pathlib import Path
 from types import SimpleNamespace
+
+import numpy as np
 import pytest
 
-from pathlib import Path
+from datacube import Datacube
+from datacube.api.query import query_group_by
 from datacube.testutils import (
+    gen_tiff_dataset,
     mk_sample_dataset,
     mk_test_image,
-    gen_tiff_dataset,
 )
-from datacube.testutils.io import write_gtiff, rio_slurp, rio_slurp_xarray, get_raster_info
+from datacube.testutils.io import (
+    get_raster_info,
+    rio_slurp,
+    rio_slurp_xarray,
+    write_gtiff,
+)
 from datacube.testutils.iodriver import NetCDF
 from datacube.utils import ignore_exceptions_if
 
@@ -249,8 +255,8 @@ def test_load_data_cbk(tmpdir) -> None:
 
 
 def test_hdf5_lock_release_on_failure() -> None:
-    from datacube.storage._rio import RasterDatasetDataSource, HDF5_LOCK
     from datacube.storage import BandInfo
+    from datacube.storage._rio import HDF5_LOCK, RasterDatasetDataSource
 
     band = dict(name='xx',
                 layer='xx',
@@ -375,7 +381,7 @@ def test_missing_file_handling() -> None:
 
 
 def test_native_load(tmpdir) -> None:
-    from datacube.testutils.io import native_load, native_geobox
+    from datacube.testutils.io import native_geobox, native_load
 
     tmpdir = Path(str(tmpdir))
     spatial = dict(resolution=(15, -15),

--- a/tests/test_metadata_fields.py
+++ b/tests/test_metadata_fields.py
@@ -2,14 +2,15 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-import yaml
 import datetime
 import decimal
 from textwrap import dedent
-import pytest
 
-from datacube.model.fields import get_dataset_fields, parse_search_field, Expression
+import pytest
+import yaml
+
 from datacube.model import Range, metadata_from_doc
+from datacube.model.fields import Expression, get_dataset_fields, parse_search_field
 
 METADATA_DOC = yaml.safe_load('''---
 name: test

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,20 +2,31 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-import pytest
-import numpy
 import pickle
 from copy import deepcopy
-from datacube.testutils import mk_sample_dataset, mk_sample_product
-from datacube.model import (Product, GridSpec, Measurement,
-                            MetadataType, Range, ranges_overlap)
+
+import numpy
+import pytest
 from odc.geo import CRS, BoundingBox
 from odc.geo.geom import polygon
-from datacube.utils.documents import InvalidDocException
-from datacube.storage import measurement_paths
-from datacube.testutils import suppress_deprecations
-from datacube.testutils.geom import AlbersGS
+
 from datacube.api.core import output_geobox
+from datacube.model import (
+    GridSpec,
+    Measurement,
+    MetadataType,
+    Product,
+    Range,
+    ranges_overlap,
+)
+from datacube.storage import measurement_paths
+from datacube.testutils import (
+    mk_sample_dataset,
+    mk_sample_product,
+    suppress_deprecations,
+)
+from datacube.testutils.geom import AlbersGS
+from datacube.utils.documents import InvalidDocException
 
 
 def test_gridspec() -> None:

--- a/tests/test_testutils.py
+++ b/tests/test_testutils.py
@@ -3,10 +3,11 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import pytest
-from datacube.testutils.threads import FakeThreadPoolExecutor
-from datacube.testutils import mk_sample_xr_dataset, mk_sample_dataset
-from datacube.testutils.io import native_geobox
 from odc.geo import xy_
+
+from datacube.testutils import mk_sample_dataset, mk_sample_xr_dataset
+from datacube.testutils.io import native_geobox
+from datacube.testutils.threads import FakeThreadPoolExecutor
 
 
 def test_fakethreadpool() -> None:
@@ -60,8 +61,8 @@ def test_mk_sample_xr() -> None:
 
 
 def test_native_geobox_ingested() -> None:
-    from datacube.testutils.io import native_geobox
     from datacube.testutils.geom import AlbersGS
+    from datacube.testutils.io import native_geobox
 
     gbox = AlbersGS.tile_geobox((15, -40))
     ds = mk_sample_dataset([dict(name='a')],

--- a/tests/test_utils_aws.py
+++ b/tests/test_utils_aws.py
@@ -2,28 +2,29 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-import pytest
-from unittest import mock
 import json
+from unittest import mock
+
 import botocore
+import pytest
 from botocore.credentials import ReadOnlyCredentials
 
 from datacube.testutils import write_files
 from datacube.utils.aws import (
     _fetch_text,
-    ec2_current_region,
+    _s3_cache_key,
     auto_find_region,
+    ec2_current_region,
     get_aws_settings,
-    mk_boto_session,
     get_creds_with_retry,
-    s3_url_parse,
-    s3_fmt_range,
+    mk_boto_session,
+    obtain_new_iam_auth_token,
     s3_client,
     s3_dump,
     s3_fetch,
+    s3_fmt_range,
     s3_head_object,
-    _s3_cache_key,
-    obtain_new_iam_auth_token,
+    s3_url_parse,
 )
 
 
@@ -164,8 +165,8 @@ def test_creds_with_retry() -> None:
 
 
 def test_s3_basics(without_aws_env) -> None:
-    from numpy import s_
     from botocore.credentials import ReadOnlyCredentials
+    from numpy import s_
 
     assert s3_url_parse('s3://bucket/key') == ('bucket', 'key')
     assert s3_url_parse('s3://bucket/key/') == ('bucket', 'key/')

--- a/tests/test_utils_changes.py
+++ b/tests/test_utils_changes.py
@@ -3,15 +3,16 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import pytest
+
 from datacube.utils.changes import (
-    contains,
-    classify_changes,
-    allow_any,
-    allow_removal,
-    allow_addition,
-    allow_extension,
-    allow_truncation,
     MISSING,
+    allow_addition,
+    allow_any,
+    allow_extension,
+    allow_removal,
+    allow_truncation,
+    classify_changes,
+    contains,
 )
 
 

--- a/tests/test_utils_cog.py
+++ b/tests/test_utils_cog.py
@@ -2,22 +2,19 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-import pytest
 import math
 from pathlib import Path
-import numpy as np
-import xarray as xr
 from types import SimpleNamespace
-from dask.delayed import Delayed
-from dask.base import is_dask_collection
 
-from datacube.testutils import (
-    mk_test_image,
-    gen_tiff_dataset,
-    suppress_deprecations
-)
-from datacube.testutils.io import native_load, rio_slurp_xarray, rio_slurp
-from datacube.utils.cog import write_cog, to_cog, _write_cog
+import numpy as np
+import pytest
+import xarray as xr
+from dask.base import is_dask_collection
+from dask.delayed import Delayed
+
+from datacube.testutils import gen_tiff_dataset, mk_test_image, suppress_deprecations
+from datacube.testutils.io import native_load, rio_slurp, rio_slurp_xarray
+from datacube.utils.cog import _write_cog, to_cog, write_cog
 
 
 def gen_test_data(prefix, dask=False, shape=None, dtype="int16", nodata=-999):

--- a/tests/test_utils_dask.py
+++ b/tests/test_utils_dask.py
@@ -2,32 +2,31 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-import pytest
-import moto
 from pathlib import Path
+
 import dask
 import dask.delayed
-
-from datacube.utils.io import slurp
-
-from datacube.utils.dask import (
-    start_local_dask,
-    get_total_available_memory,
-    compute_memory_per_worker,
-    compute_tasks,
-    pmap,
-    partition_map,
-    save_blob_to_file,
-    save_blob_to_s3,
-    _save_blob_to_file,
-    _save_blob_to_s3,
-)
+import moto
+import pytest
 
 from datacube.utils.aws import (
-    s3_url_parse,
-    s3_fetch,
     s3_client,
+    s3_fetch,
+    s3_url_parse,
 )
+from datacube.utils.dask import (
+    _save_blob_to_file,
+    _save_blob_to_s3,
+    compute_memory_per_worker,
+    compute_tasks,
+    get_total_available_memory,
+    partition_map,
+    pmap,
+    save_blob_to_file,
+    save_blob_to_s3,
+    start_local_dask,
+)
+from datacube.utils.io import slurp
 
 
 def test_compute_tasks() -> None:

--- a/tests/test_utils_dates.py
+++ b/tests/test_utils_dates.py
@@ -2,21 +2,22 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from datetime import datetime
+
 import numpy as np
 import pytest
-from datetime import datetime
+from dateutil.relativedelta import relativedelta
+from dateutil.rrule import DAILY, MONTHLY, YEARLY
+
 from datacube.utils.dates import (
+    mk_time_coord,
+    normalise_dt,
     parse_duration,
     parse_interval,
     parse_time,
-    mk_time_coord,
-    normalise_dt,
     tz_aware,
-    tzutc
+    tzutc,
 )
-
-from dateutil.rrule import YEARLY, MONTHLY, DAILY
-from dateutil.relativedelta import relativedelta
 
 
 def test_parse() -> None:

--- a/tests/test_utils_docs.py
+++ b/tests/test_utils_docs.py
@@ -8,10 +8,10 @@ Test utility functions from :module:`datacube.utils`
 
 """
 import os
-from pathlib import Path
 from collections import OrderedDict
-from types import SimpleNamespace
 from collections.abc import Iterable
+from pathlib import Path
+from types import SimpleNamespace
 from uuid import UUID, uuid4
 
 import numpy as np
@@ -19,25 +19,38 @@ import pytest
 import toolz
 
 from datacube.model import MetadataType
-from datacube.model.utils import traverse_datasets, flatten_datasets, dedup_lineage, remap_lineage_doc
-from datacube.testutils import mk_sample_product, make_graph_abcde, gen_dataset_test_dag, dataset_maker
-from datacube.utils import (read_documents, InvalidDocException,
-                            SimpleDocNav)
-from datacube.utils.changes import check_doc_unchanged, get_doc_changes, MISSING, DocumentMismatchError
+from datacube.model.utils import (
+    dedup_lineage,
+    flatten_datasets,
+    remap_lineage_doc,
+    traverse_datasets,
+)
+from datacube.testutils import (
+    dataset_maker,
+    gen_dataset_test_dag,
+    make_graph_abcde,
+    mk_sample_product,
+)
+from datacube.utils import InvalidDocException, SimpleDocNav, read_documents
+from datacube.utils.changes import (
+    MISSING,
+    DocumentMismatchError,
+    check_doc_unchanged,
+    get_doc_changes,
+)
 from datacube.utils.documents import (
-    parse_yaml,
-    without_lineage_sources,
-    _open_from_s3,
-    netcdf_extract_string,
     DocReader,
-    is_supported_document_type,
+    _open_from_s3,
     get_doc_offset,
-    transform_object_tree,
+    is_supported_document_type,
     metadata_subset,
+    netcdf_extract_string,
+    parse_yaml,
+    transform_object_tree,
+    without_lineage_sources,
 )
 from datacube.utils.serialise import jsonify_document
 from datacube.utils.uris import as_url
-
 
 doc_changes = [
     (1, 1, []),
@@ -521,8 +534,8 @@ def sample_document_files(data_folder):
 
 def test_jsonify() -> None:
     from datetime import datetime
-    from uuid import UUID
     from decimal import Decimal
+    from uuid import UUID
 
     assert sorted(jsonify_document({'a': (1.0, 2.0, 3.0),
                                     'b': float("inf"),

--- a/tests/test_utils_generic.py
+++ b/tests/test_utils_generic.py
@@ -3,10 +3,11 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 from queue import Queue
+
 from datacube.utils.generic import (
-    qmap,
     it2q,
     map_with_lookahead,
+    qmap,
     thread_local_cache,
 )
 

--- a/tests/test_utils_other.py
+++ b/tests/test_utils_other.py
@@ -20,22 +20,31 @@ from hypothesis import given
 from hypothesis.strategies import integers, text
 from pandas import to_datetime
 
-from datacube.utils import gen_password, write_user_secret_file, slurp
 from datacube.model.utils import xr_apply
+from datacube.testutils import mk_sample_product, suppress_deprecations
+from datacube.utils import gen_password, slurp, write_user_secret_file
 from datacube.utils.dates import date_sequence
+from datacube.utils.io import check_write_path
 from datacube.utils.math import (
-    num2numpy,
-    valid_mask,
     invalid_mask,
+    num2numpy,
     unsqueeze_data_array,
     unsqueeze_dataset,
+    valid_mask,
 )
 from datacube.utils.py import sorted_items
-from datacube.utils.uris import (uri_to_local_path, mk_part_uri, get_part_from_uri, as_url, is_url,
-                                 pick_uri, uri_resolve, is_vsipath,
-                                 normalise_path, default_base_dir)
-from datacube.utils.io import check_write_path
-from datacube.testutils import mk_sample_product, suppress_deprecations
+from datacube.utils.uris import (
+    as_url,
+    default_base_dir,
+    get_part_from_uri,
+    is_url,
+    is_vsipath,
+    mk_part_uri,
+    normalise_path,
+    pick_uri,
+    uri_resolve,
+    uri_to_local_path,
+)
 
 
 def test_stats_dates() -> None:
@@ -182,7 +191,7 @@ def test_testutils_mk_sample() -> None:
 
 
 def test_testutils_write_files() -> None:
-    from datacube.testutils import write_files, assert_file_structure
+    from datacube.testutils import assert_file_structure, write_files
 
     files = {'a.txt': 'string',
              'aa.txt': ('line1\n', 'line2\n')}
@@ -287,8 +296,9 @@ def test_default_base_dir(monkeypatch) -> None:
 
 
 def test_time_info() -> None:
-    from datacube.model.utils import time_info
     from datetime import datetime
+
+    from datacube.model.utils import time_info
 
     date = '2019-03-03T00:00:00'
     ee = time_info(datetime(2019, 3, 3))
@@ -340,7 +350,7 @@ def test_testutils_testimage() -> None:
 
 def test_testutils_gtif(tmpdir) -> None:
     from datacube.testutils import mk_test_image
-    from datacube.testutils.io import write_gtiff, rio_slurp
+    from datacube.testutils.io import rio_slurp, write_gtiff
 
     w, h, dtype, nodata, ndw = 96, 64, 'int16', -999, 7
 
@@ -412,9 +422,10 @@ def test_testutils_gtif(tmpdir) -> None:
 
 
 def test_testutils_geobox() -> None:
-    from datacube.testutils.io import dc_crs_from_rio, rio_geobox
-    from rasterio.crs import CRS
     from affine import Affine
+    from rasterio.crs import CRS
+
+    from datacube.testutils.io import dc_crs_from_rio, rio_geobox
 
     assert rio_geobox({}) is None
 

--- a/tests/test_utils_rio.py
+++ b/tests/test_utils_rio.py
@@ -2,18 +2,19 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-import pytest
-from unittest import mock
 import os
+from unittest import mock
+
+import pytest
 
 from datacube.testutils import write_files
 from datacube.utils.rio import (
+    activate_from_config,
     activate_rio_env,
+    configure_s3_access,
     deactivate_rio_env,
     get_rio_env,
     set_default_rio_config,
-    activate_from_config,
-    configure_s3_access,
 )
 
 

--- a/tests/test_xarray_extension.py
+++ b/tests/test_xarray_extension.py
@@ -2,13 +2,14 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+import numpy as np
 import numpy.testing as npt
+import pandas as pd
 import pytest
 import xarray as xr
-import pandas as pd
-import numpy as np
-from datacube.testutils.geom import epsg4326, epsg3857
+
 from datacube.testutils import mk_sample_xr_dataset, remove_crs
+from datacube.testutils.geom import epsg3857, epsg4326
 from datacube.utils.xarray_geoextensions import _xarray_affine
 
 multi_coords = xr.DataArray(

--- a/tests/ui/test_common.py
+++ b/tests/ui/test_common.py
@@ -9,8 +9,12 @@ from pathlib import Path
 
 import pytest
 
-from datacube.testutils import write_files, assert_file_structure
-from datacube.ui.common import get_metadata_path, _find_any_metadata_suffix, ui_path_doc_stream
+from datacube.testutils import assert_file_structure, write_files
+from datacube.ui.common import (
+    _find_any_metadata_suffix,
+    get_metadata_path,
+    ui_path_doc_stream,
+)
 
 
 def test_get_metadata_path() -> None:

--- a/tests/ui/test_expression_parsing.py
+++ b/tests/ui/test_expression_parsing.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
+
 from dateutil.tz import tzutc
 
 from datacube.model import Range

--- a/tests/ui/test_task_app.py
+++ b/tests/ui/test_task_app.py
@@ -82,7 +82,8 @@ def test_task_app_with_no_tasks(tmpdir) -> None:
 
 def test_task_app_year_splitting() -> None:
     import pandas as pd
-    from datacube.ui.task_app import validate_year, break_query_into_years
+
+    from datacube.ui.task_app import break_query_into_years, validate_year
     one_millisecond = pd.Timedelta('1 ms')
 
     def is_close(ts1, ts2, max_delta=one_millisecond):
@@ -140,7 +141,11 @@ def test_task_app_year_splitting() -> None:
 
 
 def test_task_app_cell_index(tmpdir) -> None:
-    from datacube.ui.task_app import validate_cell_index, validate_cell_list, cell_list_to_file
+    from datacube.ui.task_app import (
+        cell_list_to_file,
+        validate_cell_index,
+        validate_cell_list,
+    )
 
     assert validate_cell_index(None, None, None) is None
     assert validate_cell_index(None, None, '17,-12') == (17, -12)


### PR DESCRIPTION
### Reason for this pull request

This is basically a drop-in
replacement for isort, except
that it's much faster.

This will reduce merge conflicts
since the fields within imports
are always kept in the same
order.

Also fix the configuration error I
introduced since this is a flat
repository, and ignore the upgrade
rules for  `_version.py` that keeps
being regenerated in my working
tree.

The only manual changes in this PR
is to `pyproject.toml`, the rest is done
by Ruff sorting imports from `--fix`.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1858.org.readthedocs.build/en/1858/

<!-- readthedocs-preview opendatacube end -->