### PR TITLE
Replace custom cached_property with stdlib

### DIFF
--- a/datacube/drivers/postgis/_fields.py
+++ b/datacube/drivers/postgis/_fields.py
@@ -86,8 +86,8 @@ class PgField(Field):
                 self.search_index_table,
                 and_(
                     Dataset.id == self.search_index_table.dataset_ref,  # type: ignore[attr-defined]
-                    self.search_index_table.search_key == self.name  # type: ignore[attr-defined]
-                )
+                    self.search_index_table.search_key == self.name,  # type: ignore[attr-defined]
+                ),
             )
         else:
             return (self.search_index_table,)

--- a/datacube/drivers/postgis/_fields.py
+++ b/datacube/drivers/postgis/_fields.py
@@ -85,9 +85,9 @@ class PgField(Field):
             return (
                 self.search_index_table,
                 and_(
-                    Dataset.id == self.search_index_table.dataset_ref,
-                    self.search_index_table.search_key == self.name,
-                ),
+                    Dataset.id == self.search_index_table.dataset_ref,  # type: ignore[attr-defined]
+                    self.search_index_table.search_key == self.name  # type: ignore[attr-defined]
+                )
             )
         else:
             return (self.search_index_table,)
@@ -103,7 +103,7 @@ class PgField(Field):
     @property
     def search_alchemy_expression(self) -> ColumnExpressionArgument:
         if self.indexed:
-            return self.search_index_table.search_val
+            return self.search_index_table.search_val  # type: ignore[attr-defined]
         else:
             return self.alchemy_expression
 

--- a/datacube/drivers/postgis/_fields.py
+++ b/datacube/drivers/postgis/_fields.py
@@ -11,6 +11,7 @@ from collections import namedtuple
 from collections.abc import Callable
 from datetime import date, datetime, timezone
 from decimal import Decimal
+from functools import cached_property
 from typing import Any, TypeAlias
 
 from sqlalchemy import and_, cast, func
@@ -26,7 +27,7 @@ from datacube import utils
 from datacube.drivers.postgis._schema import Dataset, search_field_index_map
 from datacube.model import Range
 from datacube.model.fields import Expression, Field
-from datacube.utils import cached_property, get_doc_offset
+from datacube.utils import get_doc_offset
 from datacube.utils.dates import tz_as_utc
 
 DatasetJoinArgs = tuple[FromClause] | tuple[FromClause, ColumnExpressionArgument]

--- a/datacube/index/abstract/_index.py
+++ b/datacube/index/abstract/_index.py
@@ -5,6 +5,7 @@
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping, Sequence
+from functools import cached_property
 from urllib.parse import ParseResult, urlparse
 
 from deprecat import deprecat
@@ -13,7 +14,7 @@ from odc.geo import CRS
 from datacube.cfg import ODCEnvironment, ODCOptionHandler
 from datacube.migration import ODC2DeprecationWarning
 from datacube.model import Field, MetadataType
-from datacube.utils import cached_property, report_to_user
+from datacube.utils import report_to_user
 from datacube.utils.generic import thread_local_cache
 
 from ._datasets import AbstractDatasetResource

--- a/datacube/index/abstract/_types.py
+++ b/datacube/index/abstract/_types.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 from collections.abc import Iterable, Sequence
+from functools import cached_property
 from typing import NamedTuple
 from uuid import UUID
 
@@ -10,7 +11,6 @@ from deprecat import deprecat
 
 from datacube.migration import ODC2DeprecationWarning
 from datacube.model import Dataset, Product
-from datacube.utils import cached_property
 from datacube.utils.documents import JsonDict
 
 

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -13,6 +13,7 @@ import math
 from collections import OrderedDict
 from collections.abc import Generator, Iterable, Iterator, Mapping, Sequence
 from datetime import datetime
+from functools import cached_property
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -23,7 +24,6 @@ from typing_extensions import override
 
 from datacube.utils import (
     DocReader,
-    cached_property,
     parse_time,
     schema_validated,
     uri_to_local_path,

--- a/datacube/utils/__init__.py
+++ b/datacube/utils/__init__.py
@@ -30,7 +30,7 @@ from .math import (
     unsqueeze_data_array,
     unsqueeze_dataset,
 )
-from .py import cached_property, ignore_exceptions_if, import_function
+from .py import ignore_exceptions_if, import_function
 from .serialise import jsonify_document
 from .uris import get_part_from_uri, is_url, is_vsipath, mk_part_uri, uri_to_local_path
 
@@ -41,7 +41,6 @@ __all__ = [
     "NoDatesSafeLoader",
     "SimpleDocNav",
     "_readable_offset",
-    "cached_property",
     "check_write_path",
     "gen_password",
     "get_doc_offset",


### PR DESCRIPTION
Since Python 3.8 there's functools.cached_property, which works the same way, but also passes type information through.



 - [x] Tests passed
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1866.org.readthedocs.build/en/1866/

<!-- readthedocs-preview opendatacube end -->