### PR TITLE
Speed up S3 Client tests with mocks

### DIFF
--- a/datacube/utils/aws/__init__.py
+++ b/datacube/utils/aws/__init__.py
@@ -228,7 +228,7 @@ def _mk_s3_client(profile: str | None = None,
                                   creds=creds,
                                   region_name=region_name)
 
-    extras = {}  # type: dict[str, Any]
+    extras: dict[str, str|None] = {}
     if creds is not None:
         extras.update(aws_access_key_id=creds.access_key,
                       aws_secret_access_key=creds.secret_key,

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -38,6 +38,7 @@ Next Version
 - Sort imports with Ruff :pull:`1858`
 - Fix documentation parameter names :pull:`1857`
 - Add pandas types for development :pull:`1867`
+- Speed up AWS Utils tests :pull:`1878`
 
 v1.9.3 (15th April 2025)
 ========================

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,12 +21,18 @@ from datacube.index.eo3 import prep_eo3
 from datacube.model import Dataset, Measurement, MetadataType, Product
 from datacube.utils.documents import read_documents
 
-AWS_ENV_VARS = (
-    "AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN"
-    "AWS_DEFAULT_REGION AWS_DEFAULT_OUTPUT AWS_PROFILE "
-    "AWS_ROLE_SESSION_NAME AWS_CA_BUNDLE "
-    "AWS_SHARED_CREDENTIALS_FILE AWS_CONFIG_FILE"
-).split(" ")
+AWS_ENV_VARS = [
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AWS_DEFAULT_REGION",
+    "AWS_DEFAULT_OUTPUT",
+    "AWS_PROFILE",
+    "AWS_ROLE_SESSION_NAME",
+    "AWS_CA_BUNDLE",
+    "AWS_SHARED_CREDENTIALS_FILE",
+    "AWS_CONFIG_FILE",
+]
 
 
 @pytest.fixture

--- a/tests/test_utils_aws.py
+++ b/tests/test_utils_aws.py
@@ -6,6 +6,7 @@ import json
 from unittest import mock
 
 import botocore
+import moto
 import pytest
 from botocore.credentials import ReadOnlyCredentials
 
@@ -164,9 +165,7 @@ def test_creds_with_retry() -> None:
     assert session.get_credentials.call_count == 2
 
 
-def test_s3_basics(without_aws_env) -> None:
-    from botocore.credentials import ReadOnlyCredentials
-    from numpy import s_
+def test_s3_url_parsing() -> None:
 
     assert s3_url_parse('s3://bucket/key') == ('bucket', 'key')
     assert s3_url_parse('s3://bucket/key/') == ('bucket', 'key/')
@@ -174,6 +173,10 @@ def test_s3_basics(without_aws_env) -> None:
 
     with pytest.raises(ValueError):
         s3_url_parse("file://some/path")
+
+
+def test_s3_fmt_range() -> None:
+    from numpy import s_
 
     assert s3_fmt_range((0, 3)) == "bytes=0-2"
     assert s3_fmt_range(s_[4:10]) == "bytes=4-9"
@@ -184,17 +187,23 @@ def test_s3_basics(without_aws_env) -> None:
         with pytest.raises(ValueError):
             s3_fmt_range(bad)
 
+
+def test_s3_client(without_aws_env) -> None:
+    from botocore.credentials import ReadOnlyCredentials
+
     creds = ReadOnlyCredentials('fake-key', 'fake-secret', None)
 
-    assert str(s3_client(region_name='kk')._endpoint) == 's3(https://s3.kk.amazonaws.com)'
-    assert str(s3_client(region_name='kk', use_ssl=False)._endpoint) == 's3(http://s3.kk.amazonaws.com)'
+    # Mock AWS to make the test run faster.
+    # From ~5 seconds to ~ 0.3s
+    with moto.mock_aws():
+        assert str(s3_client(region_name='kk')._endpoint) == 's3(https://s3.kk.amazonaws.com)'
+        assert str(s3_client(region_name='kk', use_ssl=False)._endpoint) == 's3(http://s3.kk.amazonaws.com)'
 
-    s3 = s3_client(region_name='us-west-2', creds=creds)
-    assert s3 is not None
+        s3 = s3_client(region_name='us-west-2', creds=creds)
+        assert s3 is not None
 
 
 def test_s3_io(monkeypatch, without_aws_env) -> None:
-    import moto
     from numpy import s_
 
     url = "s3://bucket/file.txt"
@@ -226,12 +235,13 @@ def test_s3_io(monkeypatch, without_aws_env) -> None:
 
 
 def test_s3_unsigned(monkeypatch, without_aws_env) -> None:
-    s3 = s3_client(aws_unsigned=True)
-    assert s3._request_signer.signature_version == botocore.UNSIGNED
+    with moto.mock_aws():
+        s3 = s3_client(aws_unsigned=True)
+        assert s3._request_signer.signature_version == botocore.UNSIGNED
 
-    monkeypatch.setenv("AWS_UNSIGNED", "yes")
-    s3 = s3_client()
-    assert s3._request_signer.signature_version == botocore.UNSIGNED
+        monkeypatch.setenv("AWS_UNSIGNED", "yes")
+        s3 = s3_client()
+        assert s3._request_signer.signature_version == botocore.UNSIGNED
 
 
 @mock.patch('datacube.utils.aws.ec2_current_region', return_value="us-west-2")
@@ -239,11 +249,14 @@ def test_s3_client_cache(monkeypatch, without_aws_env) -> None:
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "fake-key-id")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "fake-secret")
 
-    s3 = s3_client(cache=True)
-    assert s3 is s3_client(cache=True)
-    assert s3 is s3_client(cache='purge')
-    assert s3_client(cache='purge') is None
-    assert s3 is not s3_client(cache=True)
+    # Mock AWS to make the test run faster.
+    # From ~5 seconds to ~ 0.3s
+    with moto.mock_aws():
+        s3 = s3_client(cache=True)
+        assert s3 is s3_client(cache=True)
+        assert s3 is s3_client(cache='purge')
+        assert s3_client(cache='purge') is None
+        assert s3 is not s3_client(cache=True)
 
     opts = (dict(),
             dict(region_name="foo"),

--- a/tests/test_utils_rio.py
+++ b/tests/test_utils_rio.py
@@ -5,6 +5,7 @@
 import os
 from unittest import mock
 
+import moto
 import pytest
 
 from datacube.testutils import write_files
@@ -116,12 +117,13 @@ def test_rio_env_aws_auto_region(monkeypatch, without_aws_env) -> None:
 def test_rio_env_aws_auto_region_dummy() -> None:
     """Just call it we don't know if it will succeed"""
 
-    # at least it should not raise error since we haven't asked for region_name='auto'
-    ee = activate_rio_env(aws={})
-    assert isinstance(ee, dict)
+    with moto.mock_aws():
+        # at least it should not raise error since we haven't asked for region_name='auto'
+        ee = activate_rio_env(aws={})
+        assert isinstance(ee, dict)
 
-    deactivate_rio_env()
-    assert get_rio_env() == {}
+        deactivate_rio_env()
+        assert get_rio_env() == {}
 
 
 def test_rio_env_via_config() -> None:


### PR DESCRIPTION
The tests creating an `s3_client` were taking ~10 seconds to run 3 tests. They were waiting on a socket connection to a fake region to fail.

This change:
- makes the AWS utils tests more granular
- adds `moto.mock_aws` around the slow client creation.

On my machine it brings the runtime of `test_utils_aws.py` down from 9.6s to 1.3s.

And the runtime for the entire `tests/` directory down from 18.5s to 8.4s.

### Before
![image](https://github.com/user-attachments/assets/0e6db5ad-4f5d-4825-8b7a-c0f01db740a8)


### After
![image](https://github.com/user-attachments/assets/189790bb-04e6-4df1-8dd8-e78bc4cef95e)



<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1878.org.readthedocs.build/en/1878/

<!-- readthedocs-preview opendatacube end -->