### PR TITLE
Fix more docstrings

### DIFF
--- a/datacube/index/abstract/_products.py
+++ b/datacube/index/abstract/_products.py
@@ -104,7 +104,7 @@ class AbstractProductResource(ABC):
 
         API Note: This API method is not finalised and may be subject to change.
 
-        :param batch_types: An iterable of one batch's worth of Product objects to add
+        :param batch_products: An iterable of one batch's worth of Product objects to add
         :return: BatchStatus named tuple.
         """
         b_skipped = 0

--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -418,7 +418,7 @@ class Doc2Dataset:
                  source_tree: LineageTree | None = None) -> DatasetOrError:
         """Attempt to construct dataset from metadata document and a uri.
 
-        :param doc: Dictionary or SimpleDocNav object
+        :param doc_in: Dictionary or SimpleDocNav object
         :param uri: String "location" property of the Dataset
 
         :return: (dataset, None) is successful,

--- a/datacube/index/postgis/_lineage.py
+++ b/datacube/index/postgis/_lineage.py
@@ -25,7 +25,6 @@ class LineageResource(AbstractLineageResource, IndexResourceAddIn):
     def __init__(self, db: PostGisDb, index: AbstractIndex) -> None:
         """
         :type db: datacube.drivers.postgis._connections.PostgresDb
-        :type metadata_type_resource: datacube.index._metadata_types.MetadataTypeResource
         """
         self._db = db
         super().__init__(index)

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -51,7 +51,6 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
     def __init__(self, db, index) -> None:
         """
         :type db: datacube.drivers.postgres._connections.PostgresDb
-        :type dataset_type_resource: datacube.index._products.ProductResource
         """
         self._db = db
         super().__init__(index)

--- a/datacube/storage/_rio.py
+++ b/datacube/storage/_rio.py
@@ -164,8 +164,7 @@ class RasterDatasetDataSource(RasterioDataSource):
         """
         Initialise for reading from a Data Cube Dataset.
 
-        :param dataset: dataset to read from
-        :param measurement_id: measurement to read. a single 'band' or 'slice'
+        :param band: band to read.
         """
         self._band_info = band
         self._hdf = _is_hdf(band.format)

--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -469,7 +469,7 @@ def _set_doc_offset(offset: list[str | int], document: dict, value) -> None:
 class DocReader:
     def __init__(self, type_definition, search_fields, doc) -> None:
         """
-        :type system_offsets: dict[str,list[str]]
+        :type type_definition: dict[str,list[str]]
         :type doc: dict
         """
         self.__dict__['_doc'] = doc

--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -167,7 +167,7 @@ class CRS:
     """
     Wrapper around `pyproj.CRS` for backwards compatibility.
 
-    :param crs_str: string representation of a CRS, often an EPSG code like 'EPSG:4326'
+    :param crs_spec: string representation of a CRS, often an EPSG code like 'EPSG:4326'
     :raises: `pyproj.exceptions.CRSError`
     """
     DEFAULT_WKT_VERSION = (WktVersion.WKT1_GDAL if Version(rasterio.__gdal_version__) < Version("3.0.0")

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -36,7 +36,7 @@ Next Version
 - pytest: configure in pyproject.toml :pull:`1844`
 - Remove executable permission :pull:`1846`
 - Sort imports with Ruff :pull:`1858`
-- Fix documentation parameter names :pull:`1857`
+- Fix documentation parameter names :pull:`1857`, :pull:`1880`
 - Add pandas types for development :pull:`1867`
 - Speed up AWS Utils tests :pull:`1878`
 

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -65,7 +65,6 @@ _DATASET_METADATA = {
 @pytest.mark.parametrize('datacube_env_name', ('datacube', ))
 def test_metadata_indexes_views_exist(index, default_metadata_type) -> None:
     """
-    :type initialised_postgres_db: datacube.drivers.postgres._connections.PostgresDb
     :type default_metadata_type: datacube.model.MetadataType
     """
     # Metadata indexes should no longer exist.
@@ -78,7 +77,6 @@ def test_metadata_indexes_views_exist(index, default_metadata_type) -> None:
 @pytest.mark.parametrize('datacube_env_name', ('datacube', ))
 def test_dataset_indexes_views_exist(index, ls5_telem_type) -> None:
     """
-    :type initialised_postgres_db: datacube.drivers.postgres._connections.PostgresDb
     :type ls5_telem_type: datacube.model.DatasetType
     """
     assert ls5_telem_type.name == 'ls5_telem_test'
@@ -175,7 +173,6 @@ def _object_exists(index, index_name) -> bool:
 
 def test_idempotent_add_dataset_type(index, ls8_eo3_product, extended_eo3_product_doc) -> None:
     """
-    :type ls5_telem_type: datacube.model.DatasetType
     :type index: datacube.index.Index
     """
     assert index.products.get_by_name(ls8_eo3_product.name) is not None
@@ -460,7 +457,7 @@ def _to_yaml(ls5_telem_doc):
 
 def test_update_metadata_type(index, default_metadata_type) -> None:
     """
-    :type default_metadata_type_docs: list[dict]
+    :type default_metadata_type: list[dict]
     :type index: datacube.index.Index
     """
     mt_doc = next(d for d in default_metadata_type_docs() if d['name'] == default_metadata_type.name)
@@ -502,7 +499,6 @@ def test_update_metadata_type(index, default_metadata_type) -> None:
 
 def test_filter_types_by_fields(index, wo_eo3_product) -> None:
     """
-    :type ls5_telem_type: datacube.model.DatasetType
     :type index: datacube.index.Index
     """
     res = list(index.metadata_types.get_with_fields(['platform', 'instrument', 'region_code']))
@@ -520,7 +516,6 @@ def test_filter_types_by_fields(index, wo_eo3_product) -> None:
 
 def test_filter_products_by_types(index, wo_eo3_product) -> None:
     """
-    :type ls5_telem_type: datacube.model.DatasetType
     :type index: datacube.index.Index
     """
     res = list(index.products.get_with_types([wo_eo3_product.metadata_type]))
@@ -529,7 +524,6 @@ def test_filter_products_by_types(index, wo_eo3_product) -> None:
 
 def test_filter_types_by_search(index, wo_eo3_product, ls8_eo3_product) -> None:
     """
-    :type ls5_telem_type: datacube.model.DatasetType
     :type index: datacube.index.Index
     """
     assert index.products

--- a/integration_tests/test_config_tool.py
+++ b/integration_tests/test_config_tool.py
@@ -243,8 +243,6 @@ def test_user_creation(clirunner, example_user) -> None:
     Add a user, grant them, delete them.
 
     This test requires role creation privileges on the PostgreSQL instance used for testing...
-
-    :type db: datacube.drivers.postgres._connections.PostgresDb
     """
     username, user_description = example_user
 


### PR DESCRIPTION
### Reason for this pull request

Found some more faulty doc strings under a different "fault code" in PyCharm, so fix those as well. Conceptually this belongs to #1857.

Fix the parameter names for the
things in datacube/, remove
the lines that do not correspond
to the code at all in the tests.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1880.org.readthedocs.build/en/1880/

<!-- readthedocs-preview opendatacube end -->