### PR TITLE
Dependabot: disable weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,18 +26,18 @@ updates:
           - "boto3-stubs"
           - "botocore"
           - "botocore-stubs"
-  - package-ecosystem: "uv"
-    # Have two jobs with same eco-system/directory by setting target-branch
-    # for one of them:
-    # https://github.com/dependabot/dependabot-core/issues/1778#issuecomment-1988140219
-    target-branch: "develop"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    groups:
-      uv-weekly-deps:
-        patterns:
-          - "boto3"
-          - "boto3-stubs"
-          - "botocore"
-          - "botocore-stubs"
+#  - package-ecosystem: "uv"
+#    # Have two jobs with same eco-system/directory by setting target-branch
+#    # for one of them:
+#    # https://github.com/dependabot/dependabot-core/issues/1778#issuecomment-1988140219
+#    target-branch: "develop"
+#    directory: "/"
+#    schedule:
+#      interval: "weekly"
+#    groups:
+#      uv-weekly-deps:
+#        patterns:
+#          - "boto3"
+#          - "boto3-stubs"
+#          - "botocore"
+#          - "botocore-stubs"

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -32,7 +32,7 @@ Massive cleaning effort across the codebase, spearheaded by @pjonsson, with a fo
  - Improvements in type annotation
  - Linting fixes
  - Code formatting and import ordering
- - Continuous integration improvements 
+ - Continuous integration improvements
 
 .. _odc-geo: https://odc-geo.readthedocs.io/
 .. _ODC Statistician: https://github.com/opendatacube/odc-stats
@@ -71,8 +71,8 @@ Other Changes
 - Fix documentation parameter names :pull:`1857`, :pull:`1880`
 - Add pandas types for development :pull:`1867`
 - Speed up AWS Utils tests :pull:`1878`
+- Dependabot: disable weekly updates :pull:`1886`
 - pyproject: set a fallback version :pull:`1887`
-
 
 v1.9.3 (15th April 2025)
 ========================


### PR DESCRIPTION
### Reason for this pull request

Dependabot isn't doing what we want
and I'm busy today so disable
the weekly job for now.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1886.org.readthedocs.build/en/1886/

<!-- readthedocs-preview opendatacube end -->