### PR TITLE
pyproject: set a fallback version

### DIFF
--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -71,6 +71,7 @@ Other Changes
 - Fix documentation parameter names :pull:`1857`, :pull:`1880`
 - Add pandas types for development :pull:`1867`
 - Speed up AWS Utils tests :pull:`1878`
+- pyproject: set a fallback version :pull:`1887`
 
 
 v1.9.3 (15th April 2025)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,7 @@ include = ['datacube*']
 
 [tool.setuptools_scm]
 write_to = 'datacube/_version.py'
+fallback_version = "1.9.3+"
 
 [tool.mypy]
 python_version = '3.10'


### PR DESCRIPTION
### Reason for this pull request

Set a fallback version for setuptools-scm
so Dependabot jobs can complete despite
not checking out all the tags.

Suggestion of version from @SpacemanPaul,
this sets a version that is greater than
the current release and smaller than
the next release.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1887.org.readthedocs.build/en/1887/

<!-- readthedocs-preview opendatacube end -->