### PR TITLE
CI: run tests with docker compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,14 +2,21 @@
 .circleci
 .github
 .travis
+.pre-commit-config.yaml
+.readthedocs.yaml
+.mergify.yml
 integration_tests
+tests
+!tests/drivers/fail_drivers
+
+docker-compose.yml
 
 # Byte-compiled / optimized / DLL files
-__pycache__/
-*.py[cod]
+**/__pycache__
+**/*.py[cod]
 
 # C extensions
-*.so
+**/*.so
 
 # Distribution / packaging
 .Python
@@ -25,9 +32,11 @@ lib64/
 parts/
 sdist/
 var/
-*.egg-info/
+.venv
+**/*.egg-info/
 .installed.cfg
-*.egg
+**/*.egg
+conda-environment.yml
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -39,18 +48,23 @@ var/
 pip-log.txt
 pip-delete-this-directory.txt
 
-# Unit test / coverage reports
+# Test / coverage reports
 htmlcov/
 .tox/
 .coverage
+.coveragerc
 .coverage.*
 .cache
 nosetests.xml
 coverage.xml
-*,cover
+*.cover
 .hypothesis
 .pytest_cache
 .mypy_cache
+pylintrc
+.ruff_cache
+spellcheck.yaml
+wordlist.txt
 
 # Translations
 *.mo
@@ -80,3 +94,9 @@ docs/notebooks/
 #Local Visual Studio Code configurations
 .vscode/
 .env
+
+CONTRIBUTING.md
+code-of-conduct.md
+.editorconfig
+LICENSE
+README.rst

--- a/.dockerignore
+++ b/.dockerignore
@@ -9,7 +9,9 @@ integration_tests
 tests
 !tests/drivers/fail_drivers
 
+# Files that are only used by docker compose.
 docker-compose.yml
+docker/assets/create-pg-databases.sh
 
 # Byte-compiled / optimized / DLL files
 **/__pycache__

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,8 +50,9 @@ jobs:
 
     - name: Verify and Run Tests
       run: |
-        docker run --rm -i -v $(pwd):/code ${{ env.DOCKER_IMAGE }} bash --login -c \
-          "pytest -r a \
+        docker compose up --quiet-pull --wait -d
+        docker compose exec --user odc -T core /bin/bash --login -c \
+          "source /env/bin/activate && pytest -r a \
             --cov datacube \
             --cov-report=xml \
             --doctest-ignore-import-errors \
@@ -59,6 +60,7 @@ jobs:
             datacube \
             tests \
             integration_tests"
+        docker compose down
 
     - name: Install uv
       uses: astral-sh/setup-uv@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,22 +50,15 @@ jobs:
 
     - name: Verify and Run Tests
       run: |
-        echo "Run tests"
-        cat <<EOF | docker run --rm -i -v $(pwd):/code ${{ env.DOCKER_IMAGE }} bash -
-          set -euo pipefail
-
-          pip install -e /code/tests/drivers/fail_drivers --no-deps
-          pip install -e /code/examples/io_plugin --no-deps
-
-          pytest -r a \
+        docker run --rm -i -v $(pwd):/code ${{ env.DOCKER_IMAGE }} bash --login -c \
+          "pytest -r a \
             --cov datacube \
             --cov-report=xml \
             --doctest-ignore-import-errors \
             --durations=5 \
             datacube \
             tests \
-            integration_tests
-        EOF
+            integration_tests"
 
     - name: Install uv
       uses: astral-sh/setup-uv@v6

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ lib64/
 parts/
 sdist/
 var/
+.venv
 *.egg-info/
 .installed.cfg
 *.egg
@@ -41,10 +42,11 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
-*,cover
+*.cover
 .hypothesis
 .pytest_cache
 .mypy_cache
+.ruff_cache
 
 # Translations
 *.mo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,22 @@
 ---
 services:
   core:
+    image: ghcr.io/opendatacube/datacube-core:tests
     build:
       context: .
       dockerfile: docker/Dockerfile
     environment:
       - POSTGRES_HOSTNAME=postgres
-      - POSTGRES_PORT=35432
+      - PGPORT=35432
       - POSTGRES_USER=opendatacube
       - POSTGRES_PASSWORD=opendatacubepassword
-      - POSTGRES_DB=opendatacube
+      - POSTGRES_DB=pgintegration,pgisintegration
+      - ODC_DATACUBE_INDEX_DRIVER=postgres
+      - ODC_POSTGIS_INDEX_DRIVER=postgis
+      - ODC_NOSUCHDRIVERENV_INDEX_DRIVER=no_such_driver
+      - ODC_DATACUBE_DB_URL=${ODC_DATACUBE_DB_URL:-postgresql://opendatacube:opendatacubepassword@postgres:35432/pgintegration}
+      - ODC_POSTGIS_DB_URL=${ODC_POSTGIS_DB_URL:-postgresql://opendatacube:opendatacubepassword@postgres:35432/pgisintegration}
+      - ODC_NOSUCHDRIVERENV_DB_URL=${ODC_NOSUCHDRIVERENV_DB_URL:-postgresql://opendatacube:opendatacubepassword@postgres:35432/nosuchdriverenv}
     tty: true
     stdin_open: true
     volumes:
@@ -23,18 +30,19 @@ services:
     hostname: postgres
     environment:
       - POSTGRES_DB=opendatacube
-      - POSTGRES_PORT=35432
+      - PGPORT=35432
       - POSTGRES_PASSWORD=opendatacubepassword
       - POSTGRES_USER=opendatacube
     ports:
       - "35432:35432"
     restart: always
     volumes:
+      - ./docker/assets/create-pg-databases.sh:/docker-entrypoint-initdb.d/create-pg-databases.sh
       - type: tmpfs
         target: /var/lib/postgresql/data
     command: -c fsync=off -c full_page_writes=off -c synchronous_commit=off
     healthcheck:
-      test: ["CMD", "pg_isready", "-h", "postgres", "-q", "-d", "opendatacube", "-U", "opendatacube"]
+      test: ["CMD", "pg_isready", "-h", "postgres", "-q", "--port", "35432", "-d", "pgintegration", "-U", "opendatacube"]
       timeout: 45s
       interval: 10s
       retries: 10

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,6 +59,8 @@ RUN groupmod ubuntu -n odc  \
 
 USER odc
 
+COPY --chown=odc:odc docker/assets/datacube_integration.conf /home/odc/.datacube_integration.conf
+
 WORKDIR /env
 
 RUN virtualenv /env

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,6 @@ FROM base
 COPY --from=builder --link /usr/local/bin/uv* /usr/local/bin/
 
 ARG V_PG=16
-ARG V_PGIS=16-postgis-3
 
 # Update and install Ubuntu packages
 
@@ -35,11 +34,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         libhdf5-dev libnetcdf-dev libgeos-dev libudunits2-dev \
         python3-dev virtualenv \
         build-essential \
-        postgresql \
         redis-server \
         postgresql-client-${V_PG} \
-        postgresql-${V_PG} \
-        postgresql-${V_PGIS} \
         sudo make graphviz \
         tini
 
@@ -87,10 +83,6 @@ RUN  --mount=type=cache,id=odc-python-312-cache,target=/home/odc/.cache \
     && python3 -m pip --disable-pip-version-check install /code/tests/drivers/fail_drivers
 
 USER root
-
-# prep db
-RUN  install --owner postgres --group postgres -D -d /var/run/postgresql /srv/postgresql \
-  && sudo -u postgres "$(find /usr/lib/postgresql/ -type f -name initdb)" -D "/srv/postgresql" --auth-host=md5 --encoding=UTF8
 
 VOLUME /code
 WORKDIR /code

--- a/docker/assets/create-pg-databases.sh
+++ b/docker/assets/create-pg-databases.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOF
+  CREATE USER odc WITH SUPERUSER;
+  CREATE DATABASE odc;
+EOF
+for db in "pgintegration" "pgisintegration"; do
+  psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOF
+    CREATE DATABASE $db;
+    GRANT ALL PRIVILEGES ON DATABASE $db TO odc;
+EOF
+done

--- a/docker/assets/datacube_integration.conf
+++ b/docker/assets/datacube_integration.conf
@@ -1,0 +1,19 @@
+[datacube]
+db_hostname:
+db_database: pgintegration
+index_driver: default
+
+[postgis]
+db_hostname:
+db_database: pgisintegration
+index_driver: postgis
+
+[nosuchdriverenv]
+db_hostname:
+index_driver: no_such_driver
+
+[nulldriver]
+index_driver: null
+
+[localmemory]
+index_driver: memory

--- a/docker/assets/datacube_integration.conf
+++ b/docker/assets/datacube_integration.conf
@@ -1,17 +1,3 @@
-[datacube]
-db_hostname:
-db_database: pgintegration
-index_driver: default
-
-[postgis]
-db_hostname:
-db_database: pgisintegration
-index_driver: postgis
-
-[nosuchdriverenv]
-db_hostname:
-index_driver: no_such_driver
-
 [nulldriver]
 index_driver: null
 

--- a/docker/assets/with_bootstrap
+++ b/docker/assets/with_bootstrap
@@ -1,37 +1,12 @@
 #!/bin/bash
 
-launch_db () {
-    local pgdata="${1:-/srv/postgresql}"
-    local dbuser="${2:-odc}"
-    local bin=$(find /usr/lib/postgresql/ -type d -name bin)
-
-    [ -e "${pgdata}/PG_VERSION" ] || {
-        sudo -u postgres "${bin}/initdb" -A -D "${pgdata}" --auth-host=md5 --encoding=UTF8
-    }
-
-    sudo -u postgres "${bin}/pg_ctl" -D "${pgdata}" -l "${pgdata}/pg.log" start
-
-    sudo -u postgres createuser --superuser "${dbuser}"
-    sudo -u postgres createdb "${dbuser}"
-    sudo -u postgres createdb datacube
-    sudo -u postgres createdb pgintegration
-    sudo -u postgres createdb pgisintegration
-}
-
 # Become `odc` user with UID/GID compatible to datacube-core volume
 #  If Running As root
-#    launch db server
 #    If outside volume not owned by root
 #       change `odc` to have compatible UID/GID
 #       re-exec this script as odc user
 
 [[ $UID -ne 0 ]] || {
-    [[ "${SKIP_DB:-no}" == "yes" ]] || {
-        launch_db /srv/postgresql odc > /dev/null 2> /dev/null || {
-            echo "WARNING: Failed to launch db, integration tests might not run"
-        }
-    }
-
     target_uid=$(stat -c '%u' .)
     target_gid=$(stat -c '%g' .)
 

--- a/docker/assets/with_bootstrap
+++ b/docker/assets/with_bootstrap
@@ -55,29 +55,6 @@ launch_db () {
 
 [[ $UID -ne 0 ]] || echo "WARNING: Running as root"
 
-cat <<EOL > $HOME/.datacube_integration.conf
-[datacube]
-db_hostname:
-db_database: pgintegration
-index_driver: default
-
-[postgis]
-db_hostname:
-db_database: pgisintegration
-index_driver: postgis
-
-[nosuchdriverenv]
-db_hostname:
-index_driver: no_such_driver
-
-[nulldriver]
-index_driver: null
-
-[localmemory]
-index_driver: memory
-
-EOL
-
 env="${PYENV:-/env}"
 
 if [ -e "${env}/bin/activate" ]; then

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -74,6 +74,7 @@ Other Changes
 - Dependabot: disable weekly updates :pull:`1886`
 - pyproject: set a fallback version :pull:`1887`
 - ``compliance-checker``` is no longer a dependency :pull:`1888`, :pull:`1897`
+- CI: run tests with docker compose :pull:`1896`
 - Enable flake8-comprehensions :pull:`1900`
 - model: remove old asserts :pull:`1898`
 


### PR DESCRIPTION
### Reason for this pull request

Use the postgis image running in a separate container as database for the CI tests, and remove the database from the image.

Keep the postgresql client so it's easy to inspect the data in the database.

Also move the datacube configuration from the init script in the `Dockerfile` to a file in the repository, and add some more entries to `dockerignore` so the docker cache is hit more often.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1896.org.readthedocs.build/en/1896/

<!-- readthedocs-preview opendatacube end -->