### PR TITLE
dependabot: set to weekly schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     groups:
       uv-deps:
         patterns:

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -77,6 +77,7 @@ Other Changes
 - Enable flake8-comprehensions :pull:`1900`
 - model: remove old asserts :pull:`1898`
 - Remove pytest-timeout :pull:`1899`
+- Dependabot: set to weekly schedule :pull:`1901`
 
 v1.9.3 (15th April 2025)
 ========================


### PR DESCRIPTION
### Reason for this pull request

Dependabot is making more pull requests
than we want, and I have a few other
things on my plate that are more
urgent, so set it to a weekly schedule
for now.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1901.org.readthedocs.build/en/1901/

<!-- readthedocs-preview opendatacube end -->