### PR TITLE
Group all uv dependabot PRs together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,15 +17,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    groups:
-      uv-deps:
-        patterns:
-          - "*"
-        exclude-patterns: # Packages updated almost every day.
-          - "boto3"
-          - "boto3-stubs"
-          - "botocore"
-          - "botocore-stubs"
+#    groups:
+#      uv-deps:
+#        patterns:
+#          - "*"
+#        exclude-patterns: # Packages updated almost every day.
+#          - "boto3"
+#          - "boto3-stubs"
+#          - "botocore"
+#          - "botocore-stubs"
 #  - package-ecosystem: "uv"
 #    # Have two jobs with same eco-system/directory by setting target-branch
 #    # for one of them:

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -10,6 +10,7 @@ Next Release
 
 - Update dependencies :pull:`1925`
 - Run Ruff format on all code :pull:`1926`, :pull:`1927`
+- Group all dependabot updates in the 'uv' ecosystem. :pull:`1928`
 
 v1.9.4 (20 May 2025)
 ====================

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -141,7 +141,7 @@ dbs
 dea
 deafrica
 dem
-Dependabot
+dependabot
 Deprecations
 dev
 df


### PR DESCRIPTION
The existing configuration is splitting out each of the boto{3/core}{-stubs} dependencies into separate PRs and it's a pain.

Instead of using `exclude-patterns` for the one `group`, the entire `package-ecosystem` for `uv` should have had an [`ignore` key ](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#ignore--) listing the `boto*` packages.

I can't be bothered messing around with it more at the moment.

I think since `datacube-core` isn't an "application" that gets published with all dependencies, it's preferable to leave the dependabot PRs on a weekly schedule.

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1928.org.readthedocs.build/en/1928/

<!-- readthedocs-preview opendatacube end -->