### PR TITLE
Actually group all python dependabot deps together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,10 +17,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-#    groups:
-#      uv-deps:
-#        patterns:
-#          - "*"
+    groups:
+      python-deps:
+        patterns:
+          - "*"
 #        exclude-patterns: # Packages updated almost every day.
 #          - "boto3"
 #          - "boto3-stubs"

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -10,7 +10,7 @@ Next Release
 
 - Update dependencies :pull:`1925`
 - Run Ruff format on all code :pull:`1926`, :pull:`1927`
-- Group all dependabot updates in the 'uv' ecosystem. :pull:`1928`
+- Group all dependabot updates in the 'uv' ecosystem. :pull:`1928`, :pull:`1934`
 
 v1.9.4 (20 May 2025)
 ====================


### PR DESCRIPTION
I was too hasty in #1928 and forgot that by default dependabot splits everything by default, instead of grouping everything.

Lets switch to grouping all the python dependency updates together and see how we go with that.



<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1934.org.readthedocs.build/en/1934/

<!-- readthedocs-preview opendatacube end -->