### PR TITLE
Move deprecated imports

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -34,10 +34,10 @@ from datacube.model.utils import xr_apply
 from datacube.storage import BandInfo, reproject_and_fuse
 from datacube.utils import ignore_exceptions_if
 from datacube.utils.dates import normalise_dt
-from datacube.utils.geometry import GeoBox as LegacyGeoGeoBox
 
 if TYPE_CHECKING:
     from datacube.model import GridSpec
+    from datacube.utils.geometry import GeoBox as LegacyGeoGeoBox
 
 from ..drivers import new_datasource
 from ..index import Index, extract_geom_from_query, index_connect
@@ -1186,6 +1186,8 @@ def output_geobox(
         if isinstance(like, GeoBox):
             # Is already a GeoBox
             return like
+        from datacube.utils.geometry import GeoBox as LegacyGeoGeoBox
+
         if isinstance(like, LegacyGeoGeoBox):
             # Is a legacy GeoBox: convert to odc.geo.geobox.GeoBox.
             crs = None if like.crs is None else CRS(like.crs._str)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -11,6 +11,7 @@ Next Release
 - Update dependencies :pull:`1925`
 - Run Ruff format on all code :pull:`1926`, :pull:`1927`
 - Group all dependabot updates in the 'uv' ecosystem. :pull:`1928`, :pull:`1934`
+- Move deprecated imports :pull:`1938`
 
 v1.9.4 (20 May 2025)
 ====================


### PR DESCRIPTION
### Reason for this pull request

Put the deprecated imports under
TYPE_CHECKING or just before
they are used so they don't
give false warnings.

Refs #1916

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1938.org.readthedocs.build/en/1938/

<!-- readthedocs-preview opendatacube end -->