### PR TITLE
index: add return types

### DIFF
--- a/datacube/index/abstract/_metadata_types.py
+++ b/datacube/index/abstract/_metadata_types.py
@@ -283,8 +283,8 @@ class AbstractMetadataTypeResource(ABC):
             This will halt other user's requests until completed.
 
             If false, creation will be slightly slower and cannot be done in a transaction.
-        :param: rebuild_views: whether or not views should be rebuilt
-        :param: rebuild_indexes: whether or not views should be rebuilt
+        :param rebuild_views: whether or not views should be rebuilt
+        :param rebuild_indexes: whether or not views should be rebuilt
         """
 
     @abstractmethod

--- a/datacube/index/memory/_metadata_types.py
+++ b/datacube/index/memory/_metadata_types.py
@@ -117,7 +117,7 @@ class MetadataTypeResource(AbstractMetadataTypeResource):
 
         if not safe_changes and not unsafe_changes:
             _LOG.warning(f"No changes detected for metadata type {metadata_type.name}")
-            return cast(MetadataType, self.get_by_name(metadata_type.name))
+            return self.get_by_name_unsafe(metadata_type.name)
 
         if not can_update:
             errs = ", ".join(_readable_offset(change[0]) for change in unsafe_changes)

--- a/datacube/index/postgis/_metadata_types.py
+++ b/datacube/index/postgis/_metadata_types.py
@@ -57,7 +57,9 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
         return self._make(definition)
 
     @override
-    def add(self, metadata_type: MetadataType, allow_table_lock: bool = False):
+    def add(
+        self, metadata_type: MetadataType, allow_table_lock: bool = False
+    ) -> MetadataType:
         """
         :param datacube.model.MetadataType metadata_type:
         :param allow_table_lock:
@@ -81,13 +83,13 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
                 jsonify_document(metadata_type.definition),
                 f"Metadata Type {metadata_type.name}",
             )
-        else:
-            with self._db_connection() as connection:
-                connection.insert_metadata_type(
-                    name=metadata_type.name,
-                    definition=metadata_type.definition,
-                )
-        return self.get_by_name(metadata_type.name)
+            return existing
+        with self._db_connection() as connection:
+            connection.insert_metadata_type(
+                name=metadata_type.name,
+                definition=metadata_type.definition,
+            )
+        return self.get_by_name_unsafe(metadata_type.name)
 
     @override
     def _add_batch(self, batch_types: Iterable[MetadataType]) -> BatchStatus:
@@ -160,7 +162,7 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
         metadata_type: MetadataType,
         allow_unsafe_updates: bool = False,
         allow_table_lock: bool = False,
-    ):
+    ) -> MetadataType:
         """
         Update a metadata type from the document. Unsafe changes will throw a ValueError by default.
 
@@ -181,9 +183,7 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
 
         if not safe_changes and not unsafe_changes:
             _LOG.warning("No changes detected for metadata type %s", metadata_type.name)
-            return self.get_by_name(metadata_type.name)
-
-        if not can_update:
+        elif not can_update:
             raise ValueError(
                 f"Unsafe changes in {metadata_type.name}: "
                 + (
@@ -192,18 +192,18 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
                     )
                 )
             )
+        else:
+            _LOG.info("Updating metadata type %s", metadata_type.name)
 
-        _LOG.info("Updating metadata type %s", metadata_type.name)
+            with self._db_connection() as connection:
+                connection.update_metadata_type(
+                    name=metadata_type.name,
+                    definition=metadata_type.definition,
+                )
 
-        with self._db_connection() as connection:
-            connection.update_metadata_type(
-                name=metadata_type.name,
-                definition=metadata_type.definition,
-            )
-
-        self.get_by_name_unsafe.cache_clear()  # type: ignore[attr-defined]
-        self.get_unsafe.cache_clear()  # type: ignore[attr-defined]
-        return self.get_by_name(metadata_type.name)
+            self.get_by_name_unsafe.cache_clear()  # type: ignore[attr-defined]
+            self.get_unsafe.cache_clear()  # type: ignore[attr-defined]
+        return self.get_by_name_unsafe(metadata_type.name)
 
     @override
     def update_document(

--- a/datacube/index/postgres/_metadata_types.py
+++ b/datacube/index/postgres/_metadata_types.py
@@ -57,7 +57,9 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
         return self._make(definition)
 
     @override
-    def add(self, metadata_type: MetadataType, allow_table_lock: bool = False):
+    def add(
+        self, metadata_type: MetadataType, allow_table_lock: bool = False
+    ) -> MetadataType:
         """
         :param datacube.model.MetadataType metadata_type:
         :param allow_table_lock:
@@ -82,14 +84,14 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
                 jsonify_document(metadata_type.definition),
                 f"Metadata Type {metadata_type.name}",
             )
-        else:
-            with self._db_connection(transaction=allow_table_lock) as connection:
-                connection.insert_metadata_type(
-                    name=metadata_type.name,
-                    definition=metadata_type.definition,
-                    concurrently=not allow_table_lock,
-                )
-        return self.get_by_name(metadata_type.name)
+            return existing
+        with self._db_connection(transaction=allow_table_lock) as connection:
+            connection.insert_metadata_type(
+                name=metadata_type.name,
+                definition=metadata_type.definition,
+                concurrently=not allow_table_lock,
+            )
+        return self.get_by_name_unsafe(metadata_type.name)
 
     @override
     def can_update(
@@ -151,7 +153,7 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
         metadata_type: MetadataType,
         allow_unsafe_updates: bool = False,
         allow_table_lock: bool = False,
-    ):
+    ) -> MetadataType:
         """
         Update a metadata type from the document. Unsafe changes will throw a ValueError by default.
 
@@ -172,9 +174,7 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
 
         if not safe_changes and not unsafe_changes:
             _LOG.warning("No changes detected for metadata type %s", metadata_type.name)
-            return self.get_by_name(metadata_type.name)
-
-        if not can_update:
+        elif not can_update:
             raise ValueError(
                 f"Unsafe changes in {metadata_type.name}: "
                 + (
@@ -183,19 +183,19 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
                     )
                 )
             )
+        else:
+            _LOG.info("Updating metadata type %s", metadata_type.name)
 
-        _LOG.info("Updating metadata type %s", metadata_type.name)
+            with self._db_connection(transaction=allow_table_lock) as connection:
+                connection.update_metadata_type(
+                    name=metadata_type.name,
+                    definition=metadata_type.definition,
+                    concurrently=not allow_table_lock,
+                )
 
-        with self._db_connection(transaction=allow_table_lock) as connection:
-            connection.update_metadata_type(
-                name=metadata_type.name,
-                definition=metadata_type.definition,
-                concurrently=not allow_table_lock,
-            )
-
-        self.get_by_name_unsafe.cache_clear()  # type: ignore[attr-defined]
-        self.get_unsafe.cache_clear()  # type: ignore[attr-defined]
-        return self.get_by_name(metadata_type.name)
+            self.get_by_name_unsafe.cache_clear()  # type: ignore[attr-defined]
+            self.get_unsafe.cache_clear()  # type: ignore[attr-defined]
+        return self.get_by_name_unsafe(metadata_type.name)
 
     @override
     def update_document(

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,7 @@ What's New
 Next Release
 ============
 
+- index: add return types :pull:`1939`
 - Update dependencies :pull:`1925`
 - Run Ruff format on all code :pull:`1926`, :pull:`1927`
 - Group all dependabot updates in the 'uv' ecosystem. :pull:`1928`, :pull:`1934`


### PR DESCRIPTION
### Reason for this pull request

Add return types to some methods that were missing them. Switch the code in
the methods to use unsafe methods since the preceeding code guarantees that the
lookup will find the name. These changes save a database lookup when adding an
already existing MetadataType.

The methods in the memory index already had type annotations, but change the
implementation to use the unsafe method there too, which removes a type cast.


Also add a commit that fixes a pydoc formatting issue for the code in question.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1939.org.readthedocs.build/en/1939/

<!-- readthedocs-preview opendatacube end -->