### PR TITLE
Convert doc strings to type annotations

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -36,6 +36,8 @@ from datacube.utils import ignore_exceptions_if
 from datacube.utils.dates import normalise_dt
 
 if TYPE_CHECKING:
+    from pandas import DataFrame
+
     from datacube.model import GridSpec
     from datacube.utils.geometry import GeoBox as LegacyGeoGeoBox
 
@@ -49,8 +51,6 @@ from .query import GroupBy, Query, query_group_by
 _LOG: logging.Logger = logging.getLogger(__name__)
 
 
-# Either a Pandas dataframe or a list of flat dictionaries.
-# Pandas is loaded dynamically, so cannot be statically typed: use DataFrameLike | Any
 DataFrameLike = list[dict[str, str | int | float | None]]
 
 
@@ -146,7 +146,7 @@ class Datacube:
 
     def list_products(
         self, with_pandas: bool = True, dataset_count: bool = False
-    ) -> DataFrameLike | Any:
+    ) -> DataFrame | DataFrameLike:
         """
         List all products in the datacube. This will produce a ``pandas.DataFrame``
         or list of dicts containing useful information about each product, including:
@@ -238,7 +238,7 @@ class Datacube:
     )
     def list_measurements(
         self, show_archived: bool = False, with_pandas: bool = True
-    ) -> DataFrameLike | Any:
+    ) -> DataFrame | DataFrameLike:
         """
         List measurements for each product
 
@@ -277,7 +277,7 @@ class Datacube:
         self,
         product: str | None = None,
         measurements: str | list[str] | None = None,
-        output_crs: Any = None,
+        output_crs: str | None = None,
         resolution: (
             int | float | tuple[int | float, int | float] | Resolution | None
         ) = None,

--- a/datacube/api/grid_workflow.py
+++ b/datacube/api/grid_workflow.py
@@ -305,7 +305,9 @@ class GridWorkflow:
         return datasets, query
 
     @staticmethod
-    def group_into_cells(observations, group_by) -> dict[tuple[int, int], Tile]:
+    def group_into_cells(
+        observations, group_by: GroupBy
+    ) -> dict[tuple[int, int], Tile]:
         """
         Group observations into a stack of source tiles.
 
@@ -326,7 +328,9 @@ class GridWorkflow:
         return cells
 
     @staticmethod
-    def tile_sources(observations, group_by: GroupBy):
+    def tile_sources(
+        observations, group_by: GroupBy
+    ) -> dict[tuple[int, int, np.datetime64], Tile]:
         """
         Split observations into tiles and group into source tiles
 
@@ -404,7 +408,7 @@ class GridWorkflow:
         fuse_func=None,
         resampling=None,
         skip_broken_datasets=False,
-    ):
+    ) -> xr.Dataset:
         """
         Load data for a cell/tile.
 

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -14,7 +14,9 @@ import warnings
 
 import numpy as np
 import pandas
+import xarray
 from odc.geo import Geometry
+from odc.geo.geobox import GeoBox
 from odc.geo.geom import lonlat_bounds, mid_longitude
 from pandas import to_datetime as pandas_to_datetime
 from typing_extensions import override
@@ -69,7 +71,12 @@ OTHER_KEYS = (
 
 class Query:
     def __init__(
-        self, index=None, product=None, geopolygon=None, like=None, **search_terms
+        self,
+        index=None,
+        product=None,
+        geopolygon=None,
+        like: GeoBox | xarray.Dataset | xarray.DataArray | None = None,
+        **search_terms,
     ) -> None:
         """Parses search terms in preparation for querying the Data Cube Index.
 
@@ -146,7 +153,7 @@ class Query:
             self.geopolygon = getattr(like, "extent", self.geopolygon)
 
             if "time" not in self.search:
-                time_coord = like.coords.get("time")
+                time_coord = like.coords.get("time")  # type: ignore[union-attr]
                 if time_coord is not None:
                     self.search["time"] = _time_to_search_dims(
                         # convert from np.datetime64 to datetime.datetime

--- a/datacube/drivers/netcdf/writer.py
+++ b/datacube/drivers/netcdf/writer.py
@@ -13,6 +13,7 @@ from collections.abc import Sequence
 from datetime import datetime, timezone
 from os import PathLike
 
+import netCDF4
 import numpy
 from netCDF4 import Dataset
 from odc.geo import CRS
@@ -78,7 +79,9 @@ def append_netcdf(netcdf_path) -> Dataset:
     return Dataset(netcdf_path, "a")
 
 
-def create_coordinate(nco, name: str, labels: Sequence[str], units):
+def create_coordinate(
+    nco: Dataset, name: str, labels: Sequence[str], units: str
+) -> netCDF4.Variable:
     """
     :type nco: netCDF4.Dataset
     :type name: str

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -41,6 +41,7 @@ from typing_extensions import override
 from datacube.index.abstract import DSID
 from datacube.index.fields import OrExpression
 from datacube.model import Range
+from datacube.model.fields import Expression
 from datacube.model.lineage import LineageDirection, LineageRelation
 from datacube.utils.uris import split_uri
 
@@ -330,7 +331,7 @@ class PostgisDbAPI:
         )
         return res.rowcount > 0
 
-    def insert_dataset_location(self, dataset_id, uri) -> bool:
+    def insert_dataset_location(self, dataset_id: DSID, uri: str) -> bool:
         """
         Add a location to a dataset if it is not already recorded.
 
@@ -352,7 +353,7 @@ class PostgisDbAPI:
 
         return r.rowcount > 0
 
-    def insert_dataset_search(self, search_table, dataset_id, key, value) -> bool:
+    def insert_dataset_search(self, search_table, dataset_id: DSID, key, value) -> bool:
         """
         Add/update a search field index entry for a dataset
 
@@ -385,7 +386,9 @@ class PostgisDbAPI:
         r = self._connection.execute(insert(search_table).values(values))
         return r.rowcount
 
-    def insert_dataset_spatial(self, dataset_id, crs, extent) -> bool:
+    def insert_dataset_spatial(
+        self, dataset_id: DSID, crs: CRS, extent: Geometry
+    ) -> bool:
         """
         Add/update a spatial index entry for a dataset
 
@@ -523,7 +526,9 @@ class PostgisDbAPI:
     def get_dataset_sources(self, dataset_id):
         raise NotImplementedError()
 
-    def search_datasets_by_metadata(self, metadata, archived):
+    def search_datasets_by_metadata(
+        self, metadata: dict, archived: bool | None
+    ) -> dict:
         """
         Find any datasets that have the given metadata.
 
@@ -539,7 +544,7 @@ class PostgisDbAPI:
         query = select(*_dataset_select_fields()).where(where)
         return self._connection.execute(query).fetchall()
 
-    def search_products_by_metadata(self, metadata):
+    def search_products_by_metadata(self, metadata: dict) -> dict:
         """
         Find any datasets that have the given metadata.
 
@@ -576,15 +581,15 @@ class PostgisDbAPI:
 
     def search_datasets_query(
         self,
-        expressions,
-        source_exprs=None,
-        select_fields=None,
+        expressions: Iterable[Expression],
+        source_exprs: Iterable[Expression] | None = None,
+        select_fields: Iterable[PgField] | None = None,
         with_source_ids: bool = False,
         limit: int | None = None,
-        geom=None,
+        geom: Geometry | None = None,
         archived: bool | None = False,
-        order_by=None,
-    ):
+        order_by: Iterable | None = None,
+    ) -> Select:
         """
         :type expressions: Tuple[Expression]
         :type source_exprs: Tuple[Expression]
@@ -621,7 +626,8 @@ class PostgisDbAPI:
             order_by = []
 
         select_columns = tuple(
-            f.alchemy_expression.label(f.name) for f in select_fields
+            f.alchemy_expression.label(f.name)  # type: ignore[union-attr]
+            for f in select_fields
         )
         if geom:
             SpatialIndex, spatialquery = self.geospatial_query(geom)  # noqa: N806
@@ -651,12 +657,12 @@ class PostgisDbAPI:
 
     def search_datasets(
         self,
-        expressions,
-        source_exprs=None,
-        select_fields=None,
+        expressions: Iterable[Expression],
+        source_exprs: Iterable[Expression] | None = None,
+        select_fields: Iterable[PgField] | None = None,
         with_source_ids: bool = False,
         limit: int | None = None,
-        geom=None,
+        geom: Geometry | None = None,
         archived: bool | None = False,
         order_by=None,
     ) -> Iterator:
@@ -848,8 +854,11 @@ class PostgisDbAPI:
             yield drow
 
     def count_datasets(
-        self, expressions, archived: bool | None = False, geom: Geometry | None = None
-    ):
+        self,
+        expressions: Iterable[Expression],
+        archived: bool | None = False,
+        geom: Geometry | None = None,
+    ) -> int:
         """
         :type expressions: tuple[datacube.drivers.postgis._fields.PgExpression]
         :rtype: int
@@ -877,8 +886,13 @@ class PostgisDbAPI:
         return self._connection.scalar(select_query)
 
     def count_datasets_through_time(
-        self, start, end, period, time_field, expressions
-    ) -> Iterator:
+        self,
+        start: datetime.datetime,
+        end: datetime.datetime,
+        period,
+        time_field,
+        expressions: Iterable[Expression],
+    ) -> Iterator[tuple[tuple[datetime.datetime, datetime.datetime], int]]:
         """
         :type period: str
         :type start: datetime.datetime

--- a/datacube/drivers/postgis/_fields.py
+++ b/datacube/drivers/postgis/_fields.py
@@ -119,14 +119,14 @@ class PgField(Field):
         )
 
     @override
-    def __eq__(self, value):
+    def __eq__(self, value) -> Expression:  # type: ignore[override]
         """
         :rtype: Expression
         """
         return EqualsExpression(self, value)
 
     @override
-    def between(self, low, high):
+    def between(self, low, high) -> Expression:
         """
         :rtype: Expression
         """
@@ -295,14 +295,14 @@ class SimpleDocField(PgDocField):
         )
 
     @override
-    def __eq__(self, value):
+    def __eq__(self, value) -> Expression:  # type: ignore[override]
         """
         :rtype: Expression
         """
         return EqualsExpression(self, value)
 
     @override
-    def between(self, low, high):
+    def between(self, low, high) -> Expression:
         """
         :rtype: Expression
         """
@@ -476,7 +476,7 @@ class RangeDocField(PgDocField):
         ).label(self.name)
 
     @override
-    def __eq__(self, value):
+    def __eq__(self, value) -> Expression:  # type: ignore[override]
         """
         :rtype: Expression
         """
@@ -520,7 +520,7 @@ class NumericRangeDocField(RangeDocField):
         return self.value_to_alchemy(value)
 
     @override
-    def between(self, low, high):
+    def between(self, low, high) -> Expression:
         """
         :rtype: Expression
         """
@@ -586,7 +586,7 @@ class DateRangeDocField(RangeDocField):
             return tuple(tz_as_utc(v) for v in value)
 
     @override
-    def between(self, low, high):
+    def between(self, low, high) -> Expression:
         """
         :rtype: Expression
         """
@@ -711,7 +711,7 @@ class EqualsExpression(PgExpression):
         return self.field.evaluate(ctx) == self.value
 
 
-def parse_fields(doc, table_column):
+def parse_fields(doc: dict, table_column) -> dict[str, PgField]:
     """
     Parse a field spec document into objects.
 

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -22,6 +22,7 @@ from typing import cast as type_cast
 
 from sqlalchemy import (
     Label,
+    Select,
     String,
     and_,
     bindparam,
@@ -41,6 +42,7 @@ from sqlalchemy.engine import Row
 from sqlalchemy.exc import IntegrityError
 from typing_extensions import override
 
+from datacube.index.abstract import DSID
 from datacube.index.exceptions import MissingRecordError
 from datacube.index.fields import Expression, Field, OrExpression
 from datacube.model import Range
@@ -266,7 +268,7 @@ class PostgresDbAPI:
         )
         return res.rowcount > 0
 
-    def insert_dataset_location(self, dataset_id, uri) -> bool:
+    def insert_dataset_location(self, dataset_id: DSID, uri: str) -> bool:
         """
         Add a location to a dataset if it is not already recorded.
 
@@ -461,7 +463,9 @@ class PostgresDbAPI:
 
         return self._connection.execute(query).fetchall()
 
-    def search_datasets_by_metadata(self, metadata, archived: bool | None = False):
+    def search_datasets_by_metadata(
+        self, metadata: dict, archived: bool | None = False
+    ) -> dict:
         """
         Find any datasets that have the given metadata.
 
@@ -478,7 +482,7 @@ class PostgresDbAPI:
         query = select(*_DATASET_SELECT_FIELDS).where(where_clause)
         return self._connection.execute(query).fetchall()
 
-    def search_products_by_metadata(self, metadata):
+    def search_products_by_metadata(self, metadata: dict) -> dict:
         """
         Find any products that have the given metadata.
 
@@ -501,14 +505,14 @@ class PostgresDbAPI:
 
     @staticmethod
     def search_datasets_query(
-        expressions,
-        source_exprs=None,
-        select_fields=None,
+        expressions: Iterable[Expression],
+        source_exprs: Iterable[Expression] | None = None,
+        select_fields: Iterable[PgField] | None = None,
         with_source_ids: bool = False,
         limit: int | None = None,
         archived: bool | None = False,
         order_by=None,
-    ):
+    ) -> Select:
         """
         :type expressions: tuple[Expression]
         :type source_exprs: tuple[Expression]
@@ -572,9 +576,7 @@ class PostgresDbAPI:
 
         if not source_exprs:
             return (
-                select(
-                    *select_columns  # type: ignore[arg-type]
-                )
+                select(*select_columns)
                 .select_from(from_expression)
                 .where(where_expr)
                 .order_by(*order_by)
@@ -646,9 +648,9 @@ class PostgresDbAPI:
 
     def search_datasets(
         self,
-        expressions,
-        source_exprs=None,
-        select_fields=None,
+        expressions: Iterable[Expression],
+        source_exprs: Iterable[Expression] | None = None,
+        select_fields: Iterable[PgField] | None = None,
         with_source_ids: bool = False,
         limit: int | None = None,
         archived: bool | None = False,
@@ -849,7 +851,9 @@ class PostgresDbAPI:
 
         return self._connection.execute(final_query)
 
-    def count_datasets(self, expressions, archived: bool | None = False):
+    def count_datasets(
+        self, expressions: Iterable[Expression], archived: bool | None = False
+    ) -> int:
         """
         :type expressions: tuple[datacube.drivers.postgres._fields.PgExpression]
         :rtype: int
@@ -872,8 +876,13 @@ class PostgresDbAPI:
         return self._connection.scalar(select_query)
 
     def count_datasets_through_time(
-        self, start, end, period, time_field, expressions
-    ) -> Iterator:
+        self,
+        start: datetime.datetime,
+        end: datetime.datetime,
+        period: str,
+        time_field,
+        expressions: Iterable[Expression],
+    ) -> Iterator[tuple[tuple[datetime.datetime, datetime.datetime], int]]:
         """
         :type period: str
         :type start: datetime.datetime

--- a/datacube/drivers/postgres/_fields.py
+++ b/datacube/drivers/postgres/_fields.py
@@ -69,14 +69,14 @@ class PgField(Field):
         return "btree"
 
     @override
-    def __eq__(self, value):
+    def __eq__(self, value) -> Expression:  # type: ignore[override]
         """
         :rtype: Expression
         """
         return EqualsExpression(self, value)
 
     @override
-    def between(self, low, high):
+    def between(self, low, high) -> Expression:
         """
         :rtype: Expression
         """
@@ -221,14 +221,14 @@ class SimpleDocField(PgDocField):
         )
 
     @override
-    def __eq__(self, value):
+    def __eq__(self, value) -> Expression:  # type: ignore[override]
         """
         :rtype: Expression
         """
         return EqualsExpression(self, value)
 
     @override
-    def between(self, low, high):
+    def between(self, low, high) -> Expression:
         """
         :rtype: Expression
         """
@@ -382,7 +382,7 @@ class RangeDocField(PgDocField):
         ).label(self.name)
 
     @override
-    def __eq__(self, value):
+    def __eq__(self, value) -> Expression:  # type: ignore[override]
         """
         :rtype: Expression
         """
@@ -417,7 +417,7 @@ class NumericRangeDocField(RangeDocField):
         )
 
     @override
-    def between(self, low, high):
+    def between(self, low, high) -> Expression:
         """
         :rtype: Expression
         """
@@ -440,7 +440,7 @@ class IntRangeDocField(RangeDocField):
         )
 
     @override
-    def between(self, low, high):
+    def between(self, low, high) -> Expression:
         """
         :rtype: Expression
         """
@@ -463,7 +463,7 @@ class DoubleRangeDocField(RangeDocField):
         )
 
     @override
-    def between(self, low, high):
+    def between(self, low, high) -> Expression:
         """
         :rtype: Expression
         """
@@ -488,7 +488,7 @@ class DateRangeDocField(RangeDocField):
         )
 
     @override
-    def between(self, low, high):
+    def between(self, low, high) -> Expression:
         """
         :rtype: Expression
         """
@@ -606,7 +606,7 @@ class EqualsExpression(PgExpression):
         return self.field.evaluate(ctx) == self.value
 
 
-def parse_fields(doc, table_column):
+def parse_fields(doc: dict, table_column) -> dict[str, PgField]:
     """
     Parse a field spec document into objects.
 

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -6,6 +6,8 @@
 API for dataset indexing, access and search.
 """
 
+from __future__ import annotations
+
 import datetime
 import json
 import logging
@@ -13,7 +15,7 @@ import warnings
 from collections import namedtuple
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from time import monotonic
-from typing import Any, NamedTuple, cast
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
 from uuid import UUID
 
 from deprecat import deprecat
@@ -50,9 +52,13 @@ from datacube.model import Dataset, LineageTree, Product, Range
 from datacube.model._base import QueryField
 from datacube.model.fields import Field
 from datacube.utils import _readable_offset, changes, jsonify_document
-from datacube.utils.changes import Offset, get_doc_changes
+from datacube.utils.changes import Change, Offset, get_doc_changes
 from datacube.utils.documents import JsonDict
 from datacube.utils.uris import split_uri
+
+if TYPE_CHECKING:
+    from datacube.drivers.postgis import PostGisDb
+    from datacube.index.postgis.index import Index
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -65,7 +71,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
     :type products: datacube.index._products.ProductResource
     """
 
-    def __init__(self, db, index) -> None:
+    def __init__(self, db: PostGisDb, index: Index) -> None:
         """
         :type db: datacube.drivers.postgis._connections.PostgresDb
         :type index: datacube.index._products.ProductResource
@@ -336,7 +342,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
     @override
     def can_update(
         self, dataset: Dataset, updates_allowed=None
-    ) -> tuple[bool, list, list]:
+    ) -> tuple[bool, list[Change], list[Change]]:
         """
         Check if dataset can be updated. Return bool,safe_changes,unsafe_changes
 
@@ -502,7 +508,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         return purged
 
     @override
-    def get_all_dataset_ids(self, archived: bool | None = False) -> list:
+    def get_all_dataset_ids(self, archived: bool | None = False) -> list[UUID]:
         """
         Get list of all dataset IDs based only on archived status
 
@@ -521,7 +527,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         category=ODC2DeprecationWarning,
     )
     @override
-    def get_locations(self, id_) -> list:
+    def get_locations(self, id_) -> list[str | None]:
         """
         Get the list of storage locations for the given dataset id
 
@@ -552,7 +558,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         category=ODC2DeprecationWarning,
     )
     @override
-    def get_archived_locations(self, id_) -> list:
+    def get_archived_locations(self, id_: DSID) -> list[str]:
         """
         Find locations which have been archived for a dataset
 
@@ -568,7 +574,9 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         category=ODC2DeprecationWarning,
     )
     @override
-    def get_archived_location_times(self, id_) -> list:
+    def get_archived_location_times(
+        self, id_: DSID
+    ) -> list[tuple[str, datetime.datetime]]:
         """
         Get each archived location along with the time it was archived.
 
@@ -584,7 +592,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         category=ODC2DeprecationWarning,
     )
     @override
-    def add_location(self, id_, uri) -> bool:
+    def add_location(self, id_: DSID, uri: str) -> bool:
         """
         Add a location to the dataset if it doesn't already exist.
 
@@ -715,7 +723,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
     @override
     def search_by_metadata(
         self, metadata: JsonDict, archived: bool | None = False
-    ) -> Iterable:
+    ) -> Iterable[Dataset]:
         """
         Perform a search using arbitrary metadata, returning results as Dataset objects.
 
@@ -746,7 +754,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         archived: bool | None = False,
         order_by=None,
         **query,
-    ) -> Iterable:
+    ) -> Iterable[Dataset]:
         """
         Perform a search, returning results as Dataset objects.
 
@@ -865,7 +873,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
     @override
     def count_by_product(
         self, archived: bool | None = False, **query
-    ) -> Iterable[tuple]:
+    ) -> Iterable[tuple[Product, int]]:
         """
         Perform a search, returning a count of for each matching product type.
 
@@ -876,9 +884,10 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         """
         return self._do_count_by_product(query, archived=archived)
 
-    # FIXME: Missing parameters from super method.
     @override
-    def count_by_product_through_time(self, period, **query):
+    def count_by_product_through_time(
+        self, period: str, archived: bool | None = False, **query: QueryField
+    ) -> Iterable[tuple[Product, Iterable[tuple[Range, int]]]]:
         """
         Perform a search, returning counts for each product grouped in time slices
         of the given period.
@@ -890,9 +899,10 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         """
         return self._do_time_count(period, query)
 
-    # FIXME: Missing parameters from super method.
     @override
-    def count_product_through_time(self, period, **query):
+    def count_product_through_time(
+        self, period: str, archived: bool | None = False, **query: QueryField
+    ) -> Iterable[tuple[Range, int]]:
         """
         Perform a search, returning counts for a single product grouped in time slices
         of the given period.
@@ -1104,7 +1114,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                     pass
             else:
 
-                class DatasetLight(result_type):  # type: ignore
+                class DatasetLight(result_type):  # type: ignore[no-redef]
                     __slots__ = ()
 
             with self._db_connection() as connection:
@@ -1128,7 +1138,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
     def make_select_fields(
         self, product, field_names: Sequence[str], custom_offsets
-    ) -> list:
+    ) -> list[PgField]:
         """
         Parse and generate the list of select fields to be passed to the database API.
         """

--- a/datacube/index/postgis/_metadata_types.py
+++ b/datacube/index/postgis/_metadata_types.py
@@ -2,9 +2,12 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import logging
 from collections.abc import Iterable, Mapping
 from time import monotonic
+from typing import TYPE_CHECKING
 
 from cachetools.func import lru_cache
 from typing_extensions import override
@@ -22,11 +25,15 @@ from datacube.utils.changes import (
 )
 from datacube.utils.documents import JsonDict
 
+if TYPE_CHECKING:
+    from datacube.drivers.postgis import PostGisDb
+    from datacube.index.postgis.index import Index
+
 _LOG: logging.Logger = logging.getLogger(__name__)
 
 
 class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
-    def __init__(self, db, index) -> None:
+    def __init__(self, db: PostGisDb, index: Index) -> None:
         """
         :type db: datacube.drivers.postgis._connections.PostgresDb
         """

--- a/datacube/index/postgis/_products.py
+++ b/datacube/index/postgis/_products.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import datetime
 import logging
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Generator, Iterable, Mapping, Sequence
 from time import monotonic
 from typing import TYPE_CHECKING, cast
 
@@ -241,7 +241,7 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
 
         _LOG.info("Updating product %s", product.name)
 
-        existing = cast(Product, self.get_by_name(product.name))
+        existing = self.get_by_name_unsafe(product.name)
         changing_metadata_type = (
             product.metadata_type.name != existing.metadata_type.name
         )
@@ -287,7 +287,7 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
         definition,
         allow_unsafe_updates: bool = False,
         allow_table_lock: bool = False,
-    ):
+    ) -> Product | None:
         """
         Update a Product using its definition
 
@@ -418,7 +418,7 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
                 yield type_, remaining_matchable
 
     @override
-    def search_by_metadata(self, metadata):
+    def search_by_metadata(self, metadata) -> Generator[Product]:
         """
         Perform a search using arbitrary metadata, returning results as Product objects.
 

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -6,6 +6,8 @@
 API for dataset indexing, access and search.
 """
 
+from __future__ import annotations
+
 import datetime
 import json
 import logging
@@ -13,7 +15,7 @@ import warnings
 from collections import namedtuple
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from time import monotonic
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 from deprecat import deprecat
@@ -32,12 +34,16 @@ from datacube.index.abstract import (
 )
 from datacube.index.postgres._transaction import IndexResourceAddIn
 from datacube.migration import ODC2DeprecationWarning
-from datacube.model import Dataset, Product
+from datacube.model import Dataset, Product, Range
 from datacube.model._base import QueryField
 from datacube.model.fields import Expression, Field
 from datacube.model.utils import flatten_datasets
 from datacube.utils import _readable_offset, changes, jsonify_document
 from datacube.utils.changes import Offset, get_doc_changes
+
+if TYPE_CHECKING:
+    from datacube.drivers.postgres import PostgresDb
+    from datacube.index.postgres.index import Index
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -49,7 +55,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
     :type _db: datacube.drivers.postgres._connections.PostgresDb
     """
 
-    def __init__(self, db, index) -> None:
+    def __init__(self, db: PostgresDb, index: Index) -> None:
         """
         :type db: datacube.drivers.postgres._connections.PostgresDb
         """
@@ -117,7 +123,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             return [self._make(r, full_info=True) for r in rows]
 
     @override
-    def get_derived(self, id_: UUID | str) -> list[Dataset]:
+    def get_derived(self, id_: DSID) -> list[Dataset]:
         """
         Get all derived datasets
 
@@ -133,7 +139,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             ]
 
     @override
-    def has(self, id_: UUID | str) -> bool:
+    def has(self, id_: DSID) -> bool:
         """
         Have we already indexed this dataset?
 
@@ -144,7 +150,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             return connection.contains_dataset(id_)
 
     @override
-    def bulk_has(self, ids_: Iterable[str | UUID]) -> list[bool]:
+    def bulk_has(self, ids_: Iterable[DSID]) -> list[bool]:
         """
         Like `has` but operates on a list of ids.
 
@@ -316,7 +322,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
     @override
     def can_update(
         self, dataset: Dataset, updates_allowed=None
-    ) -> tuple[bool, list, list]:
+    ) -> tuple[bool, list[changes.Change], list[changes.Change]]:
         """
         Check if dataset can be updated. Return bool,safe_changes,unsafe_changes
 
@@ -494,7 +500,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         return purged
 
     @override
-    def get_all_dataset_ids(self, archived: bool | None = False) -> list:
+    def get_all_dataset_ids(self, archived: bool | None = False) -> list[UUID]:
         """
         Get list of all dataset IDs based only on archived status
 
@@ -580,7 +586,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         category=ODC2DeprecationWarning,
     )
     @override
-    def add_location(self, id_, uri) -> bool:
+    def add_location(self, id_: DSID, uri: str) -> bool:
         """
         Add a location to the dataset if it doesn't already exist.
 
@@ -617,7 +623,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         category=ODC2DeprecationWarning,
     )
     @override
-    def remove_location(self, id_, uri) -> bool:
+    def remove_location(self, id_: DSID, uri: str) -> bool:
         """
         Remove a location from the dataset if it exists.
 
@@ -637,7 +643,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         category=ODC2DeprecationWarning,
     )
     @override
-    def archive_location(self, id_, uri) -> bool:
+    def archive_location(self, id_: DSID, uri: str) -> bool:
         """
         Archive a location of the dataset if it exists.
 
@@ -657,7 +663,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         category=ODC2DeprecationWarning,
     )
     @override
-    def restore_location(self, id_, uri) -> bool:
+    def restore_location(self, id_: DSID, uri: str) -> bool:
         """
         Un-archive a location of the dataset if it exists.
 
@@ -695,7 +701,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
     def _make_many(
         self, query_result, product=None, fetch_all: bool = False
-    ) -> Iterator | list:
+    ) -> Iterable[Dataset]:
         """
         :rtype list[Dataset]
         """
@@ -705,7 +711,9 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             return (self._make(dataset, product=product) for dataset in query_result)
 
     @override
-    def search_by_metadata(self, metadata, archived: bool | None = False) -> Iterable:
+    def search_by_metadata(
+        self, metadata, archived: bool | None = False
+    ) -> Iterable[Dataset]:
         """
         Perform a search using arbitrary metadata, returning results as Dataset objects.
 
@@ -737,7 +745,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         archived: bool | None = False,
         order_by=None,
         **query,
-    ) -> Iterable:
+    ) -> Iterable[Dataset]:
         """
         Perform a search, returning results as Dataset objects.
 
@@ -843,7 +851,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                 yield result_type(**kwargs)
 
     @override
-    def count(self, archived: bool | None = False, **query) -> int:
+    def count(self, archived: bool | None = False, **query: QueryField) -> int:
         """
         Perform a search, returning count of results.
 
@@ -860,8 +868,8 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
     @override
     def count_by_product(
-        self, archived: bool | None = False, **query
-    ) -> Iterable[tuple]:
+        self, archived: bool | None = False, **query: QueryField
+    ) -> Iterable[tuple[Product, int]]:
         """
         Perform a search, returning a count of for each matching product type.
 
@@ -872,9 +880,10 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         """
         return self._do_count_by_product(query, archived=archived)
 
-    # FIXME: Missing parameters from super method.
     @override
-    def count_by_product_through_time(self, period, **query):
+    def count_by_product_through_time(
+        self, period: str, archived: bool | None = False, **query: QueryField
+    ) -> Iterable[tuple[Product, Iterable[tuple[Range, int]]]]:
         """
         Perform a search, returning counts for each product grouped in time slices
         of the given period.
@@ -886,9 +895,10 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         """
         return self._do_time_count(period, query)
 
-    # FIXME: Missing parameters from super method.
     @override
-    def count_product_through_time(self, period, **query):
+    def count_product_through_time(
+        self, period: str, archived: bool | None = False, **query: QueryField
+    ) -> Iterable[tuple[Range, int]]:
         """
         Perform a search, returning counts for a single product grouped in time slices
         of the given period.
@@ -1068,7 +1078,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
     @override
     def temporal_extent(
-        self, ids: Iterable[DSID] | None = None
+        self, ids: Iterable[DSID]
     ) -> tuple[datetime.datetime, datetime.datetime]:
         """
         Returns the minimum and maximum acquisition time of the specified datasets.

--- a/datacube/index/postgres/_metadata_types.py
+++ b/datacube/index/postgres/_metadata_types.py
@@ -2,8 +2,11 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import logging
 from collections.abc import Iterable, Mapping
+from typing import TYPE_CHECKING
 
 from cachetools.func import lru_cache
 from typing_extensions import override
@@ -21,11 +24,15 @@ from datacube.utils.changes import (
 )
 from datacube.utils.documents import JsonDict
 
+if TYPE_CHECKING:
+    from datacube.drivers.postgres import PostgresDb
+    from datacube.index.postgres.index import Index
+
 _LOG: logging.Logger = logging.getLogger(__name__)
 
 
 class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
-    def __init__(self, db, index) -> None:
+    def __init__(self, db: PostgresDb, index: Index) -> None:
         """
         :type db: datacube.drivers.postgres._connections.PostgresDb
         """

--- a/datacube/index/postgres/_products.py
+++ b/datacube/index/postgres/_products.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import datetime
 import logging
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Generator, Iterable, Mapping, Sequence
 from typing import TYPE_CHECKING, cast
 
 from cachetools.func import lru_cache
@@ -277,7 +277,7 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
         definition,
         allow_unsafe_updates: bool = False,
         allow_table_lock: bool = False,
-    ):
+    ) -> Product | None:
         """
         Update a Product using its definition
 
@@ -409,7 +409,7 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
                 yield type_, remaining_matchable
 
     @override
-    def search_by_metadata(self, metadata):
+    def search_by_metadata(self, metadata) -> Generator[Product]:
         """
         Perform a search using arbitrary metadata, returning results as Product objects.
 

--- a/datacube/model/fields.py
+++ b/datacube/model/fields.py
@@ -85,7 +85,8 @@ class Field:
             f"Invalid type name {self.type_name!r}"
         )
 
-    def __eq__(self, value) -> Expression:  # type: ignore
+    @override
+    def __eq__(self, value) -> Expression:  # type: ignore[override]
         """
         Is this field equal to a value?
 

--- a/datacube/model/utils.py
+++ b/datacube/model/utils.py
@@ -6,9 +6,9 @@ import os
 import platform
 import sys
 import uuid
-from collections.abc import Mapping, Sequence
+from collections.abc import Generator, Mapping, Sequence
 from datetime import datetime, timezone
-from typing import Literal
+from typing import Any, Literal
 
 import numpy
 import toolz
@@ -17,6 +17,7 @@ import yaml
 from odc.geo import CRS
 from odc.geo.geom import Geometry, point
 from pandas import to_datetime
+from xarray import DataArray
 
 import datacube
 from datacube.model import Dataset
@@ -151,7 +152,7 @@ def source_info(source_datasets):
     }
 
 
-def datasets_to_doc(output_datasets):
+def datasets_to_doc(output_datasets: DataArray) -> DataArray:
     """
     Create a yaml document version of every dataset
 
@@ -167,7 +168,7 @@ def datasets_to_doc(output_datasets):
     return xr_apply(output_datasets, dataset_to_yaml, dtype="O").astype("S")
 
 
-def xr_iter(data_array):
+def xr_iter(data_array: DataArray) -> Generator[tuple[tuple, dict, Any]]:
     """
     Iterate over every element in an xarray, returning::
 
@@ -189,8 +190,8 @@ def xr_iter(data_array):
 
 
 def xr_apply(
-    data_array, func, dtype=None, with_numeric_index: bool = False
-) -> xarray.DataArray:
+    data_array: DataArray, func, dtype=None, with_numeric_index: bool = False
+) -> DataArray:
     """
     Apply a function to every element of a :class:`xarray.DataArray`
 

--- a/datacube/scripts/search_tool.py
+++ b/datacube/scripts/search_tool.py
@@ -137,7 +137,7 @@ def printable_dt(val: datetime.datetime) -> str:
 
 
 @printable.register(Range)
-def printable_r(val) -> str:
+def printable_r(val: Range) -> str:
     """
     :type val: sqlalchemy.dialects.postgresql.Range
     """

--- a/datacube/storage/_rio.py
+++ b/datacube/storage/_rio.py
@@ -52,7 +52,9 @@ class BandDataSource(GeoRasterReader):
     :type source: rasterio.Band
     """
 
-    def __init__(self, source, nodata=None, lock: RLock | None = None) -> None:
+    def __init__(
+        self, source: rasterio.Band, nodata=None, lock: RLock | None = None
+    ) -> None:
         self.source = source
         if nodata is None:
             nodata = self.source.ds.nodatavals[self.source.bidx - 1]

--- a/datacube/utils/dask.py
+++ b/datacube/utils/dask.py
@@ -305,7 +305,9 @@ _save_blob_to_file_delayed = delayed(
 _save_blob_to_s3_delayed = delayed(_save_blob_to_s3, name="save-to-s3", pure=False)
 
 
-def save_blob_to_file(data, fname, with_deps=None) -> tuple[Path, bool]:
+def save_blob_to_file(
+    data: bytes | str, fname: str, with_deps=None
+) -> tuple[Path, bool]:
     """
     Dump from memory to local filesystem as a dask delayed operation.
 
@@ -333,9 +335,9 @@ def save_blob_to_file(data, fname, with_deps=None) -> tuple[Path, bool]:
 
 
 def save_blob_to_s3(
-    data,
-    url,
-    profile=None,
+    data: bytes | str,
+    url: str,
+    profile: str | None = None,
     creds=None,
     region_name: str | None = None,
     with_deps=None,

--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -6,6 +6,8 @@
 Functions for working with YAML documents and configurations
 """
 
+from __future__ import annotations
+
 import collections.abc
 import gzip
 import json
@@ -13,11 +15,11 @@ import logging
 import math
 import sys
 from collections import OrderedDict
-from collections.abc import Iterator, Mapping
+from collections.abc import Generator, Iterator, Mapping
 from contextlib import contextmanager
 from copy import deepcopy
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 from uuid import UUID
@@ -26,6 +28,9 @@ import numpy
 import toolz
 import yaml
 from typing_extensions import override
+
+if TYPE_CHECKING:
+    from datacube.model import Field
 
 try:
     from yaml import CSafeLoader as SafeLoader
@@ -127,7 +132,7 @@ def load_documents(path):
             yield from parser(fh)
 
 
-def read_documents(*paths, uri: bool = False):
+def read_documents(*paths, uri: bool = False) -> Generator[tuple[str, dict]]:
     """
     Read and parse documents from the filesystem or remote URLs (yaml or json).
 
@@ -240,7 +245,7 @@ _ALL_SUPPORTED_EXTENSIONS: tuple[str, ...] = tuple(
 )
 
 
-def is_supported_document_type(path) -> bool:
+def is_supported_document_type(path: Path | str) -> bool:
     """
     Does a document path look like a supported type?
 
@@ -462,7 +467,7 @@ class SimpleDocNav:
     def location(self):
         return self._doc.get("location", None)
 
-    def without_location(self) -> "SimpleDocNav":
+    def without_location(self) -> SimpleDocNav:
         if self.location is None:
             return self
         return SimpleDocNav(toolz.dissoc(self._doc, "location"))
@@ -479,7 +484,12 @@ def _set_doc_offset(offset: list[str | int], document: dict, value) -> None:
 
 
 class DocReader:
-    def __init__(self, type_definition, search_fields, doc) -> None:
+    def __init__(
+        self,
+        type_definition: dict[str, list[str]],
+        search_fields,
+        doc: Mapping[str, Field],
+    ) -> None:
         """
         :type type_definition: dict[str,list[str]]
         :type doc: dict

--- a/datacube/utils/masking.py
+++ b/datacube/utils/masking.py
@@ -77,7 +77,7 @@ def _order_bitdefs_by_bits(bitdef):
         return defn["bits"]
 
 
-def make_mask(variable, **flags):
+def make_mask(variable: Dataset | DataArray, **flags):
     """
     Returns a mask array, based on provided flags
 
@@ -191,7 +191,7 @@ def create_mask_value(bits_def, **flags) -> tuple[int, int]:
     return mask, value
 
 
-def mask_to_dict(bits_def, mask_value):
+def mask_to_dict(bits_def: dict, mask_value: int) -> dict:
     """
     Describes which flags are set for a mask value
 
@@ -241,7 +241,7 @@ def get_flags_def(variable):
     raise ValueError("No masking variable found")
 
 
-def set_value_at_index(bitmask, index, value):
+def set_value_at_index(bitmask: int, index: int, value: bool) -> int:
     """
     Set a bit value onto an integer bitmask
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -17,6 +17,7 @@ Next Release
 - index: fix search_by_product type :pull:`1944`
 - Put coverage config in pyproject :pull:`1942`
 - Fix alembic deprecation warning :pull:`1941`
+- Convert doc strings to type annotations :pull:`1940`
 
 v1.9.4 (20 May 2025)
 ====================

--- a/examples/io_plugin/dcio_example/pickles.py
+++ b/examples/io_plugin/dcio_example/pickles.py
@@ -107,7 +107,7 @@ class PickleWriterDriver:
     def uri_scheme(self):
         return PROTOCOL
 
-    def mk_uri(self, file_path, storage_config):
+    def mk_uri(self, file_path: Path, storage_config: dict) -> str:
         """
         Constructs a URI from the file_path and storage config.
 
@@ -119,10 +119,9 @@ class PickleWriterDriver:
 
             mk_uri(file_path, storage_config) should return 'file:///path/to/my_file.pickled'
 
-        :param Path file_path: The file path of the file to be converted into a URI.
-        :param dict storage_config: The dict holding the storage config found in the ingest definition.
+        :param file_path: The file path of the file to be converted into a URI.
+        :param storage_config: The dict holding the storage config found in the ingest definition.
         :return: file_path as a URI that the Driver understands.
-        :rtype: str
         """
         return normalise_path(file_path).as_uri()
 

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -22,7 +22,7 @@ from datacube.drivers.postgres._fields import (
 from datacube.drivers.postgres._fields import PgField as PgrPgField
 from datacube.index import Index
 from datacube.index.abstract import default_metadata_type_docs
-from datacube.model import Dataset, MetadataType, Not, Product, Range
+from datacube.model import Dataset, DatasetType, MetadataType, Not, Product, Range
 from datacube.testutils import sanitise_doc, suppress_deprecations
 from datacube.utils import changes
 from datacube.utils.documents import documents_equal
@@ -60,10 +60,9 @@ _DATASET_METADATA = {
 
 
 @pytest.mark.parametrize("datacube_env_name", ("datacube",))
-def test_metadata_indexes_views_exist(index, default_metadata_type) -> None:
-    """
-    :type default_metadata_type: datacube.model.MetadataType
-    """
+def test_metadata_indexes_views_exist(
+    index, default_metadata_type: MetadataType
+) -> None:
     # Metadata indexes should no longer exist.
     assert not _object_exists(index, "dix_eo_platform")
 
@@ -72,10 +71,7 @@ def test_metadata_indexes_views_exist(index, default_metadata_type) -> None:
 
 
 @pytest.mark.parametrize("datacube_env_name", ("datacube",))
-def test_dataset_indexes_views_exist(index, ls5_telem_type) -> None:
-    """
-    :type ls5_telem_type: datacube.model.DatasetType
-    """
+def test_dataset_indexes_views_exist(index, ls5_telem_type: DatasetType) -> None:
     assert ls5_telem_type.name == "ls5_telem_test"
 
     # Ensure field indexes were created for the dataset type (following the naming conventions):
@@ -172,11 +168,8 @@ def _object_exists(index, index_name) -> bool:
 
 
 def test_idempotent_add_dataset_type(
-    index, ls8_eo3_product, extended_eo3_product_doc
+    index: Index, ls8_eo3_product, extended_eo3_product_doc
 ) -> None:
-    """
-    :type index: datacube.index.Index
-    """
     assert index.products.get_by_name(ls8_eo3_product.name) is not None
 
     # Re-add should have no effect, because it's equal to the current one.
@@ -192,10 +185,9 @@ def test_idempotent_add_dataset_type(
 
 
 @pytest.mark.parametrize("datacube_env_name", ("datacube",))
-def test_update_dataset(index, ls5_telem_doc, example_ls5_nbar_metadata_doc) -> None:
-    """
-    :type index: datacube.index.Index
-    """
+def test_update_dataset(
+    index: Index, ls5_telem_doc, example_ls5_nbar_metadata_doc
+) -> None:
     ls5_telem_type = index.products.add_document(ls5_telem_doc)
     assert ls5_telem_type
 
@@ -278,12 +270,8 @@ def test_update_dataset(index, ls5_telem_doc, example_ls5_nbar_metadata_doc) -> 
 
 @pytest.mark.parametrize("datacube_env_name", ("datacube",))
 def test_update_product_type(
-    index, ls5_telem_type, ls5_telem_doc, ga_metadata_type_doc
+    index: Index, ls5_telem_type: Product, ls5_telem_doc, ga_metadata_type_doc
 ) -> None:
-    """
-    :type ls5_telem_type: datacube.model.Product
-    :type index: datacube.index.Index
-    """
     assert index.products.get_by_name(ls5_telem_type.name) is not None
 
     # Update with a new description
@@ -488,11 +476,7 @@ def _to_yaml(ls5_telem_doc):
     return yaml.safe_dump(ls5_telem_doc, allow_unicode=True)
 
 
-def test_update_metadata_type(index, default_metadata_type) -> None:
-    """
-    :type default_metadata_type: list[dict]
-    :type index: datacube.index.Index
-    """
+def test_update_metadata_type(index: Index, default_metadata_type: list[dict]) -> None:
     mt_doc = next(
         d
         for d in default_metadata_type_docs()
@@ -533,10 +517,7 @@ def test_update_metadata_type(index, default_metadata_type) -> None:
     ) or isinstance(updated_type.dataset_fields["time"], PgsNumericRangeDocField)
 
 
-def test_filter_types_by_fields(index, wo_eo3_product) -> None:
-    """
-    :type index: datacube.index.Index
-    """
+def test_filter_types_by_fields(index: Index, wo_eo3_product) -> None:
     res = list(
         index.metadata_types.get_with_fields(["platform", "instrument", "region_code"])
     )
@@ -562,18 +543,12 @@ def test_filter_types_by_fields(index, wo_eo3_product) -> None:
     assert len(res) == 0
 
 
-def test_filter_products_by_types(index, wo_eo3_product) -> None:
-    """
-    :type index: datacube.index.Index
-    """
+def test_filter_products_by_types(index: Index, wo_eo3_product) -> None:
     res = list(index.products.get_with_types([wo_eo3_product.metadata_type]))
     assert res == [wo_eo3_product]
 
 
-def test_filter_types_by_search(index, wo_eo3_product, ls8_eo3_product) -> None:
-    """
-    :type index: datacube.index.Index
-    """
+def test_filter_types_by_search(index: Index, wo_eo3_product, ls8_eo3_product) -> None:
     assert index.products
 
     # No arguments, return all.


### PR DESCRIPTION
### Reason for this pull request

Add the types from the doc strings into the type signature. Sphinx is already configured for injecting the type annotations back into the doc strings, so no need to reconfigure Sphinx.

This is already a 250 line PR, so I left the type annotations in the doc strings so the types would be easier to review. It should be fairly easy to get perl to remove the types from the doc strings in a separate PR after this is merged.


### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1940.org.readthedocs.build/en/1940/

<!-- readthedocs-preview opendatacube end -->