### PR TITLE
Fix alembic deprecation warning

### DIFF
--- a/datacube/drivers/postgis/alembic.ini
+++ b/datacube/drivers/postgis/alembic.ini
@@ -17,6 +17,7 @@ prepend_sys_path = .
 # version_path_separator = :
 # version_path_separator = space
 version_path_separator = os  # Use os.pathsep. Default configuration used for new projects.
+path_separator = os
 
 [post_write_hooks]
 # post_write_hooks defines scripts or Python functions that are run

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -12,6 +12,7 @@ Next Release
 - Run Ruff format on all code :pull:`1926`, :pull:`1927`
 - Group all dependabot updates in the 'uv' ecosystem. :pull:`1928`, :pull:`1934`
 - Move deprecated imports :pull:`1938`
+- Fix alembic deprecation warning :pull:`1941`
 
 v1.9.4 (20 May 2025)
 ====================


### PR DESCRIPTION
### Reason for this pull request

Version 0.16 changed to using
path_separator, so add that
into the alembic configuration,
but keep the old directive for
pre-0.16 alembic installations.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1941.org.readthedocs.build/en/1941/

<!-- readthedocs-preview opendatacube end -->