### PR TITLE
Remove types from doc strings

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -61,8 +61,6 @@ class TerminateCurrentLoad(Exception):  # noqa: N818
 class Datacube:
     """
     Interface to search, read and write a datacube.
-
-    :type index: datacube.index.Index
     """
 
     def __init__(
@@ -86,7 +84,7 @@ class Datacube:
             - A list of file system paths to search for config files. The first readable file found will be used.
             If an index or an explicit ODCEnvironment is supplied, config and raw_config should be None.
 
-        :param str env: The datacube environment to use.
+        :param env: The datacube environment to use.
             Either an explicit ODCEnvironment object, or a str which is a section name in the loaded config file.
 
             Defaults to 'default'. Falls back to 'datacube' with a deprecation warning if config file does not
@@ -106,10 +104,9 @@ class Datacube:
             The application name is used to track down problems with database queries, so it is strongly
             advised that be used.  Should be None if an index is supplied.
 
-        :param bool validate_connection: Check that the database connection is available and valid.
+        :param validate_connection: Check that the database connection is available and valid.
             Defaults to True. Ignored if index is passed.
         """
-
         # Validate arguments
 
         if index is not None:
@@ -154,16 +151,15 @@ class Datacube:
             'default_resolution' or 'grid_spec.crs'
             'dataset_count' (optional)
 
-        :param bool with_pandas:
+        :param with_pandas:
             Return the list as a Pandas DataFrame. Defaults to True.  If False, return a list of dicts.
 
-        :param bool dataset_count:
+        :param dataset_count:
             Return a "dataset_count" column containing the number of datasets
             for each product. This can take several minutes on large datacubes.
             Defaults to False.
 
         :return: A table or list of every product in the datacube.
-        :rtype: pandas.DataFrame or list(dict)
         """
 
         def _get_non_default(product, col):
@@ -240,7 +236,6 @@ class Datacube:
 
         :param show_archived: include archived products in the result.
         :param with_pandas: return the list as a Pandas DataFrame, otherwise as a list of dict. (defaults to True)
-        :rtype: pandas.DataFrame or list(dict)
         """
         measurements = self._list_measurements()
         if not with_pandas:
@@ -400,7 +395,7 @@ class Datacube:
             odc-geo style xy objects are preferred for passing in resolution and align pairs to avoid x/y ordering
             ambiguity.
 
-        :param str product:
+        :param product:
             The name of the product to be loaded. Either ``product`` or ``datasets`` must be supplied
 
         :param measurements:
@@ -411,7 +406,7 @@ class Datacube:
             If a list is specified, the measurements will be returned in the order requested.
             By default, all available measurements are included.
 
-        :param str output_crs:
+        :param output_crs:
             The CRS of the returned data, for example ``EPSG:3577``.
             If no CRS is supplied, the CRS of the stored data is used if available.
 
@@ -453,19 +448,19 @@ class Datacube:
 
             Default is ``(0, 0)``
 
-        :param bool skip_broken_datasets:
+        :param skip_broken_datasets:
             Optional. If this is True, then don't break when failing to load a broken dataset.
             If None, the value will come from the environment variable of the same name.
             Default is False.
 
-        :param dict dask_chunks:
+        :param dask_chunks:
             If the data should be lazily loaded using :class:`dask.array.Array`,
             specify the chunking size in each output dimension.
 
             See the documentation on using `xarray with dask <https://xarray.pydata.org/en/stable/dask.html>`_
             for more information.
 
-        :param xarray.Dataset like:
+        :param like:
             Use the output of a previous :meth:`load()` to load data into the same spatial grid and
             resolution (i.e. :class:`odc.geo.geobox.GeoBox` or an xarray `Dataset` or `DataArray`).
             E.g.::
@@ -507,8 +502,6 @@ class Datacube:
             For example: ``'x', 'y', 'time', 'crs'``.
 
         :return: Requested data in a :class:`xarray.Dataset`
-
-        :rtype: :class:`xarray.Dataset`
         """
         if product is None and datasets is None:
             raise ValueError("Must specify a product or supply datasets")
@@ -620,7 +613,7 @@ class Datacube:
 
         :param ensure_location: only return datasets that have locations
         :param dataset_predicate: an optional predicate to filter datasets
-        :param xarray.Dataset like:
+        :param like:
             Use the output of a previous :meth:`load()` to load data into the same spatial grid and
             resolution (i.e. :class:`odc.geo.geobox.GeoBox` or an xarray `Dataset` or `DataArray`).
             E.g.::
@@ -657,7 +650,7 @@ class Datacube:
         :param limit: if provided, limit the maximum number of datasets returned
         :param ensure_location: only return datasets that have locations
         :param dataset_predicate: an optional predicate to filter datasets
-        :param xarray.Dataset like:
+        :param like:
             Use the output of a previous :meth:`load()` to load data into the same spatial grid and
             resolution (i.e. :class:`odc.geo.geobox.GeoBox` or an xarray `Dataset` or `DataArray`).
             E.g.::
@@ -665,11 +658,10 @@ class Datacube:
                 pq = dc.load(product='ls5_pq_albers', like=nbar_dataset)
         :param kwargs: see :class:`datacube.api.query.Query`
         :return: iterator of datasets
-        :rtype: __generator[:class:`datacube.model.Dataset`]
 
         .. seealso:: :meth:`group_datasets` :meth:`load_data` :meth:`find_datasets`
         """
-        query = Query(self.index, like=like, **kwargs)
+        query = Query(self.index, like=like, **kwargs)  # type: ignore[arg-type]
         if not query.product:
             raise ValueError("must specify a product")
 
@@ -695,12 +687,11 @@ class Datacube:
         Group datasets along defined non-spatial dimensions (ie. time).
 
         :param datasets: a list of datasets, typically from :meth:`find_datasets`
-        :param GroupBy group_by: Contains:
+        :param group_by: Contains:
             - a function that returns a label for a dataset
             - name of the new dimension
             - unit for the new dimension
             - function to sort by before grouping
-        :rtype: xarray.DataArray
 
         .. seealso:: :meth:`find_datasets`, :meth:`load_data`, :meth:`query_group_by`
         """
@@ -756,10 +747,10 @@ class Datacube:
 
         This function makes the in memory storage structure to hold datacube data.
 
-        :param dict coords:
+        :param coords:
             OrderedDict holding `DataArray` objects defining the dimensions not specified by `geobox`
 
-        :param GeoBox geobox:
+        :param geobox:
             A GeoBox defining the output spatial projection and resolution
 
         :param measurements:
@@ -770,10 +761,9 @@ class Datacube:
             as an argument. It should return an appropriately shaped numpy array. If not provided memory is
             allocated and filled with `nodata` value defined on a given Measurement.
 
-        :param ExtraDimensions extra_dims:
+        :param extra_dims:
             A ExtraDimensions describing any additional dimensions on top of (t, y, x)
 
-        :rtype: :class:`xarray.Dataset`
 
         .. seealso:: :meth:`find_datasets` :meth:`group_datasets`
         """
@@ -1012,16 +1002,16 @@ class Datacube:
         """
         Load data from :meth:`group_datasets` into an :class:`xarray.Dataset`.
 
-        :param xarray.DataArray sources:
+        :param sources:
             DataArray holding a list of :class:`datacube.model.Dataset`, grouped along the time dimension
 
-        :param GeoBox geobox:
+        :param geobox:
             A GeoBox defining the output spatial projection and resolution
 
         :param measurements:
             list of `Measurement` objects
 
-        :param str|dict resampling:
+        :param resampling:
             The resampling method to use if re-projection is required. This could be a string or
             a dictionary mapping band name to resampling mode. When using a dict use ``'*'`` to
             indicate "apply to all other bands", for example ``{'*': 'cubic', 'fmask': 'nearest'}`` would
@@ -1035,7 +1025,7 @@ class Datacube:
         :param fuse_func:
             function to merge successive arrays as an output. Can be a dictionary just like resampling.
 
-        :param dict dask_chunks:
+        :param dask_chunks:
             If provided, the data will be loaded on demand using :class:`dask.array.Array`.
             Should be a dictionary specifying the chunking size for each output dimension.
             Unspecified dimensions will be auto-guessed, currently this means use chunk size of 1 for non-spatial
@@ -1050,7 +1040,7 @@ class Datacube:
             if supplied will be called for every file read with `files_processed_so_far, total_files`. This is
             only applicable to non-lazy loads, ignored when using dask.
 
-        :param ExtraDimensions extra_dims:
+        :param extra_dims:
             A ExtraDimensions describing any additional dimensions on top of (t, y, x)
 
         :param Callable[[str], str], patch_url:
@@ -1059,7 +1049,6 @@ class Datacube:
         :param driver:
             Optional. If provided, use the specified driver to load the data.
 
-        :rtype: xarray.Dataset
 
         .. seealso:: :meth:`find_datasets` :meth:`group_datasets`
         """

--- a/datacube/api/grid_workflow.py
+++ b/datacube/api/grid_workflow.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import logging
 import typing
 from collections import OrderedDict
-from collections.abc import Generator, Hashable
+from collections.abc import Generator, Hashable, Iterable
 
 import numpy as np
 import pandas as pd
@@ -73,12 +73,12 @@ class Tile:
     the entire `Tile` at once.
     """
 
-    def __init__(self, sources: xr.DataArray, geobox: GeoBox):
+    def __init__(self, sources: xr.DataArray, geobox: GeoBox) -> None:
         """Create a Tile representing a dataset that can be loaded.
 
-        :param xr.DataArray sources: An array of non-spatial dimensions of the request, holding lists of
+        :param sources: An array of non-spatial dimensions of the request, holding lists of
             datacube.storage.DatasetSource objects.
-        :param model.GeoBox geobox: The spatial footprint of the Tile
+        :param geobox: The spatial footprint of the Tile
         """
         self.sources: xr.DataArray = sources
         self.geobox: GeoBox = geobox
@@ -174,11 +174,11 @@ class GridWorkflow:
 
         Either grid_spec or product must be supplied.
 
-        :param datacube.index.Index index: The database index to use.
-        :param GridSpec grid_spec: The grid projection and resolution
-        :param str product: The name of an existing product, if no grid_spec is supplied.
+        :param index: The database index to use.
+        :param grid_spec: The grid projection and resolution
+        :param product: The name of an existing product, if no grid_spec is supplied.
         """
-        self.index: Index = index
+        self.index = index
 
         # If available, use the provided grid_spec
         if grid_spec is not None:
@@ -313,7 +313,6 @@ class GridWorkflow:
 
         :param observations: datasets grouped by cell index, like from :py:meth:`cell_observations`
         :param group_by: grouping method, as returned by :py:meth:`datacube.api.query.query_group_by`
-        :type group_by: :py:class:`datacube.api.query.GroupBy`
         :return: tiles grouped by cell index
 
         .. seealso::
@@ -336,9 +335,7 @@ class GridWorkflow:
 
         :param observations: datasets grouped by cell index, like from :meth:`cell_observations`
         :param group_by: grouping method, as returned by :py:meth:`datacube.api.query.query_group_by`
-        :type group_by: :py:class:`datacube.api.query.GroupBy`
         :return: tiles grouped by cell index and time
-        :rtype: dict[tuple(int, int, numpy.datetime64), :py:class:`.Tile`]
 
         .. seealso::
             :meth:`load`
@@ -402,12 +399,12 @@ class GridWorkflow:
 
     @staticmethod
     def load(
-        tile,
-        measurements=None,
-        dask_chunks=None,
+        tile: Tile,
+        measurements: Iterable[str] | None = None,
+        dask_chunks: dict[str, str | int] | None = None,
         fuse_func=None,
-        resampling=None,
-        skip_broken_datasets=False,
+        resampling: str | dict | None = None,
+        skip_broken_datasets: bool = False,
     ) -> xr.Dataset:
         """
         Load data for a cell/tile.
@@ -420,11 +417,11 @@ class GridWorkflow:
         See the documentation on using `xr with dask <http://xr.pydata.org/en/stable/dask.html>`_
         for more information.
 
-        :param `.Tile` tile: The tile to load.
+        :param tile: The tile to load.
 
-        :param list(str) measurements: The names of measurements to load
+        :param measurements: The names of measurements to load
 
-        :param dict dask_chunks: If the data should be loaded as needed using :py:class:`dask.array.Array`,
+        :param dask_chunks: If the data should be loaded as needed using :py:class:`dask.array.Array`,
             specify the chunk size in each output direction.
 
             See the documentation on using `xr with dask <http://xr.pydata.org/en/stable/dask.html>`_
@@ -433,7 +430,7 @@ class GridWorkflow:
         :param fuse_func: Function to fuse together a tile that has been pre-grouped by calling
             :meth:`list_cells` with a ``group_by`` parameter.
 
-        :param str|dict resampling:
+        :param resampling:
 
             The resampling method to use if re-projection is required, could be
             configured per band using a dictionary (:meth: `load_data`)
@@ -442,10 +439,9 @@ class GridWorkflow:
 
             Defaults to ``'nearest'``.
 
-        :param bool skip_broken_datasets: If True, ignore broken datasets and continue processing with the data
+        :param skip_broken_datasets: If True, ignore broken datasets and continue processing with the data
              that can be loaded. If False, an exception will be raised on a broken dataset. Defaults to False.
 
-        :rtype: :py:class:`xr.Dataset`
 
         .. seealso::
             :meth:`list_tiles` :meth:`list_cells`

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -11,6 +11,7 @@ import datetime
 import logging
 import math
 import warnings
+from collections.abc import Iterable
 
 import numpy as np
 import pandas
@@ -20,6 +21,8 @@ from odc.geo.geobox import GeoBox
 from odc.geo.geom import lonlat_bounds, mid_longitude
 from pandas import to_datetime as pandas_to_datetime
 from typing_extensions import override
+
+from datacube.index import Index
 
 from ..index import extract_geom_from_query, strip_all_spatial_fields_from_query
 from ..model import Dataset, QueryField, Range
@@ -72,8 +75,8 @@ OTHER_KEYS = (
 class Query:
     def __init__(
         self,
-        index=None,
-        product=None,
+        index: Index | None = None,
+        product: str | None = None,
         geopolygon=None,
         like: GeoBox | xarray.Dataset | xarray.DataArray | None = None,
         **search_terms,
@@ -95,14 +98,14 @@ class Query:
 
         Used by :meth:`datacube.Datacube.find_datasets` and :meth:`datacube.Datacube.load`.
 
-        :param datacube.index.Index index: An optional `index` object, if checking of field names is desired.
-        :param str product: name of product
+        :param index: An optional `index` object, if checking of field names is desired.
+        :param product: name of product
         :type geopolygon: the spatial boundaries of the search, can be:
                           odc.geo.geom.Geometry: A Geometry object
                           Any string or JsonLike object that can be converted to a Geometry object.
                           An iterable of either of the above; or
                           None: no geopolygon defined (may be derived from like or lat/lon/x/y/crs search terms)
-        :param xarray.Dataset like: spatio-temporal bounds of `like` are used for the search
+        :param like: spatio-temporal bounds of `like` are used for the search
         :param search_terms:
          * `measurements` - list of measurements to retrieve
          * `latitude`, `lat`, `y`, `longitude`, `lon`, `long`, `x` - tuples (min, max) bounding spatial dimensions
@@ -124,11 +127,11 @@ class Query:
 
         search_terms = strip_all_spatial_fields_from_query(search_terms)
         remaining_keys = set(search_terms.keys()) - set(OTHER_KEYS)
-        if self.index:
+        if index:
             # Retrieve known keys for extra dimensions
-            known_dim_keys = set()
+            known_dim_keys: set = set()
             if product is not None:
-                datacube_products = index.products.search(product=product)
+                datacube_products: Iterable = index.products.search(product=product)
             else:
                 datacube_products = index.products.get_all()
 
@@ -167,8 +170,6 @@ class Query:
     def search_terms(self) -> dict:
         """
         Access the search terms as a dictionary.
-
-        :type: dict
         """
         kwargs = {}
         kwargs.update(self.search)

--- a/datacube/cfg/api.py
+++ b/datacube/cfg/api.py
@@ -40,7 +40,6 @@ class ODCConfig:
     **Attributes**
 
     .. py:attribute:: allow_envvar_overrides
-       :type: bool
        :value: True
 
        If True, environment variables can override the values explicitly specified in the supplied configuration.
@@ -49,7 +48,6 @@ class ODCConfig:
        still be read from environment variables, even if this attribute is False.
 
     .. py:attribute:: raw_text
-       :type: str | None
 
        The raw configuration text being used, as read from the configuration
        file or supplied directly by the user.  May be None if the user
@@ -58,25 +56,21 @@ class ODCConfig:
        environment variables.
 
     .. py:attribute:: raw_config
-       :type: dict[str, dict[str, Any]]
 
        The raw dictionary form of the configuration, as supplied directly
        by the user, or as parsed from raw_text. Does not include dynamic
        environments or values overridden by environment variables.
 
     .. py:attribute:: known_environments
-       :type: dict[str, "ODCEnvironment"]
 
        A dictionary containing all environments defined in raw_config,
        plus any dynamic environments read so far.
        Environment themselves are not validated until read from.
 
     .. py:attribute:: canonical_names
-       :type: dict[str, list[str]]
 
        A dictionary mapping canonical environment names to all aliases for
        that environment.
-
     """
 
     allow_envvar_overrides: bool = True

--- a/datacube/cfg/opt.py
+++ b/datacube/cfg/opt.py
@@ -50,7 +50,6 @@ class ODCOptionHandler:
         legacy_env_aliases=None,
     ) -> None:
         """
-
         :param name: Name of the option
         :param env: The ODCEnvironment the option is being read from
         :param default: The default value if not specified in the config file

--- a/datacube/drivers/netcdf/_write.py
+++ b/datacube/drivers/netcdf/_write.py
@@ -3,7 +3,14 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import logging
+from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
+
+import netCDF4
+import xarray
+from odc.geo import CRS
+from xarray.core.coordinates import DatasetCoordinates
 
 from datacube.storage._hdf5 import HDF5_LOCK
 from datacube.utils import DatacubeException
@@ -35,24 +42,24 @@ def _get_units(coord) -> str:
 
 def create_netcdf_storage_unit(
     filename: Path,
-    crs,
-    coordinates,
-    variables,
-    variable_params,
-    global_attributes=None,
-    netcdfparams=None,
-):
+    crs: CRS,
+    coordinates: DatasetCoordinates,
+    variables: Mapping[str, Any],
+    variable_params: Mapping[str, Mapping[str, Any]],
+    global_attributes: dict | None = None,
+    netcdfparams: dict | None = None,
+) -> netCDF4.Dataset:
     """
     Create a NetCDF file on disk.
 
-    :param pathlib.Path filename: filename to write to
-    :param odc.geo.crs.CRS crs: Datacube CRS object defining the spatial projection
-    :param dict coordinates: Dict of named `datacube.model.Coordinate`s to create
-    :param dict variables: Dict of named `datacube.model.Variable`s to create
-    :param dict variable_params:
+    :param filename: filename to write to
+    :param crs: Datacube CRS object defining the spatial projection
+    :param coordinates: Dict of named `datacube.model.Coordinate`s to create
+    :param variables: Dict of named `datacube.model.Variable`s to create
+    :param variable_params:
         Dict of dicts, with keys matching variable names, of extra parameters for variables
-    :param dict global_attributes: named global attributes to add to output file
-    :param dict netcdfparams: Extra parameters to use when creating netcdf file
+    :param global_attributes: named global attributes to add to output file
+    :param netcdfparams: Extra parameters to use when creating netcdf file
     :return: open netCDF4.Dataset object, ready for writing to
     """
     filename = Path(filename)
@@ -70,7 +77,9 @@ def create_netcdf_storage_unit(
 
     for name, coord in coordinates.items():
         if coord.values.ndim > 0:  # skip CRS coordinate
-            netcdf_writer.create_coordinate(nco, name, coord.values, _get_units(coord))
+            netcdf_writer.create_coordinate(
+                nco, str(name), coord.values, _get_units(coord)
+            )
 
     grid_mapping = netcdf_writer.DEFAULT_GRID_MAPPING
     netcdf_writer.create_grid_mapping_variable(nco, crs, name=grid_mapping)
@@ -96,10 +105,10 @@ def create_netcdf_storage_unit(
 
 
 def write_dataset_to_netcdf(
-    dataset,
+    dataset: xarray.Dataset,
     filename: Path,
-    global_attributes=None,
-    variable_params=None,
+    global_attributes: dict | None = None,
+    variable_params: dict | None = None,
     netcdfparams=None,
 ) -> None:
     """
@@ -107,7 +116,7 @@ def write_dataset_to_netcdf(
 
     Requires a spatial Dataset, with attached coordinates and global crs attribute.
 
-    :param `xarray.Dataset` dataset:
+    :param dataset:
     :param filename: Output filename
     :param global_attributes: Global file attributes. dict of attr_name: attr_value
     :param variable_params: dict of variable_name: {param_name: param_value, [...]}

--- a/datacube/drivers/netcdf/driver.py
+++ b/datacube/drivers/netcdf/driver.py
@@ -58,9 +58,8 @@ class NetcdfWriterDriver:
 
             mk_uri(file_path) should return 'file:///path/to/my_file.nc'
 
-        :param Path file_path: The file path of the file to be converted into a URI.
+        :param file_path: The file path of the file to be converted into a URI.
         :return: file_path as a URI that the Driver understands.
-        :rtype: str
         """
         return normalise_path(file_path).as_uri()
 

--- a/datacube/drivers/netcdf/writer.py
+++ b/datacube/drivers/netcdf/writer.py
@@ -69,7 +69,7 @@ def create_netcdf(netcdf_path: str | PathLike, **kwargs) -> Dataset:
     return nco
 
 
-def append_netcdf(netcdf_path) -> Dataset:
+def append_netcdf(netcdf_path: PathLike) -> Dataset:
     """
     Open a NetCDF file in append mode
 
@@ -82,13 +82,6 @@ def append_netcdf(netcdf_path) -> Dataset:
 def create_coordinate(
     nco: Dataset, name: str, labels: Sequence[str], units: str
 ) -> netCDF4.Variable:
-    """
-    :type nco: netCDF4.Dataset
-    :type name: str
-    :type labels: numpy.array
-    :type units: str
-    :rtype: netCDF4.Variable
-    """
     labels = netcdfy_coord(labels)
 
     nco.createDimension(name, labels.size)
@@ -102,14 +95,9 @@ def create_coordinate(
     return var
 
 
-def create_variable(nco, name: str, var, grid_mapping=None, attrs=None, **kwargs):
-    """
-    :param nco:
-    :param name:
-    :param datacube.model.Variable var:
-    :param kwargs:
-    :return:
-    """
+def create_variable(
+    nco, name: str, var: Variable, grid_mapping=None, attrs=None, **kwargs
+):
     assert var.dtype.kind != "U"  # Creates Non CF-Compliant NetCDF File
 
     def clamp_chunksizes(chunksizes: Sequence[int] | None, dim_names: Sequence[str]):

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -284,11 +284,7 @@ class PostgisDbAPI:
     def insert_dataset(self, metadata_doc, dataset_id, product_id) -> bool:
         """
         Insert dataset if not already indexed.
-        :type metadata_doc: dict
-        :type dataset_id: str or uuid.UUID
-        :type product_id: int
         :return: whether it was inserted
-        :rtype: bool
         """
         metadata_subquery = (
             select(Product.metadata_type_ref)
@@ -318,9 +314,6 @@ class PostgisDbAPI:
     def update_dataset(self, metadata_doc, dataset_id, product_id) -> bool:
         """
         Update dataset
-        :type metadata_doc: dict
-        :type dataset_id: str or uuid.UUID
-        :type product_id: int
         """
         res = self._connection.execute(
             update(Dataset.__table__)  # type: ignore[arg-type]
@@ -336,12 +329,7 @@ class PostgisDbAPI:
         Add a location to a dataset if it is not already recorded.
 
         Returns True if success, False if this location already existed
-
-        :type dataset_id: str or uuid.UUID
-        :type uri: str
-        :rtype bool:
         """
-
         scheme, body = split_uri(uri)
 
         r = self._connection.execute(
@@ -358,12 +346,6 @@ class PostgisDbAPI:
         Add/update a search field index entry for a dataset
 
         Returns True on success
-
-        :type search_table: A DatasetSearch ORM table
-        :type dataset_id: str or uuid.UUID
-        :type key: The name of the search field
-        :type value: The value for the search field for this dataset.
-        :rtype bool:
         """
         if isinstance(value, Range):
             value = list(value)
@@ -393,11 +375,6 @@ class PostgisDbAPI:
         Add/update a spatial index entry for a dataset
 
         Returns True on success
-
-        :type dataset_id: str or uuid.UUID
-        :type crs: CRS
-        :type extent: Geometry
-        :rtype bool:
         """
         values = generate_dataset_spatial_values(dataset_id, crs, extent)
         if values is None:
@@ -531,9 +508,6 @@ class PostgisDbAPI:
     ) -> dict:
         """
         Find any datasets that have the given metadata.
-
-        :type metadata: dict
-        :rtype: dict
         """
         # Find any storage types whose 'dataset_metadata' document is a subset of the metadata.
         where = Dataset.metadata_doc.contains(metadata)
@@ -547,9 +521,6 @@ class PostgisDbAPI:
     def search_products_by_metadata(self, metadata: dict) -> dict:
         """
         Find any datasets that have the given metadata.
-
-        :type metadata: dict
-        :rtype: dict
         """
         # Find any storage types whose 'dataset_metadata' document is a subset of the metadata.
         return self._connection.execute(
@@ -590,16 +561,6 @@ class PostgisDbAPI:
         archived: bool | None = False,
         order_by: Iterable | None = None,
     ) -> Select:
-        """
-        :type expressions: Tuple[Expression]
-        :type source_exprs: Tuple[Expression]
-        :type select_fields: Iterable[PgField]
-        :type with_source_ids: bool
-        :type limit: int
-        :type order_by: Iterable[Any]
-        :type geom: Geometry
-        :rtype: sqlalchemy.Expression
-        """
         # TODO: lineage handling and source search
         assert source_exprs is None
         assert not with_source_ids
@@ -667,10 +628,6 @@ class PostgisDbAPI:
         order_by=None,
     ) -> Iterator:
         """
-        :type with_source_ids: bool
-        :type select_fields: tuple[datacube.drivers.postgis._fields.PgField]
-        :type expressions: tuple[datacube.drivers.postgis._fields.PgExpression]
-
         :return: An iterable of tuples of decoded values
         """
         assert source_exprs is None
@@ -859,11 +816,6 @@ class PostgisDbAPI:
         archived: bool | None = False,
         geom: Geometry | None = None,
     ) -> int:
-        """
-        :type expressions: tuple[datacube.drivers.postgis._fields.PgExpression]
-        :rtype: int
-        """
-
         raw_expressions = self._alchemify_expressions(expressions)
         if archived:
             where_expressions = and_(Dataset.archived.is_not(None), *raw_expressions)
@@ -893,14 +845,6 @@ class PostgisDbAPI:
         time_field,
         expressions: Iterable[Expression],
     ) -> Iterator[tuple[tuple[datetime.datetime, datetime.datetime], int]]:
-        """
-        :type period: str
-        :type start: datetime.datetime
-        :type end: datetime.datetime
-        :type expressions: tuple[datacube.drivers.postgis._fields.PgExpression]
-        :rtype: list[((datetime.datetime, datetime.datetime), int)]
-        """
-
         results = self._connection.execute(
             self.count_datasets_through_time_query(
                 start, end, period, time_field, expressions

--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -189,7 +189,6 @@ def schema_is_latest(engine: Engine) -> bool:
 
     See the ``update_schema()`` function below for actually applying the updates.
     """
-
     # No schema changes recently. Everything is perfect.
 
     cfg = config.Config(ALEMBIC_INI_LOCATION)

--- a/datacube/drivers/postgis/_fields.py
+++ b/datacube/drivers/postgis/_fields.py
@@ -110,7 +110,6 @@ class PgField(Field):
     def sql_expression(self):
         """
         Get the raw SQL expression for this field as a string.
-        :rtype: str
         """
         return str(
             self.alchemy_expression.compile(
@@ -120,16 +119,10 @@ class PgField(Field):
 
     @override
     def __eq__(self, value) -> Expression:  # type: ignore[override]
-        """
-        :rtype: Expression
-        """
         return EqualsExpression(self, value)
 
     @override
     def between(self, low, high) -> Expression:
-        """
-        :rtype: Expression
-        """
         raise NotImplementedError("between expression")
 
 
@@ -296,16 +289,10 @@ class SimpleDocField(PgDocField):
 
     @override
     def __eq__(self, value) -> Expression:  # type: ignore[override]
-        """
-        :rtype: Expression
-        """
         return EqualsExpression(self, value)
 
     @override
     def between(self, low, high) -> Expression:
-        """
-        :rtype: Expression
-        """
         raise NotImplementedError("Simple field between expression")
 
     can_extract = True
@@ -477,9 +464,6 @@ class RangeDocField(PgDocField):
 
     @override
     def __eq__(self, value) -> Expression:  # type: ignore[override]
-        """
-        :rtype: Expression
-        """
         # Lower and higher are interchangeable here: they're the same type.
         casted_val = self.lower.value_to_alchemy(value)
         return RangeContainsExpression(self, casted_val)
@@ -521,9 +505,6 @@ class NumericRangeDocField(RangeDocField):
 
     @override
     def between(self, low, high) -> Expression:
-        """
-        :rtype: Expression
-        """
         return RangeBetweenExpression(self, low, high, _range_class=PgRange)
 
 
@@ -587,9 +568,6 @@ class DateRangeDocField(RangeDocField):
 
     @override
     def between(self, low, high) -> Expression:
-        """
-        :rtype: Expression
-        """
         low = _number_implies_year(low)
         high = _number_implies_year(high)
 
@@ -640,9 +618,8 @@ def _number_implies_year(v: int | datetime) -> datetime:
 
 
 class PgExpression(Expression):
-    def __init__(self, field) -> None:
+    def __init__(self, field: PgField) -> None:
         super().__init__()
-        #: :type: PgField
         self.field = field
 
     @property
@@ -737,10 +714,7 @@ def parse_fields(doc: dict, table_column) -> dict[str, PgField]:
         }
 
     :param table_column: SQLAlchemy jsonb column for the document we're reading fields from.
-    :type doc: dict
-    :rtype: dict[str, PgField]
     """
-
     # Implementations of fields for this driver
     types = {
         SimpleDocField,
@@ -761,10 +735,7 @@ def parse_fields(doc: dict, table_column) -> dict[str, PgField]:
 
     def _get_field(name: str, descriptor: dict, column) -> PgField:
         """
-        :type name: str
-        :type descriptor: dict
         :param column: SQLAlchemy table column
-        :rtype: PgField
         """
         ctorargs = descriptor.copy()
         type_name = ctorargs.pop("type", "string")

--- a/datacube/drivers/postgis/alembic/env.py
+++ b/datacube/drivers/postgis/alembic/env.py
@@ -51,7 +51,6 @@ def run_migrations_offline() -> None:
 
     Calls to context.execute() here emit the given string to the
     script output.
-
     """
     context.configure(
         dialect_name="postgresql",
@@ -126,7 +125,6 @@ def run_migrations_online() -> None:
 
     In this scenario we need to create an Engine
     and associate a connection with the context.
-
     """
     # An active postgis Connection:
     connection = config.attributes.get("connection")

--- a/datacube/drivers/postgis/sql.py
+++ b/datacube/drivers/postgis/sql.py
@@ -39,7 +39,6 @@ begin
 end;
 $$ language plpgsql;
 """
-
 INSTALL_TRIGGER_SQL_TEMPLATE = [
     "drop trigger if exists row_update_time_{table} on {schema}.{table}",
     """
@@ -99,7 +98,6 @@ def visit_name(element, compiler, **kw) -> str:
 def pg_exists(conn, name: str) -> bool:
     """
     Does a postgres object exist?
-    :rtype bool
     """
     return conn.execute(text(f"SELECT to_regclass('{name}')")).scalar() is not None
 
@@ -107,7 +105,6 @@ def pg_exists(conn, name: str) -> bool:
 def pg_column_exists(conn, table, column) -> bool:
     """
     Does a postgres object exist?
-    :rtype bool
     """
     return (
         conn.execute(

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -215,11 +215,7 @@ class PostgresDbAPI:
     def insert_dataset(self, metadata_doc, dataset_id, product_id):
         """
         Insert dataset if not already indexed.
-        :type metadata_doc: dict
-        :type dataset_id: str or uuid.UUID
-        :type product_id: int
         :return: whether it was inserted
-        :rtype: bool
         """
         dataset_type_ref = bindparam("dataset_type_ref")
         ret = self._connection.execute(
@@ -252,9 +248,6 @@ class PostgresDbAPI:
     def update_dataset(self, metadata_doc, dataset_id, product_id) -> bool:
         """
         Update dataset
-        :type metadata_doc: dict
-        :type dataset_id: str or uuid.UUID
-        :type product_id: int
         """
         res = self._connection.execute(
             DATASET.update()
@@ -273,12 +266,7 @@ class PostgresDbAPI:
         Add a location to a dataset if it is not already recorded.
 
         Returns True if success, False if this location already existed
-
-        :type dataset_id: str or uuid.UUID
-        :type uri: str
-        :rtype bool:
         """
-
         scheme, body = split_uri(uri)
 
         r = self._connection.execute(
@@ -468,11 +456,7 @@ class PostgresDbAPI:
     ) -> dict:
         """
         Find any datasets that have the given metadata.
-
-        :type metadata: dict
-        :rtype: dict
         """
-
         # Find any storage types whose 'dataset_metadata' document is a subset of the metadata.
         where_clause = DATASET.c.metadata.contains(metadata)
         if archived:
@@ -485,9 +469,6 @@ class PostgresDbAPI:
     def search_products_by_metadata(self, metadata: dict) -> dict:
         """
         Find any products that have the given metadata.
-
-        :type metadata: dict
-        :rtype: dict
         """
         # Find any products types whose metadata document contains the passed in metadata
         return self._connection.execute(
@@ -513,15 +494,6 @@ class PostgresDbAPI:
         archived: bool | None = False,
         order_by=None,
     ) -> Select:
-        """
-        :type expressions: tuple[Expression]
-        :type source_exprs: tuple[Expression]
-        :type select_fields: Iterable[PgField]
-        :type with_source_ids: bool
-        :type limit: int
-        :rtype: sqlalchemy.Expression
-        """
-
         if select_fields:
             # Expand select fields, inserting placeholder columns selections for fields that aren't defined for
             # this product query.
@@ -656,11 +628,6 @@ class PostgresDbAPI:
         archived: bool | None = False,
         order_by=None,
     ):
-        """
-        :type with_source_ids: bool
-        :type select_fields: tuple[datacube.drivers.postgres._fields.PgField]
-        :type expressions: tuple[datacube.drivers.postgres._fields.PgExpression]
-        """
         select_query = self.search_datasets_query(
             expressions,
             source_exprs,
@@ -854,11 +821,6 @@ class PostgresDbAPI:
     def count_datasets(
         self, expressions: Iterable[Expression], archived: bool | None = False
     ) -> int:
-        """
-        :type expressions: tuple[datacube.drivers.postgres._fields.PgExpression]
-        :rtype: int
-        """
-
         raw_expressions = self._alchemify_expressions(expressions)
         if archived:
             where_exprs = and_(DATASET.c.archived.is_not(None), *raw_expressions)
@@ -883,14 +845,6 @@ class PostgresDbAPI:
         time_field,
         expressions: Iterable[Expression],
     ) -> Iterator[tuple[tuple[datetime.datetime, datetime.datetime], int]]:
-        """
-        :type period: str
-        :type start: datetime.datetime
-        :type end: datetime.datetime
-        :type expressions: tuple[datacube.drivers.postgres._fields.PgExpression]
-        :rtype: list[((datetime.datetime, datetime.datetime), int)]
-        """
-
         results = self._connection.execute(
             self.count_datasets_through_time_query(
                 start, end, period, time_field, expressions

--- a/datacube/drivers/postgres/_dynamic.py
+++ b/datacube/drivers/postgres/_dynamic.py
@@ -87,7 +87,6 @@ def check_dynamic_fields(
     """
     Check that we have expected indexes and views for the given fields
     """
-
     # If this type has time/space fields, create composite indexes (as they are often searched together)
     # We will probably move these into product configuration in the future.
     composite_indexes = (

--- a/datacube/drivers/postgres/_fields.py
+++ b/datacube/drivers/postgres/_fields.py
@@ -56,7 +56,6 @@ class PgField(Field):
     def sql_expression(self):
         """
         Get the raw SQL expression for this field as a string.
-        :rtype: str
         """
         return str(
             self.alchemy_expression.compile(
@@ -70,16 +69,10 @@ class PgField(Field):
 
     @override
     def __eq__(self, value) -> Expression:  # type: ignore[override]
-        """
-        :rtype: Expression
-        """
         return EqualsExpression(self, value)
 
     @override
     def between(self, low, high) -> Expression:
-        """
-        :rtype: Expression
-        """
         raise NotImplementedError("between expression")
 
 
@@ -222,16 +215,10 @@ class SimpleDocField(PgDocField):
 
     @override
     def __eq__(self, value) -> Expression:  # type: ignore[override]
-        """
-        :rtype: Expression
-        """
         return EqualsExpression(self, value)
 
     @override
     def between(self, low, high) -> Expression:
-        """
-        :rtype: Expression
-        """
         raise NotImplementedError("Simple field between expression")
 
     can_extract = True
@@ -383,9 +370,6 @@ class RangeDocField(PgDocField):
 
     @override
     def __eq__(self, value) -> Expression:  # type: ignore[override]
-        """
-        :rtype: Expression
-        """
         # Lower and higher are interchangeable here: they're the same type.
         casted_val = self.lower.value_to_alchemy(value)
         return RangeContainsExpression(self, casted_val)
@@ -418,9 +402,6 @@ class NumericRangeDocField(RangeDocField):
 
     @override
     def between(self, low, high) -> Expression:
-        """
-        :rtype: Expression
-        """
         return RangeBetweenExpression(self, low, high, _range_class=postgres.Range)
 
 
@@ -441,9 +422,6 @@ class IntRangeDocField(RangeDocField):
 
     @override
     def between(self, low, high) -> Expression:
-        """
-        :rtype: Expression
-        """
         return RangeBetweenExpression(self, low, high, _range_class=postgres.Range)
 
 
@@ -464,9 +442,6 @@ class DoubleRangeDocField(RangeDocField):
 
     @override
     def between(self, low, high) -> Expression:
-        """
-        :rtype: Expression
-        """
         return RangeBetweenExpression(
             self, low, high, _range_class=func.agdc.float8range
         )
@@ -489,9 +464,6 @@ class DateRangeDocField(RangeDocField):
 
     @override
     def between(self, low, high) -> Expression:
-        """
-        :rtype: Expression
-        """
         low = _number_implies_year(low)
         high = _number_implies_year(high)
 
@@ -533,9 +505,8 @@ def _number_implies_year(v: int | datetime) -> datetime:
 
 
 class PgExpression(Expression):
-    def __init__(self, field) -> None:
+    def __init__(self, field: PgField) -> None:
         super().__init__()
-        #: :type: PgField
         self.field = field
 
     @property
@@ -632,10 +603,7 @@ def parse_fields(doc: dict, table_column) -> dict[str, PgField]:
         }
 
     :param table_column: SQLAlchemy jsonb column for the document we're reading fields from.
-    :type doc: dict
-    :rtype: dict[str, PgField]
     """
-
     # Implementations of fields for this driver
     types = {
         SimpleDocField,
@@ -656,10 +624,7 @@ def parse_fields(doc: dict, table_column) -> dict[str, PgField]:
 
     def _get_field(name: str, descriptor: dict, column) -> PgField:
         """
-        :type name: str
-        :type descriptor: dict
         :param column: SQLAlchemy table column
-        :rtype: PgField
         """
         ctorargs = descriptor.copy()
         type_name = ctorargs.pop("type", "string")

--- a/datacube/drivers/postgres/sql.py
+++ b/datacube/drivers/postgres/sql.py
@@ -139,7 +139,6 @@ def visit_name(element, compiler, **kw) -> str:
 def pg_exists(conn, name: str) -> bool:
     """
     Does a postgres object exist?
-    :rtype bool
     """
     return conn.execute(text(f"SELECT to_regclass('{name}')")).scalar() is not None
 
@@ -147,7 +146,6 @@ def pg_exists(conn, name: str) -> bool:
 def pg_column_exists(conn, table, column) -> bool:
     """
     Does a postgres object exist?
-    :rtype bool
     """
     return (
         conn.execute(

--- a/datacube/drivers/readers.py
+++ b/datacube/drivers/readers.py
@@ -86,7 +86,6 @@ def choose_datasource(band: BandInfo) -> DatasourceFactory:
     - Available IO plugins
 
     NOTE: we assume that all bands can be loaded with the same implementation.
-
     """
     from datacube.storage._rio import RasterDatasetDataSource
 
@@ -108,9 +107,7 @@ def new_datasource(band: BandInfo) -> DataSource | None:
     ``DataSource`` can be found.
 
     :param band: The band to choose data source from.
-
     """
-
     source_type = choose_datasource(band)
 
     if source_type is None:

--- a/datacube/index/abstract/_datasets.py
+++ b/datacube/index/abstract/_datasets.py
@@ -64,7 +64,6 @@ class AbstractDatasetResource(ABC):
         :param include_sources: include the full provenance tree for the dataset.
         :param include_deriveds: include the full derivative tree for the dataset.
         :param max_depth: The maximum depth of the source and/or derived tree.  Defaults to 0, meaning no limit.
-        :rtype: Dataset model (None if not found)
         """
 
     def get(
@@ -89,7 +88,6 @@ class AbstractDatasetResource(ABC):
         :param include_sources: include the full provenance tree for the dataset.
         :param include_deriveds: include the full derivative tree for the dataset.
         :param max_depth: The maximum depth of the source and/or derived tree.  Defaults to 0, meaning no limit.
-        :rtype: Dataset model (None if not found)
         """
         try:
             return self.get_unsafe(id_, include_sources, include_deriveds, max_depth)
@@ -134,7 +132,6 @@ class AbstractDatasetResource(ABC):
         Get all datasets derived from a dataset (NOT recursive)
 
         :param id_: dataset id
-        :rtype: list[Dataset]
         """
 
     @abstractmethod
@@ -208,7 +205,7 @@ class AbstractDatasetResource(ABC):
         """
         Check if dataset can be updated. Return bool,safe_changes,unsafe_changes
 
-        :param Dataset dataset: Dataset to update
+        :param dataset: Dataset to update
         :param updates_allowed: Allowed updates
         :return: Tuple of: boolean (can/can't update); safe changes; unsafe changes
         """
@@ -222,7 +219,7 @@ class AbstractDatasetResource(ABC):
     ) -> Dataset:
         """
         Update dataset metadata and location
-        :param Dataset dataset: Dataset model with unpersisted updates
+        :param dataset: Dataset model with unpersisted updates
         :param updates_allowed: Allowed updates
         :param archive_less_mature: Find and archive less mature datasets with ms delta
         :return: Persisted dataset model
@@ -240,7 +237,7 @@ class AbstractDatasetResource(ABC):
         """
         Archive less mature versions of a dataset
 
-        :param Dataset ds: dataset to search
+        :param ds: dataset to search
         :param delta: millisecond delta for time range.
             If True, default to 500ms. If False, do not find or archive less mature datasets.
             Bool value accepted only for improving backwards compatibility, int preferred.
@@ -258,7 +255,7 @@ class AbstractDatasetResource(ABC):
         """
         Find less mature versions of a dataset
 
-        :param Dataset ds: Dataset to search
+        :param ds: Dataset to search
         :param delta: millisecond delta for time range.
             If True, default to 500ms. If None or False, do not find or archive less mature datasets.
             Bool value accepted only for improving backwards compatibility, int preferred.

--- a/datacube/index/abstract/_products.py
+++ b/datacube/index/abstract/_products.py
@@ -5,7 +5,7 @@
 import datetime
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Generator, Iterable, Sequence
 from time import monotonic
 from typing import TYPE_CHECKING, cast
 
@@ -282,7 +282,7 @@ class AbstractProductResource(ABC):
         """
         Add a Product using its definition
 
-        :param dict definition: product definition document
+        :param definition: product definition document
         :return: Persisted Product model
         """
         type_ = self.from_doc(definition)
@@ -296,7 +296,7 @@ class AbstractProductResource(ABC):
         Delete the specified products.
 
         :param products: Products to be deleted
-        :param bool allow_delete_active:
+        :param allow_delete_active:
             Whether to allow the deletion of a Product with active datasets
             (and thereby said active datasets). Use with caution.
 
@@ -392,7 +392,7 @@ class AbstractProductResource(ABC):
             out.update(prod.metadata_type.dataset_fields)
         return out
 
-    def search(self, **query: QueryField) -> Iterator[Product]:
+    def search(self, **query: QueryField) -> Generator[Product]:
         """
         Return products that match the supplied query
 

--- a/datacube/index/eo3.py
+++ b/datacube/index/eo3.py
@@ -118,7 +118,6 @@ def eo3_grid_spatial(
           geo_ref_points: {ll: {x:<>, y:<>}, ...}
           valid_data: {...}
     ```
-
     """
     gridspecs = doc.get("grids", {})
     crs = doc.get("crs", None)

--- a/datacube/index/fields.py
+++ b/datacube/index/fields.py
@@ -84,7 +84,5 @@ def _to_expression(get_field, name: str, value) -> Expression:
 def to_expressions(get_field, **query) -> list[Expression]:
     """
     Convert a simple query (dict of param names and values) to expression objects.
-    :type get_field: (str) -> Field
-    :type query: dict[str,str|float|datacube.model.Range]
     """
     return [_to_expression(get_field, name, value) for name, value in query.items()]

--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -70,7 +70,6 @@ ProductMatcher = Callable[[Mapping[str, Any]], Product]
 def product_matcher(rules: Sequence[ProductRule]) -> ProductMatcher:
     """Given product matching rules return a function mapping a document to a
     matching product.
-
     """
     assert len(rules) > 0
 
@@ -116,9 +115,7 @@ def product_matcher(rules: Sequence[ProductRule]) -> ProductMatcher:
 
 def check_dataset_consistent(dataset: Dataset) -> tuple[bool, str | None]:
     """
-    :type dataset: datacube.model.Dataset
     :return: (Is consistent, [error message|None])
-    :rtype: (bool, str or None)
     """
     product_measurements = set(dataset.product.measurements.keys())
 
@@ -389,24 +386,24 @@ class Doc2Dataset:
 
     :param index: an open Database connection
 
-    :param list products: List of product names against which to match datasets
+    :param products: List of product names against which to match datasets
                           (including lineage datasets). If not supplied we will
                           consider all products.
 
-    :param list exclude_products: List of products to exclude from matching
+    :param exclude_products: List of products to exclude from matching
 
     :param fail_on_missing_lineage: If True fail resolve if any lineage
                                     datasets are missing from the DB
 
                                     Only False supported if index.supports_external_lineage is True.
 
-    :param verify_lineage: If True check that lineage datasets in the
+    :param verify_lineage: If True, check that lineage datasets in the
                            supplied document are identical to DB versions
 
                            Ignored for EO3 documents.  Will be dropped in ODCv2 as only eo3 documents
                            will be supported.
 
-    :param skip_lineage: If True ignore lineage sub-tree in the supplied
+    :param skip_lineage: If True, ignore lineage sub-tree in the supplied
                          document and construct dataset without lineage datasets
     :param eo3: 'auto'/True/False by default auto-detect EO3 datasets and pre-process them
 

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -13,7 +13,7 @@ import json
 import logging
 import warnings
 from collections import namedtuple
-from collections.abc import Iterable, Iterator, Mapping, Sequence
+from collections.abc import Generator, Iterable, Iterator, Mapping, Sequence
 from time import monotonic
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
 from uuid import UUID
@@ -66,16 +66,7 @@ _LOG: logging.Logger = logging.getLogger(__name__)
 # It's a public api, so we can't reorganise old methods.
 # pylint: disable=too-many-public-methods, too-many-lines
 class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
-    """
-    :type _db: datacube.drivers.postgis._connections.PostgresDb
-    :type products: datacube.index._products.ProductResource
-    """
-
     def __init__(self, db: PostGisDb, index: Index) -> None:
-        """
-        :type db: datacube.drivers.postgis._connections.PostgresDb
-        :type index: datacube.index._products.ProductResource
-        """
         self._db = db
         super().__init__(index)
 
@@ -94,7 +85,6 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         :param include_sources: include the full provenance tree for the dataset.
         :param include_deriveds: include the full derivative tree for the dataset.
         :param max_depth: The maximum depth of the source and/or derived tree.  Defaults to 0, meaning no limit.
-        :rtype: Dataset model (None if not found)
         """
         if isinstance(id_, str):
             id_ = UUID(id_)
@@ -135,12 +125,11 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         category=ODC2DeprecationWarning,
     )
     @override
-    def get_derived(self, id_: UUID | str) -> list[Dataset]:
+    def get_derived(self, id_: DSID) -> list[Dataset]:
         """
         Get all derived datasets
 
-        :param Union[str,UUID] id_: dataset id
-        :rtype: list[Dataset]
+        :param id_: dataset id
         """
         if not isinstance(id_, UUID):
             id_ = UUID(id_)
@@ -151,26 +140,23 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             ]
 
     @override
-    def has(self, id_: UUID | str) -> bool:
+    def has(self, id_: DSID) -> bool:
         """
         Have we already indexed this dataset?
 
-        :param typing.Union[UUID, str] id_: dataset id
-        :rtype: bool
+        :param id_: dataset id
         """
         with self._db_connection() as connection:
             return connection.contains_dataset(id_)
 
     @override
-    def bulk_has(self, ids_: Iterable[str | UUID]) -> list[bool]:
+    def bulk_has(self, ids_: Iterable[DSID]) -> list[bool]:
         """
         Like `has` but operates on a list of ids.
 
         For every supplied id check if database contains a dataset with that id.
 
-        :param [typing.Union[UUID, str]] ids_: list of dataset ids
-
-        :rtype: [bool]
+        :param ids_: list of dataset ids
         """
         with self._db_connection() as connection:
             existing = set(connection.datasets_intersection(ids_))
@@ -197,8 +183,6 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         :param archive_less_mature: if integer, search for less
                mature versions of the dataset with the int value as a millisecond
                delta in timestamp comparison
-
-        :rtype: Dataset
         """
         _LOG.info("Indexing %s", dataset.id)
 
@@ -340,14 +324,13 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
     @override
     def can_update(
-        self, dataset: Dataset, updates_allowed=None
+        self, dataset: Dataset, updates_allowed: Mapping | None = None
     ) -> tuple[bool, list[Change], list[Change]]:
         """
         Check if dataset can be updated. Return bool,safe_changes,unsafe_changes
 
-        :param Dataset dataset: Dataset to update
-        :param dict updates_allowed: Allowed updates
-        :rtype: bool,list[change],list[change]
+        :param dataset: Dataset to update
+        :param updates_allowed: Allowed updates
         """
         need_sources = dataset.sources is not None
         # TODO: Source retrieval is broken.
@@ -393,12 +376,11 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
     ) -> Dataset:
         """
         Update dataset metadata and location
-        :param Dataset dataset: Dataset to update
+        :param dataset: Dataset to update
         :param updates_allowed: Allowed updates
         :param archive_less_mature: if integer, search for less
                mature versions of the dataset with the int value as a millisecond
                delta in timestamp comparison
-        :rtype: Dataset
         """
         can_update, safe_changes, unsafe_changes = self.can_update(
             dataset, updates_allowed
@@ -460,22 +442,22 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                 tr.insert_dataset_location(dataset.id, dataset.uri)
 
     @override
-    def archive(self, ids: Iterable[str | UUID]) -> None:
+    def archive(self, ids: Iterable[DSID]) -> None:
         """
         Mark datasets as archived
 
-        :param Iterable[UUID] ids: list of dataset ids to archive
+        :param ids: list of dataset ids to archive
         """
         with self._db_connection(transaction=True) as transaction:
             for id_ in ids:
                 transaction.archive_dataset(id_)
 
     @override
-    def restore(self, ids: Iterable[str | UUID]) -> None:
+    def restore(self, ids: Iterable[DSID]) -> None:
         """
         Mark datasets as not archived
 
-        :param Iterable[UUID] ids: list of dataset ids to restore
+        :param ids: list of dataset ids to restore
         """
         with self._db_connection(transaction=True) as transaction:
             for id_ in ids:
@@ -515,7 +497,6 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         only intended for small and/or experimental databases.
 
         :param archived:
-        :rtype: list[UUID]
         """
         with self._db_connection(transaction=True) as transaction:
             return [dsid[0] for dsid in transaction.all_dataset_ids(archived)]
@@ -526,22 +507,20 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         category=ODC2DeprecationWarning,
     )
     @override
-    def get_locations(self, id_) -> list[str | None]:
+    def get_locations(self, id_: DSID) -> list[str | None]:
         """
         Get the list of storage locations for the given dataset id
 
-        :param typing.Union[UUID, str] id_: dataset id
-        :rtype: list[str]
+        :param id_: dataset id
         """
         return [self.get_location(id_)]
 
     @override
-    def get_location(self, id_: str | UUID) -> str | None:
+    def get_location(self, id_: DSID) -> str | None:
         """
         Get the list of storage locations for the given dataset id
 
-        :param typing.Union[UUID, str] id_: dataset id
-        :rtype: list[str]
+        :param id_: dataset id
         """
         with self._db_connection() as connection:
             location = connection.get_location(id_)
@@ -561,8 +540,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         """
         Find locations which have been archived for a dataset
 
-        :param typing.Union[UUID, str] id_: dataset id
-        :rtype: list[str]
+        :param id_: dataset id
         """
         return []
 
@@ -579,8 +557,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         """
         Get each archived location along with the time it was archived.
 
-        :param typing.Union[UUID, str] id_: dataset id
-        :rtype: list[Tuple[str, datetime.datetime]]
+        :param id_: dataset id
         """
         return []
 
@@ -595,9 +572,9 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         """
         Add a location to the dataset if it doesn't already exist.
 
-        :param typing.Union[UUID, str] id_: dataset id
-        :param str uri: fully qualified uri
-        :returns bool: Was one added?
+        :param id_: dataset id
+        :param uri: fully qualified uri
+        :return: Was one added?
         """
         if not uri:
             warnings.warn(f"Cannot add empty uri. (dataset {id_})")
@@ -621,7 +598,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         Find datasets that exist at the given URI
 
         :param uri: search uri
-        :param str mode: 'exact', 'prefix' or None (to guess)
+        :param mode: 'exact', 'prefix' or None (to guess)
         :return:
         """
         with self._db_connection() as connection:
@@ -637,12 +614,12 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         category=ODC2DeprecationWarning,
     )
     @override
-    def remove_location(self, id_, uri) -> bool:
+    def remove_location(self, id_: DSID, uri: str) -> bool:
         """
         Remove a location from the dataset if it exists.
 
-        :param typing.Union[UUID, str] id_: dataset id
-        :param str uri: fully qualified uri
+        :param id_: dataset id
+        :param uri: fully qualified uri
         :returns bool: Was one removed?
         """
         with self._db_connection() as connection:
@@ -656,12 +633,12 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         category=ODC2DeprecationWarning,
     )
     @override
-    def archive_location(self, id_, uri) -> bool:
+    def archive_location(self, id_: DSID, uri: str) -> bool:
         """
         Archive a location of the dataset if it exists.
 
-        :param typing.Union[UUID, str] id_: dataset id
-        :param str uri: fully qualified uri
+        :param id_: dataset id
+        :param uri: fully qualified uri
         :return bool: location was able to be archived
         """
         return False
@@ -673,12 +650,12 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         category=ODC2DeprecationWarning,
     )
     @override
-    def restore_location(self, id_, uri) -> bool:
+    def restore_location(self, id_: DSID, uri: str) -> bool:
         """
         Un-archive a location of the dataset if it exists.
 
-        :param typing.Union[UUID, str] id_: dataset id
-        :param str uri: fully qualified uri
+        :param id_: dataset id
+        :param uri: fully qualified uri
         :return bool: location was able to be restored
         """
         return False
@@ -692,9 +669,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         derived_tree: LineageTree | None = None,
     ) -> Dataset:
         """
-        :rtype Dataset
-
-        :param bool full_info: Include all available fields
+        :param full_info: Include all available fields
         """
         kwargs = {}
         if not isinstance(dataset_res, dict):
@@ -714,9 +689,6 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         )
 
     def _make_many(self, query_result, product=None) -> Iterator:
-        """
-        :rtype list[Dataset]
-        """
         return (self._make(dataset, product=product) for dataset in query_result)
 
     @override
@@ -728,9 +700,8 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
         Caution - slow! This will usually not use indexes.
 
-        :param dict metadata:
+        :param metadata:
         :param archived: include archived datasets
-        :rtype: list[Dataset]
         """
         with self._db_connection() as connection:
             yield from self._make_many(
@@ -751,17 +722,16 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         self,
         limit: int | None = None,
         archived: bool | None = False,
-        order_by=None,
-        **query,
-    ) -> Iterable[Dataset]:
+        order_by: Iterable | None = None,
+        **query: QueryField,
+    ) -> Generator[Dataset]:
         """
         Perform a search, returning results as Dataset objects.
 
-        :param int limit: Limit number of datasets
+        :param limit: Limit number of datasets
         :param archived: include archived datasets
-        :param Iterable[str|Field|Function] order_by:
-        :param Union[str,float,Range,list] query:
-        :rtype: __generator[Dataset]
+        :param order_by:
+        :param query:
         """
         source_filter = query.pop("source_filter", None)
         for product, datasets in self._do_search_by_product(
@@ -775,14 +745,13 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
     @override
     def search_by_product(
-        self, archived: bool | None = False, **query
-    ) -> Iterable[tuple[Product, Iterable[Dataset]]]:
+        self, archived: bool | None = False, **query: QueryField
+    ) -> Generator[tuple[Product, Iterable[Dataset]]]:
         """
         Perform a search, returning datasets grouped by product type.
 
         :param archived: include archived datasets
-        :param dict[str,str|float|datacube.model.Range] query:
-        :rtype: __generator[(Product,  __generator[Dataset])]
+        :param query:
         """
         for product, datasets in self._do_search_by_product(query, archived=archived):
             yield product, self._make_many(datasets, product)
@@ -796,7 +765,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         archived: bool | None = False,
         order_by: Iterable[Any] | None = None,
         **query: QueryField,
-    ) -> Iterable[tuple]:
+    ) -> Generator[tuple]:
         """
         Perform a search, returning only the specified fields.
 
@@ -804,13 +773,13 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
         It also allows for returning rows other than datasets, such as a row per uri when requesting field 'uri'.
 
-        :param tuple[str] field_names:
-        :param Union[str,float,Range,list] query:
-        :param int limit: Limit number of datasets
+        :param field_names:
+        :param query:
+        :param limit: Limit number of datasets
         :param archived: include archived datasets
-        :param Iterable[Any] order_by: sql text, dataset field, or sqlalchemy expression
+        :param order_by: sql text, dataset field, or sqlalchemy expression
         by which to order results
-        :returns __generator[tuple]: sequence of results, each result is a namedtuple of your requested fields
+        :return: sequence of results, each result is a namedtuple of your requested fields
         """
         field_name_d: dict[str, None] = {}
         if field_names is None and custom_offsets is None:
@@ -854,13 +823,12 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                 yield result_type(**kwargs)
 
     @override
-    def count(self, archived: bool | None = False, **query) -> int:
+    def count(self, archived: bool | None = False, **query: QueryField) -> int:
         """
         Perform a search, returning count of results.
 
         :param archived: include archived datasets
-        :param dict[str,str|float|datacube.model.Range] query:
-        :rtype: int
+        :param query:
         """
         # This may be optimised into one query in the future.
         result = 0
@@ -871,15 +839,14 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
     @override
     def count_by_product(
-        self, archived: bool | None = False, **query
+        self, archived: bool | None = False, **query: QueryField
     ) -> Iterable[tuple[Product, int]]:
         """
         Perform a search, returning a count of for each matching product type.
 
         :param archived: include archived datasets
-        :param dict[str,str|float|datacube.model.Range] query:
+        :param query:
         :returns: Sequence of (product, count)
-        :rtype: __generator[(Product,  int)]
         """
         return self._do_count_by_product(query, archived=archived)
 
@@ -891,10 +858,9 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         Perform a search, returning counts for each product grouped in time slices
         of the given period.
 
-        :param dict[str,str|float|datacube.model.Range] query:
-        :param str period: Time range for each slice: '1 month', '1 day' etc.
+        :param query:
+        :param period: Time range for each slice: '1 month', '1 day' etc.
         :returns: For each matching product type, a list of time ranges and their count.
-        :rtype: __generator[(Product, list[(datetime.datetime, datetime.datetime), int])]
         """
         return self._do_time_count(period, query)
 
@@ -908,10 +874,9 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
         Will raise an error if the search terms match more than one product.
 
-        :param dict[str,str|float|datacube.model.Range] query:
-        :param str period: Time range for each slice: '1 month', '1 day' etc.
+        :param query:
+        :param period: Time range for each slice: '1 month', '1 day' etc.
         :returns: For each matching product type, a list of time ranges and their count.
-        :rtype: list[(str, list[(datetime.datetime, datetime.datetime), int])]
         """
         return next(self._do_time_count(period, query, ensure_single=True))[1]
 
@@ -1045,8 +1010,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         """
         Perform a search, returning just the search fields of each dataset.
 
-        :param dict[str,str|float|datacube.model.Range] query:
-        :rtype: __generator[dict]
+        :param query:
         """
         for _, results in self._do_search_by_product(
             query, return_fields=True, archived=archived
@@ -1097,7 +1061,6 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         :return: A Dynamically generated DatasetLight (a subclass of namedtuple and possibly with
         property functions).
         """
-
         assert field_names
 
         for product, query_exprs in self.make_query_expr(query, custom_offsets):
@@ -1141,7 +1104,6 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         """
         Parse and generate the list of select fields to be passed to the database API.
         """
-
         assert product and field_names
 
         dataset_fields = product.metadata_type.dataset_fields
@@ -1184,7 +1146,6 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         """
         Generate query expressions including queries based on custom fields
         """
-
         product_queries = list(self._get_product_queries(query))
         custom_query = {}
         if not product_queries:

--- a/datacube/index/postgis/_lineage.py
+++ b/datacube/index/postgis/_lineage.py
@@ -23,9 +23,6 @@ from datacube.model.lineage import LineageRelations
 
 class LineageResource(AbstractLineageResource, IndexResourceAddIn):
     def __init__(self, db: PostGisDb, index: AbstractIndex) -> None:
-        """
-        :type db: datacube.drivers.postgis._connections.PostgresDb
-        """
         self._db = db
         super().__init__(index)
 

--- a/datacube/index/postgis/_metadata_types.py
+++ b/datacube/index/postgis/_metadata_types.py
@@ -34,9 +34,6 @@ _LOG: logging.Logger = logging.getLogger(__name__)
 
 class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
     def __init__(self, db: PostGisDb, index: Index) -> None:
-        """
-        :type db: datacube.drivers.postgis._connections.PostgresDb
-        """
         self._db = db
         self._index = index
 
@@ -58,8 +55,7 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
     @override
     def from_doc(self, definition: JsonDict) -> MetadataType:
         """
-        :param dict definition:
-        :rtype: datacube.model.MetadataType
+        :param definition:
         """
         return self._make(definition)
 
@@ -68,13 +64,12 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
         self, metadata_type: MetadataType, allow_table_lock: bool = False
     ) -> MetadataType:
         """
-        :param datacube.model.MetadataType metadata_type:
+        :param metadata_type:
         :param allow_table_lock:
             Allow an exclusive lock to be taken on the table while creating the indexes.
             This will halt other user's requests until completed.
 
             If false, creation will be slightly slower and cannot be done in a transaction.
-        :rtype: datacube.model.MetadataType
         """
         # This column duplication is getting out of hand:
         MetadataType.validate_eo3(metadata_type.definition)
@@ -118,9 +113,8 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
 
         Safe updates currently allow new search fields to be added, description to be changed.
 
-        :param datacube.model.MetadataType metadata_type: updated MetadataType
-        :param bool allow_unsafe_updates: Allow unsafe changes. Use with caution.
-        :rtype: bool,list[change],list[change]
+        :param metadata_type: updated MetadataType
+        :param allow_unsafe_updates: Allow unsafe changes. Use with caution.
         """
         MetadataType.validate(metadata_type.definition)  # type: ignore[attr-defined]
 
@@ -175,14 +169,13 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
 
         Safe updates currently allow new search fields to be added, description to be changed.
 
-        :param datacube.model.MetadataType metadata_type: updated MetadataType
-        :param bool allow_unsafe_updates: Allow unsafe changes. Use with caution.
+        :param metadata_type: updated MetadataType
+        :param allow_unsafe_updates: Allow unsafe changes. Use with caution.
         :param allow_table_lock:
             Allow an exclusive lock to be taken on the table while creating the indexes.
             This will halt other user's requests until completed.
 
             If false, creation will be slower and cannot be done in a transaction.
-        :rtype: datacube.model.MetadataType
         """
         can_update, safe_changes, unsafe_changes = self.can_update(
             metadata_type, allow_unsafe_updates
@@ -223,9 +216,8 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
 
         Safe updates currently allow new search fields to be added, description to be changed.
 
-        :param dict definition: Updated definition
-        :param bool allow_unsafe_updates: Allow unsafe changes. Use with caution.
-        :rtype: datacube.model.MetadataType
+        :param definition: Updated definition
+        :param allow_unsafe_updates: Allow unsafe changes. Use with caution.
         """
         return self.update(
             self.from_doc(definition), allow_unsafe_updates=allow_unsafe_updates
@@ -272,8 +264,6 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
     def get_all(self) -> Iterable[MetadataType]:
         """
         Retrieve all Metadata Types
-
-        :rtype: iter[datacube.model.MetadataType]
         """
         with self._db_connection() as connection:
             return self._make_many(connection.get_all_metadata_types())
@@ -284,23 +274,12 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
             yield from connection.get_all_metadata_type_defs()
 
     def _make_many(self, query_rows) -> list[MetadataType]:
-        """
-        :rtype: list[datacube.model.MetadataType]
-        """
         return [self._make_from_query_row(c) for c in query_rows]
 
     def _make_from_query_row(self, query_row) -> MetadataType:
-        """
-        :rtype: datacube.model.MetadataType
-        """
         return self._make(query_row.definition, query_row.id)
 
     def _make(self, definition: dict, id_: int | None = None) -> MetadataType:
-        """
-        :param dict definition:
-        :param int id_:
-        :rtype: datacube.model.MetadataType
-        """
         MetadataType.validate_eo3(definition)
         return MetadataType(
             definition,

--- a/datacube/index/postgis/_products.py
+++ b/datacube/index/postgis/_products.py
@@ -19,7 +19,7 @@ from datacube.drivers.postgis import PostGisDb
 from datacube.index import fields
 from datacube.index.abstract import AbstractProductResource, BatchStatus
 from datacube.index.postgis._transaction import IndexResourceAddIn
-from datacube.model import MetadataType, Product, QueryDict
+from datacube.model import MetadataType, Product, QueryDict, QueryField
 from datacube.utils import _readable_offset, changes, jsonify_document
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes
 from datacube.utils.documents import JsonDict
@@ -37,10 +37,6 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
     """
 
     def __init__(self, db: PostGisDb, index: Index) -> None:
-        """
-        :type db: datacube.drivers.postgis._connections.PostgresDb
-        :type index: datacube.index.postgis.index.Index
-        """
         super().__init__(index)
         self._db = db
         self.get_unsafe = lru_cache()(self.get_unsafe)  # type: ignore[method-assign]
@@ -68,8 +64,7 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
             This will halt other user's requests until completed.
 
             If false, creation will be slightly slower and cannot be done in a transaction.
-        :param Product product: Product to add
-        :rtype: Product
+        :param product: Product to add
         """
         Product.validate(product.definition)  # type: ignore[attr-defined]
 
@@ -142,14 +137,13 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
         (An unsafe change is anything that may potentially make the product
         incompatible with existing datasets of that type)
 
-        :param Product product: Product to update
-        :param bool allow_unsafe_updates: Allow unsafe changes. Use with caution.
+        :param product: Product to update
+        :param allow_unsafe_updates: Allow unsafe changes. Use with caution.
         :param allow_table_lock:
             Allow an exclusive lock to be taken on the table while creating the indexes.
             This will halt other user's requests until completed.
 
             If false, creation will be slower and cannot be done in a transaction.
-        :rtype: bool,list[change],list[change]
         """
         Product.validate(product.definition)  # type: ignore[attr-defined]
 
@@ -211,16 +205,14 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
         (An unsafe change is anything that may potentially make the product
         incompatible with existing datasets of that type)
 
-        :param Product product: Product to update
-        :param bool allow_unsafe_updates: Allow unsafe changes. Use with caution.
+        :param product: Product to update
+        :param allow_unsafe_updates: Allow unsafe changes. Use with caution.
         :param allow_table_lock:
             Allow an exclusive lock to be taken on the table while creating the indexes.
             This will halt other user's requests until completed.
 
             If false, creation will be slower and cannot be done in a transaction.
-        :rtype: Product
         """
-
         can_update, safe_changes, unsafe_changes = self.can_update(
             product, allow_unsafe_updates
         )
@@ -284,21 +276,20 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
     @override
     def update_document(
         self,
-        definition,
+        definition: JsonDict,
         allow_unsafe_updates: bool = False,
         allow_table_lock: bool = False,
     ) -> Product | None:
         """
         Update a Product using its definition
 
-        :param bool allow_unsafe_updates: Allow unsafe changes. Use with caution.
-        :param dict definition: product definition document
+        :param allow_unsafe_updates: Allow unsafe changes. Use with caution.
+        :param definition: product definition document
         :param allow_table_lock:
             Allow an exclusive lock to be taken on the table while creating the indexes.
             This will halt other user's requests until completed.
 
             If false, creation will be slower and cannot be done in a transaction.
-        :rtype: Product
         """
         type_ = self.from_doc(definition)
         return self.update(
@@ -315,8 +306,7 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
         Delete Products, as well as all related datasets
 
         :param products: the Products to delete
-        :param bool allow_delete_active:
-            Whether to delete active datasets
+        :param allow_delete_active: Whether to delete active datasets
         :return: list of deleted products
         """
         deleted = []
@@ -363,12 +353,11 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
         return self._make(result)
 
     @override
-    def search_robust(self, **query) -> Iterable[tuple[Product, QueryDict]]:
+    def search_robust(
+        self, **query: QueryField
+    ) -> Generator[tuple[Product, QueryDict]]:
         """
         Return dataset types that match match-able fields and dict of remaining un-matchable fields.
-
-        :param dict query:
-        :rtype: __generator[(Product, dict)]
         """
 
         def _listify(v):
@@ -418,14 +407,13 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
                 yield type_, remaining_matchable
 
     @override
-    def search_by_metadata(self, metadata) -> Generator[Product]:
+    def search_by_metadata(self, metadata: JsonDict) -> Generator[Product]:
         """
         Perform a search using arbitrary metadata, returning results as Product objects.
 
         Caution - slow! This will usually not use indexes.
 
-        :param dict metadata:
-        :rtype: list[Product]
+        :param metadata:
         """
         with self._db_connection() as connection:
             yield from self._make_many(connection.search_products_by_metadata(metadata))

--- a/datacube/index/postgis/_users.py
+++ b/datacube/index/postgis/_users.py
@@ -19,9 +19,6 @@ if TYPE_CHECKING:
 
 class UserResource(AbstractUserResource, IndexResourceAddIn):
     def __init__(self, db: PostGisDb, index: Index) -> None:
-        """
-        :type db: datacube.drivers.postgis.PostGisDb
-        """
         self._db = db
         self._index = index
 
@@ -55,7 +52,6 @@ class UserResource(AbstractUserResource, IndexResourceAddIn):
     def list_users(self) -> Iterable[tuple[str, str, str | None]]:
         """
         :return: list of (role, user, description)
-        :rtype: list[(str, str, str)]
         """
         with self._db_connection() as connection:
             yield from connection.list_users()

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -55,11 +55,6 @@ class Index(AbstractIndex):
     :ivar datacube.index._metadata_types.MetadataTypeResource metadata_types: store and retrieve \
     :class:`datacube.model.MetadataType`
     :ivar UserResource users: user management
-
-    :type users: datacube.index._users.UserResource
-    :type datasets: datacube.index._datasets.DatasetResource
-    :type products: datacube.index._products.ProductResource
-    :type metadata_types: datacube.index._metadata_types.MetadataTypeResource
     """
 
     #   Metadata type support flags

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -13,7 +13,7 @@ import json
 import logging
 import warnings
 from collections import namedtuple
-from collections.abc import Iterable, Iterator, Mapping, Sequence
+from collections.abc import Generator, Iterable, Iterator, Mapping, Sequence
 from time import monotonic
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
@@ -51,14 +51,7 @@ _LOG: logging.Logger = logging.getLogger(__name__)
 # It's a public api, so we can't reorganise old methods.
 # pylint: disable=too-many-public-methods, too-many-lines
 class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
-    """
-    :type _db: datacube.drivers.postgres._connections.PostgresDb
-    """
-
     def __init__(self, db: PostgresDb, index: Index) -> None:
-        """
-        :type db: datacube.drivers.postgres._connections.PostgresDb
-        """
         self._db = db
         super().__init__(index)
 
@@ -73,9 +66,8 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         """
         Get dataset by id (raise KeyError if not in index)
 
-        :param UUID id_: id of the dataset to retrieve
-        :param bool include_sources: get the full provenance graph?
-        :rtype: Dataset
+        :param id_: id of the dataset to retrieve
+        :param include_sources: get the full provenance graph?
         """
         # include_derived and max_depth arguments not supported.
         self._check_get_legacy(include_deriveds, max_depth)
@@ -127,8 +119,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         """
         Get all derived datasets
 
-        :param Union[str,UUID] id_: dataset id
-        :rtype: list[Dataset]
+        :param id_: dataset id
         """
         if not isinstance(id_, UUID):
             id_ = UUID(id_)
@@ -143,8 +134,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         """
         Have we already indexed this dataset?
 
-        :param typing.Union[UUID, str] id_: dataset id
-        :rtype: bool
+        :param id_: dataset id
         """
         with self._db_connection() as connection:
             return connection.contains_dataset(id_)
@@ -156,9 +146,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
         For every supplied id check if database contains a dataset with that id.
 
-        :param [typing.Union[UUID, str]] ids_: list of dataset ids
-
-        :rtype: [bool]
+        :param ids_: list of dataset ids
         """
         with self._db_connection() as connection:
             existing = set(connection.datasets_intersection(ids_))
@@ -187,8 +175,6 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         :param archive_less_mature: if integer, search for less
                mature versions of the dataset with the int value as a millisecond
                delta in timestamp comparison
-
-        :rtype: Dataset
         """
 
         def process_bunch(dss, main_ds, transaction) -> None:
@@ -320,14 +306,13 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
     @override
     def can_update(
-        self, dataset: Dataset, updates_allowed=None
+        self, dataset: Dataset, updates_allowed: Mapping | None = None
     ) -> tuple[bool, list[changes.Change], list[changes.Change]]:
         """
         Check if dataset can be updated. Return bool,safe_changes,unsafe_changes
 
-        :param Dataset dataset: Dataset to update
-        :param dict updates_allowed: Allowed updates
-        :rtype: bool,list[change],list[change]
+        :param dataset: Dataset to update
+        :param updates_allowed: Allowed updates
         """
         need_sources = dataset.sources is not None
         existing = self.get(dataset.id, include_sources=need_sources)
@@ -366,12 +351,11 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
     ) -> Dataset:
         """
         Update dataset metadata and location
-        :param Dataset dataset: Dataset to update
+        :param dataset: Dataset to update
         :param updates_allowed: Allowed updates
         :param archive_less_mature: if integer, search for less
                mature versions of the dataset with the int value as a millisecond
                delta in timestamp comparison
-        :rtype: Dataset
         """
         existing = self.get(dataset.id)
         can_update, safe_changes, unsafe_changes = self.can_update(
@@ -452,22 +436,22 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                 ensure_locations_in_transaction(old_uris, new_uris, tr)
 
     @override
-    def archive(self, ids: Iterable[str | UUID]) -> None:
+    def archive(self, ids: Iterable[DSID]) -> None:
         """
         Mark datasets as archived
 
-        :param Iterable[UUID] ids: list of dataset ids to archive
+        :param ids: list of dataset ids to archive
         """
         with self._db_connection(transaction=True) as transaction:
             for id_ in ids:
                 transaction.archive_dataset(id_)
 
     @override
-    def restore(self, ids: Iterable[str | UUID]) -> None:
+    def restore(self, ids: Iterable[DSID]) -> None:
         """
         Mark datasets as not archived
 
-        :param Iterable[UUID] ids: list of dataset ids to restore
+        :param ids: list of dataset ids to restore
         """
         with self._db_connection(transaction=True) as transaction:
             for id_ in ids:
@@ -507,7 +491,6 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         only intended for small and/or experimental databases.
 
         :param archived:
-        :rtype: list[UUID]
         """
         with self._db_connection(transaction=True) as transaction:
             return [dsid[0] for dsid in transaction.all_dataset_ids(archived)]
@@ -518,23 +501,21 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         category=ODC2DeprecationWarning,
     )
     @override
-    def get_locations(self, id_) -> Iterable[str]:
+    def get_locations(self, id_: DSID) -> Iterable[str]:
         """
         Get the list of storage locations for the given dataset id
 
-        :param typing.Union[UUID, str] id_: dataset id
-        :rtype: list[str]
+        :param id_: dataset id
         """
         with self._db_connection() as connection:
             return connection.get_locations(id_)
 
     @override
-    def get_location(self, id_: str | UUID) -> str | None:
+    def get_location(self, id_: DSID) -> str | None:
         """
         Get the list of storage locations for the given dataset id
 
-        :param typing.Union[UUID, str] id_: dataset id
-        :rtype: list[str]
+        :param id_: dataset id
         """
         with self._db_connection() as connection:
             locations = connection.get_locations(id_)
@@ -549,12 +530,11 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         category=ODC2DeprecationWarning,
     )
     @override
-    def get_archived_locations(self, id_: UUID | str) -> list[str]:
+    def get_archived_locations(self, id_: DSID) -> list[str]:
         """
         Find locations which have been archived for a dataset
 
-        :param typing.Union[UUID, str] id_: dataset id
-        :rtype: list[str]
+        :param id_: dataset id
         """
         with self._db_connection() as connection:
             return [uri for uri, archived_dt in connection.get_archived_locations(id_)]
@@ -567,13 +547,12 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
     )
     @override
     def get_archived_location_times(
-        self, id_: UUID | str
+        self, id_: DSID
     ) -> list[tuple[str, datetime.datetime]]:
         """
         Get each archived location along with the time it was archived.
 
-        :param typing.Union[UUID, str] id_: dataset id
-        :rtype: List[Tuple[str, datetime.datetime]]
+        :param id_: dataset id
         """
         with self._db_connection() as connection:
             return list(connection.get_archived_locations(id_))
@@ -589,9 +568,9 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         """
         Add a location to the dataset if it doesn't already exist.
 
-        :param typing.Union[UUID, str] id_: dataset id
-        :param str uri: fully qualified uri
-        :returns bool: Was one added?
+        :param id_: dataset id
+        :param uri: fully qualified uri
+        :return: Was one added?
         """
         if not uri:
             warnings.warn(f"Cannot add empty uri. (dataset {id_})")
@@ -606,7 +585,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         Find datasets that exist at the given URI
 
         :param uri: search uri
-        :param str mode: 'exact', 'prefix' or None (to guess)
+        :param mode: 'exact', 'prefix' or None (to guess)
         :return:
         """
         with self._db_connection() as connection:
@@ -626,9 +605,9 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         """
         Remove a location from the dataset if it exists.
 
-        :param typing.Union[UUID, str] id_: dataset id
-        :param str uri: fully qualified uri
-        :returns bool: Was one removed?
+        :param id_: dataset id
+        :param uri: fully qualified uri
+        :return: True if one was removed
         """
         with self._db_connection() as connection:
             was_removed = connection.remove_location(id_, uri)
@@ -646,9 +625,9 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         """
         Archive a location of the dataset if it exists.
 
-        :param typing.Union[UUID, str] id_: dataset id
-        :param str uri: fully qualified uri
-        :return bool: location was able to be archived
+        :param id_: dataset id
+        :param uri: fully qualified uri
+        :return: True if location was able to be archived
         """
         with self._db_connection() as connection:
             was_archived = connection.archive_location(id_, uri)
@@ -666,9 +645,9 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         """
         Un-archive a location of the dataset if it exists.
 
-        :param typing.Union[UUID, str] id_: dataset id
-        :param str uri: fully qualified uri
-        :return bool: location was able to be restored
+        :param id_: dataset id
+        :param uri: fully qualified uri
+        :return: True if location was able to be restored
         """
         with self._db_connection() as connection:
             was_restored = connection.restore_location(id_, uri)
@@ -676,9 +655,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
     def _make(self, dataset_res, full_info: bool = False, product=None) -> Dataset:
         """
-        :rtype Dataset
-
-        :param bool full_info: Include all available fields
+        :param full_info: Include all available fields
         """
         if dataset_res.uris:
             if len(dataset_res.uris) > 1:
@@ -701,9 +678,6 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
     def _make_many(
         self, query_result, product=None, fetch_all: bool = False
     ) -> Iterable[Dataset]:
-        """
-        :rtype list[Dataset]
-        """
         if fetch_all:
             return [self._make(dataset, product=product) for dataset in query_result]
         else:
@@ -711,16 +685,15 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
     @override
     def search_by_metadata(
-        self, metadata, archived: bool | None = False
+        self, metadata: dict, archived: bool | None = False
     ) -> Iterable[Dataset]:
         """
         Perform a search using arbitrary metadata, returning results as Dataset objects.
 
         Caution - slow! This will usually not use indexes.
 
-        :param dict metadata:
+        :param metadata:
         :param archived: include archived datasets
-        :rtype: list[Dataset]
         """
         with self._db_connection() as connection:
             yield from self._make_many(
@@ -740,19 +713,18 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
     def search(
         self,
         limit: int | None = None,
-        source_filter=None,
+        source_filter: int | None = None,
         archived: bool | None = False,
         order_by=None,
-        **query,
+        **query: QueryField,
     ) -> Iterable[Dataset]:
         """
         Perform a search, returning results as Dataset objects.
 
-        :param Union[str,float,Range,list] query:
-        :param int source_filter: query terms against source datasets
+        :param query:
+        :param source_filter: query terms against source datasets
         :param archived: include archived datasets
-        :param int limit: Limit number of datasets
-        :rtype: __generator[Dataset]
+        :param limit: Limit number of datasets
         """
         for product, datasets in self._do_search_by_product(
             query,
@@ -765,14 +737,13 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
     @override
     def search_by_product(
-        self, archived: bool | None = False, **query
+        self, archived: bool | None = False, **query: QueryField
     ) -> Iterable[tuple[Product, Iterable[Dataset]]]:
         """
         Perform a search, returning datasets grouped by product type.
 
         :param archived: include archived datasets
-        :param dict[str,str|float|datacube.model.Range] query:
-        :rtype: __generator[(Product,  __generator[Dataset])]
+        :param query:
         """
         for product, datasets in self._do_search_by_product(query, archived=archived):
             yield product, self._make_many(datasets, product)
@@ -786,7 +757,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         archived: bool | None = False,
         order_by: Iterable[Any] | None = None,
         **query: QueryField,
-    ) -> Iterable[tuple]:
+    ) -> Generator[tuple]:
         """
         Perform a search, returning only the specified fields.
 
@@ -794,13 +765,13 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
         It also allows for returning rows other than datasets, such as a row per uri when requesting field 'uri'.
 
-        :param tuple[str] field_names: defaults to all known search fields
-        :param Union[str,float,Range,list] query:
-        :param int limit: Limit number of datasets
+        :param field_names: defaults to all known search fields
+        :param query:
+        :param limit: Limit number of datasets
         :param archived: include archived datasets
-        :param Iterable[Any] order_by: sql text, dataset field, sqlalchemy function, or expression
+        :param order_by: sql text, dataset field, sqlalchemy function, or expression
         by which to order results
-        :returns __generator[tuple]: sequence of results, each result is a namedtuple of your requested fields
+        :return: sequence of results, each result is a namedtuple of your requested fields
         """
         field_name_d: dict[str, None] = {}
         if field_names is None and custom_offsets is None:
@@ -855,8 +826,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         Perform a search, returning count of results.
 
         :param archived: include archived datasets
-        :param dict[str,str|float|datacube.model.Range] query:
-        :rtype: int
+        :param query:
         """
         # This may be optimised into one query in the future.
         result = 0
@@ -873,9 +843,8 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         Perform a search, returning a count of for each matching product type.
 
         :param archived: include archived datasets
-        :param dict[str,str|float|datacube.model.Range] query:
+        :param query:
         :returns: Sequence of (product, count)
-        :rtype: __generator[(Product,  int)]
         """
         return self._do_count_by_product(query, archived=archived)
 
@@ -887,10 +856,9 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         Perform a search, returning counts for each product grouped in time slices
         of the given period.
 
-        :param dict[str,str|float|datacube.model.Range] query:
-        :param str period: Time range for each slice: '1 month', '1 day' etc.
+        :param query:
+        :param period: Time range for each slice: '1 month', '1 day' etc.
         :returns: For each matching product type, a list of time ranges and their count.
-        :rtype: __generator[(Product, list[(datetime.datetime, datetime.datetime), int])]
         """
         return self._do_time_count(period, query)
 
@@ -904,10 +872,9 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
 
         Will raise an error if the search terms match more than one product.
 
-        :param dict[str,str|float|datacube.model.Range] query:
-        :param str period: Time range for each slice: '1 month', '1 day' etc.
+        :param query:
+        :param period: Time range for each slice: '1 month', '1 day' etc.
         :returns: For each matching product type, a list of time ranges and their count.
-        :rtype: list[(str, list[(datetime.datetime, datetime.datetime), int])]
         """
         return next(self._do_time_count(period, query, ensure_single=True))[1]
 
@@ -1056,14 +1023,13 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         category=ODC2DeprecationWarning,
     )
     def search_summaries(
-        self, archived: bool | None = False, **query
-    ) -> Iterable[Mapping[str, Any]]:
+        self, archived: bool | None = False, **query: QueryField
+    ) -> Generator[Mapping[str, Any]]:
         """
         Perform a search, returning just the search fields of each dataset.
 
         :param archived: include archived datasets
-        :param dict[str,str|float|datacube.model.Range] query:
-        :rtype: __generator[dict]
+        :param query:
         """
         for _, results in self._do_search_by_product(
             query, return_fields=True, archived=archived
@@ -1101,7 +1067,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         limit: int | None = None,
         archived: bool | None = False,
         **query,
-    ) -> Iterable[tuple]:
+    ) -> Generator[tuple]:
         """
         This is a dataset search function that returns the results as objects of a dynamically
         generated Dataset class that is a subclass of tuple.
@@ -1128,7 +1094,6 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         :return: A Dynamically generated DatasetLight (a subclass of namedtuple and possibly with
         property functions).
         """
-
         assert field_names
 
         for product, query_exprs in self.make_query_expr(query, custom_offsets):
@@ -1172,7 +1137,6 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         """
         Parse and generate the list of select fields to be passed to the database API.
         """
-
         assert product and field_names
 
         dataset_fields = product.metadata_type.dataset_fields
@@ -1215,7 +1179,6 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         """
         Generate query expressions including queries based on custom fields
         """
-
         product_queries = list(self._get_product_queries(query))
         custom_query = {}
         if not product_queries:
@@ -1249,7 +1212,6 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         in metadata doc and their offsets are provided. custom_query is a dict of key fields involving
         custom fields.
         """
-
         custom_exprs = []
         for key in custom_query:
             # for now, we assume all custom query fields are SimpleDocFields

--- a/datacube/index/postgres/_metadata_types.py
+++ b/datacube/index/postgres/_metadata_types.py
@@ -33,9 +33,6 @@ _LOG: logging.Logger = logging.getLogger(__name__)
 
 class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
     def __init__(self, db: PostgresDb, index: Index) -> None:
-        """
-        :type db: datacube.drivers.postgres._connections.PostgresDb
-        """
         self._db = db
         self._index = index
 
@@ -57,8 +54,7 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
     @override
     def from_doc(self, definition: JsonDict) -> MetadataType:
         """
-        :param dict definition:
-        :rtype: datacube.model.MetadataType
+        :param definition:
         """
         MetadataType.validate(definition)  # type: ignore[attr-defined]
         return self._make(definition)
@@ -68,14 +64,13 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
         self, metadata_type: MetadataType, allow_table_lock: bool = False
     ) -> MetadataType:
         """
-        :param datacube.model.MetadataType metadata_type:
+        :param metadata_type:
         :param allow_table_lock:
             Allow an exclusive lock to be taken on the table while creating the indexes.
             This will halt other user's requests until completed.
 
             If false (and a transaction is not already active), creation will be slightly slower
             and cannot be done in a transaction.
-        :rtype: datacube.model.MetadataType
         """
         # This column duplication is getting out of hand:
         MetadataType.validate(metadata_type.definition)  # type: ignore[attr-defined]
@@ -109,9 +104,8 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
 
         Safe updates currently allow new search fields to be added, description to be changed.
 
-        :param datacube.model.MetadataType metadata_type: updated MetadataType
-        :param bool allow_unsafe_updates: Allow unsafe changes. Use with caution.
-        :rtype: bool,list[change],list[change]
+        :param metadata_type: updated MetadataType
+        :param allow_unsafe_updates: Allow unsafe changes. Use with caution.
         """
         MetadataType.validate(metadata_type.definition)  # type: ignore[attr-defined]
 
@@ -166,14 +160,13 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
 
         Safe updates currently allow new search fields to be added, description to be changed.
 
-        :param datacube.model.MetadataType metadata_type: updated MetadataType
-        :param bool allow_unsafe_updates: Allow unsafe changes. Use with caution.
+        :param metadata_type: updated MetadataType
+        :param allow_unsafe_updates: Allow unsafe changes. Use with caution.
         :param allow_table_lock:
             Allow an exclusive lock to be taken on the table while creating the indexes.
             This will halt other user's requests until completed.
 
             If false, creation will be slower and cannot be done in a transaction.
-        :rtype: datacube.model.MetadataType
         """
         can_update, safe_changes, unsafe_changes = self.can_update(
             metadata_type, allow_unsafe_updates
@@ -215,9 +208,8 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
 
         Safe updates currently allow new search fields to be added, description to be changed.
 
-        :param dict definition: Updated definition
-        :param bool allow_unsafe_updates: Allow unsafe changes. Use with caution.
-        :rtype: datacube.model.MetadataType
+        :param definition: Updated definition
+        :param allow_unsafe_updates: Allow unsafe changes. Use with caution.
         """
         return self.update(
             self.from_doc(definition), allow_unsafe_updates=allow_unsafe_updates
@@ -269,8 +261,6 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
     def get_all(self) -> Iterable[MetadataType]:
         """
         Retrieve all Metadata Types
-
-        :rtype: iter[datacube.model.MetadataType]
         """
         with self._db_connection() as connection:
             return self._make_many(connection.get_all_metadata_types())
@@ -282,22 +272,15 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
                 yield row[0]
 
     def _make_many(self, query_rows) -> list[MetadataType]:
-        """
-        :rtype: list[datacube.model.MetadataType]
-        """
         return [self._make_from_query_row(c) for c in query_rows]
 
     def _make_from_query_row(self, query_row) -> MetadataType:
-        """
-        :rtype: datacube.model.MetadataType
-        """
         return self._make(query_row.definition, query_row.id)
 
     def _make(self, definition: dict, id_: int | None = None) -> MetadataType:
         """
-        :param dict definition:
-        :param int id_:
-        :rtype: datacube.model.MetadataType
+        :param definition:
+        :param id_:
         """
         return MetadataType(
             definition,

--- a/datacube/index/postgres/_products.py
+++ b/datacube/index/postgres/_products.py
@@ -16,7 +16,7 @@ from datacube.drivers.postgres import PostgresDb
 from datacube.index import fields
 from datacube.index.abstract import AbstractProductResource
 from datacube.index.postgres._transaction import IndexResourceAddIn
-from datacube.model import MetadataType, Product
+from datacube.model import MetadataType, Product, QueryField
 from datacube.utils import _readable_offset, changes, jsonify_document
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes
 from datacube.utils.documents import JsonDict
@@ -34,10 +34,6 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
     """
 
     def __init__(self, db: PostgresDb, index: Index) -> None:
-        """
-        :type db: datacube.drivers.postgres._connections.PostgresDb
-        :type index: datacube.index.postgres.index.Index
-        """
         super().__init__(index)
         self._db = db
 
@@ -67,8 +63,7 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
 
             If false, creation will be slightly slower
 
-        :param Product product: Product to add
-        :rtype: Product
+        :param product: Product to add
         """
         Product.validate(product.definition)  # type: ignore[attr-defined]
 
@@ -128,14 +123,13 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
         (An unsafe change is anything that may potentially make the product
         incompatible with existing datasets of that type)
 
-        :param Product product: Product to update
-        :param bool allow_unsafe_updates: Allow unsafe changes. Use with caution.
+        :param product: Product to update
+        :param allow_unsafe_updates: Allow unsafe changes. Use with caution.
         :param allow_table_lock:
             Allow an exclusive lock to be taken on the table while creating the indexes.
             This will halt other user's requests until completed.
 
             If false, creation will be slower and cannot be done in a transaction.
-        :rtype: bool,list[change],list[change]
         """
         Product.validate(product.definition)  # type: ignore[attr-defined]
 
@@ -197,16 +191,14 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
         (An unsafe change is anything that may potentially make the product
         incompatible with existing datasets of that type)
 
-        :param Product product: Product to update
-        :param bool allow_unsafe_updates: Allow unsafe changes. Use with caution.
+        :param product: Product to update
+        :param allow_unsafe_updates: Allow unsafe changes. Use with caution.
         :param allow_table_lock:
             Allow an exclusive lock to be taken on the table while creating the indexes.
             This will halt other user's requests until completed.
 
             If false, creation will be slower and cannot be done in a transaction.
-        :rtype: Product
         """
-
         can_update, safe_changes, unsafe_changes = self.can_update(
             product, allow_unsafe_updates
         )
@@ -274,21 +266,20 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
     @override
     def update_document(
         self,
-        definition,
+        definition: JsonDict,
         allow_unsafe_updates: bool = False,
         allow_table_lock: bool = False,
     ) -> Product | None:
         """
         Update a Product using its definition
 
-        :param bool allow_unsafe_updates: Allow unsafe changes. Use with caution.
-        :param dict definition: product definition document
+        :param allow_unsafe_updates: Allow unsafe changes. Use with caution.
+        :param definition: product definition document
         :param allow_table_lock:
             Allow an exclusive lock to be taken on the table while creating the indexes.
             This will halt other user's requests until completed.
 
             If false, creation will be slower and cannot be done in a transaction.
-        :rtype: Product
         """
         type_ = self.from_doc(definition)
         return self.update(
@@ -305,7 +296,7 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
         Delete Products, as well as all related datasets
 
         :param products: the Products to delete
-        :param bool allow_delete_active:
+        :param allow_delete_active:
             Whether to delete products with active datasets
         :return: list of deleted products
         """
@@ -357,12 +348,11 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
         return self._make(result)
 
     @override
-    def search_robust(self, **query):
+    def search_robust(self, **query: QueryField):
         """
         Return dataset types that match match-able fields and dict of remaining un-matchable fields.
 
-        :param dict query:
-        :rtype: __generator[(Product, dict)]
+        :param query:
         """
 
         def _listify(v):
@@ -409,14 +399,13 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
                 yield type_, remaining_matchable
 
     @override
-    def search_by_metadata(self, metadata) -> Generator[Product]:
+    def search_by_metadata(self, metadata: dict) -> Generator[Product]:
         """
         Perform a search using arbitrary metadata, returning results as Product objects.
 
         Caution - slow! This will usually not use indexes.
 
-        :param dict metadata:
-        :rtype: list[Product]
+        :param metadata:
         """
         with self._db_connection() as connection:
             yield from self._make_many(connection.search_products_by_metadata(metadata))

--- a/datacube/index/postgres/_users.py
+++ b/datacube/index/postgres/_users.py
@@ -19,9 +19,6 @@ if TYPE_CHECKING:
 
 class UserResource(AbstractUserResource, IndexResourceAddIn):
     def __init__(self, db: PostgresDb, index: Index) -> None:
-        """
-        :type db: datacube.drivers.postgres._connections.PostgresDb
-        """
         self._db = db
         self._index = index
 
@@ -55,7 +52,6 @@ class UserResource(AbstractUserResource, IndexResourceAddIn):
     def list_users(self) -> Iterable[tuple[str, str, str | None]]:
         """
         :return: list of (role, user, description)
-        :rtype: list[(str, str, str)]
         """
         with self._db_connection() as connection:
             yield from connection.list_users()

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -47,11 +47,6 @@ class Index(AbstractIndex):
     :ivar datacube.index._metadata_types.MetadataTypeResource metadata_types: store and retrieve \
     :class:`datacube.model.MetadataType`
     :ivar UserResource users: user management
-
-    :type users: datacube.index._users.UserResource
-    :type datasets: datacube.index._datasets.DatasetResource
-    :type products: datacube.index._products.ProductResource
-    :type metadata_types: datacube.index._metadata_types.MetadataTypeResource
     """
 
     #   Metadata type support flags

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 import math
 from collections import OrderedDict
-from collections.abc import Iterable, Iterator, Mapping, Sequence
+from collections.abc import Generator, Iterable, Iterator, Mapping, Sequence
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -338,7 +338,6 @@ class Dataset:
         (an archived dataset is one that is not intended to be used by users anymore: eg. it has been
         replaced by another dataset. It will not show up in search results, but still exists in the
         system via provenance chains or through id lookup.)
-
         """
         return self.archived_time is not None
 
@@ -353,7 +352,6 @@ class Dataset:
         Is this dataset active?
 
         (ie. dataset hasn't been archived)
-
         """
         return not self.is_archived
 
@@ -451,7 +449,6 @@ class Measurement:
 
     Can also include attributes like alternative names 'aliases', and spectral and bit flags
     definitions to aid with interpreting the data.
-
     """
 
     REQUIRED_KEYS = ("name", "dtype", "nodata", "units")
@@ -661,8 +658,8 @@ class Product:
     """
     Product definition
 
-    :param MetadataType metadata_type:
-    :param dict definition:
+    :param metadata_type:
+    :param definition:
     """
 
     def __init__(
@@ -1054,11 +1051,11 @@ class GridSpec:
                0.0, -0.1, -48.05), CRS('EPSG:4326'))), ((1, 1), GeoBox((10, 10), Affine(0.1, 0.0, 140.95,
                0.0, -0.1, -48.05), CRS('EPSG:4326')))]
 
-    :param odc.geo.crs.CRS crs: Coordinate System used to define the grid
-    :param [float,float] tile_size: (Y, X) size of each tile, in CRS units
-    :param [float,float] resolution: (Y, X) size of each data point in the grid, in CRS units. Y will
+    :param crs: Coordinate System used to define the grid
+    :param tile_size: (Y, X) size of each tile, in CRS units
+    :param resolution: (Y, X) size of each data point in the grid, in CRS units. Y will
         usually be negative.
-    :param [float,float] origin: (Y, X) coordinates of a corner of the (0,0) tile in CRS units. default is (0.0, 0.0)
+    :param origin: (Y, X) coordinates of a corner of the (0,0) tile in CRS units. default is (0.0, 0.0)
     """
 
     def __init__(
@@ -1098,7 +1095,6 @@ class GridSpec:
     def dimensions(self) -> tuple[str, str]:
         """
         List of dimension names of the grid spec
-
         """
         return self.crs.dimensions
 
@@ -1140,7 +1136,7 @@ class GridSpec:
         """
         Tile geobox.
 
-        :param (int,int) tile_index:
+        :param tile_index:
         """
         res_y, res_x = self.resolution
         y, x = self.tile_coords(tile_index)
@@ -1152,7 +1148,7 @@ class GridSpec:
 
     def tiles(
         self, bounds: BoundingBox, geobox_cache: dict | None = None
-    ) -> Iterator[tuple[tuple[int, int], GeoBox]]:
+    ) -> Generator[tuple[tuple[int, int], GeoBox]]:
         """
         Returns an iterator of tile_index, :py:class:`GeoBox` tuples across
         the grid and overlapping with the specified `bounds` rectangle.
@@ -1162,8 +1158,8 @@ class GridSpec:
            Grid cells are referenced by coordinates `(x, y)`, which is the opposite to the usual CRS
            dimension order.
 
-        :param BoundingBox bounds: Boundary coordinates of the required grid
-        :param dict geobox_cache: Optional cache to reuse geoboxes instead of creating new one each time
+        :param bounds: Boundary coordinates of the required grid
+        :param geobox_cache: Optional cache to reuse geoboxes instead of creating new one each time
         :return: iterator of grid cells with :py:class:`GeoBox` tiles
         """
 
@@ -1193,7 +1189,7 @@ class GridSpec:
         geopolygon: Geometry,
         tile_buffer: tuple[float, float] | None = None,
         geobox_cache: dict | None = None,
-    ) -> Iterator[tuple[tuple[int, int], GeoBox]]:
+    ) -> Generator[tuple[tuple[int, int], GeoBox]]:
         """
         Returns an iterator of tile_index, :py:class:`GeoBox` tuples across
         the grid and overlapping with the specified `geopolygon`.
@@ -1203,10 +1199,10 @@ class GridSpec:
            Grid cells are referenced by coordinates `(x, y)`, which is the opposite to the usual CRS
            dimension order.
 
-        :param odc.geo.Geometry geopolygon: Polygon to tile
+        :param geopolygon: Polygon to tile
         :param tile_buffer: Optional <float,float> tuple, (extra padding for the query
                             in native units of this GridSpec)
-        :param dict geobox_cache: Optional cache to reuse geoboxes instead of creating new one each time
+        :param geobox_cache: Optional cache to reuse geoboxes instead of creating new one each time
         :return: iterator of grid cells with :py:class:`GeoBox` tiles
         """
         geopolygon = geopolygon.to_crs(self.crs)
@@ -1264,7 +1260,7 @@ def metadata_from_doc(doc: Mapping[str, Any]) -> MetadataType:
     """
     from .fields import get_dataset_fields
 
-    MetadataType.validate(doc)  # type: ignore
+    MetadataType.validate(doc)  # type: ignore[attr-defined]
     return MetadataType(doc, get_dataset_fields(doc))
 
 

--- a/datacube/model/fields.py
+++ b/datacube/model/fields.py
@@ -228,7 +228,6 @@ def parse_search_field(doc, name: str = "") -> RangeField | SimpleField:
 def get_dataset_fields(metadata_definition: Mapping[str, Any]) -> dict[str, Field]:
     """Construct search fields dictionary not tied to any specific db
     implementation.
-
     """
     fields = toolz.get_in(["dataset", "search_fields"], metadata_definition, {})
     return {n: parse_search_field(doc, name=n) for n, doc in fields.items()}

--- a/datacube/model/utils.py
+++ b/datacube/model/utils.py
@@ -20,7 +20,7 @@ from pandas import to_datetime
 from xarray import DataArray
 
 import datacube
-from datacube.model import Dataset
+from datacube.model import Dataset, Product
 from datacube.utils import InvalidDocException, SimpleDocNav
 from datacube.utils.py import sorted_items
 
@@ -114,8 +114,8 @@ def new_dataset_info() -> dict[str, str]:
 
 def band_info(band_names: Sequence[str], band_uris: dict | None = None) -> dict:
     """
-    :param list band_names: names of the bands
-    :param dict band_uris: mapping from names to dicts with 'path' and 'layer' specs
+    :param band_names: names of the bands
+    :param band_uris: mapping from names to dicts with 'path' and 'layer' specs
     """
     if band_uris is None:
         band_uris = {name: {"path": "", "layer": name} for name in band_names}
@@ -157,9 +157,7 @@ def datasets_to_doc(output_datasets: DataArray) -> DataArray:
     Create a yaml document version of every dataset
 
     :param output_datasets: An array of :class:`datacube.model.Dataset`
-    :type output_datasets: :py:class:`xarray.DataArray`
     :return: An array of yaml document strings
-    :rtype: :py:class:`xarray.DataArray`
     """
 
     def dataset_to_yaml(index, dataset):
@@ -177,9 +175,7 @@ def xr_iter(data_array: DataArray) -> Generator[tuple[tuple, dict, Any]]:
         * the element (same as ``da[10, 1].item()``)
 
     :param data_array: Array to iterate over
-    :type data_array: xarray.DataArray
     :return: i-index, label-index, value of da element
-    :rtype tuple, dict, da.dtype
     """
     values = data_array.values
     coords = {coord_name: v.values for coord_name, v in data_array.coords.items()}
@@ -195,13 +191,11 @@ def xr_apply(
     """
     Apply a function to every element of a :class:`xarray.DataArray`
 
-    :type data_array: xarray.DataArray
     :param func: function that takes a dict of labels and an element of the array,
         and returns a value of the given dtype
     :param dtype: The dtype of the returned array, default to the same as original
-    :param bool with_numeric_index: If true include numeric index: func(index, labels, value)
+    :param with_numeric_index: If true include numeric index: func(index, labels, value)
     :return: The array with output of the function for every element.
-    :rtype: xarray.DataArray
     """
     if dtype is None:
         dtype = data_array.dtype
@@ -217,37 +211,36 @@ def xr_apply(
 
 
 def make_dataset(
-    product,
-    sources,
+    product: Product,
+    sources: Sequence[Dataset],
     extent: Geometry,
     center_time,
     valid_data: Geometry | None = None,
     uri: str | None = None,
-    app_info=None,
-    band_uris=None,
+    app_info: dict | None = None,
+    band_uris: dict | None = None,
     start_time=None,
     end_time=None,
 ) -> Dataset:
     """
     Create :class:`datacube.model.Dataset` for the data
 
-    :param Product product: Product the dataset is part of
-    :param list[:class:`Dataset`] sources: datasets used to produce the dataset
-    :param Geometry extent: extent of the dataset
-    :param Geometry valid_data: extent of the valid data
+    :param product: Product the dataset is part of
+    :param sources: datasets used to produce the dataset
+    :param extent: extent of the dataset
+    :param valid_data: extent of the valid data
     :param center_time: time of the central point of the dataset
-    :param str uri: The uri of the dataset
-    :param dict app_info: Additional metadata to be stored about the generation of the product
-    :param dict band_uris: band name to uri mapping
+    :param uri: The uri of the dataset
+    :param app_info: Additional metadata to be stored about the generation of the product
+    :param band_uris: band name to uri mapping
     :param start_time: start time of the dataset (defaults to `center_time`)
     :param end_time: end time of the dataset (defaults to `center_time`)
-    :rtype: class:`Dataset`
     """
     document: dict = {}
     merge(document, product.metadata_doc)
     merge(document, new_dataset_info())
     merge(document, machine_info())
-    merge(document, band_info(product.measurements.keys(), band_uris=band_uris))
+    merge(document, band_info(list(product.measurements.keys()), band_uris=band_uris))
     merge(document, source_info(sources))
     merge(document, geobox_info(extent, valid_data))
     merge(document, time_info(center_time, start_time, end_time))
@@ -261,15 +254,11 @@ def make_dataset(
     )
 
 
-def merge(a: dict, b: dict, path: list | None = None) -> dict:
+def merge(a: dict, b: Mapping, path: list | None = None) -> dict:
     """
     Merge dictionary `b` into dictionary `a`
 
     See: http://stackoverflow.com/a/7205107/5262498
-
-    :type a: dict
-    :type b: dict
-    :rtype: dict
     """
     if path is None:
         path = []
@@ -314,7 +303,6 @@ def traverse_datasets(
 
     mode=post-order -- Visit all lineage first, only then visit top level
     mode=pre-order --  Visit top level first, only then visit lineage
-
     """
 
     def visit_pre_order(
@@ -415,7 +403,7 @@ def dedup_lineage(root: dict | SimpleDocNav):
     path from root) has either conflicting metadata or conflicting lineage
     data.
 
-    :param dict|SimpleDocNav root:
+    :param root:
 
     Returns a new document that has the same structure as input document, but
     with duplicate entries now being aliases rather than copies.

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -494,7 +494,6 @@ def _write_yaml(infos):
 
     (Ordered dicts are output identically to normal yaml dicts: their order is purely for readability)
     """
-
     return yaml.dump_all(
         infos, sys.stdout, SafeDatacubeDumper, default_flow_style=False, indent=4
     )

--- a/datacube/scripts/metadata.py
+++ b/datacube/scripts/metadata.py
@@ -140,7 +140,6 @@ def show_metadata_type(
     """
     Show information about a metadata type.
     """
-
     if len(metadata_type_name) == 0:
         mm = list(index.metadata_types.get_all())
     else:

--- a/datacube/scripts/product.py
+++ b/datacube/scripts/product.py
@@ -339,7 +339,6 @@ def show_product(dc, product_name: str, output_format: str) -> None:
     """
     Show details about a product in the generic index.
     """
-
     if len(product_name) == 0:
         products = list(dc.index.products.get_all())
     else:

--- a/datacube/scripts/search_tool.py
+++ b/datacube/scripts/search_tool.py
@@ -130,17 +130,11 @@ def printable_none(val) -> str:
 
 @printable.register(datetime.datetime)
 def printable_dt(val: datetime.datetime) -> str:
-    """
-    :type val: datetime.datetime
-    """
     return tz_as_utc(val).isoformat()
 
 
 @printable.register(Range)
 def printable_r(val: Range) -> str:
-    """
-    :type val: sqlalchemy.dialects.postgresql.Range
-    """
     if val.lower_inf:
         return printable(val.upper)
     if val.upper_inf:

--- a/datacube/scripts/user.py
+++ b/datacube/scripts/user.py
@@ -60,7 +60,6 @@ def _write_yaml(index: Iterable) -> None:
 
     (Ordered dicts are output identically to normal yaml dicts: their order is purely for readability)
     """
-
     return yaml.dump_all(
         index, sys.stdout, SafeDatacubeDumper, default_flow_style=False, indent=4
     )

--- a/datacube/storage/__init__.py
+++ b/datacube/storage/__init__.py
@@ -5,7 +5,6 @@
 """
 Modules for creating and accessing Data Store Units
 
-
 """
 
 from ..drivers.datasource import DataSource, GeoRasterReader, RasterShape, RasterWindow

--- a/datacube/storage/_base.py
+++ b/datacube/storage/_base.py
@@ -25,7 +25,6 @@ def _get_band_and_layer(b: dict[str, Any]) -> tuple[int | None, str | None]:
          int    -    (int,  - )
          int   str   (int, str)
           -    str   ( - , str)
-
     """
     band = b.get("band")
     layer = b.get("layer")

--- a/datacube/storage/_rio.py
+++ b/datacube/storage/_rio.py
@@ -48,8 +48,6 @@ def maybe_lock(lock):
 class BandDataSource(GeoRasterReader):
     """
     Wrapper for a :class:`rasterio.Band` object
-
-    :type source: rasterio.Band
     """
 
     def __init__(
@@ -100,7 +98,6 @@ class BandDataSource(GeoRasterReader):
 class RasterioDataSource(DataSource):
     """
     Abstract class used by fuse_sources and :func:`read_from_source`
-
     """
 
     def __init__(self, filename, nodata, lock=None) -> None:

--- a/datacube/testutils/__init__.py
+++ b/datacube/testutils/__init__.py
@@ -56,11 +56,7 @@ def assert_file_structure(
     """
     Assert that the contents of a folder (filenames and subfolder names recursively)
     match the given nested dictionary structure.
-
-    :type folder: pathlib.Path
-    :type expected_structure: dict[str,str|dict]
     """
-
     expected_filenames = set(expected_structure.keys())
     actual_filenames = {f.name for f in folder.iterdir()}
 
@@ -98,8 +94,6 @@ def write_files(file_dict: Mapping[str, str | Sequence[str]]) -> pathlib.Path:
 
     writeFiles({'test.txt': 'contents of text file'})
 
-    :type file_dict: dict
-    :rtype: pathlib.Path
     :return: Created temporary directory path
     """
     containing_dir = tempfile.mkdtemp(suffix="neotestrun")
@@ -118,9 +112,6 @@ def _write_files_to_dir(
 ) -> None:
     """
     Convenience method for writing a bunch of files to a given directory.
-
-    :type directory_path: str
-    :type file_dict: dict
     """
     for filename, contents in file_dict.items():
         path = os.path.join(directory_path, filename)
@@ -386,7 +377,6 @@ def mk_test_image(w, h, dtype: str = "int16", nodata=-999, nodata_width: int = 4
 
     Pixels along the diagonal are set to nodata values (to disable set nodata_width=0)
     """
-
     dtype = np.dtype(dtype)
 
     xx, yy = np.meshgrid(np.arange(w), np.arange(h))
@@ -495,7 +485,6 @@ def mk_sample_xr_dataset(
 
     xy (x: float, y: float) -- location of the top-left corner of the top-left pixel in CRS units
     """
-
     if isinstance(crs, str):
         crs = CRS(crs)
 

--- a/datacube/testutils/geom.py
+++ b/datacube/testutils/geom.py
@@ -84,7 +84,6 @@ def xy_norm(
     - (x, y) == A*(x', y')
     - [x|y]'.min() == 0
     - [x|y]'.max() == 1
-
     """
 
     def norm_v(v):
@@ -154,7 +153,6 @@ def gen_test_image_xy(
     :returns: 2xWxH ndarray encoding X,Y coordinates of pixel centers in some
               normalised space, and a callable that can convert from normalised
               space back to coordinate space.
-
     """
     dtype = np.dtype(dtype)
 

--- a/datacube/testutils/io.py
+++ b/datacube/testutils/io.py
@@ -377,7 +377,6 @@ def rio_slurp(fname, *args, **kw):
 
     rio_slurp_read(fname, out_shape, ..)
     rio_slurp_reproject(fname, geobox, ...)
-
     """
     if len(args) == 0:
         if "geobox" in kw:

--- a/datacube/ui/click.py
+++ b/datacube/ui/click.py
@@ -271,9 +271,9 @@ def pass_config(f):
 def pass_index(app_name: str | None = None, expect_initialised: bool = True):
     """Get a connection to the index as the first argument.
 
-    :param str app_name:
+    :param app_name:
         A short name of the application for logging purposes.
-    :param bool expect_initialised:
+    :param expect_initialised:
         Whether to connect immediately on startup. Useful to catch connection config issues immediately,
         but if you're planning to fork before any usage (such as in the case of some web servers),
         you may not want this. For more information on thread/process usage, see datacube.index.Index
@@ -309,9 +309,9 @@ def pass_datacube(app_name: str | None = None, expect_initialised: bool = True):
     """
     Get a DataCube from the current or default local settings.
 
-    :param str app_name:
+    :param app_name:
         A short name of the application for logging purposes.
-    :param bool expect_initialised:
+    :param expect_initialised:
         Whether to connect immediately on startup. Useful to catch connection config issues immediately,
         but if you're planning to fork before any usage (such as in the case of some web servers),
         you may not want this. For More information on thread/process usage, see datacube.index.Index

--- a/datacube/ui/common.py
+++ b/datacube/ui/common.py
@@ -62,8 +62,6 @@ def _find_any_metadata_suffix(path: Path) -> Path | None:
 
     Eg. searching for '/tmp/ga-metadata' will find if any files such as '/tmp/ga-metadata.yaml' or
     '/tmp/ga-metadata.json', or '/tmp/ga-metadata.yaml.gz' etc that exist: any suffix supported by read_documents()
-
-    :type path: pathlib.Path
     """
     existing_paths = list(
         filter(is_supported_document_type, path.parent.glob(path.name + "*"))
@@ -95,7 +93,6 @@ def ui_path_doc_stream(paths, logger=None, uri: bool = True, raw: bool = False):
 
     :param raw: By default docs are wrapped in :class:`SimpleDocNav`, but you can
     instead request them to be raw dictionaries
-
     """
 
     def _resolve_doc_files(paths):

--- a/datacube/ui/task_app.py
+++ b/datacube/ui/task_app.py
@@ -9,7 +9,7 @@ import os
 import pickle
 import re
 import time
-from collections.abc import Sequence
+from collections.abc import Generator, Sequence
 from pathlib import Path
 
 import click
@@ -51,12 +51,12 @@ def unpickle_stream(filename):
                 break
 
 
-def save_tasks(config, tasks, taskfile: str) -> int:
+def save_tasks(config: dict, tasks, taskfile: str) -> int:
     """Saves the config
 
     :param config: dict of configuration options common to all tasks
     :param tasks:
-    :param str taskfile: Name of output file
+    :param taskfile: Name of output file
     :return: Number of tasks saved to the file
     """
     i = pickle_stream(itertools.chain([config], tasks), taskfile)
@@ -175,7 +175,7 @@ def break_query_into_years(time_query, **kwargs):
     ]
 
 
-def year_splitter(start, end):
+def year_splitter(start: str, end: str) -> Generator[tuple[str, str]]:
     """
     Produces a list of time ranges based that represent each year in the range.
 
@@ -185,8 +185,8 @@ def year_splitter(start, end):
         [('1992-01-01 00:00:00', '1992-12-31 23:59:59.9999999'),
          ('1993-01-01 00:00:00', '1993-12-31 23:59:59.9999999')]
 
-    :param str start: start year
-    :param str end: end year
+    :param start: start year
+    :param end: end year
     :return Generator[tuple(str, str)]: strings representing the ranges
     """
     start_ts = pd.Timestamp(start)

--- a/datacube/utils/aws/__init__.py
+++ b/datacube/utils/aws/__init__.py
@@ -284,7 +284,6 @@ def s3_client(
                   ``"purge"`` - delete from cache and return what was there to begin with
 
     :param cfg: passed on to ``botocore.client.Config(..)``
-
     """
     if aws_unsigned is None:
         if creds is None:
@@ -408,7 +407,6 @@ def s3_dump(data: bytes | str | IO, url: str, s3: MaybeS3 = None, **kwargs):
     ContentType
     ACL
     """
-
     s3 = s3 or s3_client()
     bucket, key = s3_url_parse(url)
 

--- a/datacube/utils/changes.py
+++ b/datacube/utils/changes.py
@@ -27,7 +27,6 @@ def contains(v1: Changeable, v2: Changeable, case_sensitive: bool = False) -> bo
     For dicts contains(v1[k], v2[k]) for all k in v2
     For other types v1 == v2
     v2 None is interpreted as {}
-
     """
     if not case_sensitive:
         if isinstance(v1, str):
@@ -81,9 +80,6 @@ def get_doc_changes(
     3. What is in `new`
 
     If the documents are identical, an empty list is returned.
-
-    :type original: Union[dict, list, int]
-    :rtype: list[(tuple, object, object)]
 
 
     """
@@ -184,7 +180,7 @@ def classify_changes(
     """
     Classify list of changes into good(allowed) and bad(not allowed) based on allowed changes.
 
-    :param list[(tuple,object,object)] changes: result of get_doc_changes
+    :param changes: result of get_doc_changes
     :param allowed_changes: mapping from key to change policy (subset, superset, any)
     :return: good_changes, bad_chages
     """

--- a/datacube/utils/cog.py
+++ b/datacube/utils/cog.py
@@ -366,7 +366,6 @@ def to_cog(
     :returns: ``dask.Delayed`` object if input is a Dask array
 
     Also see :py:meth:`~datacube.utils.cog.write_cog`
-
     """
     bb = write_cog(  # Call to deprecated function from deprecated function
         geo_im,

--- a/datacube/utils/dask.py
+++ b/datacube/utils/dask.py
@@ -100,9 +100,7 @@ def start_local_dask(
     .. note::
 
         if ``memory_limit=`` is supplied, it will be parsed and divided equally between workers.
-
     """
-
     # if dashboard.link set to default value and running behind hub, make dashboard link go via proxy
     if (
         dask.config.get("distributed.dashboard.link")
@@ -198,7 +196,6 @@ def compute_tasks(
           there is no point calling this function if you want one active
           task and supporting exactly 2 active tasks is not worth the complexity,
           for now. We might special-case 2 at some point.
-
     """
     # New thread:
     #    1. Take dask task from iterator
@@ -329,7 +326,6 @@ def save_blob_to_file(
 
        Dask workers must be local or have network filesystem mounted in
        the same path as calling code.
-
     """
     return _save_blob_to_file_delayed(data, fname, with_deps=with_deps)
 

--- a/datacube/utils/dates.py
+++ b/datacube/utils/dates.py
@@ -10,7 +10,7 @@ Includes sequence generation functions to be used by statistics apps
 """
 
 from collections.abc import Iterator
-from datetime import datetime, tzinfo
+from datetime import date, datetime, tzinfo
 
 import dateutil
 import dateutil.parser
@@ -24,17 +24,19 @@ FREQS: dict[str, int] = {"y": YEARLY, "m": MONTHLY, "d": DAILY}
 DURATIONS = {"y": "years", "m": "months", "d": "days"}
 
 
-def date_sequence(start, end, stats_duration, step_size: str) -> Iterator:
+def date_sequence(
+    start: date | None, end: date | int | None, stats_duration: str, step_size: str
+) -> Iterator:
     """
     Generate a sequence of time span tuples
 
     :seealso:
         Refer to `dateutil.parser.parse` for details on date parsing.
 
-    :param str start: Start date of first interval
-    :param str end: End date. The end of the last time span may extend past this date.
-    :param str stats_duration: What period of time should be grouped
-    :param str step_size: How far apart should the start dates be
+    :param start: Start date of first interval
+    :param end: End date. The end of the last time span may extend past this date.
+    :param stats_duration: What period of time should be grouped
+    :param step_size: How far apart should the start dates be
     :return: sequence of (start_date, end_date) tuples
     """
     interval, freq = parse_interval(step_size)

--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -144,8 +144,6 @@ def read_documents(*paths, uri: bool = False) -> Generator[tuple[str, dict]]:
 
     :param uri: When True yield URIs instead of Paths
     :param paths: input Paths or URIs
-    :type uri: Bool
-    :rtype: tuple[(str, dict)]
     """
 
     def process_file(path):
@@ -248,9 +246,6 @@ _ALL_SUPPORTED_EXTENSIONS: tuple[str, ...] = tuple(
 def is_supported_document_type(path: Path | str) -> bool:
     """
     Does a document path look like a supported type?
-
-    :type path: Union[Path, str]
-    :rtype: bool
     """
     return any(
         str(path).lower().endswith(suffix) for suffix in _ALL_SUPPORTED_EXTENSIONS
@@ -294,11 +289,6 @@ class UnknownMetadataType(InvalidDocException):
 
 
 def get_doc_offset(offset: list[str | int], document: dict, default=None):
-    """
-    :type offset: list[str]
-    :type document: dict
-
-    """
     return toolz.get_in(offset, document, default=default)
 
 
@@ -338,7 +328,6 @@ def transform_object_tree(f, o, key_transform=lambda k: k):
     :param f: Function to apply on values.
     :param o: document/object
     :param key_transform: Optional function to apply on any dictionary keys.
-
     """
 
     def recur(o_):
@@ -415,7 +404,6 @@ class SimpleDocNav:
     This has the assumption that a dictionary of source datasets is
     found at the offset ``lineage -> source_datasets`` inside each
     dataset dictionary.
-
     """
 
     def __init__(self, doc: Mapping, sources_path=None) -> None:
@@ -474,10 +462,6 @@ class SimpleDocNav:
 
 
 def _set_doc_offset(offset: list[str | int], document: dict, value) -> None:
-    """
-    :type offset: list[str]
-    :type document: dict
-    """
     read_offset = offset[:-1]
     sub_doc = get_doc_offset(read_offset, document, {})
     sub_doc[offset[-1]] = value
@@ -490,10 +474,6 @@ class DocReader:
         search_fields,
         doc: Mapping[str, Field],
     ) -> None:
-        """
-        :type type_definition: dict[str,list[str]]
-        :type doc: dict
-        """
         self.__dict__["_doc"] = doc
 
         # The user-configurable search fields for this dataset type.
@@ -562,9 +542,9 @@ def without_lineage_sources(
 ) -> dict[str, Any]:
     """Replace lineage.source_datasets with {}
 
-    :param dict doc: parsed yaml/json document describing dataset
+    :param doc: parsed yaml/json document describing dataset
     :param spec: Product or MetadataType according to which `doc` to be interpreted
-    :param bool inplace: If True modify `doc` in place
+    :param inplace: If True modify `doc` in place
     """
     if not inplace:
         doc = deepcopy(doc)
@@ -584,13 +564,13 @@ def without_lineage_sources(
     return doc
 
 
-def schema_validated(schema):
+def schema_validated(schema: Path):
     """
     Decorate a class to enable validating its definition against a JSON Schema file.
 
     Adds a self.validate() method which takes a dict used to populate the instantiated class.
 
-    :param pathlib.Path schema: filename of the json schema, relative to `SCHEMA_PATH`
+    :param schema: filename of the json schema, relative to `SCHEMA_PATH`
     :return: wrapped class
     """
 

--- a/datacube/utils/generic.py
+++ b/datacube/utils/generic.py
@@ -33,7 +33,6 @@ def map_with_lookahead(it, if_one=None, if_many=None) -> Iterable:
     :param it: Sequence to iterate over
     :param if_one: Function to apply for single element sequences
     :param if_many: Function to apply for multi-element sequences
-
     """
     if_one = if_one or (lambda x: x)
     if_many = if_many or (lambda x: x)

--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -1262,7 +1262,6 @@ class GeoBox:
         OrderedDict name:str -> xr.DataArray
 
         where names are either `y,x` for projected or `latitude, longitude` for geographic.
-
         """
         spatial_ref = "spatial_ref"
         if isinstance(with_crs, str):
@@ -1400,7 +1399,6 @@ def scaled_down_geobox(src_geobox: GeoBox, scaler: int) -> GeoBox:
 
     NOTE: here we assume that pixel coordinates are 0,0 at the top-left
           corner of a top-left pixel.
-
     """
     assert scaler > 1
 

--- a/datacube/utils/geometry/tools.py
+++ b/datacube/utils/geometry/tools.py
@@ -50,7 +50,6 @@ def polygon_path(x, y=None):
        array([[0, 1, 1, 0, 0],
               [0, 0, 1, 1, 0]])
     """
-
     if y is None:
         y = x
 
@@ -155,7 +154,6 @@ def roi_normalise(roi, shape):
     Example:
           np.s_[:3, 4:  ], (10, 20) -> np._s[0:3, 4:20]
           np.s_[:3,  :-3], (10, 20) -> np._s[0:3, 0:17]
-
     """
 
     def fill_if_none(x, val_if_none):
@@ -196,7 +194,6 @@ def apply_affine(
     """
     broadcast A*(x_i, y_i) across all elements of x/y arrays in any shape (usually 2d image)
     """
-
     shape = x.shape
 
     A = np.asarray(A).reshape(3, 3)
@@ -303,8 +300,6 @@ def affine_from_pts(X, Y) -> Affine:
     Given points X,Y compute A, such that: Y = A*X.
 
     Needs at least 3 points.
-
-    :rtype: Affine
     """
     from numpy.linalg import lstsq
 
@@ -472,7 +467,6 @@ def box_overlap(
 
 def native_pix_transform(src, dst):
     """
-
     direction: from src to dst
     .back: goes the other way
     .linear: None|Affine linear transform src->dst if transform is linear (i.e. same CRS)
@@ -621,7 +615,6 @@ def compute_reproject_roi(
      .transform  : src coord -> dst coord
 
     For scale direction is: "scale > 1 --> shrink src to fit dst"
-
     """
     pts_per_side = 5
 

--- a/datacube/utils/masking.py
+++ b/datacube/utils/masking.py
@@ -94,7 +94,6 @@ def make_mask(variable: Dataset | DataArray, **flags):
     where `GOOD_PIXEL_FLAGS` is a dict of flag_name to True/False
 
     :param variable:
-    :type variable: xarray.Dataset or xarray.DataArray
     :param flags: list of boolean flags
     :return: boolean xarray.DataArray or xarray.Dataset
     """
@@ -132,7 +131,7 @@ def mask_invalid_data(data, keep_attrs: bool = True):
     This will convert numeric data to type `float`.
 
     :param Dataset or DataArray data:
-    :param bool keep_attrs: If the attributes of the data should be included in the returned .
+    :param keep_attrs: If the attributes of the data should be included in the returned .
     :return: Dataset or DataArray
     """
     if isinstance(data, Dataset):
@@ -198,7 +197,6 @@ def mask_to_dict(bits_def: dict, mask_value: int) -> dict:
     :param bits_def:
     :param mask_value:
     :return: Mapping of flag_name -> set_value
-    :rtype: dict
     """
     return_dict = {}
     for flag_name, flag_defn in bits_def.items():
@@ -256,9 +254,6 @@ def set_value_at_index(bitmask: int, index: int, value: bool) -> int:
     0b10000
 
     :param bitmask: existing int bitmask to alter
-    :type bitmask: int
-    :type index: int
-    :type value: bool
     """
     bit_val = 2**index
     if value:
@@ -277,7 +272,6 @@ def generate_table(rows):
     :param rows: A sequence of sequences with the 0th element being the table
                  header
     """
-
     # - figure out column widths
     widths = [len(max(columns, key=len)) for columns in zip(*rows)]
 

--- a/datacube/utils/math.py
+++ b/datacube/utils/math.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from collections.abc import Iterator
+from collections.abc import Generator
 from math import ceil
 from typing import Any
 
@@ -136,12 +136,14 @@ def invalid_mask(xx, nodata):
     return xx == nodata
 
 
-def num2numpy(x, dtype, ignore_range=None):
+def num2numpy(
+    x: int | float | None, dtype: str | numpy.dtype, ignore_range: bool | None = None
+):
     """
     Cast python numeric value to numpy.
 
-    :param int|float x: Numerical value to convert to numpy.type
-    :param str|numpy.dtype|numpy.type dtype: Destination dtype
+    :param x: Numerical value to convert to numpy.type
+    :param dtype: Destination dtype
     :param ignore_range: If set to True skip range check and cast anyway (for example: -1 -> 255)
                          (Not supported in numpy 2.0+)
 
@@ -183,7 +185,9 @@ def affine_from_axis(xx, yy, fallback_resolution: SomeResolution | None = None):
     return geomath.affine_from_axis(xx, yy, fallback_resolution)
 
 
-def iter_slices(shape: tuple[int, ...], chunk_size: tuple[int, ...]) -> Iterator[tuple]:
+def iter_slices(
+    shape: tuple[int, ...], chunk_size: tuple[int, ...]
+) -> Generator[tuple]:
     """
     Generate slices for a given shape.
 
@@ -192,8 +196,8 @@ def iter_slices(shape: tuple[int, ...], chunk_size: tuple[int, ...]) -> Iterator
 
     If the shape is not divisible by the chunk_size, the last chunk in each dimension will be smaller.
 
-    :param tuple(int) shape: Shape of an array
-    :param tuple(int) chunk_size: length of each slice for each dimension
+    :param shape: Shape of an array
+    :param chunk_size: length of each slice for each dimension
     :return: Yields slices that can be used on an array of the given shape
 
     >>> list(iter_slices((5,), (2,)))

--- a/datacube/utils/py.py
+++ b/datacube/utils/py.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import importlib
 import logging
+from collections.abc import Mapping
 from contextlib import contextmanager
 
 import toolz
@@ -63,14 +64,13 @@ class cached_property:  # pylint: disable=invalid-name  # noqa: N801
         return value
 
 
-def sorted_items(d, key=None, reverse: bool = False):
+def sorted_items(d: Mapping | None, key=None, reverse: bool = False) -> list:
     """Given a dictionary `d` return items: (k1, v1), (k2, v2)... sorted in
     ascending order according to key.
 
-    :param dict d: dictionary
+    :param d: dictionary
     :param key: optional function remapping key
-    :param bool reverse: If True return in descending order instead of default ascending
-
+    :param reverse: If True return in descending order instead of default ascending
     """
     if d is None:
         return []

--- a/datacube/utils/rio/_rio.py
+++ b/datacube/utils/rio/_rio.py
@@ -39,7 +39,6 @@ def get_rio_env(sanitize: bool = True):
 
     :param sanitize: If True replace sensitive Values with 'x'
     """
-
     env = rasterio.env.local._env  # pylint: disable=protected-access
     if env is None:
         return {}

--- a/datacube/utils/serialise.py
+++ b/datacube/utils/serialise.py
@@ -62,7 +62,6 @@ def jsonify_document(doc):
     Make a document ready for serialisation as JSON.
 
     Returns the new document, leaving the original unmodified.
-
     """
 
     def fixup_value(v):

--- a/datacube/utils/uris.py
+++ b/datacube/utils/uris.py
@@ -20,7 +20,6 @@ URL_RE: re.Pattern[str] = re.compile(r"\A\s*[\w\d\+]+://")
 def split_uri(uri):
     """
     Split the scheme and the remainder of the URI.
-
     """
     idx = uri.find(":")
     if idx < 0:

--- a/datacube/virtual/transformations.py
+++ b/datacube/virtual/transformations.py
@@ -400,7 +400,6 @@ class Expressions(Transformation):
        input:
            product: example_surface_reflectance_product
            measurements: [nir, red]
-
     """
 
     def __init__(self, output: Mapping, masked: bool = True) -> None:

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -17,9 +17,8 @@ Next Release
 - index: fix search_by_product type :pull:`1944`
 - Put coverage config in pyproject :pull:`1942`
 - Fix alembic deprecation warning :pull:`1941`
-- Convert doc strings to type annotations :pull:`1940`, :pull:`1950`
+- Convert doc strings to type annotations :pull:`1940`, :pull:`1950`, :pull:`1951`
 - ``archive-less-mature`` runs when re-indexing datasets :pull:`1948`
-- Convert doc strings to type annotations :pull:`1940`
 
 v1.9.4 (20 May 2025)
 ====================

--- a/examples/io_plugin/dcio_example/xarray_3d.py
+++ b/examples/io_plugin/dcio_example/xarray_3d.py
@@ -32,7 +32,7 @@ def uri_split(uri: str) -> tuple[str, str, str]:
 
     If the URI contains no '#' extension, the root group "" is returned.
 
-    :param str uri: The URI to be parsed
+    :param uri: The URI to be parsed
     :return: (protocol, root, group)
     """
     components = urlparse(uri)
@@ -63,9 +63,9 @@ class XArrayDataSource3D:
 
             The BandDataSource class to read array slices out of the xr.Dataset.
 
-            :param xr.Dataset dataset: The xr.Dataset
-            :param str var_name: The variable name of the xr.DataArray
-            :param float no_data: The no data value if known
+            :param dataset: The xr.Dataset
+            :param var_name: The variable name of the xr.DataArray
+            :param no_data: The no data value if known
             """
             self.ds = dataset
             self._var_name = var_name
@@ -118,8 +118,8 @@ class XArrayDataSource3D:
             """
             Reads a slice into the xr.DataArray.
 
-            :param RasterWindow window: The slice to read
-            :param RasterShape out_shape: The desired output shape
+            :param window: The slice to read
+            :param out_shape: The desired output shape
             :return: Requested data in a :class:`numpy.ndarray`
             """
 
@@ -144,7 +144,7 @@ class XArrayDataSource3D:
         """
         Initialises the XarrayDataSource3D class.
 
-        :param BandInfo band: BandInfo containing the dataset metadata.
+        :param band: BandInfo containing the dataset metadata.
         """
         self._band_info = band
         if band.band == 0:

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -44,7 +44,6 @@ from integration_tests.utils import (
 _SINGLE_RUN_CONFIG_TEMPLATE = """
 
 """
-
 INTEGRATION_TESTS_DIR = Path(__file__).parent
 
 _EXAMPLE_LS5_NBAR_DATASET_FILE = INTEGRATION_TESTS_DIR / "example-ls5-nbar.yaml"
@@ -712,7 +711,6 @@ def geotiffs(tmpdir_factory):
             'path':..., # path to the yaml ingestion file
             'tiffs':... # list of paths to the actual geotiffs in that dataset, one per band.
         }
-
     """
     tiffs_dir = tmpdir_factory.mktemp("tiffs")
 
@@ -737,12 +735,12 @@ def geotiffs(tmpdir_factory):
     ]
 
 
-def _make_tiffs_and_yamls(tiffs_dir, config, day_offset):
+def _make_tiffs_and_yamls(tiffs_dir: str, config: dict, day_offset: int):
     """Make a custom yaml and tiff for a day offset.
 
-    :param path-like tiffs_dir: The base path to receive the tiffs.
-    :param dict config: The yaml config to be cloned and altered.
-    :param int day_offset: how many days to offset the original yaml by.
+    :param tiffs_dir: The base path to receive the tiffs.
+    :param config: The yaml config to be cloned and altered.
+    :param day_offset: how many days to offset the original yaml by.
     """
     config = deepcopy(config)
 
@@ -795,7 +793,7 @@ def example_ls5_dataset_path(example_ls5_dataset_paths):
 
 
 @pytest.fixture
-def example_ls5_dataset_paths(tmpdir, geotiffs):
+def example_ls5_dataset_paths(tmpdir, geotiffs: list) -> dict:
     """Create sample raw observations (dataset + geotiff).
 
     This fixture should be used by eah test requiring a set of
@@ -804,9 +802,9 @@ def example_ls5_dataset_paths(tmpdir, geotiffs):
     test session, in order to save disk and time.
 
     :param tmpdir: The temp directory in which to create the datasets.
-    :param list geotiffs: List of session geotiffs and yamls, to be
+    :param geotiffs: List of session geotiffs and yamls, to be
       linked from this unique observation set sample.
-    :return: dict: Dict of directories containing each observation,
+    :return: Dict of directories containing each observation,
       indexed by dataset UUID.
     """
     dataset_dirs = _make_ls5_scene_datasets(geotiffs, tmpdir)

--- a/integration_tests/index/test_search_legacy.py
+++ b/integration_tests/index/test_search_legacy.py
@@ -1047,7 +1047,6 @@ def test_csv_search_via_cli(
 
     NB behaviour of CLI search when datasets have zero or multiple locations has changed in 1.9.
     """
-
     # Test dataset is:
     # platform: LANDSAT_8
     # from: 2014-7-26  23:48:00

--- a/integration_tests/test_dataset_add.py
+++ b/integration_tests/test_dataset_add.py
@@ -77,7 +77,6 @@ def check_with_existing_lineage(clirunner, index) -> None:
 
     Add nodes BCE(D) with auto-matching, then add node A with product restricted to A only.
     """
-
     ds = SimpleDocNav(gen_dataset_test_dag(33, force_tree=True))
 
     child_docs = [ds.sources[x].doc for x in ("ab", "ac", "ae")]

--- a/integration_tests/test_environments.py
+++ b/integration_tests/test_environments.py
@@ -19,7 +19,6 @@ db_hostname: db.opendatacube.test
 [testalt]
 db_hostname: alt-db.opendatacube.test
     """
-
     cfg = ODCConfig(text=raw_config)
     cfg_env = cfg[None]
     assert cfg_env.db_hostname == "db.opendatacube.test"

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -126,7 +126,6 @@ def _make_geotiffs(tiffs_dir, day_offset, num_bands=NUM_BANDS):
 
 def _make_ls5_scene_datasets(geotiffs, tmpdir) -> dict:
     """
-
     Create directory structures like::
 
         LS5_TM_NBAR_P54_GANBAR01-002_090_084_01

--- a/tests/api/test_masking.py
+++ b/tests/api/test_masking.py
@@ -198,7 +198,6 @@ class SimpleVariableWithFlagsDef:
           values:
             16383: true
         """
-
     flags_definition = yaml.safe_load(bits_def_yaml)
 
 
@@ -271,7 +270,6 @@ class VariableWithMultiBitFlags:
             0: False
             1: True
     """
-
     flags_definition = yaml.safe_load(bits_def_yaml)
 
 

--- a/tests/api/test_virtual.py
+++ b/tests/api/test_virtual.py
@@ -584,7 +584,6 @@ def test_fiscal_year_multi_time_dimensions() -> None:
     Test the fiscal year is applied to every
     input time dimension
     """
-
     times_mock_1 = [
         "2015-06-30T11:59:59.999999000",
         "2015-12-31T11:59:59.999999000",

--- a/tests/test_eo3.py
+++ b/tests/test_eo3.py
@@ -33,7 +33,6 @@ lineage:
   src_empty: []
 ...
 """
-
 # Crosses lon=180 line in Pacific, taken from one the Landsat scenes
 # https://landsat-pds.s3.amazonaws.com/c1/L8/074/071/LC08_L1TP_074071_20190622_20190704_01_T1/index.html
 #

--- a/tests/test_utils_docs.py
+++ b/tests/test_utils_docs.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """
 Test utility functions from :module:`datacube.utils`
-
-
 """
 
 import os
@@ -353,7 +351,6 @@ def test_simple_doc_nav() -> None:
     |
     +--> E
     """
-
     nu_map = {n: uuid4() for n in ["A", "B", "C", "D", "E"]}
     un_map = {u: n for n, u in nu_map.items()}
 

--- a/tests/test_utils_other.py
+++ b/tests/test_utils_other.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """
 Test utility functions from :module:`datacube.utils`
-
-
 """
 
 import os
@@ -511,7 +509,6 @@ def test_testutils_geobox() -> None:
     PARAMETER["false_northing",500000],
     UNIT["Meter",1]]
     """
-
     crs_ = dc_crs_from_rio(CRS.from_wkt(wkt))
     assert crs_.epsg is None
 


### PR DESCRIPTION
### Reason for this pull request

The `doc484` utility that I used only converted `:type:` and `:rtype` to type annotations, so there were a bunch of types hidden in `:param type name:` clauses. This PR removes most of those, and puts the types into the type annotations. I removed a bunch of the empty doc strings that were just there for the types since those are now in the type annotations instead.

Refs #1869

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1951.org.readthedocs.build/en/1951/

<!-- readthedocs-preview opendatacube end -->