### PR TITLE
Expose Grid Workflow classes from datacube.api.

### DIFF
--- a/datacube/api/__init__.py
+++ b/datacube/api/__init__.py
@@ -7,7 +7,7 @@ Modules for the Storage and Access Query API
 """
 
 from .core import Datacube, TerminateCurrentLoad
-from .grid_workflow import Tile, GridWorkflow, GridWorkflowException
+from .grid_workflow import GridWorkflow, GridWorkflowException, Tile
 
 __all__ = [
     "Datacube",

--- a/datacube/api/__init__.py
+++ b/datacube/api/__init__.py
@@ -7,8 +7,12 @@ Modules for the Storage and Access Query API
 """
 
 from .core import Datacube, TerminateCurrentLoad
+from .grid_workflow import Tile, GridWorkflow, GridWorkflowException
 
 __all__ = [
     "Datacube",
+    "GridWorkflow",
+    "GridWorkflowException",
     "TerminateCurrentLoad",
+    "Tile",
 ]

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -21,7 +21,7 @@ Next Release
 - ``archive-less-mature`` runs when re-indexing datasets :pull:`1948`
 - Convert doc strings to type annotations :pull:`1940`
 - Document alembic upgrades :pull:`1955`
-- Export grid workflow classes from datacube.api :pull:`1956`
+- Export grid workflow classes from datacube.api :pull:`1958`
 
 v1.9.4 (20 May 2025)
 ====================

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -21,6 +21,7 @@ Next Release
 - ``archive-less-mature`` runs when re-indexing datasets :pull:`1948`
 - Convert doc strings to type annotations :pull:`1940`
 - Document alembic upgrades :pull:`1955`
+- Export grid workflow classes from datacube.api :pull:`1956`
 
 v1.9.4 (20 May 2025)
 ====================


### PR DESCRIPTION
### Reason for this pull request

RTD builds breaking: #1953


### Proposed changes

- expose `Tile`, `GridWorkflow` and `GridWorkflowException` from `datacube.api`



 - [x] Closes #1953
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1958.org.readthedocs.build/en/1958/

<!-- readthedocs-preview opendatacube end -->