### PR TITLE
postgis: stop parsing table names

### DIFF
--- a/datacube/drivers/postgis/_connections.py
+++ b/datacube/drivers/postgis/_connections.py
@@ -233,11 +233,11 @@ class PostGisDb:
         :return:
         """
         try:
-            spidx = self.spindexes.get(crs_to_epsg(crs))
+            crs_id = crs_to_epsg(crs)
+            spidx = self.spindexes.get(crs_id)
             if spidx is None:
                 spidx = spindex_for_crs(crs)
-                assert spidx is not None  # for type checker
-                ensure_spindex(self._engine, spidx)
+                ensure_spindex(self._engine, spidx, crs_id)
                 self._refresh_spindexes()
         except ValueError:
             _LOG.warning("Could not dynamically model an index for CRS %s", crs._str)
@@ -251,10 +251,11 @@ class PostGisDb:
         :param crs:
         :return:
         """
-        spidx = self.spindexes.get(crs_to_epsg(crs))
+        crs_id = crs_to_epsg(crs)
+        spidx = self.spindexes.get(crs_id)
         if spidx is None:
             return False
-        result = drop_spindex(self._engine, spidx)
+        result = drop_spindex(self._engine, spidx, crs_id)
         self._refresh_spindexes()
         return result
 

--- a/datacube/drivers/postgis/_schema.py
+++ b/datacube/drivers/postgis/_schema.py
@@ -282,13 +282,6 @@ class SpatialIndexRecord(Base):
         Text, server_default=func.current_user(), comment="added by whom"
     )
 
-    @classmethod
-    def from_spindex(cls, spindex: type[SpatialIndex]) -> "SpatialIndexRecord":
-        return cls(
-            srid=int(spindex.__tablename__[8:]),  # type: ignore [attr-defined]
-            table_name=spindex.__tablename__,  # type: ignore [attr-defined]
-        )
-
 
 # In theory could put dataset_ref and search_key in shared parent class, but having a foreign key
 # in such a class requires weird and esoteric SQLAlchemy features.  Just leave as separate

--- a/datacube/drivers/postgis/_spatial.py
+++ b/datacube/drivers/postgis/_spatial.py
@@ -143,13 +143,11 @@ def spindex_for_record(rec: SpatialIndexRecord) -> type[SpatialIndex]:
     return spindex_for_epsg(rec.srid)
 
 
-def ensure_spindex(engine: Engine, sp_idx: type[SpatialIndex]) -> None:
+def ensure_spindex(engine: Engine, sp_idx: type[SpatialIndex], crs_id: int) -> None:
     """Ensure a Spatial Index exists in a particular database."""
     with Session(engine) as session:
         results = session.execute(
-            select(SpatialIndexRecord.srid).where(
-                SpatialIndexRecord.srid == int(sp_idx.__tablename__[8:])  # type: ignore[arg-type,attr-defined]
-            )
+            select(SpatialIndexRecord.srid).where(SpatialIndexRecord.srid == crs_id)
         )
         for _ in results:
             # SpatialIndexRecord exists - actual index assumed to exist too.
@@ -157,7 +155,7 @@ def ensure_spindex(engine: Engine, sp_idx: type[SpatialIndex]) -> None:
         # SpatialIndexRecord doesn't exist - create the index table...
         orm_registry.metadata.create_all(engine, [sp_idx.__table__])  # type: ignore[attr-defined]
         # ... and add a SpatialIndexRecord
-        session.add(SpatialIndexRecord.from_spindex(sp_idx))
+        session.add(SpatialIndexRecord(srid=crs_id, table_name=sp_idx.__tablename__))  # type: ignore[attr-defined]
         session.commit()
         session.flush()
     # Permissions Management
@@ -174,12 +172,10 @@ def ensure_spindex(engine: Engine, sp_idx: type[SpatialIndex]) -> None:
     return
 
 
-def drop_spindex(engine: Engine, sp_idx: type[SpatialIndex]) -> bool:
+def drop_spindex(engine: Engine, sp_idx: type[SpatialIndex], crs_id: int) -> bool:
     with Session(engine) as session:
         results = session.execute(
-            select(SpatialIndexRecord).where(
-                SpatialIndexRecord.srid == int(sp_idx.__tablename__[8:])  # type: ignore[arg-type,attr-defined]
-            )
+            select(SpatialIndexRecord).where(SpatialIndexRecord.srid == crs_id)
         )
         spidx_record = None
         for result in results:

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -21,6 +21,7 @@ Next Release
 - ``archive-less-mature`` runs when re-indexing datasets :pull:`1948`
 - Convert doc strings to type annotations :pull:`1940`
 - Document alembic upgrades :pull:`1955`
+- postgis: stop parsing table names :pull:`1961`
 
 v1.9.4 (20 May 2025)
 ====================


### PR DESCRIPTION
### Reason for this pull request

There is an integer available further
up the call chain, so pass that along
instead of repeatedly parsing
the tablename and adding ignores for
MyPy.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1961.org.readthedocs.build/en/1961/

<!-- readthedocs-preview opendatacube end -->