### PR TITLE
serialize with `canonical_name` in `Measurement`

### DIFF
--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -596,7 +596,9 @@ class Measurement:
         return {key: value for key, value in self.items() if key not in self.ATTR_SKIP}
 
     def __getstate__(self):
-        return self._data
+        state = {**self._data}
+        state["canonical_name"] = self.canonical_name
+        return state
 
     def __setstate__(self, state):
         self.__init__(**state)

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -24,6 +24,7 @@ Next Release
 - postgis: stop parsing table names :pull:`1961`
 - postgis: fix alembic metadata object :pull:`1960`
 - Export grid workflow classes from datacube.api :pull:`1958`
+- Fix issue :issue:`1936` :pull: `1962`
 
 v1.9.4 (20 May 2025)
 ====================

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -367,7 +367,7 @@ def test_measurement_equality() -> None:
 
 @pytest.mark.parametrize("protocol", range(pickle.HIGHEST_PROTOCOL))
 def test_measurement_pickling(protocol) -> None:
-    m = Measurement(name="t", dtype="uint8", nodata=255, units="1")
+    m = Measurement(canonical_name="s", name="t", dtype="uint8", nodata=255, units="1")
 
     serialised_m = pickle.dumps(m, protocol=protocol)
 
@@ -379,7 +379,7 @@ def test_measurement_pickling(protocol) -> None:
 def test_measurement_cloudpickle() -> None:
     import cloudpickle
 
-    m = Measurement(name="t", dtype="uint8", nodata=255, units="1")
+    m = Measurement(canonical_name="s", name="t", dtype="uint8", nodata=255, units="1")
     serialised = cloudpickle.dumps(m)
 
     deserialised = cloudpickle.loads(serialised)


### PR DESCRIPTION
### Reason for this pull request

fix the bug #1936 


### Proposed changes

- save `canonical_name` in addition to `_data` in Measurement
- 



 - [x] Closes #1936 
 - [x] Tests added / passed
 - [x] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1962.org.readthedocs.build/en/1962/

<!-- readthedocs-preview opendatacube end -->