### PR TITLE
Dockerfile: switch to ubuntu user

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,8 +50,10 @@ jobs:
 
     - name: Verify and Run Tests
       run: |
+        export LOCAL_UID=$(id -u $USER)
+        export LOCAL_GID=$(id -g $USER)
         docker compose up --quiet-pull --wait -d
-        docker compose exec --user odc -T core /bin/bash --login -c \
+        docker compose exec --user ubuntu -T core /bin/bash --login -c \
           "source /env/bin/activate && pytest -r a \
             --cov datacube \
             --cov-report=xml \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       context: .
       dockerfile: docker/Dockerfile
     environment:
+      - LOCAL_UID=${LOCAL_UID:-1000}
+      - LOCAL_GID=${LOCAL_GID:-1000}
       - POSTGRES_HOSTNAME=postgres
       - PGPORT=35432
       - POSTGRES_USER=opendatacube

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,6 +30,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
         git \
+        gosu \
         libpq-dev libudunits2-dev libproj-dev \
         libhdf5-dev libnetcdf-dev libgeos-dev libudunits2-dev \
         python3-dev virtualenv \
@@ -41,21 +42,20 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 # Copy bootstrap script into image.
 COPY --chown=root:root docker/assets/with_bootstrap /usr/local/bin/
+# Add login-script for UID/GID-remapping.
+COPY --chown=root:root --link docker/assets/remap-user.sh /usr/local/bin/remap-user.sh
 
 # users and groups.
-RUN groupmod ubuntu -n odc  \
-  && usermod -m -d /home/odc ubuntu -l odc \
-  && adduser odc users \
-  && adduser odc sudo \
+RUN usermod -aG sudo ubuntu \
   && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
   && mkdir /env /code \
-  && chown odc:odc /env /code
+  && chown ubuntu:ubuntu /env /code
 
 # Build constrained python environment
 
-USER odc
+USER ubuntu
 
-COPY --chown=odc:odc docker/assets/datacube_integration.conf /home/odc/.datacube_integration.conf
+COPY --chown=ubuntu:ubuntu docker/assets/datacube_integration.conf /home/ubuntu/.datacube_integration.conf
 
 WORKDIR /env
 
@@ -67,17 +67,17 @@ ENV PYENV=/env \
 
 COPY docker/constraints.txt docker/nobinary.txt /conf/
 
-RUN --mount=type=cache,id=odc-python-312-cache,target=/home/odc/.cache \
-    sudo chown odc:odc /home/odc/.cache \
+RUN --mount=type=cache,id=odc-python-312-cache,target=/home/ubuntu/.cache \
+    sudo chown ubuntu:ubuntu /home/ubuntu/.cache \
     && . /env/bin/activate \
     && python3 -m pip --disable-pip-version-check install --upgrade pip setuptools \
     && python3 -m pip --disable-pip-version-check install -r /conf/constraints.txt \
                            -c /conf/nobinary.txt
 
 # Copy datacube-core source code into container and install from source (with addons for tests).
-COPY --chown=odc:odc . /code
+COPY --chown=ubuntu:ubuntu . /code
 
-RUN  --mount=type=cache,id=odc-python-312-cache,target=/home/odc/.cache \
+RUN  --mount=type=cache,id=odc-python-312-cache,target=/home/ubuntu/.cache \
     . /env/bin/activate && python3 -m pip --disable-pip-version-check install '/code/[all]' \
     && python3 -m pip --disable-pip-version-check install /code/examples/io_plugin \
     && python3 -m pip --disable-pip-version-check install /code/tests/drivers/fail_drivers
@@ -87,4 +87,5 @@ USER root
 VOLUME /code
 WORKDIR /code
 
-ENTRYPOINT ["/bin/tini", "-s", "--", "/usr/local/bin/with_bootstrap"]
+ENTRYPOINT ["/usr/local/bin/remap-user.sh"]
+CMD ["/usr/local/bin/with_bootstrap"]

--- a/docker/assets/remap-user.sh
+++ b/docker/assets/remap-user.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+# Script that gives the container user uid $LOCAL_UID and gid $LOCAL_GID.
+# If $LOCAL_UID or $LOCAL_GID are not set, they default to 1000 (default
+# for the first user created in Ubuntu).
+
+USER_ID=${LOCAL_UID:-1000}
+GROUP_ID=${LOCAL_GID:-1000}
+
+[[ "$USER_ID" == "1000" ]] || usermod -u $USER_ID -o -m -d /home/ubuntu ubuntu
+[[ "$GROUP_ID" == "1000" ]] || groupmod -g $GROUP_ID ubuntu
+[[ $(id -u) != "0" ]] || GOSU="/usr/sbin/gosu ubuntu"
+exec /usr/bin/tini -- $GOSU "$@"

--- a/docker/assets/with_bootstrap
+++ b/docker/assets/with_bootstrap
@@ -1,35 +1,5 @@
 #!/bin/bash
 
-# Become `odc` user with UID/GID compatible to datacube-core volume
-#  If Running As root
-#    If outside volume not owned by root
-#       change `odc` to have compatible UID/GID
-#       re-exec this script as odc user
-
-[[ $UID -ne 0 ]] || {
-    target_uid=$(stat -c '%u' .)
-    target_gid=$(stat -c '%g' .)
-
-    [[ $target_uid -eq 0 ]] || {
-
-        # unless gid already matches update gid
-        [[ $(id -g odc) -eq ${target_gid} ]] || {
-            groupmod --gid ${target_gid} odc
-            usermod --gid ${target_gid} odc
-        }
-
-        # unless uid already matches: change it and update HOME and /env
-        [[ $(id -u odc) -eq ${target_uid} ]] || {
-            usermod --uid ${target_uid} odc
-            chown -R odc:odc /home/odc/ /env
-        }
-
-        exec sudo -u odc -E -H bash "$0" "$@"
-    }
-}
-
-[[ $UID -ne 0 ]] || echo "WARNING: Running as root"
-
 env="${PYENV:-/env}"
 
 if [ -e "${env}/bin/activate" ]; then

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -25,7 +25,8 @@ Next Release
 - postgis: stop parsing table names :pull:`1961`
 - postgis: fix alembic metadata object :pull:`1960`
 - Export grid workflow classes from datacube.api :pull:`1958`
-- Fix issue :issue:`1936` :pull: `1962`
+- Fix issue :issue:`1936` :pull:`1962`
+- Dockerfile: switch to ubuntu user :pull:`1964`
 
 v1.9.4 (20 May 2025)
 ====================


### PR DESCRIPTION
### Reason for this pull request

Switch to using the default ubuntu
user already available in the base
image, and use gosu for the UID/GID
switch. The reason to use gosu is that
both su and sudo have strange TTY and
signal-forwarding behavior.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1964.org.readthedocs.build/en/1964/

<!-- readthedocs-preview opendatacube end -->