### PR TITLE
Dockerfile: let rasterio detect data path

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,7 +33,7 @@ jobs:
         python-version: ["3.12"]
         lintcommand:
           - "pylint -j 2 --report no datacube"
-          - "mypy datacube"
+          - "mypy datacube tests/test_utils_rio.py"
     name: Linting
     steps:
       - name: checkout git

--- a/datacube/utils/rio/_rio.py
+++ b/datacube/utils/rio/_rio.py
@@ -6,6 +6,7 @@
 
 import threading
 from types import SimpleNamespace
+from typing import Literal
 
 import rasterio
 import rasterio.env
@@ -34,7 +35,7 @@ def _state(purge: bool = False):
     )
 
 
-def get_rio_env(sanitize: bool = True):
+def get_rio_env(sanitize: bool = True) -> dict:
     """Get GDAL params configured by rasterio for the current thread.
 
     :param sanitize: If True replace sensitive Values with 'x'
@@ -57,7 +58,9 @@ def deactivate_rio_env() -> None:
         state.env.__exit__(None, None, None)
 
 
-def activate_rio_env(aws=None, cloud_defaults: bool = False, **kwargs):
+def activate_rio_env(
+    aws: Literal["auto"] | dict | None = None, cloud_defaults: bool = False, **kwargs
+) -> dict:
     """Inject activated rasterio.Env into current thread.
 
     This de-activates previously setup environment.

--- a/docker/assets/with_bootstrap
+++ b/docker/assets/with_bootstrap
@@ -44,17 +44,6 @@ if [ -e "${env}/bin/activate" ]; then
             python -m pip install -e /code/tests/drivers/fail_drivers --no-deps
             python -m pip install -e /code/examples/io_plugin --no-deps
         }
-
-        [ -n "${GDAL_DATA:-}" ] || {
-            # if binary version of rasterio was used, set GDAL_DATA to that
-            RIO_GDAL_DATA=$(dirname $(python -c 'import rasterio; print(rasterio.__file__)'))"/gdal_data"
-
-            if [ -d "${RIO_GDAL_DATA}" ]; then
-                export GDAL_DATA="${RIO_GDAL_DATA}"
-            else
-                export GDAL_DATA=$(gdal-config --datadir)
-            fi
-        }
     }
 fi
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,7 @@ What's New
 Next Release
 ============
 
+- Dockerfile: let rasterio detect data path :pull:`1966`
 - index: add return types :pull:`1939`
 - Update dependencies :pull:`1925`
 - Run Ruff format on all code :pull:`1926`, :pull:`1927`

--- a/tests/test_utils_rio.py
+++ b/tests/test_utils_rio.py
@@ -26,7 +26,6 @@ def test_rio_env_no_aws() -> None:
     assert get_rio_env() == {}
 
     ee = activate_rio_env(FAKE_OPTION=1)
-    assert isinstance(ee, dict)
     assert ee == get_rio_env()
     assert "GDAL_DISABLE_READDIR_ON_OPEN" not in ee
     if os.getenv("GDAL_DATA", None):
@@ -49,7 +48,7 @@ def test_rio_env_aws() -> None:
     assert get_rio_env() == {}
 
     with pytest.raises(ValueError):
-        activate_rio_env(aws="something")
+        activate_rio_env(aws="something")  # type: ignore[arg-type]
 
     # note: setting region_name to avoid auto-lookup
     ee = activate_rio_env(aws={"aws_unsigned": True, "region_name": "us-west-1"})
@@ -125,8 +124,7 @@ def test_rio_env_aws_auto_region_dummy() -> None:
 
     with moto.mock_aws():
         # at least it should not raise error since we haven't asked for region_name='auto'
-        ee = activate_rio_env(aws={})
-        assert isinstance(ee, dict)
+        _ = activate_rio_env(aws={})
 
         deactivate_rio_env()
         assert get_rio_env() == {}


### PR DESCRIPTION
### Reason for this pull request

Rasterio and shapely are coupled
to the GDAL versions they are built
with, so let rasterio use the data
files it is configured with.

Also add type signatures since I was
looking at these functions, and remove
some `isinstance` checks in the tests
since this is ensured by the type checker.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1966.org.readthedocs.build/en/1966/

<!-- readthedocs-preview opendatacube end -->