### PR TITLE
examples/tests: fix dependencies

### DIFF
--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -10,6 +10,7 @@ Next Release
 
 - examples: remove unimplemented zeros :pull:`1974`
 - examples: fix function signatures :pull:`1972`
+- examples/tests: fix dependencies :pull:`1975`
 
 v1.9.5 (17 June 2025)
 =====================

--- a/examples/io_plugin/pyproject.toml
+++ b/examples/io_plugin/pyproject.toml
@@ -16,5 +16,5 @@ xarray_3d = "dcio_example.xarray_3d:reader_driver_init"
 pickle = "dcio_example.pickles:writer_driver_init"
 
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=69"]
 build-backend = "setuptools.build_meta"

--- a/examples/io_plugin/pyproject.toml
+++ b/examples/io_plugin/pyproject.toml
@@ -6,6 +6,7 @@ authors = [
     {name = "Open Data Cube"},
 ]
 requires-python = ">=3.10"
+dependencies = ["datacube"]
 
 [project.entry-points."datacube.plugins.io.read"]
 pickle = "dcio_example.pickles:rdr_driver_init"

--- a/tests/drivers/fail_drivers/pyproject.toml
+++ b/tests/drivers/fail_drivers/pyproject.toml
@@ -6,6 +6,7 @@ authors = [
     {name = "AGDC Collaboration"},
 ]
 requires-python = ">=3.10"
+dependencies = ["datacube"]
 
 [project.entry-points."datacube.plugins.io.read"]
 bad_end_point = "dc_tests_io.nosuch.module:init"

--- a/tests/drivers/fail_drivers/pyproject.toml
+++ b/tests/drivers/fail_drivers/pyproject.toml
@@ -14,5 +14,5 @@ failing_end_point_none = "dc_tests_io.dummy:init_to_none"
 failing_end_point_throw = "dc_tests_io.dummy:fail_to_init"
 
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=69"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
### Reason for this pull request

Make the driver packages depend on datacube itself.

Also align the setuptools requirements with the datacube
requirements when I'm updating these files.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1975.org.readthedocs.build/en/1975/

<!-- readthedocs-preview opendatacube end -->