### PR TITLE
docs: document named tuple parameters

### DIFF
--- a/datacube/index/abstract/_types.py
+++ b/datacube/index/abstract/_types.py
@@ -18,11 +18,11 @@ class BatchStatus(NamedTuple):
     """
     A named tuple representing the results of a batch add operation:
 
-      - completed: Number of objects added to theMay be None for internal functions and for datasets.
-      - skipped: Number of objects skipped, either because they already exist
+    :param completed: Number of objects added to theMay be None for internal functions and for datasets.
+    :param skipped: Number of objects skipped, either because they already exist
         or the documents are invalid for this driver.
-      - seconds_elapsed: seconds elapsed during the bulk add operation;
-      - safe: an optional list of names of bulk added objects that are safe to be
+    :param seconds_elapsed: seconds elapsed during the bulk add operation;
+    :param safe: an optional list of names of bulk added objects that are safe to be
         used for lower level bulk adds. Includes objects added, and objects skipped
         because they already exist in the index and are identical to the version
         being added.  May be None for internal functions and for datasets.
@@ -52,9 +52,9 @@ def dsid_to_uuid(dsid: DSID) -> UUID:
 class DatasetTuple(NamedTuple):
     """
     A named tuple representing a complete dataset:
-    - product: A Product model.
-    - metadata: The dataset metadata document
-    - uri_: The dataset location or list of locations
+    :param product: A Product model.
+    :param metadata: The dataset metadata document
+    :param uri\\_: The dataset location or list of locations
     """
 
     product: Product

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,7 @@ extensions = [
     # 'sphinx.ext.napoleon',
     "sphinx_design",
     # 'sphinx.ext.autosectionlabel',
+    "sphinx_toolbox.more_autodoc.autonamedtuple",
     "IPython.sphinxext.ipython_console_highlighting",  # Highlights notebook cells
 ]
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -13,6 +13,10 @@ alembic==1.16.2
     # via datacube (pyproject.toml)
 antimeridian==0.4.1
     # via datacube (pyproject.toml)
+apeye==1.4.1
+    # via sphinx-toolbox
+apeye-core==1.1.5
+    # via apeye
 asttokens==3.0.0
     # via stack-data
 attrs==25.3.0
@@ -22,7 +26,9 @@ attrs==25.3.0
     #   rasterio
     #   referencing
 autodocsumm==0.2.14
-    # via datacube (pyproject.toml:doc)
+    # via
+    #   datacube (pyproject.toml:doc)
+    #   sphinx-toolbox
 babel==2.17.0
     # via
     #   pydata-sphinx-theme
@@ -32,6 +38,7 @@ beautifulsoup4==4.13.4
     #   datacube (pyproject.toml:doc)
     #   nbconvert
     #   pydata-sphinx-theme
+    #   sphinx-toolbox
 bleach==6.2.0
     # via nbconvert
 boto3==1.38.37
@@ -41,6 +48,8 @@ botocore==1.38.37
     #   datacube (pyproject.toml)
     #   boto3
     #   s3transfer
+cachecontrol==0.14.3
+    # via sphinx-toolbox
 cachetools==6.1.0
     # via
     #   datacube (pyproject.toml)
@@ -50,6 +59,7 @@ certifi==2025.6.15
     #   pyproj
     #   rasterio
     #   requests
+    #   sphinx-prompt
 charset-normalizer==3.4.2
     # via requests
 click==8.2.1
@@ -72,6 +82,8 @@ cloudpickle==3.1.1
     #   distributed
 commonmark==0.9.1
     # via recommonmark
+cssutils==2.11.1
+    # via dict2css
 dask==2025.5.1
     # via
     #   datacube (pyproject.toml)
@@ -82,6 +94,8 @@ defusedxml==0.7.1
     # via nbconvert
 deprecat==2.1.3
     # via datacube (pyproject.toml)
+dict2css==0.3.0.post1
+    # via sphinx-toolbox
 distributed==2025.5.1
     # via datacube (pyproject.toml)
 docutils==0.21.2
@@ -91,18 +105,36 @@ docutils==0.21.2
     #   recommonmark
     #   sphinx
     #   sphinx-click
+    #   sphinx-prompt
+    #   sphinx-tabs
+    #   sphinx-toolbox
+domdf-python-tools==3.10.0
+    # via
+    #   apeye
+    #   apeye-core
+    #   dict2css
+    #   sphinx-toolbox
 executing==2.2.0
     # via stack-data
 fastjsonschema==2.21.1
     # via nbformat
+filelock==3.18.0
+    # via
+    #   cachecontrol
+    #   sphinx-toolbox
 fsspec==2025.5.1
     # via dask
 geoalchemy2==0.17.1
     # via datacube (pyproject.toml)
 greenlet==3.2.3
     # via sqlalchemy
+html5lib==1.1
+    # via sphinx-toolbox
 idna==3.10
-    # via requests
+    # via
+    #   apeye-core
+    #   requests
+    #   sphinx-prompt
 imagesize==1.4.1
     # via sphinx
 ipython==9.2.0
@@ -117,6 +149,7 @@ jinja2==3.1.6
     #   nbconvert
     #   nbsphinx
     #   sphinx
+    #   sphinx-jinja2-compat
 jmespath==1.0.1
     # via
     #   boto3
@@ -150,12 +183,19 @@ markupsafe==3.0.2
     #   jinja2
     #   mako
     #   nbconvert
+    #   sphinx-jinja2-compat
 matplotlib-inline==0.1.7
     # via ipython
 mistune==3.1.3
     # via nbconvert
+more-itertools==10.7.0
+    # via cssutils
 msgpack==1.1.1
-    # via distributed
+    # via
+    #   cachecontrol
+    #   distributed
+natsort==8.4.0
+    # via domdf-python-tools
 nbclient==0.10.2
     # via nbconvert
 nbconvert==7.16.6
@@ -201,7 +241,9 @@ partd==1.4.2
 pexpect==4.9.0
     # via ipython
 platformdirs==4.3.8
-    # via jupyter-core
+    # via
+    #   apeye
+    #   jupyter-core
 prompt-toolkit==3.0.51
     # via ipython
 psutil==7.0.0
@@ -220,6 +262,8 @@ pygments==2.19.1
     #   nbconvert
     #   pydata-sphinx-theme
     #   sphinx
+    #   sphinx-prompt
+    #   sphinx-tabs
 pyparsing==3.2.3
     # via rasterio
 pyproj==3.7.1
@@ -250,13 +294,18 @@ referencing==0.36.2
     #   jsonschema
     #   jsonschema-specifications
 requests==2.32.4
-    # via sphinx
+    # via
+    #   apeye
+    #   cachecontrol
+    #   sphinx
 rpds-py==0.25.1
     # via
     #   jsonschema
     #   referencing
 ruamel-yaml==0.18.14
-    # via datacube (pyproject.toml)
+    # via
+    #   datacube (pyproject.toml)
+    #   sphinx-toolbox
 ruamel-yaml-clib==0.2.12
     # via ruamel-yaml
 s3transfer==0.13.0
@@ -267,7 +316,9 @@ shapely==2.1.1
     #   antimeridian
     #   odc-geo
 six==1.17.0
-    # via python-dateutil
+    # via
+    #   html5lib
+    #   python-dateutil
 snowballstemmer==3.0.1
     # via sphinx
 sortedcontainers==2.4.0
@@ -284,11 +335,24 @@ sphinx==8.1.3
     #   sphinx-autodoc-typehints
     #   sphinx-click
     #   sphinx-design
+    #   sphinx-prompt
+    #   sphinx-tabs
+    #   sphinx-toolbox
 sphinx-autodoc-typehints==3.0.1
-    # via datacube (pyproject.toml:doc)
+    # via
+    #   datacube (pyproject.toml:doc)
+    #   sphinx-toolbox
 sphinx-click==6.0.0
     # via datacube (pyproject.toml:doc)
 sphinx-design==0.6.1
+    # via datacube (pyproject.toml:doc)
+sphinx-jinja2-compat==0.3.0
+    # via sphinx-toolbox
+sphinx-prompt==1.9.0
+    # via sphinx-toolbox
+sphinx-tabs==3.4.5
+    # via sphinx-toolbox
+sphinx-toolbox==4.0.0
     # via datacube (pyproject.toml:doc)
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
@@ -309,6 +373,8 @@ sqlalchemy==2.0.41
     #   geoalchemy2
 stack-data==0.6.3
     # via ipython
+tabulate==0.9.0
+    # via sphinx-toolbox
 tblib==3.1.0
     # via distributed
 tinycss2==1.4.0
@@ -337,8 +403,10 @@ typing-extensions==4.14.0
     # via
     #   alembic
     #   beautifulsoup4
+    #   domdf-python-tools
     #   pydata-sphinx-theme
     #   referencing
+    #   sphinx-toolbox
     #   sqlalchemy
 tzdata==2025.2
     # via pandas
@@ -347,11 +415,13 @@ urllib3==2.4.0
     #   botocore
     #   distributed
     #   requests
+    #   sphinx-prompt
 wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
     # via
     #   bleach
+    #   html5lib
     #   tinycss2
 wrapt==1.17.2
     # via deprecat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ doc = [
     'sphinx_autodoc_typehints',  # Propagate mypy info into docs
     'sphinx-click',
     'sphinx-design',
+    'sphinx-toolbox',
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.12'",
+    "python_full_version >= '3.13'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -63,6 +64,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/de/4f/b83d7ea4ee0ff64fa36906f82d6f2c227aa36828481f60eafbf320dea6c1/antimeridian-0.4.1.tar.gz", hash = "sha256:4efe7aa15ef1bc66169392870d54b945c31ef9574e08bc930650f0b7beefc354", size = 12570569, upload-time = "2025-04-10T12:56:59.515Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/7a/12dcb24f69cb8fb8b65b810d9590038b06c528f5b57c6db9bfaecc7121e0/antimeridian-0.4.1-py3-none-any.whl", hash = "sha256:45c31d5fc834863175a1d20b522c1da941edb906dfd84a05fae5007985efe405", size = 14946, upload-time = "2025-04-10T12:56:57.255Z" },
+]
+
+[[package]]
+name = "apeye"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "apeye-core" },
+    { name = "domdf-python-tools" },
+    { name = "platformdirs" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/6b/cc65e31843d7bfda8313a9dc0c77a21e8580b782adca53c7cb3e511fe023/apeye-1.4.1.tar.gz", hash = "sha256:14ea542fad689e3bfdbda2189a354a4908e90aee4bf84c15ab75d68453d76a36", size = 99219, upload-time = "2023-08-14T15:32:41.381Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/7b/2d63664777b3e831ac1b1d8df5bbf0b7c8bee48e57115896080890527b1b/apeye-1.4.1-py3-none-any.whl", hash = "sha256:44e58a9104ec189bf42e76b3a7fe91e2b2879d96d48e9a77e5e32ff699c9204e", size = 107989, upload-time = "2023-08-14T15:32:40.064Z" },
+]
+
+[[package]]
+name = "apeye-core"
+version = "1.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "domdf-python-tools" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e5/4c/4f108cfd06923bd897bf992a6ecb6fb122646ee7af94d7f9a64abd071d4c/apeye_core-1.1.5.tar.gz", hash = "sha256:5de72ed3d00cc9b20fea55e54b7ab8f5ef8500eb33a5368bc162a5585e238a55", size = 96511, upload-time = "2024-01-30T17:45:48.727Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/9f/fa9971d2a0c6fef64c87ba362a493a4f230eff4ea8dfb9f4c7cbdf71892e/apeye_core-1.1.5-py3-none-any.whl", hash = "sha256:dc27a93f8c9e246b3b238c5ea51edf6115ab2618ef029b9f2d9a190ec8228fbf", size = 99286, upload-time = "2024-01-30T17:45:46.764Z" },
 ]
 
 [[package]]
@@ -244,6 +273,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/96/82837f96be9abd2651565b9becc2f393eefe6d5a515606d662c6962df4b0/bottleneck-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:bda7c475d4a7e271dbd0b1d4bbce29065edc8891361857105b7212fe383c9a36", size = 386361, upload-time = "2025-05-13T21:11:07.191Z" },
     { url = "https://files.pythonhosted.org/packages/73/40/ddf00a9b0065d037792d6d2095a4998f15787f2c60fbdcf638767a75c37f/bottleneck-1.5.0-cp313-cp313t-win32.whl", hash = "sha256:a107ed8b5f998918c24a1e476dbd2dfc3514ab0082df7132c460b01e6ffd8cf4", size = 109355, upload-time = "2025-05-13T21:11:08.253Z" },
     { url = "https://files.pythonhosted.org/packages/33/56/c05fd1459f2b65941fcaf2697b81fe7d3428855c8e66ab1951eed04a13e2/bottleneck-1.5.0-cp313-cp313t-win_amd64.whl", hash = "sha256:816c910c5d1fb53adb32581c52a513b206f503ae253ace70cb32d1fe4e45af1d", size = 113739, upload-time = "2025-05-13T21:11:10.297Z" },
+]
+
+[[package]]
+name = "cachecontrol"
+version = "0.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msgpack" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/3a/0cbeb04ea57d2493f3ec5a069a117ab467f85e4a10017c6d854ddcbff104/cachecontrol-0.14.3.tar.gz", hash = "sha256:73e7efec4b06b20d9267b441c1f733664f989fb8688391b670ca812d70795d11", size = 28985, upload-time = "2025-04-30T16:45:06.135Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/4c/800b0607b00b3fd20f1087f80ab53d6b4d005515b0f773e4831e37cfa83f/cachecontrol-0.14.3-py3-none-any.whl", hash = "sha256:b35e44a3113f17d2a31c1e6b27b9de6d4405f84ae51baa8c1d3cc5b633010cae", size = 21802, upload-time = "2025-04-30T16:45:03.863Z" },
+]
+
+[package.optional-dependencies]
+filecache = [
+    { name = "filelock" },
 ]
 
 [[package]]
@@ -631,6 +678,18 @@ wheels = [
 ]
 
 [[package]]
+name = "cssutils"
+version = "2.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/9f/329d26121fe165be44b1dfff21aa0dc348f04633931f1d20ed6cf448a236/cssutils-2.11.1.tar.gz", hash = "sha256:0563a76513b6af6eebbe788c3bf3d01c920e46b3f90c8416738c5cfc773ff8e2", size = 711657, upload-time = "2024-06-04T15:51:39.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/ec/bb273b7208c606890dc36540fe667d06ce840a6f62f9fae7e658fcdc90fb/cssutils-2.11.1-py3-none-any.whl", hash = "sha256:a67bfdfdff4f3867fab43698ec4897c1a828eca5973f4073321b3bccaf1199b1", size = 385747, upload-time = "2024-06-04T15:51:37.499Z" },
+]
+
+[[package]]
 name = "dask"
 version = "2025.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -744,6 +803,7 @@ doc = [
     { name = "sphinx-autodoc-typehints" },
     { name = "sphinx-click" },
     { name = "sphinx-design" },
+    { name = "sphinx-toolbox" },
 ]
 
 [package.metadata]
@@ -819,6 +879,7 @@ doc = [
     { name = "sphinx-autodoc-typehints" },
     { name = "sphinx-click" },
     { name = "sphinx-design" },
+    { name = "sphinx-toolbox" },
 ]
 
 [[package]]
@@ -849,6 +910,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8a/c3/551fe0655f52b3469cbef2d3ebdf6ed94423ce22463beaed0767550b97c7/deprecat-2.1.3.tar.gz", hash = "sha256:d93cdd493af68981f0c7d198c2b9df2358ead5e54ce3e671a3522af8785917e8", size = 16734, upload-time = "2024-07-24T00:08:23.103Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/e7/edd1e6d95770450ada89bdd8be4623c751764eed0717f1f7ed51321722a3/deprecat-2.1.3-py2.py3-none-any.whl", hash = "sha256:8cdff88f0d47711a671a5ef2cfdab13bb213d8d7b74f7a40e1a35facdd68227d", size = 10138, upload-time = "2024-07-24T00:08:21.297Z" },
+]
+
+[[package]]
+name = "dict2css"
+version = "0.3.0.post1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cssutils" },
+    { name = "domdf-python-tools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/eb/776eef1f1aa0188c0fc165c3a60b71027539f71f2eedc43ad21b060e9c39/dict2css-0.3.0.post1.tar.gz", hash = "sha256:89c544c21c4ca7472c3fffb9d37d3d926f606329afdb751dc1de67a411b70719", size = 7845, upload-time = "2023-11-22T11:09:20.958Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/47/290daabcf91628f4fc0e17c75a1690b354ba067066cd14407712600e609f/dict2css-0.3.0.post1-py3-none-any.whl", hash = "sha256:f006a6b774c3e31869015122ae82c491fd25e7de4a75607a62aa3e798f837e0d", size = 25647, upload-time = "2023-11-22T11:09:19.221Z" },
 ]
 
 [[package]]
@@ -896,6 +970,19 @@ wheels = [
 ]
 
 [[package]]
+name = "domdf-python-tools"
+version = "3.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "natsort" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/8b/ab2d8a292bba8fe3135cacc8bfd3576710a14b8f2d0a8cde19130d5c9d21/domdf_python_tools-3.10.0.tar.gz", hash = "sha256:2ae308d2f4f1e9145f5f4ba57f840fbfd1c2983ee26e4824347789649d3ae298", size = 100458, upload-time = "2025-02-12T17:34:05.747Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/11/208f72084084d3f6a2ed5ebfdfc846692c3f7ad6dce65e400194924f7eed/domdf_python_tools-3.10.0-py3-none-any.whl", hash = "sha256:5e71c1be71bbcc1f881d690c8984b60e64298ec256903b3147f068bc33090c36", size = 126860, upload-time = "2025-02-12T17:34:04.093Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -923,6 +1010,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8b/50/4b769ce1ac4071a1ef6d86b1a3fb56cdc3a37615e8c5519e1af96cdac366/fastjsonschema-2.21.1.tar.gz", hash = "sha256:794d4f0a58f848961ba16af7b9c85a3e88cd360df008c59aac6fc5ae9323b5d4", size = 373939, upload-time = "2024-12-02T10:55:15.133Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/90/2b/0817a2b257fe88725c25589d89aec060581aabf668707a8d03b2e9e0cb2a/fastjsonschema-2.21.1-py3-none-any.whl", hash = "sha256:c9e5b7e908310918cf494a434eeb31384dd84a98b57a30bcb1f535015b554667", size = 23924, upload-time = "2024-12-02T10:55:07.599Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/10/c23352565a6544bdc5353e0b15fc1c563352101f30e24bf500207a54df9a/filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2", size = 18075, upload-time = "2025-03-14T07:11:40.47Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/36/2a115987e2d8c300a974597416d9de88f2444426de9571f4b59b2cca3acc/filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de", size = 16215, upload-time = "2025-03-14T07:11:39.145Z" },
 ]
 
 [[package]]
@@ -997,6 +1093,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cd/41/96ba2bf948f67b245784cd294b84e3d17933597dffd3acdb367a210d1949/greenlet-3.2.2-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:b50a8c5c162469c3209e5ec92ee4f95c8231b11db6a04db09bbe338176723bb8", size = 1105752, upload-time = "2025-05-09T15:27:08.217Z" },
     { url = "https://files.pythonhosted.org/packages/68/3b/3b97f9d33c1f2eb081759da62bd6162159db260f602f048bc2f36b4c453e/greenlet-3.2.2-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:45f9f4853fb4cc46783085261c9ec4706628f3b57de3e68bae03e8f8b3c0de51", size = 1125170, upload-time = "2025-05-09T14:54:04.082Z" },
     { url = "https://files.pythonhosted.org/packages/31/df/b7d17d66c8d0f578d2885a3d8f565e9e4725eacc9d3fdc946d0031c055c4/greenlet-3.2.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:9ea5231428af34226c05f927e16fc7f6fa5e39e3ad3cd24ffa48ba53a47f4240", size = 269899, upload-time = "2025-05-09T14:54:01.581Z" },
+]
+
+[[package]]
+name = "html5lib"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/b6/b55c3f49042f1df3dcd422b7f224f939892ee94f22abcf503a9b7339eaf2/html5lib-1.1.tar.gz", hash = "sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f", size = 272215, upload-time = "2020-06-22T23:32:38.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/dd/a834df6482147d48e225a49515aabc28974ad5a4ca3215c18a882565b028/html5lib-1.1-py2.py3-none-any.whl", hash = "sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d", size = 112173, upload-time = "2020-06-22T23:32:36.781Z" },
 ]
 
 [[package]]
@@ -1082,7 +1191,8 @@ name = "ipython"
 version = "9.2.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12'",
+    "python_full_version >= '3.13'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
@@ -1345,6 +1455,15 @@ wheels = [
 ]
 
 [[package]]
+name = "more-itertools"
+version = "10.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/a0/834b0cebabbfc7e311f30b46c8188790a37f89fc8d756660346fe5abfd09/more_itertools-10.7.0.tar.gz", hash = "sha256:9fddd5403be01a94b204faadcff459ec3568cf110265d3c54323e1e866ad29d3", size = 127671, upload-time = "2025-04-22T14:17:41.838Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/9f/7ba6f94fc1e9ac3d2b853fdff3035fb2fa5afbed898c4a72b8a020610594/more_itertools-10.7.0-py3-none-any.whl", hash = "sha256:d43980384673cb07d2f7d2d918c616b30c659c089ee23953f601d6609c67510e", size = 65278, upload-time = "2025-04-22T14:17:40.49Z" },
+]
+
+[[package]]
 name = "moto"
 version = "5.1.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1461,6 +1580,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "natsort"
+version = "8.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/a9/a0c57aee75f77794adaf35322f8b6404cbd0f89ad45c87197a937764b7d0/natsort-8.4.0.tar.gz", hash = "sha256:45312c4a0e5507593da193dedd04abb1469253b601ecaf63445ad80f0a1ea581", size = 76575, upload-time = "2023-06-20T04:17:19.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl", hash = "sha256:4732914fb471f56b5cce04d7bae6f164a592c7712e1c85f9ef585e197299521c", size = 38268, upload-time = "2023-06-20T04:17:17.522Z" },
 ]
 
 [[package]]
@@ -2580,6 +2708,79 @@ wheels = [
 ]
 
 [[package]]
+name = "sphinx-jinja2-compat"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "markupsafe" },
+    { name = "standard-imghdr", marker = "python_full_version >= '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/df/27282da6f8c549f765beca9de1a5fc56f9651ed87711a5cac1e914137753/sphinx_jinja2_compat-0.3.0.tar.gz", hash = "sha256:f3c1590b275f42e7a654e081db5e3e5fb97f515608422bde94015ddf795dfe7c", size = 4998, upload-time = "2024-06-19T10:27:00.781Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/42/2fd09d672eaaa937d6893d8b747d07943f97a6e5e30653aee6ebd339b704/sphinx_jinja2_compat-0.3.0-py3-none-any.whl", hash = "sha256:b1e4006d8e1ea31013fa9946d1b075b0c8d2a42c6e3425e63542c1e9f8be9084", size = 7883, upload-time = "2024-06-19T10:26:59.121Z" },
+]
+
+[[package]]
+name = "sphinx-prompt"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "docutils" },
+    { name = "idna" },
+    { name = "pygments" },
+    { name = "sphinx" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/fe/ac4e24f35b5148b31ac717ae7dcc7a2f7ec56eb729e22c7252ed8ad2d9a5/sphinx_prompt-1.9.0.tar.gz", hash = "sha256:471b3c6d466dce780a9b167d9541865fd4e9a80ed46e31b06a52a0529ae995a1", size = 5340, upload-time = "2024-08-07T15:46:51.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/98/e90ca466e0ede452d3e5a8d92b8fb68db6de269856e019ed9cab69440522/sphinx_prompt-1.9.0-py3-none-any.whl", hash = "sha256:fd731446c03f043d1ff6df9f22414495b23067c67011cc21658ea8d36b3575fc", size = 7311, upload-time = "2024-08-07T15:46:50.329Z" },
+]
+
+[[package]]
+name = "sphinx-tabs"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "pygments" },
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/32/ab475e252dc2b704e82a91141fa404cdd8901a5cf34958fd22afacebfccd/sphinx-tabs-3.4.5.tar.gz", hash = "sha256:ba9d0c1e3e37aaadd4b5678449eb08176770e0fc227e769b6ce747df3ceea531", size = 16070, upload-time = "2024-01-21T12:13:39.392Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/9f/4ac7dbb9f23a2ff5a10903a4f9e9f43e0ff051f63a313e989c962526e305/sphinx_tabs-3.4.5-py3-none-any.whl", hash = "sha256:92cc9473e2ecf1828ca3f6617d0efc0aa8acb06b08c56ba29d1413f2f0f6cf09", size = 9904, upload-time = "2024-01-21T12:13:37.67Z" },
+]
+
+[[package]]
+name = "sphinx-toolbox"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "apeye" },
+    { name = "autodocsumm" },
+    { name = "beautifulsoup4" },
+    { name = "cachecontrol", extra = ["filecache"] },
+    { name = "dict2css" },
+    { name = "docutils" },
+    { name = "domdf-python-tools" },
+    { name = "filelock" },
+    { name = "html5lib" },
+    { name = "ruamel-yaml" },
+    { name = "sphinx" },
+    { name = "sphinx-autodoc-typehints" },
+    { name = "sphinx-jinja2-compat" },
+    { name = "sphinx-prompt" },
+    { name = "sphinx-tabs" },
+    { name = "tabulate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/d2/fd68940102a02cbff392b91317618e0f87458e98a9684c0f74b1c58d4e49/sphinx_toolbox-4.0.0.tar.gz", hash = "sha256:48c31451db2e2d8c71c03939e72a19ef7bc92ca7850a62db63fc7bb8395b6785", size = 113819, upload-time = "2025-05-12T17:11:39.104Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/fd/5f03a1ad6623b3533a4b7ce8156f0b6a185f4a276d12567e434b855040d1/sphinx_toolbox-4.0.0-py3-none-any.whl", hash = "sha256:c700937baee505e440d44d46bc47ccd036ec282ae61b04e40342944128721117", size = 195781, upload-time = "2025-05-12T17:11:37.45Z" },
+]
+
+[[package]]
 name = "sphinxcontrib-applehelp"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2690,6 +2891,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
+name = "standard-imghdr"
+version = "3.10.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/d2/2eb5521072c9598886035c65c023f39f7384bcb73eed70794f469e34efac/standard_imghdr-3.10.14.tar.gz", hash = "sha256:2598fe2e7c540dbda34b233295e10957ab8dc8ac6f3bd9eaa8d38be167232e52", size = 5474, upload-time = "2024-04-21T18:55:10.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/d0/9852f70eb01f814843530c053542b72d30e9fbf74da7abb0107e71938389/standard_imghdr-3.10.14-py3-none-any.whl", hash = "sha256:cdf6883163349624dee9a81d2853a20260337c4cd41c04e99c082e01833a08e2", size = 5598, upload-time = "2024-04-21T18:54:48.587Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c", size = 81090, upload-time = "2022-10-06T17:21:48.54Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f", size = 35252, upload-time = "2022-10-06T17:21:44.262Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Reason for this pull request

Add a Sphinx extension so named tuples can be documented. This removes an `ERROR:` from the Sphinx output.


### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1977.org.readthedocs.build/en/1977/

<!-- readthedocs-preview opendatacube end -->