### PR TITLE
docs: fix links in migration document

### DIFF
--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -10,6 +10,7 @@ Next Release
 
 - examples: remove unimplemented zeros :pull:`1974`
 - examples: fix function signatures :pull:`1972`
+- docs: fix links in migration document :pull:`1980`
 
 v1.9.5 (17 June 2025)
 =====================

--- a/docs/installation/MIGRATION-1.8-to-1.9.rst
+++ b/docs/installation/MIGRATION-1.8-to-1.9.rst
@@ -65,7 +65,7 @@ Major Changes between 1.8.x and 1.9.x
 
    a. Previously multiple config files could be read and merged to generate the final effective configuration file.
       From 1.9.0 only a single config file is ever read at a time
-      (see :ref:`Merging-multiple-config-files`).
+      (see :ref:`Only one`).
 
       Managed instances which have previously allowed
       user customisation by the user creating a minimal config file which was loaded merged on top of a default system
@@ -84,7 +84,7 @@ Major Changes between 1.8.x and 1.9.x
 
       There is now a consistent and systematic approach taken to the interaction between the
       active configuration file and environment variables
-      (see :ref:`4. Generic Environment Variable Overrides`).  Partial backwards compatibility is attempted, but
+      (see :ref:`generic-environment-variables`).  Partial backwards compatibility is attempted, but
       full backwards compatibility is not possible due to the ad hoc nature of the previous implementation.
 
       The new (preferred) environment variable names are of the form ``$ODC_<env_name>_<item_name>``.
@@ -118,7 +118,7 @@ Major Changes between 1.8.x and 1.9.x
    The postgis driver uses Alembic for managing schema migrations, so future changes to the postgis database
    schema will be much easier to roll out than in the past.
 
-   See below for more information about migrating to the :ref:`The New Postgis Index Driver`.
+   See below for more information about migrating to the :ref:`new-postgis-index-driver`.
 
    Note that many other libraries in the ODC ecosystem may not work well with the Postgis driver at first.
 
@@ -150,6 +150,8 @@ Major Changes between 1.8.x and 1.9.x
 
 .. _`odc-geo`: https://github.com/opendatacube/odc-geo
 .. _`odc-loader`: https://github.com/opendatacube/odc-loader
+
+.. _new-postgis-index-driver:
 
 The New Postgis Index Driver
 ----------------------------
@@ -191,7 +193,7 @@ for EPSG:3577::
 
     datacube -E new spindex create 3577
 
-For more information, see :ref:`Create Spatial Indexes (Postgis Driver Only)`.
+For more information, see :ref:`create-spatial-indexes-postgis-driver-only`.
 
 Migrating (Cloning) Data From a Postgres Index
 ++++++++++++++++++++++++++++++++++++++++++++++

--- a/docs/installation/database/configuration.rst
+++ b/docs/installation/database/configuration.rst
@@ -96,6 +96,8 @@ variables, e.g.:
 Configuration Files
 ===================
 
+.. _format:
+
 Format
 ------
 

--- a/docs/installation/database/passing-configuration.rst
+++ b/docs/installation/database/passing-configuration.rst
@@ -40,8 +40,6 @@ user configuration file, then you will now need to take a copy of the system con
 add your extensions to your copy, and ensure that the Open Data Cube reads from your
 modified file.
 
-.. _`Only one`: #Merging-multiple-config-files
-
 1a. Default Search Paths
 ++++++++++++++++++++++++
 
@@ -236,6 +234,8 @@ Refer to the ``--help`` text for more information.
    environment can be specified with the ``$ODC_ENVIRONMENT`` environment
    variable.
 
+.. _generic-environment-variables:
+
 4. Generic Environment Variable Overrides
 -----------------------------------------
 
@@ -357,6 +357,8 @@ Migrating from datacube-1.8
 The new configuration engine introduced in datacube-1.9 is not fully backwards compatible with that used
 previously.  This section notes the changes which administrators, maintainers and developers should be aware
 of before upgrading.
+
+.. _`Only one`:
 
 Merging multiple config files
 -----------------------------

--- a/docs/installation/database/setup.rst
+++ b/docs/installation/database/setup.rst
@@ -136,6 +136,8 @@ Or to initialise a database schema for an environment other than the default::
 .. click:: datacube.scripts.system:database_init
    :prog: datacube system
 
+.. _create-spatial-indexes-postgis-driver-only:
+
 Create Spatial Indexes (Postgis Driver Only)
 ============================================
 


### PR DESCRIPTION
### Reason for this pull request

This broke when the autosectionlabel
extension was disabled. Re-enabling
that gives a wall of red text,
so create references manually to
fix the errors.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Fully documented, including `docs/about/whats_new.rst` for all changes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1980.org.readthedocs.build/en/1980/

<!-- readthedocs-preview opendatacube end -->