### PR TITLE
PR and release process updates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 
  - [ ] Closes #xxxx
  - [ ] Tests added / passed
- - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes
+ - [ ] Pull Request Title will make sense in ODC Release Notes
 
 <!--
 See https://github.com/blog/2111-issue-and-pull-request-templates for more

--- a/docs/about/release_process.rst
+++ b/docs/about/release_process.rst
@@ -8,10 +8,13 @@ Release Process
 
    uv lock
 
-#. Update the release notes in about/whats_new.rst and the fallback version number in pyproject.toml in the
+#. Create a new **Tag** and **Draft Release** using the `GitHub Releases Web UI`_
+
+#. Based on the generated release notes from GitHub, update the release notes in
+   about/whats_new.rst and the fallback version number in pyproject.toml in the
    ``develop`` branch via a PR.
 
-#. Create a new **Tag** and **Release** using the `GitHub Releases Web UI`_
+#. Change the Draft Release to Published using the `GitHub Releases Web UI`_
 
 #. Wait for the `GitHub Action`_ to run and publish the new release to PyPI_
 


### PR DESCRIPTION

### Reason for this pull request

The background to this, is that I've been frustrated both creating and merging PRs into ODC Core. This has changed recently for a couple of reasons. Collectively we're doing a lot better at creating small, tightly focused PRs that are easy to review and merge. And we're also enjoying a lot more work from around the world, meaning from different timezones, meaning you wake up in the morning and have several PRs to review and merge.

The existing process of updating the `whats_new.rst` file in every PR is a problem because it requires a created PR to get it's number, and then updating the commits with the PR number placed into a commit to whats_new.

Then doubly bad, is that due to GitHub not supporting fast-forward merges, every, single, merged, PR, requires, editing, the, next, before it can be merged.


### Proposed changes

Instead of requiring the `whats_new.rst` file be updated in every PR, we record changes using good quality titles on PRs and then have the release manager update the `whats_new.rst` file when doing a release.

A minor drawback is that we won't have upcoming changes in the documentation about the next release.

But has the benefit of not requiring a commit/create pr/update pr number/commit/push dance  for every PR. And not creating merge conflicts in the `whats_new.rst` file on every PR merge.

See discussion in: Issue #1982


 - [x] Closes #1982
<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1983.org.readthedocs.build/en/1983/

<!-- readthedocs-preview opendatacube end -->