### PR TITLE
Put JSON type aliases in separate file

### DIFF
--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -29,6 +29,9 @@ import toolz
 import yaml
 from typing_extensions import override
 
+# Compatibility-imports to preserve the API.
+from datacube.utils.json_types import JsonAtom, JsonDict, JsonLike  # noqa: F401
+
 if TYPE_CHECKING:
     from datacube.model import Field
 
@@ -39,10 +42,6 @@ except ImportError:
 
 from datacube.utils.generic import map_with_lookahead
 from datacube.utils.uris import as_url, mk_part_uri, uri_to_local_path
-
-JsonAtom = None | bool | str | float | int
-JsonLike = JsonAtom | list["JsonLike"] | dict[str, "JsonLike"]
-JsonDict = dict[str, JsonLike]
 
 PY35: bool = sys.version_info <= (3, 6)
 _LOG: logging.Logger = logging.getLogger(__name__)

--- a/datacube/utils/json_types.py
+++ b/datacube/utils/json_types.py
@@ -1,0 +1,16 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2025 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Module for JSON type aliases.
+"""
+
+from __future__ import annotations
+
+from typing import TypeAlias
+
+JsonAtom: TypeAlias = None | bool | str | float | int
+JsonLike: TypeAlias = JsonAtom | list["JsonLike"] | dict[str, "JsonLike"]
+JsonDict = dict[str, JsonLike]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,6 +39,9 @@ extensions = [
     "IPython.sphinxext.ipython_console_highlighting",  # Highlights notebook cells
 ]
 
+# Sphinx 8.1.3 does not manage to resolve the cyclic JsonLike type alias, so mock it.
+autodoc_mock_imports = ["datacube.utils.json_types"]
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 


### PR DESCRIPTION
### Reason for this pull request

Sphinx 8.1.3 cannot resolve the cyclic
JsonLike alias, and there are numerous
open issues around these kinds of problems.

Put the JSON type alises in a separate
module, and configure Sphinx to mock
that module. The documentation for
those 3 aliases is lost, but several
big red WARNING: are eliminated when
building the documentation.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1986.org.readthedocs.build/en/1986/

<!-- readthedocs-preview opendatacube end -->