### PR TITLE
Remove unused PY35 constant

### DIFF
--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -42,7 +42,6 @@ except ImportError:
 from datacube.utils.generic import map_with_lookahead
 from datacube.utils.uris import as_url, mk_part_uri, uri_to_local_path
 
-
 _LOG: logging.Logger = logging.getLogger(__name__)
 
 

--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -13,7 +13,6 @@ import gzip
 import json
 import logging
 import math
-import sys
 from collections import OrderedDict
 from collections.abc import Generator, Iterator, Mapping
 from contextlib import contextmanager
@@ -44,7 +43,6 @@ JsonAtom = None | bool | str | float | int
 JsonLike = JsonAtom | list["JsonLike"] | dict[str, "JsonLike"]
 JsonDict = dict[str, JsonLike]
 
-PY35: bool = sys.version_info <= (3, 6)
 _LOG: logging.Logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
### Reason for this pull request

The support for Python 3.5 is long
gone, so remove the symbol.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1987.org.readthedocs.build/en/1987/

<!-- readthedocs-preview opendatacube end -->