### PR TITLE
CI: run with fewer permissions

### DIFF
--- a/.github/workflows/doc-qa.yaml
+++ b/.github/workflows/doc-qa.yaml
@@ -5,6 +5,8 @@ on:
     paths:
       - '**'
 
+permissions: {}
+
 # When a PR is updated, cancel the jobs from the previous version. Merges
 # do not define head_ref, so use run_id to never cancel those jobs.
 concurrency:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,8 @@ on:
 env:
   DOCKER_IMAGE: ghcr.io/opendatacube/datacube-core:tests
 
+permissions: {}
+
 # When a PR is updated, cancel the jobs from the previous version. Merges
 # do not define head_ref, so use run_id to never cancel those jobs.
 concurrency:

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -5,6 +5,8 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
+permissions: {}
+
 # When a PR is updated, cancel the jobs from the previous version. Merges
 # do not define head_ref, so use run_id to never cancel those jobs.
 concurrency:

--- a/.github/workflows/test-conda-build.yml
+++ b/.github/workflows/test-conda-build.yml
@@ -10,6 +10,8 @@ on:
     paths:
       - '**'
 
+permissions: {}
+
 # When a PR is updated, cancel the jobs from the previous version. Merges
 # do not define head_ref, so use run_id to never cancel those jobs.
 concurrency:


### PR DESCRIPTION

### Reason for this pull request

Set the top level permissions
to the empty set so CI jobs
don't run with excessive
permissions.


### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--1997.org.readthedocs.build/en/1997/

<!-- readthedocs-preview opendatacube end -->