### PR TITLE
cli: only read files once

### DIFF
--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -981,10 +981,6 @@ class PostgisDbAPI:
             query = query.where(Product.name.in_(product_names))
         elif dsids:
             query = query.where(Dataset.id.in_(dsids))
-
-        def xytuple(o):
-            return o["x"], o["y"]
-
         for result in self._connection.execute(query):
             dsid = result[0]
             geom = extract_geometry_from_eo3_projection(result[1])

--- a/datacube/scripts/metadata.py
+++ b/datacube/scripts/metadata.py
@@ -41,9 +41,10 @@ def add_metadata_types(index: Index, allow_exclusive_lock: bool, files: list) ->
         print_help_msg(add_metadata_types)
         sys.exit(1)
 
-    exit_on_empty_file(list(read_documents(*files)))
+    docs = list(read_documents(*files))
+    exit_on_empty_file(docs)
 
-    for descriptor_path, parsed_doc in read_documents(*files):
+    for descriptor_path, parsed_doc in docs:
         try:
             type_ = index.metadata_types.from_doc(parsed_doc)
             index.metadata_types.add(type_, allow_table_lock=allow_exclusive_lock)
@@ -90,9 +91,9 @@ def update_metadata_types(
         print_help_msg(update_metadata_types)
         sys.exit(1)
 
-    exit_on_empty_file(list(read_documents(*files)))
-
-    for descriptor_path, parsed_doc in read_documents(*files):
+    docs = list(read_documents(*files))
+    exit_on_empty_file(docs)
+    for descriptor_path, parsed_doc in docs:
         try:
             type_ = index.metadata_types.from_doc(parsed_doc)
         except InvalidDocException as e:

--- a/datacube/scripts/product.py
+++ b/datacube/scripts/product.py
@@ -53,9 +53,9 @@ bigger your database the longer it will take. Just wait a bit.""")
 
     signal.signal(signal.SIGINT, on_ctrlc)
 
-    exit_on_empty_file(list(read_documents(*files)))
-
-    for descriptor_path, parsed_doc in read_documents(*files):
+    docs = list(read_documents(*files))
+    exit_on_empty_file(docs)
+    for descriptor_path, parsed_doc in docs:
         try:
             type_ = index.products.from_doc(parsed_doc)
             echo(f'Adding "{type_.name}" (this might take a while)', nl=False)
@@ -104,10 +104,10 @@ def update_products(
         print_help_msg(update_products)
         sys.exit(1)
 
-    exit_on_empty_file(list(read_documents(*files)))
-
+    docs = list(read_documents(*files))
+    exit_on_empty_file(docs)
     failures = 0
-    for descriptor_path, parsed_doc in read_documents(*files):
+    for descriptor_path, parsed_doc in docs:
         try:
             type_ = index.products.from_doc(parsed_doc)
         except InvalidDocException as e:

--- a/datacube/scripts/product.py
+++ b/datacube/scripts/product.py
@@ -45,6 +45,9 @@ def add_products(index: Index, allow_exclusive_lock: bool, files: list) -> None:
         print_help_msg(add_products)
         sys.exit(1)
 
+    docs = list(read_documents(*files))
+    exit_on_empty_file(docs)
+
     def on_ctrlc(sig, frame) -> None:
         echo("""Can not abort `product add` without leaving database in bad state.
 
@@ -53,8 +56,6 @@ bigger your database the longer it will take. Just wait a bit.""")
 
     signal.signal(signal.SIGINT, on_ctrlc)
 
-    docs = list(read_documents(*files))
-    exit_on_empty_file(docs)
     for descriptor_path, parsed_doc in docs:
         try:
             type_ = index.products.from_doc(parsed_doc)

--- a/datacube/ui/click.py
+++ b/datacube/ui/click.py
@@ -419,5 +419,5 @@ def print_help_msg(command) -> None:
 
 def exit_on_empty_file(read_files_list) -> None:
     if len(read_files_list) == 0:
-        click.echo("All files are empty, exit")
+        click.echo("All files are empty, exit", err=True)
         sys.exit(1)

--- a/datacube/ui/click.py
+++ b/datacube/ui/click.py
@@ -417,7 +417,7 @@ def print_help_msg(command) -> None:
         click.echo(command.get_help(ctx))
 
 
-def exit_on_empty_file(read_files_list) -> None:
+def exit_on_empty_file(read_files_list: list) -> None:
     if len(read_files_list) == 0:
         click.echo("All files are empty, exit", err=True)
         sys.exit(1)

--- a/integration_tests/test_dataset_add.py
+++ b/integration_tests/test_dataset_add.py
@@ -146,7 +146,7 @@ def check_inconsistent_lineage(clirunner, index) -> None:
     assert index.datasets.has(ds.sources["ac"].sources["cd"].id) is False
 
     # now again but skipping verification check
-    r = clirunner(["dataset", "add", "--no-verify-lineage", str(prefix / "main.yml")])
+    _ = clirunner(["dataset", "add", "--no-verify-lineage", str(prefix / "main.yml")])
 
     assert index.datasets.has(ds.id)
     assert index.datasets.has(ds.sources["ab"].id)
@@ -183,7 +183,7 @@ def check_missing_lineage(clirunner, index) -> None:
     # now add lineage and try again
     clirunner(["dataset", "add", str(prefix / "lineage.yml")])
     assert index.datasets.has(ds.sources["ae"].id)
-    r = clirunner(["dataset", "add", "--no-auto-add-lineage", str(prefix / "main.yml")])
+    _ = clirunner(["dataset", "add", "--no-auto-add-lineage", str(prefix / "main.yml")])
 
     assert index.datasets.has(ds.id)
 
@@ -380,13 +380,13 @@ metadata:
 
     # check that forcing product works
     ds, fname = dss[0], "dataset1.yml"
-    r = clirunner(["dataset", "add", "--product", "A", str(prefix / fname)])
+    _ = clirunner(["dataset", "add", "--product", "A", str(prefix / fname)])
 
     assert index.datasets.has(ds.id) is True
 
     # check that forcing via exclude works
     ds, fname = dss[1], "dataset2.yml"
-    r = clirunner(["dataset", "add", "--exclude-product", "B", str(prefix / fname)])
+    _ = clirunner(["dataset", "add", "--exclude-product", "B", str(prefix / fname)])
 
     assert index.datasets.has(ds.id) is True
 
@@ -510,7 +510,7 @@ measurements:
     )
 
     clirunner(["metadata", "add", p.metadata])
-    r = clirunner(["product", "add", str(prefix / "products.yml")])
+    _ = clirunner(["product", "add", str(prefix / "products.yml")])
 
     pp = list(index.products.get_all())
     assert len(pp) == 1
@@ -627,7 +627,7 @@ def test_dataset_archive_restore_invalid(
     non_existent_uuid = "00000000-1036-5607-a62f-fde5e3fec985"
 
     # With non-existent uuid, operations should halt.
-    r = clirunner(
+    _ = clirunner(
         ["dataset", "archive", str(ds.id), non_existent_uuid], expect_success=False
     )
     r = clirunner(["dataset", "info", str(ds.id)])
@@ -636,7 +636,7 @@ def test_dataset_archive_restore_invalid(
 
     # With non-existent uuid, operations should halt.
     d_id = ds.sources["ac"].sources["cd"].id
-    r = clirunner(
+    _ = clirunner(
         ["dataset", "archive", "--archive-derived", str(d_id), non_existent_uuid],
         expect_success=False,
     )
@@ -660,23 +660,23 @@ def test_dataset_archive_restore(dataset_add_configs, index_empty, clirunner) ->
     p, index, ds = dataset_archive_prep(dataset_add_configs, index_empty, clirunner)
 
     # Run for real
-    r = clirunner(["dataset", "archive", str(ds.id)])
+    _ = clirunner(["dataset", "archive", str(ds.id)])
     r = clirunner(["dataset", "info", str(ds.id)])
     assert "status: archived" in r.output
 
     # restore dry run
-    r = clirunner(["dataset", "restore", "--dry-run", str(ds.id)])
+    _ = clirunner(["dataset", "restore", "--dry-run", str(ds.id)])
     r = clirunner(["dataset", "info", str(ds.id)])
     assert "status: archived" in r.output
 
     # restore for real
-    r = clirunner(["dataset", "restore", str(ds.id)])
+    _ = clirunner(["dataset", "restore", str(ds.id)])
     r = clirunner(["dataset", "info", str(ds.id)])
     assert "status: active" in r.output
 
     # archive derived
     d_id = ds.sources["ac"].sources["cd"].id
-    r = clirunner(["dataset", "archive", "--archive-derived", str(d_id)])
+    _ = clirunner(["dataset", "archive", "--archive-derived", str(d_id)])
     r = clirunner(
         [
             "dataset",
@@ -690,7 +690,7 @@ def test_dataset_archive_restore(dataset_add_configs, index_empty, clirunner) ->
     assert "status: archived" in r.output
 
     # restore derived
-    r = clirunner(["dataset", "restore", "--restore-derived", str(d_id)])
+    _ = clirunner(["dataset", "restore", "--restore-derived", str(d_id)])
     r = clirunner(
         [
             "dataset",


### PR DESCRIPTION
### Reason for this pull request

These commands read the files once to figure out if there were no documents, and a second time to process the documents. Use the same result for input validation and processing so the files are just read once. Also delay the trapping of Ctrl-C to as late as possible so the program can be interrupted when it is safe to do so.

Throw in a couple of semi-unrelated commits, one that removes unused variables from the test for adding products, one that removes an unused function in postgis, and one that echoes the error message to stderr instead of stdout.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2000.org.readthedocs.build/en/2000/

<!-- readthedocs-preview opendatacube end -->