### PR TITLE
tests: fix return value checks

### DIFF
--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -14,6 +14,7 @@ from copy import copy, deepcopy
 from datetime import timedelta
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Literal
 from uuid import uuid4
 
 import pytest
@@ -942,7 +943,7 @@ def clirunner(datacube_env_name: str):
         cli_method=datacube.scripts.cli_app.cli,
         skip_env: bool = False,
         skip_config_paths: bool = False,
-        verbose_flag: str = "-v",
+        verbose_flag: Literal[False] | str = "-v",
     ) -> Result:
         # If raw config passed in, skip default test config
         exe_opts = (

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -334,7 +334,9 @@ def test_product_update_cli(
     Test updating products via cli
     """
 
-    def run_update_product(file_path, allow_unsafe=False):
+    def run_update_product(
+        file_path, expect_success: bool = True, allow_unsafe: bool = False
+    ):
         if allow_unsafe:
             allow_unsafe = ["--allow-unsafe"]
         else:
@@ -343,7 +345,7 @@ def test_product_update_cli(
         return clirunner(
             ["product", "update", str(file_path)] + allow_unsafe,
             catch_exceptions=False,
-            expect_success=False,
+            expect_success=expect_success,
         )
 
     def get_current(index, product_doc):
@@ -367,7 +369,7 @@ def test_product_update_cli(
     modified_doc["newly_added_property"] = {}
     file_path = tmpdir.join("invalid-product.yaml")
     file_path.write(_to_yaml(modified_doc))
-    result = run_update_product(file_path)
+    result = run_update_product(file_path, expect_success=False)
 
     # The error message differs between jsonschema versions, but should always mention the invalid property name.
     assert "newly_added_property" in result.output
@@ -383,7 +385,7 @@ def test_product_update_cli(
     modified_doc["metadata"][42] = "hello"
     file_path = tmpdir.join("unsafe-change-to-product.yaml")
     file_path.write(_to_yaml(modified_doc))
-    result = run_update_product(file_path)
+    result = run_update_product(file_path, expect_success=False)
     assert "Unsafe change in metadata.42 from missing to 'hello'" in result.output
     # Return error code for failure!
     assert result.exit_code == 1
@@ -432,9 +434,7 @@ def test_product_delete_cli(
     clirunner(["dataset", "archive", "c21648b1-a6fa-4de0-9dc3-9c445d8b295a"])
 
     runner = clirunner(
-        ["product", "delete", "ga_ls8c_ard_3", "ga_ls_wo_3"],
-        verbose_flag=False,
-        expect_success=False,
+        ["product", "delete", "ga_ls8c_ard_3", "ga_ls_wo_3"], verbose_flag=False
     )
     assert "1 out of 2 products successfully deleted" in runner.output
     assert "ga_ls_wo_3 could not be deleted" not in runner.output

--- a/integration_tests/index/test_index_cloning.py
+++ b/integration_tests/index/test_index_cloning.py
@@ -44,9 +44,7 @@ def test_index_clone_cli(cfg_env_pair, index_pair_populated_empty, clirunner) ->
         expect_success=False,
     )
     clirunner(
-        ["-E", target_cfg._name, "system", "clone", source_cfg._name],
-        skip_env=True,
-        expect_success=True,
+        ["-E", target_cfg._name, "system", "clone", source_cfg._name], skip_env=True
     )
 
 
@@ -66,5 +64,4 @@ def test_index_clone_cli_small_batch(
             source_cfg._name,
         ],
         skip_env=True,
-        expect_success=True,
     )

--- a/integration_tests/test_cli_output.py
+++ b/integration_tests/test_cli_output.py
@@ -24,7 +24,7 @@ def test_cli_product_subcommand(index_empty, clirunner, dataset_add_configs) -> 
     assert "Add or update products in" in runner.output
     assert runner.exit_code == 1
 
-    runner = clirunner(["product", "list"], verbose_flag=False, expect_success=False)
+    runner = clirunner(["product", "list"], verbose_flag=False)
     assert "Usage:  [OPTIONS] [FILES]" not in runner.output
     assert runner.exit_code == 0
 

--- a/integration_tests/test_cli_spatial_indexes.py
+++ b/integration_tests/test_cli_spatial_indexes.py
@@ -8,35 +8,27 @@ import pytest
 
 @pytest.mark.parametrize("datacube_env_name", ("postgis",))
 def test_cli_spatial_indexes(index, clirunner) -> None:
-    runner = clirunner(["spindex", "list"], verbose_flag=False, expect_success=True)
+    runner = clirunner(["spindex", "list"], verbose_flag=False)
     assert "EPSG:4326" in runner.output
     assert "EPSG:3577" not in runner.output
     assert runner.exit_code == 0
 
-    runner = clirunner(
-        ["spindex", "create", "epsg:3577"], verbose_flag=False, expect_success=True
-    )
+    runner = clirunner(["spindex", "create", "epsg:3577"], verbose_flag=False)
     assert runner.exit_code == 0
 
     # Double creation succeeds silently
-    runner = clirunner(
-        ["spindex", "create", "3577"], verbose_flag=False, expect_success=True
-    )
+    runner = clirunner(["spindex", "create", "3577"], verbose_flag=False)
     assert runner.exit_code == 0
 
-    # Double creation succeeds silently
-    runner = clirunner(
-        ["spindex", "update", "3577"], verbose_flag=False, expect_success=True
-    )
+    runner = clirunner(["spindex", "update", "3577"], verbose_flag=False)
     assert runner.exit_code == 0
 
-    # Double creation succeeds silently
     runner = clirunner(
         ["spindex", "update", "EPSG:3857"], verbose_flag=False, expect_success=False
     )
     assert runner.exit_code == 1
 
-    runner = clirunner(["spindex", "list"], verbose_flag=False, expect_success=True)
+    runner = clirunner(["spindex", "list"], verbose_flag=False)
     assert "EPSG:4326" in runner.output
     assert "EPSG:3577" in runner.output
     assert runner.exit_code == 0
@@ -45,38 +37,30 @@ def test_cli_spatial_indexes(index, clirunner) -> None:
         ["spindex", "drop", "3577"], verbose_flag=False, expect_success=False
     )
     assert runner.exit_code == 1
-    runner = clirunner(
-        ["spindex", "drop", "--force", "3577"], verbose_flag=False, expect_success=True
-    )
+    runner = clirunner(["spindex", "drop", "--force", "3577"], verbose_flag=False)
     assert runner.exit_code == 0
 
-    runner = clirunner(["spindex", "list"], verbose_flag=False, expect_success=True)
+    runner = clirunner(["spindex", "list"], verbose_flag=False)
     assert "EPSG:4326" in runner.output
     assert "EPSG:3577" not in runner.output
     assert runner.exit_code == 0
 
     # Drop non-existent spindex ignored.
-    runner = clirunner(
-        ["spindex", "drop", "--force", "3577"], verbose_flag=False, expect_success=True
-    )
+    runner = clirunner(["spindex", "drop", "--force", "3577"], verbose_flag=False)
     assert runner.exit_code == 0
 
 
 @pytest.mark.parametrize("datacube_env_name", ("postgis",))
 def test_cli_spatial_index_create_and_update(index, clirunner) -> None:
-    runner = clirunner(["spindex", "list"], verbose_flag=False, expect_success=True)
+    runner = clirunner(["spindex", "list"], verbose_flag=False)
     assert "EPSG:4326" in runner.output
     assert "EPSG:3577" not in runner.output
     assert runner.exit_code == 0
 
-    runner = clirunner(
-        ["spindex", "create", "--update", "3577"],
-        verbose_flag=False,
-        expect_success=True,
-    )
+    runner = clirunner(["spindex", "create", "--update", "3577"], verbose_flag=False)
     assert runner.exit_code == 0
 
-    runner = clirunner(["spindex", "list"], verbose_flag=False, expect_success=True)
+    runner = clirunner(["spindex", "list"], verbose_flag=False)
     assert "EPSG:4326" in runner.output
     assert "EPSG:3577" in runner.output
     assert runner.exit_code == 0
@@ -85,9 +69,7 @@ def test_cli_spatial_index_create_and_update(index, clirunner) -> None:
         ["spindex", "drop", "3577"], verbose_flag=False, expect_success=False
     )
     assert runner.exit_code == 1
-    runner = clirunner(
-        ["spindex", "drop", "--force", "3577"], verbose_flag=False, expect_success=True
-    )
+    runner = clirunner(["spindex", "drop", "--force", "3577"], verbose_flag=False)
     assert runner.exit_code == 0
 
 

--- a/integration_tests/test_config_tool.py
+++ b/integration_tests/test_config_tool.py
@@ -54,9 +54,7 @@ def test_add_example_dataset_types(
             )
             existing_mappings = mappings_count
 
-        result = clirunner(
-            ["-v", "metadata", "show", "-f", "json", "eo"], expect_success=True
-        )
+        result = clirunner(["-v", "metadata", "show", "-f", "json", "eo"])
         assert result.exit_code == 0
 
     # EO3 test examples
@@ -73,15 +71,13 @@ def test_add_example_dataset_types(
         )
         existing_mappings = mappings_count
 
-    result = clirunner(
-        ["-v", "metadata", "show", "-f", "json", "eo3"], expect_success=True
-    )
+    result = clirunner(["-v", "metadata", "show", "-f", "json", "eo3"])
     assert result.exit_code == 0
 
     result = clirunner(["-v", "metadata", "list"])
     assert result.exit_code == 0
 
-    result = clirunner(["-v", "metadata", "show"], expect_success=True)
+    result = clirunner(["-v", "metadata", "show"])
     assert result.exit_code == 0
 
     result = clirunner(["-v", "product", "list"])

--- a/integration_tests/test_config_tool.py
+++ b/integration_tests/test_config_tool.py
@@ -97,16 +97,10 @@ def test_add_example_dataset_types(
         )
         assert result.exit_code == 1
 
-        result = clirunner(
-            ["-v", "product", "show", "-f", "json", "ga_ls8c_ard_3"],
-            expect_success=False,
-        )
+        result = clirunner(["-v", "product", "show", "-f", "json", "ga_ls8c_ard_3"])
         assert result.exit_code == 0
 
-        result = clirunner(
-            ["-v", "product", "show", "-f", "yaml", "ga_ls8c_ard_3"],
-            expect_success=False,
-        )
+        result = clirunner(["-v", "product", "show", "-f", "yaml", "ga_ls8c_ard_3"])
         assert result.exit_code == 0
 
 

--- a/integration_tests/test_dataset_add.py
+++ b/integration_tests/test_dataset_add.py
@@ -273,7 +273,7 @@ def test_dataset_add(dataset_add_configs, index_empty, clirunner) -> None:
     assert _ds.metadata_doc == ds.doc
 
     # Check dataset search
-    r = clirunner(["dataset", "search"], expect_success=True)
+    r = clirunner(["dataset", "search"])
     assert str(ds.id) in r.output
     assert str(ds_bad1.id) not in r.output
     assert str(ds.sources["ab"].id) in r.output


### PR DESCRIPTION
### Reason for this pull request

CLI tests that are supposed to work are setting the `expect_success` parameter to the wrong value, fix those tests.

After that, the `clirunner` defaults `expect_success=True`, so remove calls that set that so the calls that expect failure
stand out.

Also fix the type signature of `clirunner` to correspond with how the tests actually uses it.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2001.org.readthedocs.build/en/2001/

<!-- readthedocs-preview opendatacube end -->