### PR TITLE
Switch decorator order to appease lint/typing

### DIFF
--- a/datacube/drivers/postgis/_fields.py
+++ b/datacube/drivers/postgis/_fields.py
@@ -154,8 +154,8 @@ class NativeField(PgField):
         self.affects_row_selection = affects_row_selection
         self.join_clause = join_clause
 
-    @override
     @property
+    @override
     def alchemy_expression(self) -> ColumnExpressionArgument:
         expression = (
             self._expression if self._expression is not None else self.alchemy_column

--- a/datacube/drivers/rio/_reader.py
+++ b/datacube/drivers/rio/_reader.py
@@ -148,28 +148,28 @@ class RIOReader(GeoRasterReader):
         self._dtype = src.dtypes[band_idx - 1]
         self._pool = pool
 
-    @override
     @property
+    @override
     def crs(self) -> CRS | None:
         return self._crs
 
-    @override
     @property
+    @override
     def transform(self) -> Affine | None:
         return self._transform
 
-    @override
     @property
+    @override
     def dtype(self) -> np.dtype:
         return np.dtype(self._dtype)
 
-    @override
     @property
+    @override
     def shape(self) -> RasterShape:
         return self._src.shape
 
-    @override
     @property
+    @override
     def nodata(self) -> int | float | None:
         return self._nodata
 
@@ -228,13 +228,13 @@ class RDEntry(ReaderDriverEntry):
     PROTOCOLS = ["file", "http", "https", "s3", "ftp", "zip"]
     FORMATS = ["GeoTIFF", "NetCDF", "JPEG2000"]
 
-    @override
     @property
+    @override
     def protocols(self) -> list[str]:
         return RDEntry.PROTOCOLS
 
-    @override
     @property
+    @override
     def formats(self) -> list[str]:
         return RDEntry.FORMATS
 

--- a/datacube/index/memory/index.py
+++ b/datacube/index/memory/index.py
@@ -63,48 +63,48 @@ class Index(AbstractIndex):
             counter += 1
             self._index_id = f"memory={counter}"
 
-    @override
     @property
+    @override
     def name(self) -> str:
         return "memory_index"
 
-    @override
     @property
+    @override
     def environment(self) -> ODCEnvironment:
         return self._env
 
-    @override
     @property
+    @override
     def users(self) -> UserResource:
         return self._users
 
-    @override
     @property
+    @override
     def metadata_types(self) -> MetadataTypeResource:
         return self._metadata_types
 
-    @override
     @property
+    @override
     def products(self) -> ProductResource:
         return self._products
 
-    @override
     @property
+    @override
     def lineage(self) -> LineageResource:
         return self._lineage
 
-    @override
     @property
+    @override
     def datasets(self) -> DatasetResource:
         return self._datasets
 
-    @override
     @property
+    @override
     def url(self) -> str:
         return "memory"
 
-    @override
     @property
+    @override
     def index_id(self) -> str:
         return self._index_id
 

--- a/datacube/index/null/index.py
+++ b/datacube/index/null/index.py
@@ -49,48 +49,48 @@ class Index(AbstractIndex):
         self._lineage = NoLineageResource(self)
         self._datasets = DatasetResource(self)
 
-    @override
     @property
+    @override
     def name(self) -> str:
         return "null_index"
 
-    @override
     @property
+    @override
     def environment(self) -> ODCEnvironment:
         return self._env
 
-    @override
     @property
+    @override
     def users(self) -> UserResource:
         return self._users
 
-    @override
     @property
+    @override
     def metadata_types(self) -> MetadataTypeResource:
         return self._metadata_types
 
-    @override
     @property
+    @override
     def products(self) -> ProductResource:
         return self._products
 
-    @override
     @property
+    @override
     def lineage(self) -> NoLineageResource:
         return self._lineage
 
-    @override
     @property
+    @override
     def datasets(self) -> DatasetResource:
         return self._datasets
 
-    @override
     @property
+    @override
     def url(self) -> str:
         return "null"
 
-    @override
     @property
+    @override
     def index_id(self) -> str:
         return "null"
 

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -84,43 +84,43 @@ class Index(AbstractIndex):
         self._lineage = LineageResource(db, self)
         self._datasets = DatasetResource(db, self)
 
-    @override
     @property
+    @override
     def name(self) -> str:
         return "pgis_index"
 
-    @override
     @property
+    @override
     def environment(self) -> ODCEnvironment:
         return self._env
 
-    @override
     @property
+    @override
     def users(self) -> UserResource:
         return self._users
 
-    @override
     @property
+    @override
     def metadata_types(self) -> MetadataTypeResource:
         return self._metadata_types
 
-    @override
     @property
+    @override
     def products(self) -> ProductResource:
         return self._products
 
-    @override
     @property
+    @override
     def lineage(self) -> LineageResource:
         return self._lineage
 
-    @override
     @property
+    @override
     def datasets(self) -> DatasetResource:
         return self._datasets
 
-    @override
     @property
+    @override
     def url(self) -> str:
         return str(self._db.url)
 
@@ -177,8 +177,8 @@ class Index(AbstractIndex):
         """
         self._db.close()
 
-    @override
     @property
+    @override
     def index_id(self) -> str:
         return self.url
 

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -74,43 +74,43 @@ class Index(AbstractIndex):
         self._lineage = LineageResource(db, self)
         self._datasets = DatasetResource(db, self)
 
-    @override
     @property
+    @override
     def name(self) -> str:
         return "pg_index"
 
-    @override
     @property
+    @override
     def environment(self) -> ODCEnvironment:
         return self._env
 
-    @override
     @property
+    @override
     def users(self) -> UserResource:
         return self._users
 
-    @override
     @property
+    @override
     def metadata_types(self) -> MetadataTypeResource:
         return self._metadata_types
 
-    @override
     @property
+    @override
     def products(self) -> ProductResource:
         return self._products
 
-    @override
     @property
+    @override
     def lineage(self) -> LineageResource:
         return self._lineage
 
-    @override
     @property
+    @override
     def datasets(self) -> DatasetResource:
         return self._datasets
 
-    @override
     @property
+    @override
     def url(self) -> str:
         return str(self._db.url)
 
@@ -159,8 +159,8 @@ class Index(AbstractIndex):
         """
         self._db.close()
 
-    @override
     @property
+    @override
     def index_id(self) -> str:
         return f"legacy_{self.url}"
 


### PR DESCRIPTION
The order should be `@property` then `@override` so that `@property` is the outer level and is noticed correctly by anything looking at the method. `@override` doesn't pass anything useful through.

See https://peps.python.org/pep-0698/#limitations-of-setting-override for more.





 - [x] Closes #2003

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2004.org.readthedocs.build/en/2004/

<!-- readthedocs-preview opendatacube end -->