### PR TITLE
Use datetime.UTC instead of datetime.pytz()

### DIFF
--- a/datacube/index/fields.py
+++ b/datacube/index/fields.py
@@ -8,7 +8,7 @@ Common datatypes for DB drivers.
 
 from datetime import date, datetime, time
 
-from dateutil.tz import tz
+from dateutil.tz import UTC
 from typing_extensions import override
 
 from datacube.model import Not, Range
@@ -66,8 +66,8 @@ def as_expression(field: Field, value) -> Expression:
         return as_expression(
             field,
             Range(
-                datetime.combine(value, time.min.replace(tzinfo=tz.tzutc())),
-                datetime.combine(value, time.max.replace(tzinfo=tz.tzutc())),
+                datetime.combine(value, time.min.replace(tzinfo=UTC)),
+                datetime.combine(value, time.max.replace(tzinfo=UTC)),
             ),
         )
     return field == value

--- a/datacube/utils/dates.py
+++ b/datacube/utils/dates.py
@@ -18,7 +18,7 @@ import numpy as np
 import xarray as xr
 from dateutil.relativedelta import relativedelta
 from dateutil.rrule import DAILY, MONTHLY, YEARLY, rrule
-from dateutil.tz import tzutc
+from dateutil.tz import UTC
 
 FREQS: dict[str, int] = {"y": YEARLY, "m": MONTHLY, "d": DAILY}
 DURATIONS = {"y": "years", "m": "months", "d": "days"}
@@ -76,11 +76,11 @@ def normalise_dt(dt: str | datetime) -> datetime:
     if isinstance(dt, str):
         dt = parse_time(dt)
     if dt.tzinfo is not None:
-        dt = dt.astimezone(tzutc()).replace(tzinfo=None)
+        dt = dt.astimezone(UTC).replace(tzinfo=None)
     return dt
 
 
-def tz_aware(dt: datetime, default: tzinfo = tzutc()) -> datetime:
+def tz_aware(dt: datetime, default: tzinfo = UTC) -> datetime:
     """Ensure a datetime is timezone aware, defaulting to UTC or a user-selected default"""
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=default)
@@ -90,8 +90,8 @@ def tz_aware(dt: datetime, default: tzinfo = tzutc()) -> datetime:
 def tz_as_utc(dt: datetime) -> datetime:
     """Ensure a datetime has a UTC timezone"""
     if dt.tzinfo is None:
-        return dt.replace(tzinfo=tzutc())
-    return dt.astimezone(tzutc())
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
 
 
 def mk_time_coord(dts: list[datetime], name: str = "time", units=None) -> xr.DataArray:

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -14,7 +14,7 @@ from typing import Any
 import pytest
 import yaml
 from antimeridian import FixWindingWarning
-from dateutil import tz
+from dateutil.tz import UTC
 
 import datacube.scripts.search_tool
 from datacube import Datacube
@@ -574,7 +574,7 @@ def test_search_returning_eo3(
     assert format_ == "GeoTIFF"
 
     # It's always UTC in the document
-    expected_time = creation_time.astimezone(tz.tzutc()).replace(tzinfo=None)
+    expected_time = creation_time.astimezone(UTC).replace(tzinfo=None)
     assert expected_time.isoformat() == ls8_eo3_dataset.metadata.creation_dt
     assert label == ls8_eo3_dataset.metadata.label
 
@@ -928,8 +928,8 @@ def test_count_time_groups(index: Index, ls8_eo3_dataset: Dataset) -> None:
             "1 day",
             product=ls8_eo3_dataset.product.name,
             time=Range(
-                datetime.datetime(2016, 5, 11, tzinfo=tz.tzutc()),
-                datetime.datetime(2016, 5, 13, tzinfo=tz.tzutc()),
+                datetime.datetime(2016, 5, 11, tzinfo=UTC),
+                datetime.datetime(2016, 5, 13, tzinfo=UTC),
             ),
         )
     )
@@ -938,15 +938,15 @@ def test_count_time_groups(index: Index, ls8_eo3_dataset: Dataset) -> None:
     assert timeline == [
         (
             Range(
-                datetime.datetime(2016, 5, 11, tzinfo=tz.tzutc()),
-                datetime.datetime(2016, 5, 12, tzinfo=tz.tzutc()),
+                datetime.datetime(2016, 5, 11, tzinfo=UTC),
+                datetime.datetime(2016, 5, 12, tzinfo=UTC),
             ),
             0,
         ),
         (
             Range(
-                datetime.datetime(2016, 5, 12, tzinfo=tz.tzutc()),
-                datetime.datetime(2016, 5, 13, tzinfo=tz.tzutc()),
+                datetime.datetime(2016, 5, 12, tzinfo=UTC),
+                datetime.datetime(2016, 5, 13, tzinfo=UTC),
             ),
             1,
         ),

--- a/integration_tests/index/test_search_legacy.py
+++ b/integration_tests/index/test_search_legacy.py
@@ -15,7 +15,7 @@ from uuid import UUID
 
 import pytest
 import yaml
-from dateutil import tz
+from dateutil.tz import UTC
 from odc.geo import CRS
 from sqlalchemy.dialects.postgresql.ranges import Range as SQLARange
 
@@ -571,7 +571,7 @@ def test_search_returning(
     assert format_ == "PSEUDOMD"
 
     # It's always UTC in the document
-    expected_time = creation_time.astimezone(tz.tzutc()).replace(tzinfo=None)
+    expected_time = creation_time.astimezone(UTC).replace(tzinfo=None)
     assert expected_time.isoformat() == pseudo_ls8_dataset.metadata_doc["creation_dt"]
     assert label == pseudo_ls8_dataset.metadata_doc["ga_label"]
 

--- a/tests/scripts/test_search_tool.py
+++ b/tests/scripts/test_search_tool.py
@@ -8,7 +8,7 @@ Module
 
 import datetime
 
-from dateutil import tz
+from dateutil.tz import UTC
 from sqlalchemy.dialects.postgresql import Range as PgRange
 
 from datacube.index.fields import Field
@@ -37,7 +37,7 @@ def test_csv_serialise() -> None:
         [
             {"f1": 12, "f2": PgRange(1.0, 2.0)},
             {
-                "f1": datetime.datetime(2014, 7, 26, 23, 48, 0, tzinfo=tz.tzutc()),
+                "f1": datetime.datetime(2014, 7, 26, 23, 48, 0, tzinfo=UTC),
                 "f2": PgRange(-1.0, 2.0),
             },
             {"f1": datetime.datetime(2014, 7, 26, 23, 48, 0), "f2": "landsat"},
@@ -63,7 +63,7 @@ def test_pretty_serialise() -> None:
         [
             {"f1": 12, "field 2": PgRange(1.0, 2.0)},
             {
-                "f1": datetime.datetime(2014, 7, 26, 23, 48, 0, tzinfo=tz.tzutc()),
+                "f1": datetime.datetime(2014, 7, 26, 23, 48, 0, tzinfo=UTC),
                 "field 2": PgRange(-1.0, 2.0),
             },
             {"f1": datetime.datetime(2014, 7, 26, 23, 48, 0), "field 2": "landsat"},

--- a/tests/test_utils_dates.py
+++ b/tests/test_utils_dates.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 from dateutil.relativedelta import relativedelta
 from dateutil.rrule import DAILY, MONTHLY, YEARLY
+from dateutil.tz import UTC
 
 from datacube.utils.dates import (
     mk_time_coord,
@@ -16,7 +17,6 @@ from datacube.utils.dates import (
     parse_interval,
     parse_time,
     tz_aware,
-    tzutc,
 )
 
 
@@ -63,7 +63,7 @@ def test_tz_aware() -> None:
 
     dt_notz = parse_time("2020-11-15T15:11:56.23456")
     assert dt_notz.tzinfo is None
-    assert tz_aware(parse_time("2020-11-15T15:11:56.23456")).tzinfo == tzutc()
+    assert tz_aware(parse_time("2020-11-15T15:11:56.23456")).tzinfo == UTC
     assert (
         tz_aware(parse_time("2020-11-15T15:11:56.23456"), default=dt_tz.tzinfo).tzinfo
         == dt_tz.tzinfo

--- a/tests/ui/test_expression_parsing.py
+++ b/tests/ui/test_expression_parsing.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
 
-from dateutil.tz import tzutc
+from dateutil.tz import UTC
 
 from datacube.model import Range
 from datacube.ui import parse_expressions
@@ -81,15 +81,15 @@ def test_parse_uri_expression() -> None:
 def test_parse_dates() -> None:
     assert parse_expressions("time in 2014-03-02") == {
         "time": Range(
-            begin=datetime(2014, 3, 2, 0, 0, tzinfo=tzutc()),
-            end=datetime(2014, 3, 2, 23, 59, 59, 999999, tzinfo=tzutc()),
+            begin=datetime(2014, 3, 2, 0, 0, tzinfo=UTC),
+            end=datetime(2014, 3, 2, 23, 59, 59, 999999, tzinfo=UTC),
         )
     }
 
     assert parse_expressions("time in 2014-3-2") == {
         "time": Range(
-            begin=datetime(2014, 3, 2, 0, 0, tzinfo=tzutc()),
-            end=datetime(2014, 3, 2, 23, 59, 59, 999999, tzinfo=tzutc()),
+            begin=datetime(2014, 3, 2, 0, 0, tzinfo=UTC),
+            end=datetime(2014, 3, 2, 23, 59, 59, 999999, tzinfo=UTC),
         )
     }
 
@@ -98,8 +98,8 @@ def test_parse_dates() -> None:
     # for backwards compatibility.
     march_2014 = {
         "time": Range(
-            begin=datetime(2014, 3, 1, 0, 0, tzinfo=tzutc()),
-            end=datetime(2014, 3, 31, 23, 59, 59, 999999, tzinfo=tzutc()),
+            begin=datetime(2014, 3, 1, 0, 0, tzinfo=UTC),
+            end=datetime(2014, 3, 31, 23, 59, 59, 999999, tzinfo=UTC),
         )
     }
     assert parse_expressions("time in 2014-03") == march_2014
@@ -107,8 +107,8 @@ def test_parse_dates() -> None:
 
     implied_feb_march_2014 = {
         "time": Range(
-            begin=datetime(2014, 2, 1, 0, 0, tzinfo=tzutc()),
-            end=datetime(2014, 3, 31, 23, 59, 59, 999999, tzinfo=tzutc()),
+            begin=datetime(2014, 2, 1, 0, 0, tzinfo=UTC),
+            end=datetime(2014, 3, 31, 23, 59, 59, 999999, tzinfo=UTC),
         )
     }
     assert parse_expressions("time in [2014-02, 2014-03]") == implied_feb_march_2014
@@ -117,8 +117,8 @@ def test_parse_dates() -> None:
 def test_parse_date_ranges() -> None:
     eighth_march_2014 = {
         "time": Range(
-            datetime(2014, 3, 8, tzinfo=tzutc()),
-            datetime(2014, 3, 8, 23, 59, 59, 999999, tzinfo=tzutc()),
+            datetime(2014, 3, 8, tzinfo=UTC),
+            datetime(2014, 3, 8, 23, 59, 59, 999999, tzinfo=UTC),
         )
     }
     assert parse_expressions("time in 2014-03-08") == eighth_march_2014
@@ -126,8 +126,8 @@ def test_parse_date_ranges() -> None:
 
     march_2014 = {
         "time": Range(
-            datetime(2014, 3, 1, tzinfo=tzutc()),
-            datetime(2014, 3, 31, 23, 59, 59, 999999, tzinfo=tzutc()),
+            datetime(2014, 3, 1, tzinfo=UTC),
+            datetime(2014, 3, 31, 23, 59, 59, 999999, tzinfo=UTC),
         )
     }
     assert parse_expressions("time in 2014-03") == march_2014
@@ -135,8 +135,8 @@ def test_parse_date_ranges() -> None:
     # Leap year, 28 days
     feb_2014 = {
         "time": Range(
-            datetime(2014, 2, 1, tzinfo=tzutc()),
-            datetime(2014, 2, 28, 23, 59, 59, 999999, tzinfo=tzutc()),
+            datetime(2014, 2, 1, tzinfo=UTC),
+            datetime(2014, 2, 28, 23, 59, 59, 999999, tzinfo=UTC),
         )
     }
     assert parse_expressions("time in 2014-02") == feb_2014
@@ -145,8 +145,8 @@ def test_parse_date_ranges() -> None:
     # Entire year
     year_2014 = {
         "time": Range(
-            datetime(2014, 1, 1, tzinfo=tzutc()),
-            datetime(2014, 12, 31, 23, 59, 59, 999999, tzinfo=tzutc()),
+            datetime(2014, 1, 1, tzinfo=UTC),
+            datetime(2014, 12, 31, 23, 59, 59, 999999, tzinfo=UTC),
         )
     }
     assert parse_expressions("time in 2014") == year_2014


### PR DESCRIPTION
pytz() always returns the UTC singleton, but, it looks like a function and so is less immediately obvious what's what it does.

It's even more of a problem when definiing it as the default value of a function argument, where calling a function can be extremely misleading.

### Reason for this pull request

...


### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2010.org.readthedocs.build/en/2010/

<!-- readthedocs-preview opendatacube end -->