### PR TITLE
CI: pin actions by hash

### DIFF
--- a/.github/workflows/doc-preview.yaml
+++ b/.github/workflows/doc-preview.yaml
@@ -27,6 +27,6 @@ jobs:
   documentation-preview:
     runs-on: ubuntu-latest
     steps:
-      - uses: readthedocs/actions/preview@v1
+      - uses: readthedocs/actions/preview@b8bba1484329bda1a3abe986df7ebc80a8950333 # v1.5
         with:
           project-slug: "opendatacube"

--- a/.github/workflows/doc-qa.yaml
+++ b/.github/workflows/doc-qa.yaml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Spellcheck
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
-      - uses: igsekor/pyspelling-any@v1.0.5
+      - uses: igsekor/pyspelling-any@44278deea34ea69d8f0d5179ac409c140b0a2f5a # v1.0.5
         name: Spellcheck
 
   doctor-rst:
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -   name: "Checkout"
-          uses: actions/checkout@v4
+          uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       -   name: "Create cache dir"
           run: mkdir .cache
@@ -40,7 +40,7 @@ jobs:
           id: extract_base_branch
 
       -   name: "Cache DOCtor-RST"
-          uses: actions/cache@v4
+          uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
           with:
               path: .cache
               key: doctor-rst-${{ runner.os }}-${{ steps.extract_base_branch.outputs.branch }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -37,12 +37,12 @@ jobs:
     name: Linting
     steps:
       - name: checkout git
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
       - name: run linter
         run: |
           uv run ${LINT_COMMAND}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,15 +33,15 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
     - name: Build Docker
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
       with:
         file: docker/Dockerfile
         context: .
@@ -67,7 +67,7 @@ jobs:
         docker compose down
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
 
     - name: Build Packages
       run: |
@@ -77,10 +77,10 @@ jobs:
     # Uses to OIDC identification between GitHub and PyPI
     - name: Upload package to PyPI on GitHub Release
       if: "github.repository_owner == 'opendatacube' && github.event.action == 'published'"
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # release/v1
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
       with:
         files: ./coverage.xml
         disable_search: true

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -20,12 +20,12 @@ jobs:
       security-events: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
 
     - name: Run vulnerability scanner
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@76071ef0d7ec797419534a183b498b4d6366cf37 # master
       with:
         scan-type: 'fs'
         ignore-unfixed: true
@@ -34,6 +34,6 @@ jobs:
         severity: 'MEDIUM,HIGH,CRITICAL'
 
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/test-conda-build.yml
+++ b/.github/workflows/test-conda-build.yml
@@ -27,10 +27,10 @@ jobs:
           python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Cache conda
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         env:
           # Increase this value to reset cache if setup.py has not changed
           CACHE_NUMBER: 0
@@ -40,14 +40,14 @@ jobs:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
             hashFiles('conda-environment.yml') }}
 
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@505e6394dae86d6a5c7fbb6e3fb8938e3e863830 # v3.1.1
         continue-on-error: true
         id: conda1
         with:
           environment-file: conda-environment.yml
           auto-update-conda: true
           python-version: ${{ matrix.python-version}}
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@505e6394dae86d6a5c7fbb6e3fb8938e3e863830 # v3.1.1
         if: steps.conda1.outcome == 'failure'
         with:
           environment-file: conda-environment.yml


### PR DESCRIPTION
### Reason for this pull request

Pin the actions by hash so
a compromised release of
an action is not automatically
used and leaks our secrets.
This is not bulletproof, but
better than nothing.

Conversion done by stepsecurity
website:

https://app.stepsecurity.io/secureworkflow/opendatacube/datacube-core/test-conda-build.yml/develop?enable=pin&oldview=true

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2014.org.readthedocs.build/en/2014/

<!-- readthedocs-preview opendatacube end -->