### PR TITLE
Record rasterio/gdal/etc versions from CI runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,9 @@ jobs:
         export LOCAL_GID=$(id -g $USER)
         docker compose up --quiet-pull --wait -d
         docker compose exec --user ubuntu -T core /bin/bash --login -c \
-          "source /app/bin/activate && pytest -r a \
+          "source /app/bin/activate && \
+            rio --show-versions && \
+            pytest -r a \
             --cov datacube \
             --cov-report=xml \
             --doctest-ignore-import-errors \

--- a/.github/workflows/test-conda-build.yml
+++ b/.github/workflows/test-conda-build.yml
@@ -59,5 +59,6 @@ jobs:
         run: |
           pip install .
           python --version
+          rio --show-versions
           datacube --version
           conda env export


### PR DESCRIPTION
This is useful generally, and also specifically to work out what's going wrong with the CI tests running against GDAL 3.11+.

These are somewhat available from when the packages were installed, but when debugging issues it's vital to know what versions of GDAL/PROJ/rasterio are actually being used, and it's not always obvious, depending on how rasterio was installed.

The binary wheels from PyPI include GDAL with them, whereas installing from source with GDAL source available will be different.

Mixing and matching is where you end up in the dragon's lair.


<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->
