### PR TITLE
Normalise geobox inputs to Datacube api

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -661,7 +661,8 @@ class Datacube:
 
         .. seealso:: :meth:`group_datasets` :meth:`load_data` :meth:`find_datasets`
         """
-        _normalise_geobox(like)
+        if like is not None:
+            like = _normalise_geobox(like)
 
         query = Query(self.index, like=like, **kwargs)  # type: ignore[arg-type]
         if not query.product:
@@ -777,7 +778,7 @@ class Datacube:
         def empty_func(m: Measurement, shape: tuple[int, ...]) -> numpy.ndarray:
             return numpy.full(shape, m.nodata, dtype=m.dtype)
 
-        _normalise_geobox(geobox)
+        geobox = _normalise_geobox(geobox)
 
         crs_attrs = {}
         if geobox.crs is not None:
@@ -1060,7 +1061,7 @@ class Datacube:
             measurements, resampling=resampling, fuse_func=fuse_func
         )
 
-        _normalise_geobox(geobox)
+        geobox = _normalise_geobox(geobox)
 
         if driver is not None:
             from ..storage._loader import driver_based_load

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -1240,7 +1240,9 @@ def output_geobox(
     return GeoBox.from_geopolygon(geopolygon, resolution, crs, align)
 
 
-def _normalise_geobox(gbox):
+def _normalise_geobox(
+    gbox: GeoBox | LegacyGeoGeoBox | xarray.Dataset | xarray.DataArray,
+) -> GeoBox:
     """Retain support for legacy geoboxes by converting them to odc.geo GeoBoxes."""
     if isinstance(gbox, GeoBox):
         # Is already a GeoBox

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -42,7 +42,7 @@ from ..index import Index, extract_geom_from_query, index_connect
 from ..migration import ODC2DeprecationWarning
 from ..model import QueryField
 from ..storage._load import FuserFunction, ProgressFunction
-from .query import GroupBy, Query, query_group_by
+from .query import GroupBy, Query, _normalise_geobox, query_group_by
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -1239,28 +1239,6 @@ def output_geobox(
         align = yx_(align)
 
     return GeoBox.from_geopolygon(geopolygon, resolution, crs, align)
-
-
-def _normalise_geobox(
-    gbox: GeoBox | LegacyGeoGeoBox | xarray.Dataset | xarray.DataArray,
-) -> GeoBox:
-    """Retain support for legacy geoboxes by converting them to odc.geo GeoBoxes."""
-    if isinstance(gbox, GeoBox):
-        # Is already a GeoBox
-        return gbox
-
-    if isinstance(gbox, xarray.Dataset | xarray.DataArray):
-        # Is an Xarray object
-        return gbox.odc.geobox
-
-    # Is a legacy GeoBox: convert to odc.geo.geobox.GeoBox.
-    _LOG.warning(
-        "The use of datacube.utils.geometry.GeoBox objects is deprecated, "
-        "and support will be removed in a future release.\n"
-        "Now converting to an odc.geo GeoBox."
-    )
-    crs = None if gbox.crs is None else gbox.crs._str
-    return GeoBox(shape=gbox.shape, affine=gbox.affine, crs=crs)
 
 
 def select_datasets_inside_polygon(

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     from pandas import DataFrame
 
     from datacube.model import GridSpec
-    from datacube.utils.geometry import GeoBox as LegacyGeoGeoBox
+    from datacube.utils.geometry import GeoBox as LegacyGeoBox
 
 from ..drivers import new_datasource
 from ..index import Index, extract_geom_from_query, index_connect
@@ -1158,7 +1158,7 @@ def per_band_load_data_settings(
 
 
 def output_geobox(
-    like: GeoBox | LegacyGeoGeoBox | xarray.Dataset | xarray.DataArray | None = None,
+    like: GeoBox | LegacyGeoBox | xarray.Dataset | xarray.DataArray | None = None,
     output_crs: Any = None,
     resolution: (
         int | float | tuple[int | float, int | float] | Resolution | None

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -661,6 +661,8 @@ class Datacube:
 
         .. seealso:: :meth:`group_datasets` :meth:`load_data` :meth:`find_datasets`
         """
+        _normalise_geobox(like)
+
         query = Query(self.index, like=like, **kwargs)  # type: ignore[arg-type]
         if not query.product:
             raise ValueError("must specify a product")
@@ -735,7 +737,7 @@ class Datacube:
     @staticmethod
     def create_storage(
         coords: Mapping[str, xarray.DataArray],
-        geobox: GeoBox,
+        geobox: GeoBox | xarray.Dataset | xarray.DataArray,
         measurements: list[Measurement],
         data_func: (
             Callable[[Measurement, tuple[int, ...]], numpy.ndarray] | None
@@ -774,6 +776,8 @@ class Datacube:
 
         def empty_func(m: Measurement, shape: tuple[int, ...]) -> numpy.ndarray:
             return numpy.full(shape, m.nodata, dtype=m.dtype)
+
+        _normalise_geobox(geobox)
 
         crs_attrs = {}
         if geobox.crs is not None:
@@ -987,7 +991,7 @@ class Datacube:
     @staticmethod
     def load_data(
         sources: xarray.DataArray,
-        geobox: GeoBox,
+        geobox: GeoBox | xarray.Dataset | xarray.DataArray,
         measurements: Mapping[str, Measurement] | list[Measurement],
         resampling: Resampling | dict[str, Resampling] | None = None,
         fuse_func: FuserFunction | Mapping[str, FuserFunction | None] | None = None,
@@ -1055,6 +1059,9 @@ class Datacube:
         measurements = per_band_load_data_settings(
             measurements, resampling=resampling, fuse_func=fuse_func
         )
+
+        _normalise_geobox(geobox)
+
         if driver is not None:
             from ..storage._loader import driver_based_load
 
@@ -1168,17 +1175,7 @@ def output_geobox(
         assert output_crs is None, "'like' and 'output_crs' are not supported together"
         assert resolution is None, "'like' and 'resolution' are not supported together"
         assert align is None, "'like' and 'align' are not supported together"
-        if isinstance(like, GeoBox):
-            # Is already a GeoBox
-            return like
-        from datacube.utils.geometry import GeoBox as LegacyGeoGeoBox
-
-        if isinstance(like, LegacyGeoGeoBox):
-            # Is a legacy GeoBox: convert to odc.geo.geobox.GeoBox.
-            crs = None if like.crs is None else CRS(like.crs._str)
-            return GeoBox(shape=(like.height, like.width), affine=like.affine, crs=crs)
-        # Is an Xarray object
-        return like.odc.geobox
+        return _normalise_geobox(like)
 
     if load_hints:
         if output_crs is None:
@@ -1241,6 +1238,26 @@ def output_geobox(
         align = yx_(align)
 
     return GeoBox.from_geopolygon(geopolygon, resolution, crs, align)
+
+
+def _normalise_geobox(gbox):
+    """Retain support for legacy geoboxes by converting them to odc.geo GeoBoxes."""
+    if isinstance(gbox, GeoBox):
+        # Is already a GeoBox
+        return gbox
+
+    if isinstance(gbox, xarray.Dataset | xarray.DataArray):
+        # Is an Xarray object
+        return gbox.odc.geobox
+
+    # Is a legacy GeoBox: convert to odc.geo.geobox.GeoBox.
+    _LOG.warning(
+        "The use of datacube.utils.geometry.GeoBox objects is deprecated, "
+        "and support will be removed in a future release.\n"
+        "Now converting to an odc.geo GeoBox."
+    )
+    crs = None if gbox.crs is None else gbox.crs._str
+    return GeoBox(shape=gbox.shape, affine=gbox.affine, crs=crs)
 
 
 def select_datasets_inside_polygon(

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -26,6 +26,7 @@ from typing_extensions import override
 from datacube.index import Index
 
 from ..index import extract_geom_from_query, strip_all_spatial_fields_from_query
+from ..migration import ODC2DeprecationWarning
 from ..model import Dataset, QueryField, Range
 from ..utils.dates import normalise_dt, tz_aware
 
@@ -410,10 +411,11 @@ def _normalise_geobox(
         return gbox.odc.geobox
 
     # Is a legacy GeoBox: convert to odc.geo.geobox.GeoBox.
-    _LOG.warning(
+    warnings.warn(
         "The use of datacube.utils.geometry.GeoBox objects is deprecated, "
         "and support will be removed in a future release.\n"
-        "Now converting to an odc.geo GeoBox."
+        "Now converting to an odc.geo GeoBox.",
+        ODC2DeprecationWarning,
     )
     crs = None if gbox.crs is None else gbox.crs._str
     return GeoBox(shape=gbox.shape, affine=gbox.affine, crs=crs)

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -153,7 +153,19 @@ class Query:
             assert self.geopolygon is None, (
                 "'like' with other spatial bounding parameters is not supported"
             )
-            self.geopolygon = getattr(like, "extent", self.geopolygon)
+            if not isinstance(like, GeoBox):
+                if isinstance(like, xarray.Dataset | xarray.DataArray):
+                    like = like.odc.geobox
+                else:
+                    # Is a legacy GeoBox: convert to odc.geo.geobox.GeoBox.
+                    _LOG.warning(
+                        "The use of datacube.utils.geometry.GeoBox objects is deprecated, "
+                        "and support will be removed in a future release.\n"
+                        "Now converting to an odc.geo GeoBox."
+                    )
+                    crs = None if like.crs is None else like.crs._str
+                    like = GeoBox(shape=like.shape, affine=like.affine, crs=crs)
+            self.geopolygon = like.extent
 
             if "time" not in self.search:
                 time_coord = like.coords.get("time")  # type: ignore[union-attr]

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -12,7 +12,7 @@ import logging
 import math
 import warnings
 from collections.abc import Iterable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 import numpy as np
 import pandas
@@ -31,7 +31,7 @@ from ..model import Dataset, QueryField, Range
 from ..utils.dates import normalise_dt, tz_aware
 
 if TYPE_CHECKING:
-    from datacube.utils.geometry import GeoBox as LegacyGeoGeoBox
+    from datacube.utils.geometry import GeoBox as LegacyGeoBox
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -399,7 +399,7 @@ def solar_offset(geom: Geometry | Dataset, precision: str = "h") -> datetime.tim
 
 
 def _normalise_geobox(
-    gbox: GeoBox | LegacyGeoGeoBox | xarray.Dataset | xarray.DataArray,
+    gbox: Union[GeoBox, "LegacyGeoBox", xarray.Dataset, xarray.DataArray],
 ) -> GeoBox:
     """Retain support for legacy geoboxes by converting them to odc.geo GeoBoxes."""
     if isinstance(gbox, GeoBox):

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -162,7 +162,7 @@ class Query:
             self.geopolygon = like.extent
 
             if "time" not in self.search:
-                time_coord = like.coords.get("time")  # type: ignore[union-attr]
+                time_coord = like.coords.get("time")  # type: ignore[attr-defined]
                 if time_coord is not None:
                     self.search["time"] = _time_to_search_dims(
                         # convert from np.datetime64 to datetime.datetime

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -12,6 +12,7 @@ import logging
 import math
 import warnings
 from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas
@@ -27,6 +28,9 @@ from datacube.index import Index
 from ..index import extract_geom_from_query, strip_all_spatial_fields_from_query
 from ..model import Dataset, QueryField, Range
 from ..utils.dates import normalise_dt, tz_aware
+
+if TYPE_CHECKING:
+    from datacube.utils.geometry import GeoBox as LegacyGeoGeoBox
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -153,18 +157,7 @@ class Query:
             assert self.geopolygon is None, (
                 "'like' with other spatial bounding parameters is not supported"
             )
-            if not isinstance(like, GeoBox):
-                if isinstance(like, xarray.Dataset | xarray.DataArray):
-                    like = like.odc.geobox
-                else:
-                    # Is a legacy GeoBox: convert to odc.geo.geobox.GeoBox.
-                    _LOG.warning(
-                        "The use of datacube.utils.geometry.GeoBox objects is deprecated, "
-                        "and support will be removed in a future release.\n"
-                        "Now converting to an odc.geo GeoBox."
-                    )
-                    crs = None if like.crs is None else like.crs._str
-                    like = GeoBox(shape=like.shape, affine=like.affine, crs=crs)
+            like = _normalise_geobox(like)
             self.geopolygon = like.extent
 
             if "time" not in self.search:
@@ -402,3 +395,25 @@ def solar_offset(geom: Geometry | Dataset, precision: str = "h") -> datetime.tim
 
     # 240 == (24*60*60)/360 (seconds of a day per degree of longitude)
     return datetime.timedelta(seconds=int(lon * 240))
+
+
+def _normalise_geobox(
+    gbox: GeoBox | LegacyGeoGeoBox | xarray.Dataset | xarray.DataArray,
+) -> GeoBox:
+    """Retain support for legacy geoboxes by converting them to odc.geo GeoBoxes."""
+    if isinstance(gbox, GeoBox):
+        # Is already a GeoBox
+        return gbox
+
+    if isinstance(gbox, xarray.Dataset | xarray.DataArray):
+        # Is an Xarray object
+        return gbox.odc.geobox
+
+    # Is a legacy GeoBox: convert to odc.geo.geobox.GeoBox.
+    _LOG.warning(
+        "The use of datacube.utils.geometry.GeoBox objects is deprecated, "
+        "and support will be removed in a future release.\n"
+        "Now converting to an odc.geo GeoBox."
+    )
+    crs = None if gbox.crs is None else gbox.crs._str
+    return GeoBox(shape=gbox.shape, affine=gbox.affine, crs=crs)


### PR DESCRIPTION
### Reason for this pull request

See #2005 


### Proposed changes

- Normalise geobox-type inputs to Datacube api functions and Query constructor, converting legacy geoboxes with a warning
- Make typehint for `geobox` param of `load_data` and `create_storage` more in line with `load` and `find_datasets`



 - [x] Closes #2005
 - [x] Tests added / passed
 - [x] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2018.org.readthedocs.build/en/2018/

<!-- readthedocs-preview opendatacube end -->