### PR TITLE
Add 'test' optional dependency group so we can run the integration tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,12 @@ doc = [
     'sphinx-design',
     'sphinx-toolbox',
 ]
+test = [
+    "pylint",
+    "pytest",
+    "pytest-cov",
+    "hypothesis"
+]
 
 [project.scripts]
 datacube = 'datacube.scripts.cli_app:cli'


### PR DESCRIPTION
### Reason for this pull request

...

The documentation on the opendatacube website instructs users to install test dependencies using:

```bash
pip install --upgrade -e '.[test]'
````
However, the pyproject.toml file does not define the test. The following intergration tests section will fail

### Proposed changes

- Add missing test = [...] group under [project.optional-dependencies] in pyproject.toml to ensure test dependencies are installed.




 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2029.org.readthedocs.build/en/2029/

<!-- readthedocs-preview opendatacube end -->