### PR TITLE
cog: un-nest and align logic

### DIFF
--- a/datacube/utils/cog.py
+++ b/datacube/utils/cog.py
@@ -118,8 +118,8 @@ def _write_cog(
             overview_levels = []
         else:
             overview_levels = [2**i for i in range(1, 6)]
-
-    if fname != ":mem:":
+    not_mem = fname != ":mem:"
+    if not_mem:
         path = check_write_path(
             fname, overwrite
         )  # aborts if overwrite=False and file exists already
@@ -171,49 +171,49 @@ def _write_cog(
 
     # Deal efficiently with "no overviews needed case"
     if len(overview_levels) == 0:
-        if fname == ":mem:":
-            with rasterio.MemoryFile() as mem:
-                with mem.open(driver="GTiff", **rio_opts) as dst:
-                    _write(pix, band, dst)
-                return bytes(mem.getbuffer())
-        else:
+        if not_mem:
             with rasterio.open(path, mode="w", driver="GTiff", **rio_opts) as dst:
                 _write(pix, band, dst)
             return path
+        with rasterio.MemoryFile() as mem:
+            with mem.open(driver="GTiff", **rio_opts) as dst:
+                _write(pix, band, dst)
+            return bytes(mem.getbuffer())
 
     # copy re-compresses anyway so skip compression for temp image
     tmp_opts = toolz.dicttoolz.dissoc(rio_opts, "compress", "predictor", "zlevel")
     tmp_opts.update(intermediate_compression)
 
-    with rasterio.Env(GDAL_TIFF_OVR_BLOCKSIZE=ovr_blocksize):
-        with rasterio.MemoryFile() as mem:
-            with mem.open(driver="GTiff", **tmp_opts) as tmp:
-                _write(pix, band, tmp)
-                tmp.build_overviews(overview_levels, resampling)
+    with (
+        rasterio.Env(GDAL_TIFF_OVR_BLOCKSIZE=ovr_blocksize),
+        rasterio.MemoryFile() as mem,
+        mem.open(driver="GTiff", **tmp_opts) as tmp,
+    ):
+        _write(pix, band, tmp)
+        tmp.build_overviews(overview_levels, resampling)
 
-                if fname == ":mem:":
-                    with rasterio.MemoryFile() as mem2:
-                        rio_copy(
-                            tmp,
-                            mem2.name,
-                            driver="GTiff",
-                            copy_src_overviews=True,
-                            **toolz.dicttoolz.dissoc(
-                                rio_opts,
-                                "width",
-                                "height",
-                                "count",
-                                "dtype",
-                                "crs",
-                                "transform",
-                                "nodata",
-                            ),
-                        )
-                        return bytes(mem2.getbuffer())
+        if not_mem:
+            rio_copy(tmp, path, driver="GTiff", copy_src_overviews=True, **rio_opts)
+            return path
 
-                rio_copy(tmp, path, driver="GTiff", copy_src_overviews=True, **rio_opts)
-
-    return path
+        with rasterio.MemoryFile() as mem2:
+            rio_copy(
+                tmp,
+                mem2.name,
+                driver="GTiff",
+                copy_src_overviews=True,
+                **toolz.dicttoolz.dissoc(
+                    rio_opts,
+                    "width",
+                    "height",
+                    "count",
+                    "dtype",
+                    "crs",
+                    "transform",
+                    "nodata",
+                ),
+            )
+            return bytes(mem2.getbuffer())
 
 
 _delayed_write_cog_to_mem = dask.delayed(  # pylint: disable=invalid-name


### PR DESCRIPTION
### Reason for this pull request

Make the test once and put that
into a variable, and then use
that variable in the places
that depend on the value. This
makes it more obvious that
the definition of path in the first
if-statement corresponds to
the usage elsewhere.

Also un-nest the triple-nested with
and remove an else after return
to reduce indentation levels a bit.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2034.org.readthedocs.build/en/2034/

<!-- readthedocs-preview opendatacube end -->