### PR TITLE
BandInfo: deprecate unused 3D parameter

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -1289,14 +1289,7 @@ def _fuse_measurement(
     for ds in datasets:
         src = None
         with ignore_exceptions_if(skip_broken_datasets):
-            src = new_datasource(
-                BandInfo(
-                    ds,
-                    measurement.name,
-                    extra_dim_index=extra_dim_index,
-                    patch_url=patch_url,
-                )
-            )
+            src = new_datasource(BandInfo(ds, measurement.name, patch_url=patch_url))
 
         if src is None:
             if not skip_broken_datasets:

--- a/datacube/storage/_base.py
+++ b/datacube/storage/_base.py
@@ -6,6 +6,8 @@ from collections.abc import Callable
 from typing import Any
 from urllib.parse import urlparse
 
+from deprecat import deprecat
+
 from datacube.model import Dataset
 from datacube.utils.uris import pick_uri, uri_resolve
 
@@ -89,6 +91,14 @@ class BandInfo:
         "uri",
     )
 
+    @deprecat(
+        deprecated_args={
+            "extra_dim_index": {
+                "version": "1.9",
+                "reason": "3D code is deprecated",
+            }
+        }
+    )
     def __init__(
         self,
         ds: Dataset,


### PR DESCRIPTION
### Reason for this pull request

The constructor does not use
the parameter, so deprecate
its use.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2040.org.readthedocs.build/en/2040/

<!-- readthedocs-preview opendatacube end -->