### PR TITLE
CI: pin image by hash

### DIFF
--- a/.github/workflows/doc-qa.yaml
+++ b/.github/workflows/doc-qa.yaml
@@ -49,7 +49,7 @@ jobs:
               key: doctor-rst-${{ runner.os }}-${{ steps.extract_base_branch.outputs.branch }}
 
       -   name: "Run DOCtor-RST"
-          uses: docker://oskarstark/doctor-rst:1.67.0
+          uses: docker://oskarstark/doctor-rst:1.67.0@sha256:f2f7edaccb98bd664595475cecd62ebbab8d9f68495310f6765cf6f2e6dc5d01
           with:
               args: --short --error-format=github --cache-file=/github/workspace/.cache/doctor-rst.cache
           env:


### PR DESCRIPTION
### Reason for this pull request

I missed pinning the image when I pinned
all the actions, so pin the image too.

URL used for getting what to pin:
https://app.stepsecurity.io/secureworkflow/opendatacube/datacube-core/doc-qa.yaml/develop?enable=pin&oldview=true

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2048.org.readthedocs.build/en/2048/

<!-- readthedocs-preview opendatacube end -->