### PR TITLE
testutils: fix NoData behavior

### DIFF
--- a/datacube/testutils/io.py
+++ b/datacube/testutils/io.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import inspect
+import math
 from collections.abc import Callable, Generator, Sequence
 from os import PathLike
 from pathlib import Path
@@ -394,15 +395,21 @@ def write_gtiff(
         "transform": A,
         "predictor": 2,
         "compress": "DEFLATE",
+        # Rasterio 1.4.4 and earlier sets "INIT_DEST" to "NO_DATA". If there is no
+        # NoData value set, GDAL 3.11 returns an error, and older versions assumed
+        # NoData was 0. The next line sets nodata to NaN/0 to ensure all GDAL versions
+        # behave the same way.
+        "nodata": nodata
+        if nodata is not None
+        else math.nan
+        if pix.dtype.kind == "f"
+        else 0,
     }
 
     if blocksize is not None:
         rio_opts.update(
             tiled=True, blockxsize=min(blocksize, w), blockysize=min(blocksize, h)
         )
-
-    if nodata is not None:
-        rio_opts.update(nodata=nodata)
 
     rio_opts.update(extra_rio_opts)
 

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -771,7 +771,7 @@ def test_rasterio_nodata(tmpdir) -> None:
 
     # fallback nodata is outside source range so it shouldn't be used
     yy = dc_read(
-        mm.path, geobox=mm.geobox, fallback_nodata=-1, dst_nodata=-999, dtype="int16"
+        mm.path, geobox=mm.geobox, fallback_nodata=-1, dst_nodata=0, dtype="int16"
     )
     np.testing.assert_array_equal(xx.astype("int16"), yy)
 

--- a/tests/storage/test_storage_read.py
+++ b/tests/storage/test_storage_read.py
@@ -46,7 +46,7 @@ def test_read_paste(nearest_resampling, tmpdir) -> None:
     xx = mk_test_image(128, 64, nodata=None)
     assert (xx != -999).all()
 
-    mm = write_gtiff(pp / "tst-read-paste-128x64-int16.tif", xx, nodata=None)
+    mm = write_gtiff(pp / "tst-read-paste-128x64-int16.tif", xx, nodata=-999)
 
     def _read(
         geobox,
@@ -194,7 +194,7 @@ def test_read_paste_v2(nearest_resampling, tmpdir) -> None:
     xx = mk_test_image(128, 64, nodata=None)
     assert (xx != -999).all()
 
-    mm = write_gtiff(pp / "tst-read-paste-128x64-int16.tif", xx, nodata=None)
+    mm = write_gtiff(pp / "tst-read-paste-128x64-int16.tif", xx, nodata=-999)
 
     def _read(
         geobox,


### PR DESCRIPTION
### Reason for this pull request

Rasterio 1.4.4 and older relies on
an absent NoData value being interpreted
as NoData=0 by GDAL, which changed
in GDAL 3.11.

Update the test code to behave the same
way across all GDAL versions.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2049.org.readthedocs.build/en/2049/

<!-- readthedocs-preview opendatacube end -->