### PR TITLE
Relax click requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     'antimeridian',
     'attrs>=18.1',
     'cachetools',
-    'click>=8.2',
+    'click>=8',
     'cloudpickle>=0.4',
     'dask[array]',
     'deprecat',
@@ -77,6 +77,7 @@ postgres = ['psycopg2']
 [dependency-groups]
 dev = [
     # Test requirements
+    'click>=8.2', # Only the tests need >=8.2, everything else works with older click.
     'hypothesis',
     'moto>=5.0',
     'netcdf4',

--- a/uv.lock
+++ b/uv.lock
@@ -780,6 +780,7 @@ s3 = [
 dev = [
     { name = "boto3-stubs" },
     { name = "botocore-stubs" },
+    { name = "click" },
     { name = "hypothesis" },
     { name = "moto" },
     { name = "mypy" },
@@ -826,7 +827,7 @@ requires-dist = [
     { name = "bottleneck", marker = "extra == 'performance'" },
     { name = "cachetools" },
     { name = "ciso8601", marker = "extra == 'performance'" },
-    { name = "click", specifier = ">=8.2" },
+    { name = "click", specifier = ">=8" },
     { name = "cloudpickle", specifier = ">=0.4" },
     { name = "dask", extras = ["array"] },
     { name = "dask", extras = ["distributed"], marker = "extra == 'distributed'" },
@@ -860,6 +861,7 @@ provides-extras = ["performance", "distributed", "s3", "netcdf", "postgres"]
 dev = [
     { name = "boto3-stubs" },
     { name = "botocore-stubs" },
+    { name = "click", specifier = ">=8.2" },
     { name = "hypothesis" },
     { name = "moto", specifier = ">=5.0" },
     { name = "mypy" },
@@ -1156,7 +1158,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [


### PR DESCRIPTION
### Reason for this pull request

The explorer tests do not pass
with Click 8.2, so it cannot
use datacube-core 1.9.6 which
changes the dependencies regarding
odc-stac. Relax the click requirement
so explorer can use the next
datacube-core release.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2052.org.readthedocs.build/en/2052/

<!-- readthedocs-preview opendatacube end -->