### PR TITLE
Extend and integrate `native_load`

### DIFF
--- a/datacube/testutils/io.py
+++ b/datacube/testutils/io.py
@@ -193,7 +193,6 @@ def _native_load_1(
     dst_geobox: GeoBox | None = None,
     optional_bands: tuple[str, ...] | None = None,
     basis: str | None = None,
-    load_chunks: dict[str, int] | None = None,
     pad: int | None = None,
     **kw,
 ) -> xr.Dataset:
@@ -228,7 +227,7 @@ def _native_load_1(
             else:
                 mm.update(om)
 
-    xx = Datacube.load_data(sources, load_geobox, mm, dask_chunks=load_chunks, **kw)
+    xx = Datacube.load_data(sources, load_geobox, mm, **kw)
     return xx
 
 
@@ -240,7 +239,6 @@ def native_load(
     dst_geobox: GeoBox | None = None,
     optional_bands: tuple[str, ...] | None = None,
     basis: str | None = None,
-    load_chunks: dict[str, int] | None = None,
     pad: int | None = None,
     **kw,
 ):
@@ -287,7 +285,6 @@ def native_load(
                     dst_geobox=dst_geobox,
                     optional_bands=optional_bands,
                     basis=basis,
-                    load_chunks=load_chunks,
                     pad=pad,
                     **kw,
                 )
@@ -301,7 +298,6 @@ def native_load(
             dst_geobox=dst_geobox,
             optional_bands=optional_bands,
             basis=basis,
-            load_chunks=load_chunks,
             pad=pad,
             **kw,
         )

--- a/datacube/testutils/io.py
+++ b/datacube/testutils/io.py
@@ -146,15 +146,16 @@ def compute_native_load_geobox(
 
     Take native projection and resolution from ``ds, band`` pair and compute
     region in that projection that fully encloses footprint of the
-    ``dst_geobox`` with some padding. Construct GeoBox that encloses that
+    ``dst_geobox`` with ``buffer``. Construct GeoBox that encloses that
     region fully with resolution/pixel alignment copied from supplied band.
 
     :param ds: Sample dataset (only resolution and projection is used, not footprint)
     :param band: Reference band to use
     :param dst_geobox:
                  (resolution of output GeoBox will match resolution of this band)
-    :param buffer: Buffer in units of CRS of ``ds`` (meters usually),
-                   default is 10 pixels worth
+    :param buffer: Buffer in units of CRS of ``ds`` (meters usually) to cover enough aoi
+        when ``dst_geobox`` is different than that of input ``ds``,
+        default is 10 pixels worth
     """
     native = native_geobox(ds, basis=band)
     if dst_geobox is None:
@@ -202,7 +203,7 @@ def _native_load_1(
     :param optional_bands: List of optional band names to load
     :param basis: Name of the band to use for computing reference frame, other
     bands might be reprojected if they use different pixel grid
-    :param pad: number of pixels to pad the geobox
+    :param pad: number of pixels to pad the geobox adjusted to the requirement of reproject
 
     :param kw: Any other parameter that load_data accepts
 

--- a/datacube/testutils/io.py
+++ b/datacube/testutils/io.py
@@ -6,7 +6,7 @@ import inspect
 from collections.abc import Callable, Sequence
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any
 
 import numpy as np
 import toolz
@@ -162,9 +162,7 @@ def compute_native_load_geobox(
         return native
 
     if buffer is None:
-        buffer = 10 * cast(
-            float, max(map(abs, (native.resolution.y, native.resolution.x)))
-        )  # type: ignore
+        buffer = 10 * max(map(abs, (native.resolution.y, native.resolution.x)))
 
     assert native.crs is not None
     return GeoBox.from_geopolygon(

--- a/datacube/testutils/io.py
+++ b/datacube/testutils/io.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import inspect
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Generator, Sequence
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -18,8 +18,7 @@ from odc.geo.warp import resampling_s2rio
 from odc.geo.xr import xr_coords
 from typing_extensions import override
 
-from datacube import Datacube
-
+from ..api import Datacube
 from ..index.eo3 import EO3Grid, is_doc_eo3
 from ..model import Dataset
 from ..storage import BandInfo, reproject_and_fuse
@@ -95,7 +94,7 @@ def eo3_geobox(ds: Dataset, band: str | None = None, grid: str = "default") -> G
     return GeoBox(parsed.shape, parsed.transform, crs)
 
 
-def native_geobox(ds: Dataset, measurements=None, basis: str | None = None):
+def native_geobox(ds: Dataset, measurements=None, basis: str | None = None) -> GeoBox:
     """Compute native GeoBox for a set of bands for a given dataset
 
     :param ds: Dataset
@@ -157,7 +156,7 @@ def compute_native_load_geobox(
     :param buffer: Buffer in units of CRS of ``ds`` (meters usually),
                    default is 10 pixels worth
     """
-    native: GeoBox = native_geobox(ds, basis=band)
+    native = native_geobox(ds, basis=band)
     if dst_geobox is None:
         return native
 
@@ -240,7 +239,7 @@ def native_load(
     basis: str | None = None,
     pad: int | None = None,
     **kw,
-):
+) -> xr.Dataset | Generator[xr.Dataset, None, None]:
     """Load datasets in native resolution.
 
     :param dss: Datasets
@@ -258,7 +257,7 @@ def native_load(
 
     :return: Xarray dataset or generator of Xarray dataset
     """
-    # Filter **kwargs to match what op accepts
+    # Filter **kw to match what groupby op accepts
     sig = inspect.signature(groupby)
     accepted_kw = {
         name

--- a/datacube/testutils/io.py
+++ b/datacube/testutils/io.py
@@ -264,7 +264,6 @@ def native_load(
 
     :return: Xarray dataset or generator of Xarray dataset
     """
-
     # Filter **kwargs to match what op accepts
     sig = inspect.signature(groupby)
     accepted_kw = {
@@ -281,18 +280,22 @@ def native_load(
 
     # split datasets if they are in different grid/crs
     if "grid" in sources.coords:
-        for srcs in _split_by_grid(sources):
-            _xx = _native_load_1(
-                srcs,
-                tuple(bands),
-                dst_geobox=dst_geobox,
-                optional_bands=optional_bands,
-                basis=basis,
-                load_chunks=load_chunks,
-                pad=pad,
-                **kw,
-            )
-            yield _xx
+
+        def yield_by_grid():
+            for srcs in _split_by_grid(sources):
+                _xx = _native_load_1(
+                    srcs,
+                    tuple(bands),
+                    dst_geobox=dst_geobox,
+                    optional_bands=optional_bands,
+                    basis=basis,
+                    load_chunks=load_chunks,
+                    pad=pad,
+                    **kw,
+                )
+                yield _xx
+
+        return yield_by_grid()
     else:
         return _native_load_1(
             sources,

--- a/datacube/testutils/io.py
+++ b/datacube/testutils/io.py
@@ -199,6 +199,20 @@ def _native_load_1(
     pad: int | None = None,
     **kw,
 ) -> xr.Dataset:
+    """Load datasets with native crs
+    :param sources: grouped datasets
+    :param bands: List of band names to load
+    :param dst_geobox: Geobox of final output, if None then use geobox of input dataset
+    :param optional_bands: List of optional band names to load
+    :param basis: Name of the band to use for computing reference frame, other
+    bands might be reprojected if they use different pixel grid
+    :param load_chunks: Config of chunks if loading with dask
+    :param pad: number of pixels to pad the geobox
+
+    :param kw: Any other parameter that load_data accepts
+
+    :return: Xarray dataset
+    """
     if basis is None:
         basis = bands[0]
     (ds,) = sources.data[0]
@@ -237,12 +251,14 @@ def native_load(
     :param dss: Datasets
     :param bands: List of band names to load
     :param groupby: Function to group the datasets
-    :param args:
-    :param dst_geobox: Geobox of final output
-    :param optional_bands:
+    :param args: positional passed into gropuby
+
+    :param dst_geobox: Geobox of final output, if None then use geobox of input dataset
+    :param optional_bands: List of optional band names to load
     :param basis: Name of the band to use for computing reference frame, other
     bands might be reprojected if they use different pixel grid
-    :param pad:
+    :param load_chunks: Config of chunks if loading with dask
+    :param pad: number of pixels to pad the geobox
 
     :param kw: Any other parameter groupby or _native_load_1 accepts
 
@@ -258,13 +274,12 @@ def native_load(
         in (param.KEYWORD_ONLY, param.POSITIONAL_OR_KEYWORD, param.VAR_KEYWORD)
     }
     accepted_kw = {k: v for k, v in kw.items() if k in accepted_kw}
-
-    # source = Datacube.group_datasets(list(dss), "time")
     sources = groupby(list(dss), *args, **accepted_kw)
 
     for key in accepted_kw:
         kw.pop(key, None)
 
+    # split datasets if they are in different grid/crs
     if "grid" in sources.coords:
         for srcs in _split_by_grid(sources):
             _xx = _native_load_1(

--- a/datacube/testutils/io.py
+++ b/datacube/testutils/io.py
@@ -203,7 +203,6 @@ def _native_load_1(
     :param optional_bands: List of optional band names to load
     :param basis: Name of the band to use for computing reference frame, other
     bands might be reprojected if they use different pixel grid
-    :param load_chunks: Config of chunks if loading with dask
     :param pad: number of pixels to pad the geobox
 
     :param kw: Any other parameter that load_data accepts
@@ -253,7 +252,6 @@ def native_load(
     :param optional_bands: List of optional band names to load
     :param basis: Name of the band to use for computing reference frame, other
     bands might be reprojected if they use different pixel grid
-    :param load_chunks: Config of chunks if loading with dask
     :param pad: number of pixels to pad the geobox
 
     :param kw: Any other parameter groupby or _native_load_1 accepts

--- a/datacube/testutils/io.py
+++ b/datacube/testutils/io.py
@@ -2,18 +2,23 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+import inspect
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import toolz
-import xarray
+import xarray as xr
 from odc.geo import wh_
 from odc.geo.geobox import GeoBox, zoom_to
+from odc.geo.geobox import pad as gbox_pad
 from odc.geo.warp import resampling_s2rio
 from odc.geo.xr import xr_coords
 from typing_extensions import override
+
+from datacube import Datacube
 
 from ..index.eo3 import EO3Grid, is_doc_eo3
 from ..model import Dataset
@@ -132,32 +137,158 @@ def native_geobox(ds: Dataset, measurements=None, basis: str | None = None):
     return geobox
 
 
-def native_load(ds, measurements=None, basis=None, **kw):
-    """Load single dataset in native resolution.
+def compute_native_load_geobox(
+    ds: Dataset,
+    band: str,
+    dst_geobox: GeoBox | None = None,
+    buffer: float | None = None,
+) -> GeoBox:
+    """Compute area of interest for an input dataset given final output geobox.
 
-    :param ds: Dataset
-    :param measurements: List of band names to load
+    Take native projection and resolution from ``ds, band`` pair and compute
+    region in that projection that fully encloses footprint of the
+    ``dst_geobox`` with some padding. Construct GeoBox that encloses that
+    region fully with resolution/pixel alignment copied from supplied band.
+
+    :param ds: Sample dataset (only resolution and projection is used, not footprint)
+    :param band: Reference band to use
+    :param dst_geobox:
+                 (resolution of output GeoBox will match resolution of this band)
+    :param buffer: Buffer in units of CRS of ``ds`` (meters usually),
+                   default is 10 pixels worth
+    """
+    native: GeoBox = native_geobox(ds, basis=band)
+    if dst_geobox is None:
+        return native
+
+    if buffer is None:
+        buffer = 10 * cast(
+            float, max(map(abs, (native.resolution.y, native.resolution.x)))
+        )  # type: ignore
+
+    assert native.crs is not None
+    return GeoBox.from_geopolygon(
+        dst_geobox.extent.to_crs(native.crs).buffer(buffer),
+        crs=native.crs,
+        resolution=native.resolution,
+        align=native.alignment,
+    )
+
+
+def _split_by_grid(xx: xr.DataArray) -> list[xr.DataArray]:
+    """Split datasets by grid/crs"""
+
+    def extract(grid_id, ii):
+        yy = xx[ii]
+        crs = xx.grid2crs[grid_id]
+        yy.attrs.update(crs=crs)
+        yy.attrs.pop("grid2crs", None)
+        return yy
+
+    return [extract(grid_id, ii) for grid_id, ii in xx.groupby(xx.grid).groups.items()]
+
+
+def _native_load_1(
+    sources: xr.DataArray,
+    bands: tuple[str, ...],
+    *,
+    dst_geobox: GeoBox | None = None,
+    optional_bands: tuple[str, ...] | None = None,
+    basis: str | None = None,
+    load_chunks: dict[str, int] | None = None,
+    pad: int | None = None,
+    **kw,
+) -> xr.Dataset:
+    if basis is None:
+        basis = bands[0]
+    (ds,) = sources.data[0]
+    load_geobox = compute_native_load_geobox(ds, basis, dst_geobox)
+    if pad is not None:
+        load_geobox = gbox_pad(load_geobox, pad)
+
+    mm = ds.product.lookup_measurements(bands)
+    if optional_bands is not None:
+        for ob in optional_bands:
+            try:
+                om = ds.product.lookup_measurements(ob)
+            except KeyError:
+                continue
+            else:
+                mm.update(om)
+
+    xx = Datacube.load_data(sources, load_geobox, mm, dask_chunks=load_chunks, **kw)
+    return xx
+
+
+def native_load(
+    dss: Sequence[Dataset],
+    bands: Sequence[str],
+    groupby: Callable[..., Any],
+    *args,
+    dst_geobox: GeoBox | None = None,
+    optional_bands: tuple[str, ...] | None = None,
+    basis: str | None = None,
+    load_chunks: dict[str, int] | None = None,
+    pad: int | None = None,
+    **kw,
+):
+    """Load datasets in native resolution.
+
+    :param dss: Datasets
+    :param bands: List of band names to load
+    :param groupby: Function to group the datasets
+    :param args:
+    :param dst_geobox: Geobox of final output
+    :param optional_bands:
     :param basis: Name of the band to use for computing reference frame, other
     bands might be reprojected if they use different pixel grid
+    :param pad:
 
-    :param kw: Any other parameter load_data accepts
+    :param kw: Any other parameter groupby or _native_load_1 accepts
 
-    :return: Xarray dataset
+    :return: Xarray dataset or generator of Xarray dataset
     """
-    from datacube import Datacube
 
-    geobox = native_geobox(
-        ds, measurements, basis
-    )  # early exit via exception if no compatible grid exists
-    mm = (
-        ds.product.measurements
-        if measurements is None
-        else ds.product.lookup_measurements(measurements)
-    )
+    # Filter **kwargs to match what op accepts
+    sig = inspect.signature(groupby)
+    accepted_kw = {
+        name
+        for name, param in sig.parameters.items()
+        if param.kind
+        in (param.KEYWORD_ONLY, param.POSITIONAL_OR_KEYWORD, param.VAR_KEYWORD)
+    }
+    accepted_kw = {k: v for k, v in kw.items() if k in accepted_kw}
 
-    return Datacube.load_data(
-        Datacube.group_datasets([ds], "time"), geobox, measurements=mm, **kw
-    )
+    # source = Datacube.group_datasets(list(dss), "time")
+    sources = groupby(list(dss), *args, **accepted_kw)
+
+    for key in accepted_kw:
+        kw.pop(key, None)
+
+    if "grid" in sources.coords:
+        for srcs in _split_by_grid(sources):
+            _xx = _native_load_1(
+                srcs,
+                tuple(bands),
+                dst_geobox=dst_geobox,
+                optional_bands=optional_bands,
+                basis=basis,
+                load_chunks=load_chunks,
+                pad=pad,
+                **kw,
+            )
+            yield _xx
+    else:
+        return _native_load_1(
+            sources,
+            tuple(bands),
+            dst_geobox=dst_geobox,
+            optional_bands=optional_bands,
+            basis=basis,
+            load_chunks=load_chunks,
+            pad=pad,
+            **kw,
+        )
 
 
 def dc_read(
@@ -391,16 +522,15 @@ def rio_slurp(fname, *args, **kw):
         return rio_slurp_read(fname, *args, **kw)
 
 
-def rio_slurp_xarray(fname, *args, rgb: str = "auto", **kw) -> xarray.DataArray:
+def rio_slurp_xarray(fname, *args, rgb: str = "auto", **kw) -> xr.DataArray:
     """
     Dispatches to either:
 
     rio_slurp_read(fname, out_shape, ..)
     rio_slurp_reproject(fname, geobox, ...)
 
-    then wraps it all in xarray.DataArray with .crs,.nodata etc.
+    then wraps it all in xr.DataArray with .crs,.nodata etc.
     """
-    from xarray import DataArray
 
     if len(args) == 0:
         if "geobox" in kw:
@@ -421,6 +551,6 @@ def rio_slurp_xarray(fname, *args, rgb: str = "auto", **kw) -> xarray.DataArray:
     else:
         dims = mm.geobox.dims
 
-    return DataArray(
+    return xr.DataArray(
         im, dims=dims, coords=xr_coords(mm.geobox), attrs={"nodata": mm.nodata}
     )

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,6 +8,11 @@ What's New
 Next Release
 ============
 
+What's Changed
+--------------
+* Extend and integrate `native_load` :pull:`2053`
+
+
 v1.9.6 (11 July 2025)
 =====================
 

--- a/docs/about/whats_new.rst
+++ b/docs/about/whats_new.rst
@@ -8,11 +8,6 @@ What's New
 Next Release
 ============
 
-What's Changed
---------------
-* Extend and integrate `native_load` :pull:`2053`
-
-
 v1.9.6 (11 July 2025)
 =====================
 

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -17,6 +17,8 @@ from datacube.testutils import (
 )
 from datacube.testutils.io import (
     get_raster_info,
+    native_geobox,
+    native_load,
     rio_slurp,
     rio_slurp_xarray,
     write_gtiff,
@@ -413,8 +415,6 @@ def test_missing_file_handling() -> None:
 
 
 def test_native_load(tmpdir) -> None:
-    from datacube.testutils.io import native_geobox, native_load
-
     tmpdir = Path(str(tmpdir))
     spatial = {
         "resolution": (15, -15),
@@ -435,7 +435,7 @@ def test_native_load(tmpdir) -> None:
 
     assert set(get_raster_info(ds)) == set(ds.measurements)
 
-    xx = native_load(ds)
+    xx = native_load([ds], ["aa", "bb"], Datacube.group_datasets, "time")
     assert xx.odc.geobox == geobox
     np.testing.assert_array_equal(aa, xx.isel(time=0).aa.values)
     np.testing.assert_array_equal(aa, xx.isel(time=0).bb.values)
@@ -445,28 +445,22 @@ def test_native_load(tmpdir) -> None:
     )
 
     # cc is different size from aa,bb
-    with pytest.raises(ValueError):
-        xx = native_load(ds)
-
-    # cc is different size from aa,bb
-    with pytest.raises(ValueError):
-        xx = native_geobox(ds)
-
-    # aa and bb are the same
-    assert native_geobox(ds, ["aa", "bb"]) == geobox
-    xx = native_load(ds, ["aa", "bb"])
+    # cc is reprojected
+    xx = native_load([ds], ["aa", "bb", "cc"], Datacube.group_datasets, "time")
     assert xx.odc.geobox == geobox
+    assert xx.odc.geobox != geobox_cc
     np.testing.assert_array_equal(aa, xx.isel(time=0).aa.values)
     np.testing.assert_array_equal(aa, xx.isel(time=0).bb.values)
 
-    # cc will be reprojected
     assert native_geobox(ds, basis="aa") == geobox
-    xx = native_load(ds, basis="aa")
+    xx = native_load(
+        [ds], ["aa", "bb", "cc"], Datacube.group_datasets, "time", basis="aa"
+    )
     assert xx.odc.geobox == geobox
     np.testing.assert_array_equal(aa, xx.isel(time=0).aa.values)
     np.testing.assert_array_equal(aa, xx.isel(time=0).bb.values)
 
     # cc is compatible with self
-    xx = native_load(ds, ["cc"])
+    xx = native_load([ds], ["cc"], Datacube.group_datasets, "time")
     assert xx.odc.geobox == geobox_cc
     np.testing.assert_array_equal(cc, xx.isel(time=0).cc.values)

--- a/tests/test_utils_cog.py
+++ b/tests/test_utils_cog.py
@@ -12,6 +12,7 @@ import xarray as xr
 from dask.base import is_dask_collection
 from dask.delayed import Delayed
 
+from datacube import Datacube
 from datacube.testutils import gen_tiff_dataset, mk_test_image, suppress_deprecations
 from datacube.testutils.io import native_load, rio_slurp, rio_slurp_xarray
 from datacube.utils.cog import _write_cog, to_cog, write_cog
@@ -32,7 +33,7 @@ def gen_test_data(prefix, dask=False, shape=None, dtype="int16", nodata=-999):
     if dask:
         extras.update(dask_chunks={"time": 1})
 
-    xx = native_load(ds, **extras)
+    xx = native_load([ds], ["aa"], Datacube.group_datasets, "time", **extras)
 
     return xx.aa.isel(time=0), ds
 


### PR DESCRIPTION
### Reason for this pull request
Share common `native_load` functionality used by `datacube-alchemist` and `odc-stats`

### Proposed changes

- `native_load` from `odc-stats` into `datacube-core`
- optional `groupby`  in `native_load` instead of hardcoding "group by time"
- `geobox` from either source or dest



 - [ ] Closes #xxxx
 - [x] Tests added / passed
 - [x] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2053.org.readthedocs.build/en/2053/

<!-- readthedocs-preview opendatacube end -->