### PR TITLE
pylint: remove reports parameter

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         python-version: ["3.12"]
         lintcommand:
-          - "pylint -j 2 --report no datacube"
+          - "pylint -j 2 datacube"
           - "mypy datacube examples tests/test_utils_rio.py integration_tests/*py"
     name: Linting
     steps:

--- a/check-code.sh
+++ b/check-code.sh
@@ -22,7 +22,7 @@ if [ "${1:-}" == "--with-docker" ]; then
 fi
 
 if [ "${SKIP_STYLE_CHECK:-no}" != "yes" ]; then
-    pylint -j 2 --reports no datacube
+    pylint -j 2 datacube
 fi
 
 # Run tests, taking coverage.

--- a/pylintrc
+++ b/pylintrc
@@ -1,6 +1,4 @@
 [MASTER]
-# ndexpr is crashing pylint. Hopefully remove this ignore when https://github.com/PyCQA/pylint/issues/1563 is fixed
-ignore=ndexpr
 extension-pkg-whitelist=SharedArray,zstd,ciso8601
 
 [MESSAGES CONTROL]


### PR DESCRIPTION
### Reason for this pull request

The parameter name is "reports",
but it defaults to "False" which
is what it is set to, so stop passing
the parameter.

Also remove an ignore line that
has been in the pylint configuration
since 2017.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2061.org.readthedocs.build/en/2061/

<!-- readthedocs-preview opendatacube end -->