### PR TITLE
Require setuptools_scm >= 8

### DIFF
--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - pip
   - python >=3.10
   - setuptools
-  - setuptools_scm >=3.4
+  - setuptools_scm >=8
   - toml
   - pytest-runner
   - sphinx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,7 @@ dependencies = [
 ]
 
 [build-system]
-requires = ["setuptools>=69", "setuptools_scm[toml]>=3.4"]
-# v61 Add support for pyproject.toml, and include-package-data defaults to try when using pyproject.toml
+requires = ["setuptools>=69", "setuptools_scm[toml]>=8"]
 # v69 includes py.typed files by default
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
### Reason for this pull request

I fixed a bunch of build issues
in Explorer about a year ago, and
I no longer remember the details,
but the outcome was to require
setuptools_scm >= 8, so do
the same in this repository.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2065.org.readthedocs.build/en/2065/

<!-- readthedocs-preview opendatacube end -->