### PR TITLE
CI: shorten job timeout

### DIFF
--- a/.github/workflows/doc-preview.yaml
+++ b/.github/workflows/doc-preview.yaml
@@ -25,6 +25,7 @@ concurrency:
 
 jobs:
   documentation-preview:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - uses: readthedocs/actions/preview@b8bba1484329bda1a3abe986df7ebc80a8950333 # v1.5

--- a/.github/workflows/doc-qa.yaml
+++ b/.github/workflows/doc-qa.yaml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   pyspell:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       # Spellcheck
@@ -29,6 +30,7 @@ jobs:
         name: Spellcheck
 
   doctor-rst:
+    timeout-minutes: 15
     name: Lint (DOCtor-RST)
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,6 +27,7 @@ concurrency:
 
 jobs:
   lint:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ concurrency:
 
 jobs:
   main:
+    timeout-minutes: 45
     runs-on: ubuntu-latest
     # Permit authenticating to PyPI
     permissions:

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   cve-scanner:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     permissions:
       security-events: write

--- a/.github/workflows/test-conda-build.yml
+++ b/.github/workflows/test-conda-build.yml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
   check-conda:
+    timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
### Reason for this pull request

This prevents us from having to
wait for 6 hours if someone
hangs the CI machines.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2066.org.readthedocs.build/en/2066/

<!-- readthedocs-preview opendatacube end -->