### PR TITLE
readthedocs: remove extra_requirements

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -24,5 +24,3 @@ python:
     - requirements: docs/requirements.txt
     - method: pip
       path: .
-      extra_requirements:
-        - docs


### PR DESCRIPTION
### Reason for this pull request

The requirements.txt contains everything
except datacube-core itself.

Fixes #1786

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2067.org.readthedocs.build/en/2067/

<!-- readthedocs-preview opendatacube end -->