### PR TITLE
Typecheck tests in CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -34,7 +34,7 @@ jobs:
         python-version: ["3.12"]
         lintcommand:
           - "pylint -j 2 datacube"
-          - "mypy datacube examples tests/test_utils_rio.py integration_tests/*py"
+          - "mypy datacube examples integration_tests tests/test_utils_rio.py"
     name: Linting
     steps:
       - name: checkout git

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -34,7 +34,7 @@ jobs:
         python-version: ["3.12"]
         lintcommand:
           - "pylint -j 2 datacube"
-          - "mypy datacube examples integration_tests tests/test_utils_rio.py"
+          - "mypy datacube examples integration_tests tests"
     name: Linting
     steps:
       - name: checkout git

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -11,7 +11,7 @@ import datetime
 import logging
 import math
 import warnings
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 from typing import TYPE_CHECKING, Any, Union
 
 import numpy as np
@@ -86,7 +86,7 @@ class Query:
     def __init__(
         self,
         index: Index | None = None,
-        product: str | None = None,
+        product: str | Sequence[str] | None = None,
         geopolygon=None,
         like: GeoBox | xarray.Dataset | xarray.DataArray | None = None,
         **search_terms,

--- a/datacube/drivers/netcdf/writer.py
+++ b/datacube/drivers/netcdf/writer.py
@@ -12,13 +12,16 @@ from collections import namedtuple
 from collections.abc import Sequence
 from datetime import datetime, timezone
 from os import PathLike
+from typing import Any
 
 import netCDF4
 import numpy
+import numpy as np
 from netCDF4 import Dataset
 from odc.geo import CRS
 from odc.geo.geom import box
 from odc.geo.math import data_resolution_and_offset
+from xarray import DataArray
 
 from datacube import __version__
 from datacube.utils.masking import describe_flags_def
@@ -80,7 +83,10 @@ def append_netcdf(netcdf_path: PathLike) -> Dataset:
 
 
 def create_coordinate(
-    nco: Dataset, name: str, labels: Sequence[str], units: str
+    nco: Dataset,
+    name: str,
+    labels: np.ndarray[tuple[Any, ...], np.dtype[Any]],
+    units: str,
 ) -> netCDF4.Variable:
     labels = netcdfy_coord(labels)
 
@@ -96,7 +102,7 @@ def create_coordinate(
 
 
 def create_variable(
-    nco, name: str, var: Variable, grid_mapping=None, attrs=None, **kwargs
+    nco, name: str, var: Variable | DataArray, grid_mapping=None, attrs=None, **kwargs
 ) -> netCDF4.Variable:
     assert var.dtype.kind != "U"  # Creates Non CF-Compliant NetCDF File
 
@@ -292,11 +298,15 @@ def write_flag_definition(variable, flags_definition) -> None:
     )
 
 
-def netcdfy_coord(data):
+def netcdfy_coord(
+    data: np.ndarray[tuple[Any, ...], np.dtype[Any]],
+) -> np.ndarray[tuple[Any, ...], np.dtype[Any]]:
     return netcdfy_data(data)
 
 
-def netcdfy_data(data):
+def netcdfy_data(
+    data: np.ndarray[tuple[Any, ...], np.dtype[Any]],
+) -> np.ndarray[tuple[Any, ...], np.dtype[Any]]:
     # NetCDF/CF Conventions only seem to allow storing ascii, not unicode
     if data.dtype.kind == "S" and data.dtype.itemsize > 1:
         return data.view("S1").reshape(data.shape + (-1,))

--- a/datacube/index/abstract/_datasets.py
+++ b/datacube/index/abstract/_datasets.py
@@ -5,10 +5,10 @@
 import datetime
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Generator, Iterable, Mapping, Sequence
 from datetime import timedelta
 from time import monotonic
-from typing import Any
+from typing import Any, NamedTuple
 from uuid import UUID
 
 from deprecat import deprecat
@@ -697,26 +697,31 @@ class AbstractDatasetResource(ABC):
         archived: bool | None = False,
         order_by: Iterable[Any] | None = None,
         **query: QueryField,
-    ) -> Iterable[tuple]:
+    ) -> Generator[NamedTuple]:
         """
         Perform a search, returning only the specified fields.
 
-        This method can be faster than normal search() if you don't need all fields of each dataset.
+        This method can be faster than normal search() if you don't need all
+        fields of each dataset.
 
-        It also allows for returning rows other than datasets, such as a row per uri when requesting field 'uri'.
+        It also allows for returning rows other than datasets, such as a row
+        per uri when requesting field 'uri'.
 
-        :param field_names: Names of desired fields (default = all known search fields, unless custom_offsets is set,
-                            see below)
-        :param custom_offsets: A dictionary of offsets in the metadata doc for custom fields custom offsets
-                               are returned in addition to fields named in field_names.  Default is
-                               None, field_names only.  If field_names is None, and custom_offsets are provided,
-                               only the custom offsets are included, over-riding the normal field_names default.
+        :param field_names: Names of desired fields (default = all known search
+                            fields, unless custom_offsets is set, see below)
+        :param custom_offsets: A dictionary of offsets in the metadata doc for custom
+                               fields custom offsets are returned in addition to fields
+                               named in field_names. Default is None, field_names only.
+                               If field_names is None, and custom_offsets are provided,
+                               only the custom offsets are included, over-riding
+                               the normal field_names default.
         :param limit: Limit number of dataset (None/default = unlimited)
         :param archived: False (default): Return active datasets only.
                          None: Include archived and active datasets.
                          True: Return archived datasets only.
-        :param order_by: a field name, field, function or clause by which to sort output. None is unsorted and may allow
-                         faster return of first result depending on the index driver's implementation.
+        :param order_by: a field name, field, function or clause by which to sort
+                         output. None is unsorted and may allow faster return of first
+                         result depending on the index driver's implementation.
         :param query: search query parameters
         :return: Namedtuple of requested fields, for each matching dataset.
         """

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -7,10 +7,10 @@ import logging
 import re
 import warnings
 from collections import namedtuple
-from collections.abc import Callable, Iterable, Mapping, Sequence
+from collections.abc import Callable, Generator, Iterable, Mapping, Sequence
 from itertools import chain
 from time import monotonic
-from typing import Any, cast
+from typing import Any, NamedTuple, cast
 from uuid import UUID
 
 from deprecat import deprecat
@@ -707,7 +707,7 @@ class DatasetResource(AbstractDatasetResource):
         archived: bool | None = False,
         order_by: Iterable[Any] | None = None,
         **query: QueryField,
-    ) -> Iterable[tuple]:
+    ) -> Generator[NamedTuple]:
         if "geopolygon" in query:
             raise NotImplementedError(
                 "Spatial search index API not supported by this index."

--- a/datacube/index/null/_datasets.py
+++ b/datacube/index/null/_datasets.py
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime
-from collections.abc import Iterable, Sequence
-from typing import Any
+from collections.abc import Generator, Iterable, Mapping, Sequence
+from typing import Any, NamedTuple
 
 from deprecat import deprecat
 from typing_extensions import override
@@ -13,7 +13,7 @@ from typing_extensions import override
 from datacube.index.abstract import DSID, AbstractDatasetResource
 from datacube.migration import ODC2DeprecationWarning
 from datacube.model import Dataset, Product, QueryDict, QueryField
-from datacube.utils.changes import Change
+from datacube.utils.changes import Change, Offset
 
 
 class DatasetResource(AbstractDatasetResource):
@@ -198,13 +198,13 @@ class DatasetResource(AbstractDatasetResource):
     def search_returning(
         self,
         field_names: Iterable[str] | None = None,
-        custom_offsets=None,
+        custom_offsets: Mapping[str, Offset] | None = None,
         limit: int | None = None,
         archived: bool | None = False,
-        order_by=None,
-        **query,
-    ) -> list:
-        return []
+        order_by: Iterable[Any] | None = None,
+        **query: QueryField,
+    ) -> Generator[NamedTuple]:
+        yield from []
 
     @override
     def count(self, archived: bool | None = False, **query) -> int:

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -765,21 +765,33 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         archived: bool | None = False,
         order_by: Iterable[Any] | None = None,
         **query: QueryField,
-    ) -> Generator[tuple]:
+    ) -> Generator[NamedTuple]:
         """
         Perform a search, returning only the specified fields.
 
-        This method can be faster than normal search() if you don't need all fields of each dataset.
+        This method can be faster than normal search() if you don't need all
+        fields of each dataset.
 
-        It also allows for returning rows other than datasets, such as a row per uri when requesting field 'uri'.
+        It also allows for returning rows other than datasets, such as a row
+        per uri when requesting field 'uri'.
 
-        :param field_names:
-        :param query:
-        :param limit: Limit number of datasets
-        :param archived: include archived datasets
-        :param order_by: sql text, dataset field, or sqlalchemy expression
-        by which to order results
-        :return: sequence of results, each result is a namedtuple of your requested fields
+        :param field_names: Names of desired fields (default = all known search
+                            fields, unless custom_offsets is set, see below)
+        :param custom_offsets: A dictionary of offsets in the metadata doc for custom
+                               fields custom offsets are returned in addition to fields
+                               named in field_names. Default is None, field_names only.
+                               If field_names is None, and custom_offsets are provided,
+                               only the custom offsets are included, over-riding
+                               the normal field_names default.
+        :param limit: Limit number of dataset (None/default = unlimited)
+        :param archived: False (default): Return active datasets only.
+                         None: Include archived and active datasets.
+                         True: Return archived datasets only.
+        :param order_by: a field name, field, function or clause by which to sort
+                         output. None is unsorted and may allow faster return of first
+                          result depending on the index driver's implementation.
+        :param query: search query parameters
+        :return: Namedtuple of requested fields, for each matching dataset.
         """
         field_name_d: dict[str, None] = {}
         if field_names is None and custom_offsets is None:

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -15,7 +15,7 @@ import warnings
 from collections import namedtuple
 from collections.abc import Generator, Iterable, Iterator, Mapping, Sequence
 from time import monotonic
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 from uuid import UUID
 
 from deprecat import deprecat
@@ -757,21 +757,33 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         archived: bool | None = False,
         order_by: Iterable[Any] | None = None,
         **query: QueryField,
-    ) -> Generator[tuple]:
+    ) -> Generator[NamedTuple]:
         """
         Perform a search, returning only the specified fields.
 
-        This method can be faster than normal search() if you don't need all fields of each dataset.
+        This method can be faster than normal search() if you don't need all
+        fields of each dataset.
 
-        It also allows for returning rows other than datasets, such as a row per uri when requesting field 'uri'.
+        It also allows for returning rows other than datasets, such as a row
+        per uri when requesting field 'uri'.
 
-        :param field_names: defaults to all known search fields
-        :param query:
-        :param limit: Limit number of datasets
-        :param archived: include archived datasets
-        :param order_by: sql text, dataset field, sqlalchemy function, or expression
-        by which to order results
-        :return: sequence of results, each result is a namedtuple of your requested fields
+        :param field_names: Names of desired fields (default = all known search
+                            fields, unless custom_offsets is set, see below)
+        :param custom_offsets: A dictionary of offsets in the metadata doc for custom
+                               fields custom offsets are returned in addition to fields
+                               named in field_names. Default is None, field_names only.
+                               If field_names is None, and custom_offsets are provided,
+                               only the custom offsets are included, over-riding
+                               the normal field_names default.
+        :param limit: Limit number of dataset (None/default = unlimited)
+        :param archived: False (default): Return active datasets only.
+                         None: Include archived and active datasets.
+                         True: Return archived datasets only.
+        :param order_by: a field name, field, function or clause by which to sort
+                         output. None is unsorted and may allow faster return of first
+                          result depending on the index driver's implementation.
+        :param query: search query parameters
+        :return: Namedtuple of requested fields, for each matching dataset.
         """
         field_name_d: dict[str, None] = {}
         if field_names is None and custom_offsets is None:
@@ -1101,7 +1113,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                 product, field_names, custom_offsets
             )
             select_field_names = tuple(field.name for field in select_fields)
-            result_type = namedtuple("DatasetLight", select_field_names)  # type: ignore
+            result_type = namedtuple("DatasetLight", select_field_names)  # type: ignore[misc]
 
             if "grid_spatial" in select_field_names:
 
@@ -1109,7 +1121,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
                     pass
             else:
 
-                class DatasetLight(result_type):  # type: ignore
+                class DatasetLight(result_type):  # type: ignore[no-redef]
                     __slots__ = ()
 
             with self._db_connection() as connection:

--- a/datacube/model/_base.py
+++ b/datacube/model/_base.py
@@ -27,6 +27,6 @@ def ranges_overlap(ra: Range, rb: Range) -> bool:
 
 Not = namedtuple("Not", "value")
 QueryField: TypeAlias = (
-    str | float | int | Range | datetime.datetime | Iterable[Geometry] | Not
+    str | float | int | Range | datetime.datetime | Iterable[str | Geometry] | Not
 )
 QueryDict: TypeAlias = dict[str, QueryField]

--- a/datacube/scripts/search_tool.py
+++ b/datacube/scripts/search_tool.py
@@ -102,7 +102,7 @@ def datasets(ctx, index: Index, expressions) -> None:
     )
     ctx.obj["write_results"](
         sorted(index.products.get_field_names()),
-        (tup._asdict() for tup in index.datasets.search_returning(**expressions)),  # type: ignore[attr-defined]
+        (tup._asdict() for tup in index.datasets.search_returning(**expressions)),
     )
 
 

--- a/datacube/testutils/__init__.py
+++ b/datacube/testutils/__init__.py
@@ -529,12 +529,12 @@ def remove_crs(xx):
     return xx
 
 
-def sanitise_doc(d):
+def sanitise_doc(d: str | Mapping | list) -> str | float | dict | list:
     if isinstance(d, str):
         if d == "NaN":
             return math.nan
         return d
-    elif isinstance(d, dict):
+    elif isinstance(d, dict | Mapping):
         return {k: sanitise_doc(v) for k, v in d.items()}
     elif isinstance(d, list):
         return [sanitise_doc(i) for i in d]

--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -14,9 +14,10 @@ import json
 import logging
 import math
 from collections import OrderedDict
-from collections.abc import Generator, Iterator, Mapping
+from collections.abc import Callable, Generator, Mapping
 from contextlib import contextmanager
 from copy import deepcopy
+from io import TextIOWrapper
 from os import PathLike
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -70,7 +71,7 @@ _PROTOCOL_OPENERS = {
 }
 
 
-def load_from_yaml(handle, parse_dates: bool = False) -> Iterator:
+def load_from_yaml(handle: TextIOWrapper, parse_dates: bool = False) -> Generator[dict]:
     loader = SafeLoader if parse_dates else NoDatesSafeLoader
     yield from yaml.load_all(handle, Loader=loader)
 
@@ -80,23 +81,25 @@ def parse_yaml(doc: str) -> Mapping[str, Any]:
     return yaml.load(doc, Loader=SafeLoader)
 
 
-def load_from_json(handle):
+def load_from_json(handle) -> Generator[dict]:
     yield json.load(handle)
 
 
-def load_from_netcdf(path):
+def load_from_netcdf(path: Path) -> Generator[dict]:
     for doc in read_strings_from_netcdf(path, variable="dataset"):
         yield yaml.load(doc, Loader=NoDatesSafeLoader)
 
 
-_PARSERS = {
+_PARSERS: dict[
+    str, Callable[[str], Generator[dict]] | Callable[[TextIOWrapper], Generator[dict]]
+] = {
     ".yaml": load_from_yaml,
     ".yml": load_from_yaml,
     ".json": load_from_json,
 }
 
 
-def load_documents(path):
+def load_documents(path: str) -> Generator[dict]:
     """
     Load document/s from the specified path.
 
@@ -115,8 +118,9 @@ def load_documents(path):
     compressed = url[-3:] == ".gz"
 
     if scheme == "file" and path[-3:] == ".nc":
-        path = uri_to_local_path(url)
-        yield from load_from_netcdf(path)
+        local_path = uri_to_local_path(url)
+        assert local_path is not None
+        yield from load_from_netcdf(local_path)
     else:
         with _PROTOCOL_OPENERS[scheme](url) as fh:
             if compressed:
@@ -144,7 +148,7 @@ def read_documents(*paths, uri: bool = False) -> Generator[tuple[str, dict]]:
     :param paths: input Paths or URIs
     """
 
-    def process_file(path):
+    def process_file(path: str) -> Generator[tuple[str, dict]]:
         docs = load_documents(path)
 
         if not uri:
@@ -165,15 +169,15 @@ def read_documents(*paths, uri: bool = False) -> Generator[tuple[str, dict]]:
                 enumerate(docs), if_one=add_uri_no_part, if_many=add_uri_with_part
             )
 
-    for path in paths:
+    for p in paths:
         try:
-            yield from process_file(path)
+            yield from process_file(p)
         except InvalidDocException as e:
             raise e
         except (yaml.YAMLError, ValueError) as e:
-            raise InvalidDocException(f"Failed to load {path}: {e}") from None
+            raise InvalidDocException(f"Failed to load {p}: {e}") from None
         except Exception as e:
-            raise InvalidDocException(f"Failed to load {path}: {e}") from None
+            raise InvalidDocException(f"Failed to load {p}: {e}") from None
 
 
 def netcdf_extract_string(chars) -> str:
@@ -192,9 +196,9 @@ def netcdf_extract_string(chars) -> str:
         return str(numpy.char.decode(chars))
 
 
-def read_strings_from_netcdf(path, variable):
+def read_strings_from_netcdf(path: str | PathLike[str], variable) -> Generator[str]:
     """
-    Load all of the string encoded data from a variable in a NetCDF file.
+    Load all the string encoded data from a variable in a NetCDF file.
 
     By 'string', the CF conventions mean ascii.
 

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -35,7 +35,7 @@ from datacube.drivers.postgres import _core as pgres_core
 from datacube.index import Index, index_connect
 from datacube.index.abstract import AbstractIndex, default_metadata_type_docs
 from datacube.model import Dataset, LineageDirection, LineageTree, MetadataType, Product
-from datacube.utils import SimpleDocNav
+from datacube.utils import SimpleDocNav, read_documents
 from integration_tests.utils import (
     GEOTIFF,
     _make_geotiffs,
@@ -75,12 +75,12 @@ settings.load_profile("opendatacube")
 EO3_TESTDIR = INTEGRATION_TESTS_DIR / "data" / "eo3"
 
 
-def get_eo3_test_data_doc(path: str | Path) -> dict | None:
+def get_eo3_test_data_doc(path: str | Path) -> dict:
     from datacube.utils import read_documents
 
     for _, doc in read_documents(EO3_TESTDIR / path):
         return doc
-    return None
+    pytest.fail(f"No document found for {EO3_TESTDIR / path}", False)
 
 
 @pytest.fixture
@@ -116,7 +116,7 @@ def eo3_dataset_update_path() -> str:
 
 
 @pytest.fixture
-def dataset_with_lineage_doc() -> tuple[dict | None, str]:
+def dataset_with_lineage_doc() -> tuple[dict, str]:
     return (
         get_eo3_test_data_doc("wo_ds_with_lineage.odc-metadata.yaml"),
         "s3://dea-public-data/derivative/ga_ls_wo_3/1-6-0/090/086/2016/05/12/"
@@ -125,7 +125,7 @@ def dataset_with_lineage_doc() -> tuple[dict | None, str]:
 
 
 @pytest.fixture
-def eo3_ls8_dataset_doc() -> tuple[dict | None, str]:
+def eo3_ls8_dataset_doc() -> tuple[dict, str]:
     return (
         get_eo3_test_data_doc("ls8_dataset.yaml"),
         "s3://dea-public-data/baseline/ga_ls8c_ard_3/090/086/2016/05/12/"
@@ -134,7 +134,7 @@ def eo3_ls8_dataset_doc() -> tuple[dict | None, str]:
 
 
 @pytest.fixture
-def eo3_ls8_dataset2_doc() -> tuple[dict | None, str]:
+def eo3_ls8_dataset2_doc() -> tuple[dict, str]:
     return (
         get_eo3_test_data_doc("ls8_dataset2.yaml"),
         "s3://dea-public-data/baseline/ga_ls8c_ard_3/090/086/2016/05/28/"
@@ -143,7 +143,7 @@ def eo3_ls8_dataset2_doc() -> tuple[dict | None, str]:
 
 
 @pytest.fixture
-def eo3_ls8_dataset3_doc() -> tuple[dict | None, str]:
+def eo3_ls8_dataset3_doc() -> tuple[dict, str]:
     return (
         get_eo3_test_data_doc("ls8_dataset3.yaml"),
         "s3://dea-public-data/baseline/ga_ls8c_ard_3/101/077/2013/04/04/"
@@ -152,7 +152,7 @@ def eo3_ls8_dataset3_doc() -> tuple[dict | None, str]:
 
 
 @pytest.fixture
-def eo3_ls8_dataset4_doc() -> tuple[dict | None, str]:
+def eo3_ls8_dataset4_doc() -> tuple[dict, str]:
     return (
         get_eo3_test_data_doc("ls8_dataset4.yaml"),
         "s3://dea-public-data/baseline/ga_ls8c_ard_3/101/077/2013/07/21/"
@@ -161,7 +161,7 @@ def eo3_ls8_dataset4_doc() -> tuple[dict | None, str]:
 
 
 @pytest.fixture
-def eo3_wo_dataset_doc() -> tuple[dict | None, str]:
+def eo3_wo_dataset_doc() -> tuple[dict, str]:
     return (
         get_eo3_test_data_doc("wo_dataset.yaml"),
         "s3://dea-public-data/derivative/ga_ls_wo_3/1-6-0/090/086/2016/05/12/"
@@ -170,7 +170,7 @@ def eo3_wo_dataset_doc() -> tuple[dict | None, str]:
 
 
 @pytest.fixture
-def eo3_africa_dataset_doc() -> tuple[dict | None, str]:
+def eo3_africa_dataset_doc() -> tuple[dict, str]:
     return (
         get_eo3_test_data_doc("s2_africa_dataset.yaml"),
         "s3://deafrica-sentinel-2/sentinel-s2-l2a-cogs/37/M/CQ/"
@@ -179,7 +179,7 @@ def eo3_africa_dataset_doc() -> tuple[dict | None, str]:
 
 
 @pytest.fixture
-def eo3_africa_dataset2_doc() -> tuple[dict | None, str]:
+def eo3_africa_dataset2_doc() -> tuple[dict, str]:
     return (
         get_eo3_test_data_doc("s2_africa_dataset2.yaml"),
         "s3://deafrica-sentinel-2/sentinel-s2-l2a-cogs/39/M/XR/"
@@ -188,7 +188,7 @@ def eo3_africa_dataset2_doc() -> tuple[dict | None, str]:
 
 
 @pytest.fixture
-def s1_dataset_doc() -> tuple[dict | None, str]:
+def s1_dataset_doc() -> tuple[dict, str]:
     return (
         get_eo3_test_data_doc("ga_s1_vertical_dualpol.yaml"),
         "https://deant-data-public-dev.s3.ap-southeast-2.amazonaws.com/"
@@ -197,7 +197,7 @@ def s1_dataset_doc() -> tuple[dict | None, str]:
 
 
 @pytest.fixture
-def datasets_with_unembedded_lineage_doc() -> list[tuple[dict | None, str]]:
+def datasets_with_unembedded_lineage_doc() -> list[tuple[dict, str]]:
     return [
         (
             get_eo3_test_data_doc("ls8_dataset.yaml"),
@@ -213,47 +213,47 @@ def datasets_with_unembedded_lineage_doc() -> list[tuple[dict | None, str]]:
 
 
 @pytest.fixture
-def extended_eo3_metadata_type_doc() -> dict | None:
+def extended_eo3_metadata_type_doc() -> dict:
     return get_eo3_test_data_doc("eo3_landsat_ard.odc-type.yaml")
 
 
 @pytest.fixture
-def eo3_sentinel_metadata_type_doc() -> dict | None:
+def eo3_sentinel_metadata_type_doc() -> dict:
     return get_eo3_test_data_doc("eo3_sentinel_ard.odc-type.yaml")
 
 
 @pytest.fixture
-def eo3_s1_metadata_type_doc() -> dict | None:
+def eo3_s1_metadata_type_doc() -> dict:
     return get_eo3_test_data_doc("eo3_s1_ard.odc-type.yaml")
 
 
 @pytest.fixture
-def extended_eo3_product_doc() -> dict | None:
+def extended_eo3_product_doc() -> dict:
     return get_eo3_test_data_doc("ard_ls8.odc-product.yaml")
 
 
 @pytest.fixture
-def base_eo3_product_doc() -> dict | None:
+def base_eo3_product_doc() -> dict:
     return get_eo3_test_data_doc("ga_ls_wo_3.odc-product.yaml")
 
 
 @pytest.fixture
-def africa_s2_product_doc() -> dict | None:
+def africa_s2_product_doc() -> dict:
     return get_eo3_test_data_doc("s2_africa_product.yaml")
 
 
 @pytest.fixture
-def s2_ard_product_doc() -> dict | None:
+def s2_ard_product_doc() -> dict:
     return get_eo3_test_data_doc("ga_s2am_ard_3.odc-product.yaml")
 
 
 @pytest.fixture
-def s1_product_doc() -> dict | None:
+def s1_product_doc() -> dict:
     return get_eo3_test_data_doc("ga_s1_vertical_dualpol.odc-product.yaml")
 
 
 @pytest.fixture
-def final_dataset_doc() -> tuple[dict | None, str]:
+def final_dataset_doc() -> tuple[dict, str]:
     return (
         get_eo3_test_data_doc("final_dataset.yaml"),
         "s3://dea-public-data/baseline/ga_ls8c_ard_3/090/086/2023/04/30"
@@ -262,7 +262,7 @@ def final_dataset_doc() -> tuple[dict | None, str]:
 
 
 @pytest.fixture
-def nrt_dataset_doc() -> tuple[dict | None, str]:
+def nrt_dataset_doc() -> tuple[dict, str]:
     return (
         get_eo3_test_data_doc("nrt_dataset.yaml"),
         "s3://dea-public-data/baseline/ga_ls8c_ard_3/090/086/2023/04/30_nrt"
@@ -271,7 +271,7 @@ def nrt_dataset_doc() -> tuple[dict | None, str]:
 
 
 @pytest.fixture
-def ga_s2am_ard_3_interim_doc() -> tuple[dict | None, str]:
+def ga_s2am_ard_3_interim_doc() -> tuple[dict, str]:
     return (
         get_eo3_test_data_doc("ga_s2am_ard_3_interim.yaml"),
         "s3://dea-public-data/baseline/ga_s2am_ard_3/53/JNN/2021/07/24_interim"
@@ -280,7 +280,7 @@ def ga_s2am_ard_3_interim_doc() -> tuple[dict | None, str]:
 
 
 @pytest.fixture
-def ga_s2am_ard_3_final_doc() -> tuple[dict | None, str]:
+def ga_s2am_ard_3_final_doc() -> tuple[dict, str]:
     return (
         get_eo3_test_data_doc("ga_s2am_ard_3_final.yaml"),
         "s3://dea-public-data/baseline/ga_s2am_ard_3/53/JNN/2021/07/24"
@@ -348,30 +348,40 @@ def eo3_s1_metadata_type(index: Index, eo3_s1_metadata_type_doc) -> MetadataType
 @pytest.fixture
 def ls8_eo3_product(
     index: Index, extended_eo3_metadata_type, extended_eo3_product_doc
-) -> Product | None:
-    return index.products.add_document(extended_eo3_product_doc)
+) -> Product:
+    p = index.products.add_document(extended_eo3_product_doc)
+    assert p is not None
+    return p
 
 
 @pytest.fixture
-def wo_eo3_product(index: Index, base_eo3_product_doc) -> Product | None:
-    return index.products.add_document(base_eo3_product_doc)
+def wo_eo3_product(index: Index, base_eo3_product_doc) -> Product:
+    p = index.products.add_document(base_eo3_product_doc)
+    assert p is not None
+    return p
 
 
 @pytest.fixture
-def africa_s2_eo3_product(index: Index, africa_s2_product_doc) -> Product | None:
-    return index.products.add_document(africa_s2_product_doc)
+def africa_s2_eo3_product(index: Index, africa_s2_product_doc) -> Product:
+    p = index.products.add_document(africa_s2_product_doc)
+    assert p is not None
+    return p
 
 
 @pytest.fixture
 def ga_s2am_ard_3_product(
     index: Index, eo3_sentinel_metadata_type, s2_ard_product_doc
-) -> Product | None:
-    return index.products.add_document(s2_ard_product_doc)
+) -> Product:
+    p = index.products.add_document(s2_ard_product_doc)
+    assert p is not None
+    return p
 
 
 @pytest.fixture
-def ga_s1_product(index: Index, eo3_s1_metadata_type, s1_product_doc) -> Product | None:
-    return index.products.add_document(s1_product_doc)
+def ga_s1_product(index: Index, eo3_s1_metadata_type, s1_product_doc) -> Product:
+    p = index.products.add_document(s1_product_doc)
+    assert p is not None
+    return p
 
 
 @pytest.fixture
@@ -759,12 +769,14 @@ def ls5_telem_doc(ga_metadata_type) -> dict[str, str | dict[str, str | dict[str,
 
 
 @pytest.fixture
-def ls5_telem_type(index: Index, ls5_telem_doc) -> Product | None:
-    return index.products.add_document(ls5_telem_doc)
+def ls5_telem_type(index: Index, ls5_telem_doc) -> Product:
+    p = index.products.add_document(ls5_telem_doc)
+    assert p is not None
+    return p
 
 
 @pytest.fixture(scope="session")
-def geotiffs(tmpdir_factory) -> list[dict]:
+def geotiffs(tmpdir_factory) -> list[dict[str, str | UUID | dict]]:
     """Create test geotiffs and corresponding yamls.
 
     We create one yaml per time slice, itself comprising one geotiff
@@ -915,8 +927,7 @@ def telemetry_metadata_type_doc() -> dict:
 @pytest.fixture
 def ga_metadata_type_doc() -> dict:
     _FULL_EO_METADATA = Path(__file__).parent.joinpath("extensive-eo-metadata.yaml")  # noqa: N806
-    [(path, eo_md_type)] = datacube.utils.read_documents(_FULL_EO_METADATA)
-    return eo_md_type
+    return next(read_documents(_FULL_EO_METADATA))[1]
 
 
 @pytest.fixture
@@ -940,22 +951,21 @@ def ga_metadata_type(index: Index, ga_metadata_type_doc) -> MetadataType:
 
 
 @pytest.fixture
-def default_metadata_type(index: Index, default_metadata_types) -> MetadataType | None:
-    if index.supports_legacy:
-        return index.metadata_types.get_by_name("eo")
-    else:
-        return index.metadata_types.get_by_name("eo3")
+def default_metadata_type(index: Index, default_metadata_types) -> MetadataType:
+    m = index.metadata_types.get_by_name("eo" if index.supports_legacy else "eo3")
+    assert m is not None
+    return m
 
 
 @pytest.fixture
-def telemetry_metadata_type(
-    index: Index, default_metadata_types
-) -> MetadataType | None:
-    return index.metadata_types.get_by_name("telemetry")
+def telemetry_metadata_type(index: Index, default_metadata_types) -> MetadataType:
+    m = index.metadata_types.get_by_name("telemetry")
+    assert m is not None
+    return m
 
 
 @pytest.fixture
-def indexed_ls5_scene_products(index: Index, ga_metadata_type) -> list[Product | None]:
+def indexed_ls5_scene_products(index: Index, ga_metadata_type) -> list[Product]:
     """Add Landsat 5 scene Products into the Index"""
     products = load_test_products(
         CONFIG_SAMPLES / "dataset_types" / "ls5_scenes.yaml",
@@ -965,7 +975,9 @@ def indexed_ls5_scene_products(index: Index, ga_metadata_type) -> list[Product |
 
     types = []
     for product in products:
-        types.append(index.products.add_document(product))
+        p = index.products.add_document(product)
+        assert p is not None
+        types.append(p)
 
     return types
 

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -478,9 +478,8 @@ def _to_yaml(ls5_telem_doc):
 
 
 def test_update_metadata_type(
-    index: Index, default_metadata_type: MetadataType | None
+    index: Index, default_metadata_type: MetadataType
 ) -> None:
-    assert default_metadata_type is not None
     mt_doc = next(
         d
         for d in default_metadata_type_docs()

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -12,6 +12,8 @@ import pytest
 import yaml
 from sqlalchemy import text
 
+import datacube.index.postgis.index
+import datacube.index.postgres.index
 from datacube.drivers.postgis._fields import (
     NumericRangeDocField as PgsNumericRangeDocField,
 )
@@ -156,6 +158,9 @@ def test_field_expression_unchanged(
 
 
 def _object_exists(index: Index, index_name) -> bool:
+    assert isinstance(
+        index, datacube.index.postgres.index.Index | datacube.index.postgis.index.Index
+    )
     schema_name = "odc" if index._db.driver_name == "postgis" else "agdc"
     with index._active_connection() as connection:
         val = connection._connection.execute(
@@ -206,7 +211,9 @@ def test_update_dataset(
     assert updated.uri == "file:///test/doc.yaml"
 
     # update location
-    assert index.datasets.get(dataset.id).local_uri == "file:///test/doc.yaml"
+    d = index.datasets.get(dataset.id)
+    assert d is not None
+    assert d.local_uri == "file:///test/doc.yaml"
     update = Dataset(
         ls5_telem_type,
         example_ls5_nbar_metadata_doc,
@@ -278,11 +285,10 @@ def test_update_product_type(
     # Update with a new description
     ls5_telem_doc["description"] = "New description"
     index.products.update_document(ls5_telem_doc)
+    p = index.products.get_by_name(ls5_telem_type.name)
+    assert p is not None
     # Ensure was updated
-    assert (
-        index.products.get_by_name(ls5_telem_type.name).definition["description"]
-        == "New description"
-    )
+    assert p.definition["description"] == "New description"
 
     # Remove some match rules (looser rules -- that match more datasets -- should be allowed)
     assert "format" in ls5_telem_doc["metadata"]
@@ -349,12 +355,13 @@ def test_product_update_cli(
             expect_success=expect_success,
         )
 
-    def get_current(index: Index, product_doc):
+    def get_current(index: Index, product_doc: dict) -> str | float | dict | list:
         # It's calling out to a separate instance to update the product (through the cli),
         # so we need to clear our local index object's cache to get the updated one.
-        index.products.get_by_name_unsafe.cache_clear()
-
-        return sanitise_doc(index.products.get_by_name(product_doc["name"]).definition)
+        index.products.get_by_name_unsafe.cache_clear()  # type: ignore[attr-defined]
+        p = index.products.get_by_name(product_doc["name"])
+        assert p is not None
+        return sanitise_doc(p.definition)
 
     # Update an unchanged file, should be unchanged.
     file_path = tmpdir.join("unmodified-product.yaml")
@@ -414,7 +421,7 @@ def test_product_delete(index: Index, ls8_eo3_product: Product) -> None:
 
     index.products.delete([ls8_eo3_product])
 
-    index.products.get_by_name_unsafe.cache_clear()
+    index.products.get_by_name_unsafe.cache_clear()  # type: ignore[attr-defined]
     assert index.products.get_by_name(ls8_eo3_product.name) is None
     assert not _object_exists(index, "dix_ga_ls8c_ard_3_region_code")
     assert not _object_exists(index, "dv_ga_ls8c_ard_3_dataset")
@@ -442,7 +449,7 @@ def test_product_delete_cli(
     assert "ga_ls8c_ard_3 could not be deleted" in runner.output
     assert runner.exit_code == 0
 
-    index.products.get_by_name_unsafe.cache_clear()
+    index.products.get_by_name_unsafe.cache_clear()  # type: ignore[attr-defined]
     assert index.products.get_by_name("ga_ls8c_ard_3") is not None
     assert index.products.get_by_name("ga_ls_wo_3") is None
 
@@ -464,7 +471,7 @@ def test_product_delete_cli(
     )
     assert "No dataset found with id" in runner.output
 
-    index.products.get_by_name_unsafe.cache_clear()
+    index.products.get_by_name_unsafe.cache_clear()  # type: ignore[attr-defined]
     assert index.products.get_by_name("ga_ls8c_ard_3") is None
 
     # should be able to add product back now
@@ -555,8 +562,6 @@ def test_filter_products_by_types(index: Index, wo_eo3_product) -> None:
 
 
 def test_filter_types_by_search(index: Index, wo_eo3_product, ls8_eo3_product) -> None:
-    assert index.products
-
     # No arguments, return all.
     res = set(index.products.search())
     assert res == {ls8_eo3_product, wo_eo3_product}
@@ -590,27 +595,15 @@ def test_filter_types_by_search(index: Index, wo_eo3_product, ls8_eo3_product) -
     assert "dataset_maturity" in q
 
     # Or expression test
-    res = list(
-        index.products.search(
-            product_family=["wo", "spam"],
-        )
-    )
+    res = list(index.products.search(product_family=["wo", "spam"]))
     assert res == [wo_eo3_product]
 
     # Not expression test
-    res = list(
-        index.products.search(
-            product_family=Not("wo"),
-        )
-    )
+    res = list(index.products.search(product_family=Not("wo")))
     assert res == [ls8_eo3_product]
 
     # Mismatching fields
-    res = list(
-        index.products.search(
-            product_family="spam",
-        )
-    )
+    res = list(index.products.search(product_family="spam"))
     assert res == []
 
 

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -20,6 +20,7 @@ from datacube.index.eo3 import prep_eo3
 from datacube.index.exceptions import MissingRecordError
 from datacube.model import Dataset, MetadataType, Product
 from datacube.testutils import suppress_deprecations
+from datacube.utils.json_types import JsonDict
 
 _telemetry_uuid = UUID("4ec8fe97-e8b9-11e4-87ff-1040f381a756")
 _telemetry_dataset = {
@@ -47,7 +48,7 @@ _telemetry_dataset = {
     "lineage": {"source_datasets": {}, "blah": float("NaN")},
 }
 
-_pseudo_telemetry_dataset_type = {
+_pseudo_telemetry_dataset_type: JsonDict = {
     "name": "ls8_telemetry",
     "description": "LS8 test",
     "metadata": {
@@ -70,6 +71,7 @@ def test_archive_datasets(index: Index, ls8_eo3_dataset) -> None:
 
     # The model should show it as archived now.
     indexed_dataset = index.datasets.get(ls8_eo3_dataset.id)
+    assert indexed_dataset is not None
     assert indexed_dataset.is_archived
 
     index.datasets.restore([ls8_eo3_dataset.id])
@@ -78,6 +80,7 @@ def test_archive_datasets(index: Index, ls8_eo3_dataset) -> None:
 
     # And now active
     indexed_dataset = index.datasets.get(ls8_eo3_dataset.id)
+    assert indexed_dataset is not None
     assert not indexed_dataset.is_archived
 
 
@@ -87,10 +90,16 @@ def test_archive_less_mature(
 ) -> None:
     # case 1: add nrt then final; nrt should get archived
     index.datasets.add(nrt_dataset, with_lineage=False, archive_less_mature=True)
-    assert not index.datasets.get(nrt_dataset.id).is_archived
+    d = index.datasets.get(nrt_dataset.id)
+    assert d is not None
+    assert not d.is_archived
     index.datasets.add(final_dataset, with_lineage=False, archive_less_mature=True)
-    assert index.datasets.get(nrt_dataset.id).is_archived
-    assert not index.datasets.get(final_dataset.id).is_archived
+    d = index.datasets.get(nrt_dataset.id)
+    assert d is not None
+    assert d.is_archived
+    d = index.datasets.get(final_dataset.id)
+    assert d is not None
+    assert not d.is_archived
 
     # case 2: purge nrt; re-add with final already there
     index.datasets.purge([nrt_dataset.id])
@@ -102,9 +111,13 @@ def test_archive_less_mature(
     # case 3: re-index final; nrt should still get archived
     assert index.datasets.get(final_dataset.id) is not None
     index.datasets.add(nrt_dataset, with_lineage=False)
-    assert not index.datasets.get(nrt_dataset.id).is_archived
+    d = index.datasets.get(nrt_dataset.id)
+    assert d is not None
+    assert not d.is_archived
     index.datasets.add(final_dataset, with_lineage=False, archive_less_mature=True)
-    assert index.datasets.get(nrt_dataset.id).is_archived
+    d = index.datasets.get(nrt_dataset.id)
+    assert d is not None
+    assert d.is_archived
 
 
 @pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")
@@ -112,7 +125,9 @@ def test_cannot_search_for_less_mature(index: Index, nrt_dataset, ds_no_region) 
     # if a dataset is missing a property required for finding less mature datasets,
     # it should error
     index.datasets.add(nrt_dataset, with_lineage=False, archive_less_mature=0)
-    assert not index.datasets.get(nrt_dataset.id).is_archived
+    d = index.datasets.get(nrt_dataset.id)
+    assert d is not None
+    assert not d.is_archived
     assert ds_no_region.metadata.region_code is None
     with pytest.raises(ValueError, match="region_code"):
         index.datasets.add(ds_no_region, with_lineage=False, archive_less_mature=0)
@@ -124,30 +139,48 @@ def test_archive_less_mature_approx_timestamp(
 ) -> None:
     # test archive_less_mature where there's a slight difference in timestamps
     index.datasets.add(ga_s2am_ard3_interim, with_lineage=False)
-    assert not index.datasets.get(ga_s2am_ard3_interim.id).is_archived
+    d = index.datasets.get(ga_s2am_ard3_interim.id)
+    assert d is not None
+    assert not d.is_archived
     index.datasets.add(ga_s2am_ard3_final, with_lineage=False, archive_less_mature=True)
-    assert index.datasets.get(ga_s2am_ard3_interim.id).is_archived
-    assert not index.datasets.get(ga_s2am_ard3_final.id).is_archived
+    d = index.datasets.get(ga_s2am_ard3_interim.id)
+    assert d is not None
+    assert d.is_archived
+    d = index.datasets.get(ga_s2am_ard3_final.id)
+    assert d is not None
+    assert not d.is_archived
 
 
 @pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")
 def test_dont_archive_less_mature(index: Index, final_dataset, nrt_dataset) -> None:
     # ensure datasets aren't archive if no archive_less_mature value is provided
     index.datasets.add(nrt_dataset, with_lineage=False)
-    assert not index.datasets.get(nrt_dataset.id).is_archived
+    d = index.datasets.get(nrt_dataset.id)
+    assert d is not None
+    assert not d.is_archived
     index.datasets.add(final_dataset, with_lineage=False, archive_less_mature=None)
-    assert not index.datasets.get(nrt_dataset.id).is_archived
-    assert not index.datasets.get(final_dataset.id).is_archived
+    d = index.datasets.get(nrt_dataset.id)
+    assert d is not None
+    assert not d.is_archived
+    d = index.datasets.get(final_dataset.id)
+    assert d is not None
+    assert not d.is_archived
 
 
 @pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")
 def test_archive_less_mature_bool(index: Index, final_dataset, nrt_dataset) -> None:
     # if archive_less_mature value gets passed as a bool via an outdated script
     index.datasets.add(nrt_dataset, with_lineage=False)
-    assert not index.datasets.get(nrt_dataset.id).is_archived
+    d = index.datasets.get(nrt_dataset.id)
+    assert d is not None
+    assert not d.is_archived
     index.datasets.add(final_dataset, with_lineage=False, archive_less_mature=False)
-    assert not index.datasets.get(nrt_dataset.id).is_archived
-    assert not index.datasets.get(final_dataset.id).is_archived
+    d = index.datasets.get(nrt_dataset.id)
+    assert d is not None
+    assert not d.is_archived
+    d = index.datasets.get(final_dataset.id)
+    assert d is not None
+    assert not d.is_archived
 
 
 def test_purge_datasets(index: Index, ls8_eo3_dataset) -> None:
@@ -163,6 +196,7 @@ def test_purge_datasets(index: Index, ls8_eo3_dataset) -> None:
 
     # The model should show it as archived now.
     indexed_dataset = index.datasets.get(ls8_eo3_dataset.id)
+    assert indexed_dataset is not None
     assert indexed_dataset.is_archived
 
     # Purge dataset
@@ -182,11 +216,13 @@ def test_purge_datasets_cli(index: Index, ls8_eo3_dataset, clirunner) -> None:
     # Archive dataset
     index.datasets.archive([dsid])
     indexed_dataset = index.datasets.get(dsid)
+    assert indexed_dataset is not None
     assert indexed_dataset.is_archived
 
     # Test CLI dry run
     clirunner(["dataset", "purge", "--dry-run", str(dsid)])
     indexed_dataset = index.datasets.get(dsid)
+    assert indexed_dataset is not None
     assert indexed_dataset.is_archived
 
     # Test CLI purge
@@ -206,11 +242,13 @@ def test_purge_all_datasets_cli(
     clirunner(["dataset", "archive", "--all"])
 
     indexed_dataset = index.datasets.get(dsid)
+    assert indexed_dataset is not None
     assert indexed_dataset.is_archived
 
     # Restore all datasets
     clirunner(["dataset", "restore", "--all"])
     indexed_dataset = index.datasets.get(dsid)
+    assert indexed_dataset is not None
     assert not indexed_dataset.is_archived
 
     # Archive again
@@ -258,6 +296,7 @@ def test_get_dataset(index: Index, ls8_eo3_dataset: Dataset) -> None:
 
     for tr in (lambda x: x, lambda x: str(x)):
         ds = index.datasets.get(tr(ls8_eo3_dataset.id))
+        assert ds is not None
         assert ds.id == ls8_eo3_dataset.id
 
         (ds,) = index.datasets.bulk_get([tr(ls8_eo3_dataset.id)])
@@ -297,7 +336,9 @@ def test_transactions_api_ctx_mgr(
 
     resolver = Doc2Dataset(index, products=[ls8_eo3_product.name], verify_lineage=False)
     ds1, err = resolver(*eo3_ls8_dataset_doc)
+    assert ds1 is not None
     ds2, err = resolver(*eo3_ls8_dataset2_doc)
+    assert ds2 is not None
     with pytest.raises(Exception) as e:  # noqa: SIM117
         with index.transaction() as trans:
             assert index.datasets.get(ds1.id) is None
@@ -331,7 +372,9 @@ def test_transactions_api_ctx_mgr_nested(
 
     resolver = Doc2Dataset(index, products=[ls8_eo3_product.name], verify_lineage=False)
     ds1, err = resolver(*eo3_ls8_dataset_doc)
+    assert ds1 is not None
     ds2, err = resolver(*eo3_ls8_dataset2_doc)
+    assert ds2 is not None
     with pytest.raises(Exception) as e:  # noqa: SIM117
         with index.transaction():
             with index.transaction() as trans:
@@ -400,7 +443,9 @@ def test_transactions_api_hybrid(
 
     resolver = Doc2Dataset(index, products=[ls8_eo3_product.name], verify_lineage=False)
     ds1, err = resolver(*eo3_ls8_dataset_doc)
+    assert ds1 is not None
     ds2, err = resolver(*eo3_ls8_dataset2_doc)
+    assert ds2 is not None
     with index.transaction() as trans:
         assert index.datasets.get(ds1.id) is None
         index.datasets.add(ds1, False)
@@ -460,7 +505,7 @@ def test_index_dataset_with_sources(index: Index, default_metadata_type) -> None
     assert index.datasets.get(parent.id)
     assert index.datasets.get(child.id)
 
-    assert len(index.datasets.bulk_get([parent.id, child.id])) == 2
+    assert len(list(index.datasets.bulk_get([parent.id, child.id]))) == 2
 
     index.datasets.add(child, with_lineage=False)
     index.datasets.add(child, with_lineage=True)
@@ -478,6 +523,7 @@ def test_index_dataset_with_lineage(
     assert ds_with_lineage.source_tree
     index.datasets.add(ds_with_lineage)
     sources = index.lineage.get_source_tree(ds_with_lineage.id).children
+    assert sources is not None
     assert len(sources["ard"]) == 1
     assert sources["ard"][0].dataset_id == ls8_eo3_dataset.id
     assert index.datasets.get(ds_with_lineage.id)
@@ -491,10 +537,11 @@ def test_index_dataset_with_location(
     second_file = Path("/tmp/second/something.yaml").absolute()
 
     product = index.products.add_document(_pseudo_telemetry_dataset_type)
+    assert product is not None
     dataset = Dataset(product, _telemetry_dataset, uri=first_file.as_uri(), sources={})
     index.datasets.add(dataset)
     stored = index.datasets.get(dataset.id)
-
+    assert stored is not None
     assert stored.id == _telemetry_uuid
     # TODO: Dataset types?
     assert stored.product.id == product.id
@@ -599,6 +646,7 @@ def test_index_dataset_with_location(
             dataset.id, second_file.as_uri()
         )  # Test of deprecated method
         stored = index.datasets.get(dataset.id)
+        assert stored is not None
     assert len(stored._uris) == 2
 
     # Newest to oldest.
@@ -655,6 +703,7 @@ def test_index_dataset_with_location(
     with suppress_deprecations():
         index.datasets.add(dataset)
         stored = index.datasets.get(dataset.id)
+        assert stored is not None
         locations = index.datasets.get_locations(
             dataset.id
         )  # Test of deprecated method
@@ -684,7 +733,9 @@ def test_index_dataset_with_location(
         ]
 
         # test order using datasets.get(), it has custom query as it turns out
-        assert index.datasets.get(test_uuid)._uris == [
+        d = index.datasets.get(test_uuid)
+        assert d is not None
+        assert d._uris == [
             "file:///a",
             "file:///b",
         ]
@@ -704,9 +755,9 @@ def test_index_dataset_with_location(
             "file:///a",
             "file:///b",
         ]
-        assert index.datasets.get(
-            test_uuid
-        ).uris == [  # Test of deprecated functionality
+        d = index.datasets.get(test_uuid)
+        assert d is not None
+        assert d.uris == [  # Test of deprecated functionality
             "file:///c",
             "file:///d",
             "file:///a",

--- a/integration_tests/index/test_lineage.py
+++ b/integration_tests/index/test_lineage.py
@@ -47,6 +47,7 @@ def test_lineage_merge(index: Index, src_lineage_tree, compatible_derived_tree) 
     src_tree = index.lineage.get_source_tree(ids["root"])
     assert src_tree.dataset_id == ids["root"]
     assert src_tree.direction == LineageDirection.SOURCES
+    assert src_tree.children is not None
     for ard_subtree in src_tree.children["ard"]:
         assert ard_subtree.dataset_id in (ids["ard1"], ids["ard2"])
 
@@ -64,20 +65,25 @@ def test_lineage_tree_index_api_simple(index: Index, src_lineage_tree) -> None:
     src_tree = index.lineage.get_source_tree(ids["root"])
     assert src_tree.dataset_id == ids["root"]
     assert src_tree.direction == LineageDirection.SOURCES
+    assert src_tree.children is not None
     for ard_subtree in src_tree.children["ard"]:
         assert ard_subtree.dataset_id in (ids["ard1"], ids["ard2"])
         assert not ard_subtree.children
     # Add the test tree to depth 2
     index.lineage.add(tree, max_depth=2)
     src_tree = index.lineage.get_source_tree(ids["root"])
+    assert src_tree.children is not None
     for ard_subtree in src_tree.children["ard"]:
+        assert ard_subtree.children is not None
         assert "l1" in ard_subtree.children
         assert not ard_subtree.children["atmos_corr"][0].children
     # Add full test tree
     index.lineage.add(tree, max_depth=0)
     src_tree = index.lineage.get_source_tree(ids["root"])
     seen = False
+    assert src_tree.children is not None
     for ard_subtree in src_tree.children["ard"]:
+        assert ard_subtree.children is not None
         assert "l1" in ard_subtree.children
         assert "atmos_corr" in ard_subtree.children
         if ard_subtree.children["atmos_corr"][0].children:
@@ -86,7 +92,9 @@ def test_lineage_tree_index_api_simple(index: Index, src_lineage_tree) -> None:
     assert seen
     # And test reversing the tree
     der_tree = index.lineage.get_derived_tree(ids["atmos_parent"])
-    assert der_tree.find_subtree(ids["root"]).dataset_id == ids["root"]
+    subtree = der_tree.find_subtree(ids["root"])
+    assert subtree is not None
+    assert subtree.dataset_id == ids["root"]
     # Test Lineage removal - sourcewards
     index.lineage.remove(ids["root"], LineageDirection.SOURCES, max_depth=2)
     src_tree = index.lineage.get_source_tree(ids["root"])
@@ -117,6 +125,7 @@ def test_lineage_tree_index_api_consistent(
     tree2a = index.lineage.get_source_tree(ids["root"])
     assert tree2a.home == "extensions"
     tree2b = tree2a.find_subtree(ids["atmos"])
+    assert tree2b is not None
     tree2c = tree2b.find_subtree(ids["atmos_grandparent"])
     assert tree2c
 
@@ -153,39 +162,54 @@ def test_get_extensions(index: Index, dataset_with_external_lineage) -> None:
     dataset, src_lineage_tree, derived_lineage_tree, ids = dataset_with_external_lineage
 
     ds = index.datasets.get(ids["root"])
+    assert ds is not None
     assert ds.source_tree is None
     assert ds.derived_tree is None
 
     ds = index.datasets.get(ids["root"], include_sources=True)
+    assert ds is not None
     assert ds.source_tree is not None
     assert ds.derived_tree is None
+    assert ds.source_tree.children is not None
     assert ds.source_tree.children["ard"][0].children
 
     ds = index.datasets.get(ids["root"], include_sources=True, max_depth=1)
+    assert ds is not None
     assert ds.source_tree is not None
     assert ds.derived_tree is None
+    assert ds.source_tree.children is not None
     assert not ds.source_tree.children["ard"][0].children
 
     ds = index.datasets.get(ids["root"], include_deriveds=True)
+    assert ds is not None
     assert ds.source_tree is None
     assert ds.derived_tree is not None
+    assert ds.derived_tree.children is not None
     assert ds.derived_tree.children["dra"][0].children
 
     ds = index.datasets.get(ids["root"], include_deriveds=True, max_depth=1)
+    assert ds is not None
     assert ds.source_tree is None
     assert ds.derived_tree is not None
+    assert ds.derived_tree.children is not None
     assert not ds.derived_tree.children["dra"][0].children
 
     ds = index.datasets.get(ids["root"], include_sources=True, include_deriveds=True)
+    assert ds is not None
     assert ds.source_tree is not None
     assert ds.derived_tree is not None
+    assert ds.source_tree.children is not None
     assert ds.source_tree.children["ard"][0].children
+    assert ds.derived_tree.children is not None
     assert ds.derived_tree.children["dra"][0].children
 
     ds = index.datasets.get(
         ids["root"], include_sources=True, include_deriveds=True, max_depth=1
     )
+    assert ds is not None
     assert ds.source_tree is not None
     assert ds.derived_tree is not None
+    assert ds.source_tree.children is not None
     assert not ds.source_tree.children["ard"][0].children
+    assert ds.derived_tree.children is not None
     assert not ds.derived_tree.children["dra"][0].children

--- a/integration_tests/index/test_memory_index.py
+++ b/integration_tests/index/test_memory_index.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 import pytest
 
+import datacube.index.memory.index
 from datacube import Datacube
 from datacube.cfg import ODCEnvironment
 from datacube.model import Range
@@ -84,6 +85,7 @@ def test_mem_user_resource(mem_index_fresh: Datacube) -> None:
 
 
 def test_mem_metadatatype_resource(mem_index_fresh: Datacube) -> None:
+    assert isinstance(mem_index_fresh.index, datacube.index.memory.index.Index)
     assert len(mem_index_fresh.index.metadata_types.by_id) == len(
         mem_index_fresh.index.metadata_types.by_name
     )
@@ -136,6 +138,7 @@ def test_mem_product_resource(
     extended_eo3_product_doc,
     base_eo3_product_doc,
 ) -> None:
+    assert isinstance(mem_index_fresh.index, datacube.index.memory.index.Index)
     eo3 = mem_index_fresh.index.metadata_types.get_by_name("eo3")
     # Test Empty index works as expected:
     assert (
@@ -271,6 +274,7 @@ def test_mem_dataset_add_eo3(
 
     ds, err = resolver(doc_ls8, loc_ls8)
     assert err is None
+    assert ds is not None
     dc.index.datasets.add(ds)
     assert dc.index.datasets.has(doc_ls8["id"])
     ls8_ds = dc.index.datasets.get(doc_ls8["id"], include_sources=True)
@@ -280,6 +284,7 @@ def test_mem_dataset_add_eo3(
         datasets_with_unembedded_lineage_doc[1][1],
     )
     assert err is None
+    assert ds is not None
     dc.index.datasets.add(ds)
     assert list(dc.index.datasets.bulk_has((doc_ls8["id"], doc_wo["id"]))) == [
         True,
@@ -437,6 +442,7 @@ def test_mem_ds_updates(mem_eo3_data: tuple) -> None:
 
 
 def test_mem_ds_expand_periods(mem_index_fresh: Datacube) -> None:
+    assert isinstance(mem_index_fresh.index, datacube.index.memory.index.Index)
     periods = list(
         mem_index_fresh.index.datasets._expand_period(
             "1 day",
@@ -858,6 +864,7 @@ def test_mem_ds_count_product_through_time(mem_eo3_data: tuple) -> None:
 
 # Tests adapted from test_dataset_add
 def test_memory_dataset_add(dataset_add_configs, mem_index_fresh: Datacube) -> None:
+    assert isinstance(mem_index_fresh.index, datacube.index.memory.index.Index)
     idx = mem_index_fresh.index
     # Make sure index is empty
     assert list(idx.products.get_all()) == []
@@ -880,6 +887,7 @@ def test_memory_dataset_add(dataset_add_configs, mem_index_fresh: Datacube) -> N
         if err is not None:
             ds_bad_ids.add(ds_doc["id"])
             continue
+        assert ds is not None
         ds_ids.add(ds.id)
         idx.datasets.add(ds)
     for _, ds_doc in read_documents(dataset_add_configs.datasets_eo3):
@@ -964,7 +972,9 @@ def test_default_clone_bulk_ops_multiloc(
         assert mem_index_fresh.index.datasets.has(wo_eo3_dataset.id)
         assert mem_index_fresh.index.datasets.has(ls8_eo3_dataset.id)
         assert mem_index_fresh.index.datasets.has(ls8_eo3_dataset4.id)
-        assert len(mem_index_fresh.index.datasets.get(ls8_eo3_dataset.id)._uris) == 2
+        d = mem_index_fresh.index.datasets.get(ls8_eo3_dataset.id)
+        assert d is not None
+        assert len(d._uris) == 2
 
 
 @pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")

--- a/integration_tests/index/test_memory_index.py
+++ b/integration_tests/index/test_memory_index.py
@@ -95,9 +95,10 @@ def test_mem_metadatatype_resource(mem_index_fresh: Datacube) -> None:
     eo3 = mem_index_fresh.index.metadata_types.get_by_name("eo3")
     assert eo3 is not None and eo3.name == "eo3"
     # Verify we cannot mess with the cache
-    eo3.definition["description"] = "foo"
+    eo3.definition["description"] = "foo"  # type: ignore[index]
     eo3.definition["dataset"]["measurements"] = ["over_here", "measurements"]
     eo3_fresh = mem_index_fresh.index.metadata_types.get_by_name("eo3")
+    assert eo3_fresh is not None
     assert eo3.description != eo3_fresh.description
     assert (
         eo3.definition["dataset"]["measurements"]
@@ -107,9 +108,10 @@ def test_mem_metadatatype_resource(mem_index_fresh: Datacube) -> None:
     with pytest.raises(ValueError):
         mem_index_fresh.index.metadata_types.update(eo3)
     # Updating descriptions is safe.
-    eo3_fresh.definition["description"] = "New description"
+    eo3_fresh.definition["description"] = "New description"  # type: ignore[index]
     mem_index_fresh.index.metadata_types.update(eo3_fresh)
     eo3_fresher = mem_index_fresh.index.metadata_types.get_by_name("eo3")
+    assert eo3_fresher is not None
     assert eo3_fresher.description == eo3_fresh.description
     # Check get_with_fields
     platform_mdts = list(
@@ -140,6 +142,7 @@ def test_mem_product_resource(
 ) -> None:
     assert isinstance(mem_index_fresh.index, datacube.index.memory.index.Index)
     eo3 = mem_index_fresh.index.metadata_types.get_by_name("eo3")
+    assert eo3 is not None
     # Test Empty index works as expected:
     assert (
         list(mem_index_fresh.index.products.get_with_fields(("measurements", "extent")))
@@ -152,7 +155,9 @@ def test_mem_product_resource(
     wo_prod = mem_index_fresh.index.products.add_document(base_eo3_product_doc)
     assert wo_prod is not None
     assert wo_prod.name == "ga_ls_wo_3"
-    assert mem_index_fresh.index.products.get_by_name("ga_ls_wo_3").name == "ga_ls_wo_3"
+    p = mem_index_fresh.index.products.get_by_name("ga_ls_wo_3")
+    assert p is not None
+    assert p.name == "ga_ls_wo_3"
     # Attempt to add a product without a metadata type
     with pytest.raises(InvalidDocException):
         ls8_prod = mem_index_fresh.index.products.add_document(extended_eo3_product_doc)
@@ -163,16 +168,17 @@ def test_mem_product_resource(
     mem_index_fresh.index.metadata_types.add(eo3ext)
     # Add an extended eo3 product doc
     ls8_prod = mem_index_fresh.index.products.add_document(extended_eo3_product_doc)
+    assert ls8_prod is not None
     assert ls8_prod.name == "ga_ls8c_ard_3"
-    assert (
-        mem_index_fresh.index.products.get_by_name("ga_ls8c_ard_3").name
-        == "ga_ls8c_ard_3"
-    )
+    p = mem_index_fresh.index.products.get_by_name("ga_ls8c_ard_3")
+    assert p is not None
+    assert p.name == "ga_ls8c_ard_3"
     assert list(mem_index_fresh.index.products.get_with_types([eo3ext])) == [ls8_prod]
     # Verify we cannot mess with the cache
-    ls8_prod.definition["description"] = "foo"
+    ls8_prod.definition["description"] = "foo"  # type: ignore[index]
     ls8_prod.definition["measurements"][0]["name"] = "blueish"
     ls8_fresh = mem_index_fresh.index.products.get_by_name("ga_ls8c_ard_3")
+    assert ls8_fresh is not None
     assert ls8_prod.description != ls8_fresh.description
     assert (
         ls8_prod.definition["measurements"][0]["name"]
@@ -182,9 +188,10 @@ def test_mem_product_resource(
     with pytest.raises(ValueError):
         mem_index_fresh.index.products.update(ls8_prod)
     # Updating descriptions is safe.
-    ls8_fresh.definition["description"] = "New description"
+    ls8_fresh.definition["description"] = "New description"  # type: ignore[index]
     mem_index_fresh.index.products.update(ls8_fresh)
     ls8_fresher = mem_index_fresh.index.products.get_by_name("ga_ls8c_ard_3")
+    assert ls8_fresher is not None
     assert ls8_fresher.description == ls8_fresh.description
     # Test get_with_fields
     assert (
@@ -880,6 +887,7 @@ def test_memory_dataset_add(dataset_add_configs, mem_index_fresh: Datacube) -> N
     for _, ds_doc in read_documents(dataset_add_configs.datasets):
         ds, err = resolver(ds_doc, "file:///fake_uri")
         assert err is None
+        assert ds is not None
         ds_ids.add(ds.id)
         idx.datasets.add(ds)
     for _, ds_doc in read_documents(dataset_add_configs.datasets_bad1):
@@ -893,6 +901,7 @@ def test_memory_dataset_add(dataset_add_configs, mem_index_fresh: Datacube) -> N
     for _, ds_doc in read_documents(dataset_add_configs.datasets_eo3):
         ds, err = resolver(ds_doc, "file:///fake_eo3_uri")
         assert err is None
+        assert ds is not None
         ds_ids.add(ds.id)
         idx.datasets.add(ds)
 
@@ -907,10 +916,16 @@ def test_memory_dataset_add(dataset_add_configs, mem_index_fresh: Datacube) -> N
     ds_ = SimpleDocNav(gen_dataset_test_dag(1, force_tree=True))
     assert ds_.id in ds_ids
     ds_from_idx = idx.datasets.get(ds_.id, include_sources=True)
+    assert ds_from_idx is not None
+    assert ds_from_idx.sources is not None
     assert ds_from_idx.sources["ab"].id == ds_.sources["ab"].id
-    assert (
-        ds_from_idx.sources["ac"].sources["cd"].id == ds_.sources["ac"].sources["cd"].id
-    )
+    p1 = ds_from_idx.sources["ac"]
+    assert p1 is not None
+    assert p1.sources is not None
+    p2 = ds_.sources["ac"]
+    assert p2 is not None
+    assert p2.sources is not None
+    assert p1.sources["cd"].id == p2.sources["cd"].id
 
 
 def test_mem_transactions(mem_index_fresh: Datacube) -> None:

--- a/integration_tests/index/test_null_index.py
+++ b/integration_tests/index/test_null_index.py
@@ -154,7 +154,8 @@ def test_null_dataset_resource(null_config: ODCEnvironment) -> None:
         assert dc.index.datasets.search(foo="bar", baz=12) == []
         assert dc.index.datasets.search_by_product(foo="bar", baz=12) == []
         assert (
-            dc.index.datasets.search_returning(["foo", "bar"], foo="bar", baz=12) == []
+            list(dc.index.datasets.search_returning(["foo", "bar"], foo="bar", baz=12))
+            == []
         )
         assert dc.index.datasets.count(foo="bar", baz=12) == 0
         assert dc.index.datasets.count_by_product(foo="bar", baz=12) == []

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -16,6 +16,7 @@ import yaml
 from antimeridian import FixWindingWarning
 from dateutil.tz import UTC
 
+import datacube.scripts.cli_app
 import datacube.scripts.search_tool
 from datacube import Datacube
 from datacube.cfg import ODCEnvironment
@@ -55,7 +56,9 @@ def test_find_most_recent_change(
     assert dt == ls8_eo3_dataset3.indexed_time
     index.datasets.archive([ls8_eo3_dataset.id, ls8_eo3_dataset2.id])
     dt = index.products.most_recent_change(product.name)
-    assert dt == index.datasets.get(ls8_eo3_dataset2.id).archived_time
+    d = index.datasets.get(ls8_eo3_dataset2.id)
+    assert d is not None
+    assert dt == d.archived_time
 
 
 def test_search_dataset_equals_eo3(index: Index, ls8_eo3_dataset: Dataset) -> None:
@@ -540,12 +543,7 @@ def test_search_returning_eo3(
     assert count_by_date == 1
     results = list(
         index.datasets.search_returning(
-            (
-                "id",
-                "metadata_doc",
-            ),
-            platform="landsat-8",
-            instrument="OLI_TIRS",
+            ("id", "metadata_doc"), platform="landsat-8", instrument="OLI_TIRS"
         )
     )
     assert len(results) == 1
@@ -579,14 +577,10 @@ def test_search_returning_eo3(
     assert label == ls8_eo3_dataset.metadata.label
 
     # All Fields
-    results = list(
-        index.datasets.search_returning(
-            platform="landsat-8",
-        )
-    )
+    results = list(index.datasets.search_returning(platform="landsat-8"))
     assert len(results) == 3
 
-    assert ls8_eo3_dataset.id in (result.id for result in results)
+    assert ls8_eo3_dataset.id in (result.id for result in results)  # type: ignore[attr-defined]
 
 
 def test_search_returning_rows_eo3(
@@ -621,9 +615,9 @@ def test_search_returning_rows_eo3(
         )
     )
     assert len(results) == 1
-    assert results[0].id == dataset.id
-    assert 1.31 < results[0].cloud_shadow < 1.32
-    assert 34.58 < results[0].sun_azimuth < 34.59
+    assert results[0].id == dataset.id  # type: ignore[attr-defined]
+    assert 1.31 < results[0].cloud_shadow < 1.32  # type: ignore[attr-defined]
+    assert 34.58 < results[0].sun_azimuth < 34.59  # type: ignore[attr-defined]
 
     results = list(
         index.datasets.search_returning(
@@ -637,7 +631,7 @@ def test_search_returning_rows_eo3(
         )
     )
     assert len(results) == 1
-    assert 1.31 < results[0].cloud_shadow < 1.32
+    assert 1.31 < results[0].cloud_shadow < 1.32  # type: ignore[attr-defined]
 
     # A second dataset already has a location:
     results = set(
@@ -1064,7 +1058,9 @@ def test_cli_info_eo3(
     # Check indexed time separately, as we don't care what timezone it's displayed in.
     indexed_time = yaml_docs[0]["indexed"]
     assert isinstance(indexed_time, datetime.datetime)
-    assert tz_as_utc(indexed_time) == tz_as_utc(ls8_eo3_dataset.indexed_time)
+    t = ls8_eo3_dataset.indexed_time
+    assert t is not None
+    assert tz_as_utc(indexed_time) == tz_as_utc(t)
 
     # Request two, they should have separate yaml documents
     opts.append(str(ls8_eo3_dataset2.id))
@@ -1127,8 +1123,12 @@ def test_find_duplicates_with_time(
         warnings.simplefilter("ignore", FixWindingWarning)
         index.datasets.add(nrt_dataset, with_lineage=False)
         index.datasets.add(final_dataset, with_lineage=False)
-    assert not index.datasets.get(nrt_dataset.id).is_archived
-    assert not index.datasets.get(final_dataset.id).is_archived
+    d = index.datasets.get(nrt_dataset.id)
+    assert d is not None
+    assert not d.is_archived
+    d = index.datasets.get(final_dataset.id)
+    assert d is not None
+    assert not d.is_archived
 
     all_datasets = list(index.datasets.search())
     assert len(all_datasets) == 3

--- a/integration_tests/index/test_search_legacy.py
+++ b/integration_tests/index/test_search_legacy.py
@@ -19,6 +19,8 @@ from dateutil.tz import UTC
 from odc.geo import CRS
 from sqlalchemy.dialects.postgresql.ranges import Range as SQLARange
 
+import datacube.index.postgis.index
+import datacube.index.postgres.index
 from datacube import Datacube
 from datacube.cfg import ODCEnvironment
 from datacube.cfg.opt import _DEFAULT_DB_USER
@@ -54,6 +56,9 @@ def pseudo_ls8_type(index: Index, ga_metadata_type):
 @pytest.fixture
 def pseudo_ls8_dataset(index: Index, pseudo_ls8_type):
     id_ = str(uuid.uuid4())
+    assert isinstance(
+        index, datacube.index.postgres.index.Index | datacube.index.postgis.index.Index
+    )
     with index._active_connection() as connection:
         was_inserted = connection.insert_dataset(
             {
@@ -93,6 +98,7 @@ def pseudo_ls8_dataset(index: Index, pseudo_ls8_type):
         )
     assert was_inserted
     d = index.datasets.get(id_)
+    assert d is not None
     # The dataset should have been matched to the telemetry type.
     assert d.product.id == pseudo_ls8_type.id
 
@@ -103,6 +109,9 @@ def pseudo_ls8_dataset(index: Index, pseudo_ls8_type):
 def pseudo_ls8_dataset2(index: Index, pseudo_ls8_type):
     # Like the previous dataset, but a day later in time.
     id_ = str(uuid.uuid4())
+    assert isinstance(
+        index, datacube.index.postgres.index.Index | datacube.index.postgis.index.Index
+    )
     with index._active_connection() as connection:
         was_inserted = connection.insert_dataset(
             {
@@ -142,6 +151,7 @@ def pseudo_ls8_dataset2(index: Index, pseudo_ls8_type):
         )
     assert was_inserted
     d = index.datasets.get(id_)
+    assert d is not None
     # The dataset should have been matched to the telemetry type.
     assert d.product.id == pseudo_ls8_type.id
 
@@ -161,11 +171,14 @@ def pseudo_ls8_dataset3(
         "satellite_ref_point_start": {"x": 116, "y": 85},
         "satellite_ref_point_end": {"x": 116, "y": 87},
     }
-
+    assert isinstance(
+        index, datacube.index.postgres.index.Index | datacube.index.postgis.index.Index
+    )
     with index._active_connection() as connection:
         was_inserted = connection.insert_dataset(dataset_doc, id_, pseudo_ls8_type.id)
     assert was_inserted
     d = index.datasets.get(id_)
+    assert d is not None
     # The dataset should have been matched to the telemetry type.
     assert d.product.id == pseudo_ls8_type.id
     return d
@@ -183,11 +196,14 @@ def pseudo_ls8_dataset4(
         "satellite_ref_point_start": {"x": 116, "y": 85},
         "satellite_ref_point_end": {"x": 116, "y": 87},
     }
-
+    assert isinstance(
+        index, datacube.index.postgres.index.Index | datacube.index.postgis.index.Index
+    )
     with index._active_connection() as connection:
         was_inserted = connection.insert_dataset(dataset_doc, id_, pseudo_ls8_type.id)
         assert was_inserted
         d = index.datasets.get(id_)
+        assert d is not None
         # The dataset should have been matched to the telemetry type.
         assert d.product.id == pseudo_ls8_type.id
         return d
@@ -199,6 +215,7 @@ def ls5_dataset_w_children(
 ):
     clirunner(["dataset", "add", str(example_ls5_dataset_path)])
     doc = load_dataset_definition(example_ls5_dataset_path)
+    assert doc is not None
     return index.datasets.get(doc.id, include_sources=True)
 
 
@@ -754,21 +771,34 @@ def test_get_dataset_with_children(
 
     # Sources not loaded by default
     d = index.datasets.get(id_)
+    assert d is not None
     assert d.sources is None
 
     # Ask for all sources
     d = index.datasets.get(id_, include_sources=True)
+    assert d is not None
+    assert d.sources is not None
     assert list(d.sources.keys()) == ["level1"]
     level1 = d.sources["level1"]
+    assert level1.sources is not None
     assert list(level1.sources.keys()) == ["satellite_telemetry_data"]
-    assert list(level1.sources["satellite_telemetry_data"].sources) == []
+    sources = level1.sources["satellite_telemetry_data"]
+    assert sources.sources is not None
+    assert list(sources.sources) == []
 
     # It should also work with a string id
     d = index.datasets.get(str(id_), include_sources=True)
-    assert list(d.sources.keys()) == ["level1"]
-    level1 = d.sources["level1"]
-    assert list(level1.sources.keys()) == ["satellite_telemetry_data"]
-    assert list(level1.sources["satellite_telemetry_data"].sources) == []
+    assert d is not None
+    sources = d.sources
+    assert sources is not None
+    assert list(sources.keys()) == ["level1"]
+    level1 = sources["level1"]
+    sources = level1.sources
+    assert sources is not None
+    assert list(sources.keys()) == ["satellite_telemetry_data"]
+    s = sources["satellite_telemetry_data"]
+    assert s.sources is not None
+    assert list(s.sources) == []
 
 
 @pytest.mark.parametrize("datacube_env_name", ("datacube",))
@@ -925,7 +955,9 @@ def test_cli_info(
     # Check indexed time separately, as we don't care what timezone it's displayed in.
     indexed_time = yaml_docs[0]["indexed"]
     assert isinstance(indexed_time, datetime.datetime)
-    assert tz_as_utc(indexed_time) == tz_as_utc(pseudo_ls8_dataset.indexed_time)
+    t = pseudo_ls8_dataset.indexed_time
+    assert t is not None
+    assert tz_as_utc(indexed_time) == tz_as_utc(t)
 
     # Request two, they should have separate yaml documents
     opts.append(str(pseudo_ls8_dataset2.id))
@@ -1012,10 +1044,7 @@ def test_find_duplicates(
     ]
     f = pseudo_ls8_type.metadata_type.dataset_fields.get
     field_res = list(
-        index.datasets.search_product_duplicates(
-            pseudo_ls8_type,
-            f("time").lower.day,  # type: ignore
-        )
+        index.datasets.search_product_duplicates(pseudo_ls8_type, f("time").lower.day)
     )
 
     # Datasets 1 & 3 are on the 26th.

--- a/tests/api/test_core.py
+++ b/tests/api/test_core.py
@@ -39,7 +39,8 @@ def test_grouping_datasets() -> None:
     ]
 
     group_by = GroupBy(group_func, dimension, units, sort_key=group_func)
-    grouped = Datacube.group_datasets(datasets, group_by)
+    # FIXME: Dataset expected.
+    grouped = Datacube.group_datasets(datasets, group_by)  # type: ignore[arg-type]
     dss = grouped.isel(time=0).values[()]
     assert isinstance(dss, tuple)
     assert len(dss) == 2
@@ -51,7 +52,8 @@ def test_grouping_datasets() -> None:
     assert [ds.value for ds in dss] == ["bar"]
 
     assert str(grouped.time.dtype) == "datetime64[ns]"
-    assert grouped.loc["2016-01-01":"2016-01-15"]
+    # FIXME: Illegal slice index.
+    assert grouped.loc["2016-01-01":"2016-01-15"]  # type: ignore[misc]
 
 
 def test_group_datasets_by_time() -> None:
@@ -65,7 +67,8 @@ def test_group_datasets_by_time() -> None:
     assert ds2.center_time.tzinfo is None
     assert ds3.center_time.tzinfo is not None
 
-    xx = Datacube.group_datasets([ds1, ds2, ds3], "time")
+    # FIXME: GroupBy expected.
+    xx = Datacube.group_datasets([ds1, ds2, ds3], "time")  # type: ignore[arg-type]
     assert xx.time.shape == (2,)
     assert len(xx.data[0]) == 2
     assert len(xx.data[1]) == 1
@@ -77,12 +80,12 @@ def test_grouped_datasets_should_be_in_consistent_order() -> None:
         {"time": datetime.datetime(2016, 1, 1, 0, 2), "value": "flim"},
         {"time": datetime.datetime(2016, 2, 1, 0, 1), "value": "bar"},
     ]
-
-    grouped = _group_datasets_by_date(datasets)
+    # FIXME: GroupBy expected.
+    grouped = _group_datasets_by_date(datasets)  # type: ignore[arg-type]
 
     # Swap the two elements which get grouped together
     datasets[0], datasets[1] = datasets[1], datasets[0]
-    grouped_2 = _group_datasets_by_date(datasets)
+    grouped_2 = _group_datasets_by_date(datasets)  # type: ignore[arg-type]
 
     assert len(grouped) == len(grouped_2) == 2
     assert all(grouped.values == grouped_2.values)

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -285,13 +285,15 @@ def test_solar_day() -> None:
         metadata=_s(lon=Range(begin=150.415, end=152.975)),
     )
 
-    assert solar_day(ds) == np.datetime64("1987-05-23", "D")
-    assert solar_day(ds, longitude=0) == np.datetime64("1987-05-22", "D")
+    # FIXME: Dataset expected.
+    assert solar_day(ds) == np.datetime64("1987-05-23", "D")  # type: ignore[arg-type]
+    assert solar_day(ds, longitude=0) == np.datetime64("1987-05-22", "D")  # type: ignore[arg-type]
 
     ds.metadata = _s()
 
     with pytest.raises(ValueError) as e:
-        solar_day(ds)
+        # FIXME: Dataset expected.
+        solar_day(ds)  # type: ignore[arg-type]
 
     assert "Cannot compute solar_day: dataset is missing spatial info" in str(e.value)
 
@@ -300,8 +302,9 @@ def test_solar_day() -> None:
         center_time=parse_time("1997-05-22 22:07:44.2270250-7:00"),
         metadata=_s(lon=Range(begin=-136.615, end=-134.325)),
     )
-    assert solar_day(ds) == np.datetime64("1997-05-22", "D")
-    assert solar_day(ds, longitude=0) == np.datetime64("1997-05-23", "D")
+    # FIXME: Dataset expected.
+    assert solar_day(ds) == np.datetime64("1997-05-22", "D")  # type: ignore[arg-type]
+    assert solar_day(ds, longitude=0) == np.datetime64("1997-05-23", "D")  # type: ignore[arg-type]
 
 
 def test_solar_offset() -> None:
@@ -329,11 +332,13 @@ def test_solar_offset() -> None:
         center_time=parse_time("1987-05-22 23:07:44.2270250Z"),
         metadata=_s(lon=Range(begin=150.415, end=152.975)),
     )
-    assert solar_offset(ds) == timedelta(hours=10)
+    # FIXME: Geometry | Dataset expected.
+    assert solar_offset(ds) == timedelta(hours=10)  # type: ignore[arg-type]
     ds.metadata = _s()
 
     with pytest.raises(ValueError):
-        solar_offset(ds)
+        # FIXME: Geometry | Dataset expected.
+        solar_offset(ds)  # type: ignore[arg-type]
 
 
 def test_dateline_query_building() -> None:

--- a/tests/index/test_api_index_dataset.py
+++ b/tests/index/test_api_index_dataset.py
@@ -6,10 +6,13 @@ import datetime
 from collections import namedtuple
 from contextlib import contextmanager
 from copy import deepcopy
+from typing import cast
 from uuid import UUID
 
+from datacube.drivers.postgres import PostgresDb
 from datacube.index.exceptions import DuplicateRecordError
 from datacube.index.postgres._datasets import DatasetResource
+from datacube.index.postgres.index import Index
 from datacube.model import Dataset, MetadataType, Product
 
 _nbar_uuid = UUID("f2f12372-8366-11e5-817e-1040f381a756")
@@ -227,7 +230,7 @@ class MockIndex:
 def test_index_dataset() -> None:
     mock_db = MockDb()
     mock_index = MockIndex(mock_db, _EXAMPLE_PRODUCT)
-    datasets = DatasetResource(mock_db, mock_index)
+    datasets = DatasetResource(cast(PostgresDb, mock_db), cast(Index, mock_index))
     datasets.add(_EXAMPLE_NBAR_DATASET)
 
     ids = {d.id for d in mock_db.dataset.values()}
@@ -253,7 +256,7 @@ def test_index_dataset() -> None:
 def test_index_already_ingested_source_dataset() -> None:
     mock_db = MockDb()
     mock_index = MockIndex(mock_db, _EXAMPLE_PRODUCT)
-    datasets = DatasetResource(mock_db, mock_index)
+    datasets = DatasetResource(cast(PostgresDb, mock_db), cast(Index, mock_index))
     datasets.add(_EXAMPLE_NBAR_DATASET.sources["ortho"])
 
     assert len(mock_db.dataset) == 2
@@ -267,7 +270,7 @@ def test_index_already_ingested_source_dataset() -> None:
 def test_index_two_levels_already_ingested() -> None:
     mock_db = MockDb()
     mock_index = MockIndex(mock_db, _EXAMPLE_PRODUCT)
-    datasets = DatasetResource(mock_db, mock_index)
+    datasets = DatasetResource(cast(PostgresDb, mock_db), cast(Index, mock_index))
     datasets.add(
         _EXAMPLE_NBAR_DATASET.sources["ortho"].sources["satellite_telemetry_data"]
     )

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -84,7 +84,7 @@ def test_progress_cbk() -> None:
         output_data,
         mk_gbox(shape, crs=crs),
         dst_nodata=no_data,
-        progress_cbk=lambda *a: _cbk(*a, cbk_args),
+        progress_cbk=lambda a, b: _cbk(a, b, cbk_args),
     )
 
     assert cbk_args == [(1, 1)]
@@ -95,7 +95,7 @@ def test_progress_cbk() -> None:
         output_data,
         mk_gbox(shape, crs=crs),
         dst_nodata=no_data,
-        progress_cbk=lambda *a: _cbk(*a, cbk_args),
+        progress_cbk=lambda a, b: _cbk(a, b, cbk_args),
     )
 
     assert cbk_args == [(1, 2), (2, 2)]

--- a/tests/storage/test_storage_load.py
+++ b/tests/storage/test_storage_load.py
@@ -59,7 +59,8 @@ def test_new_xr_load(data_folder) -> None:
 
     ds = mk_sample_dataset([band_a, band_b], base)
 
-    sources = Datacube.group_datasets([ds], "time")
+    # FIXME: GroupBy expected.
+    sources = Datacube.group_datasets([ds], "time")  # type: ignore[arg-type]
 
     im, meta = rio_slurp(str(data_folder) + "/test.tif")
     measurements = [ds.product.measurements[n] for n in ("a", "b")]

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -59,7 +59,8 @@ def test_load_data(tmpdir) -> None:
     assert ds.time is not None
     assert ds.time == ds2.time
 
-    sources = Datacube.group_datasets([ds], "time")
+    # FIXME: GroupBy expected.
+    sources = Datacube.group_datasets([ds], "time")  # type: ignore[arg-type]
     sources2 = Datacube.group_datasets([ds, ds2], group_by)
 
     mm = ["aa"]
@@ -112,7 +113,8 @@ def test_load_data_dask(tmp_path) -> None:
         **spatial,
     )
 
-    sources = Datacube.group_datasets([ds], "time")
+    # FIXME: GroupBy expected
+    sources = Datacube.group_datasets([ds], "time")  # type: ignore[arg-type]
     mm = ds.product.measurements
 
     import dask
@@ -176,7 +178,8 @@ def test_load_data_with_url_mangling(tmpdir) -> None:
     assert ds.time is not None
     assert ds.time == ds2.time
 
-    sources = Datacube.group_datasets([ds], "time")
+    # FIXME: GroupBy expected.
+    sources = Datacube.group_datasets([ds], "time")  # type: ignore[arg-type]
     sources2 = Datacube.group_datasets([ds, ds2], group_by)
 
     mm = ["aa"]
@@ -247,7 +250,8 @@ def test_load_data_cbk(tmpdir) -> None:
     assert ds.time is not None
     assert ds.time == ds2.time
 
-    sources = Datacube.group_datasets([ds, ds2], "time")
+    # FIXME: GroupBy expected.
+    sources = Datacube.group_datasets([ds, ds2], "time")  # type: ignore[arg-type]
     progress_call_data = []
 
     def progress_cbk(n, nt) -> None:

--- a/tests/test_new_loader.py
+++ b/tests/test_new_loader.py
@@ -30,7 +30,8 @@ def test_with_driver(tmpdir) -> None:
     assert ds.time is not None
     mm = ["aa"]
     mm = [ds.product.measurements[k] for k in mm]
-    sources = Datacube.group_datasets([ds], "time")
+    # FIXME: GroupBy expected.
+    sources = Datacube.group_datasets([ds], "time")  # type: ignore[arg-type]
 
     ds_data = Datacube.load_data(sources, geobox, mm, driver="rio", dask_chunks={})
     assert ds_data is not None

--- a/tests/test_utils_docs.py
+++ b/tests/test_utils_docs.py
@@ -338,7 +338,8 @@ A:..:0
 
     leaf = SimpleNamespace(id="N", sources=None)
     out = []
-    traverse_datasets(leaf, visitor, out=out)
+    # FIX;E: Dataset | SimpleDocNav expected.
+    traverse_datasets(leaf, visitor, out=out)  # type: ignore[arg-type]
     assert out == ["N:..:0"]
 
 
@@ -602,7 +603,8 @@ def test_netcdf_strings() -> None:
 
 
 def test_doc_reader() -> None:
-    d = DocReader({"lat": ["extent", "lat"]}, {}, doc={"extent": {"lat": 4}})
+    # FIXME: Field expected in doc Mapping.
+    d = DocReader({"lat": ["extent", "lat"]}, {}, doc={"extent": {"lat": 4}})  # type: ignore[dict-item]
     assert hasattr(d, "lat")
     assert d.lat == 4
     assert d.doc == {"extent": {"lat": 4}}


### PR DESCRIPTION
### Reason for this pull request

Wiggle some type signatures and insert some ignores in the tests so the CI can typecheck the tests.

The bulk of these changes are just asserting that the return value is not none from the get methods. The other major thing when counting changed lines is the update to the docstring for `search_returning()` since that was out of sync with the abstract class. Since I was touching those lines anyways, I added line breaks to reduce the number of lines that contain 100+ characters.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2071.org.readthedocs.build/en/2071/

<!-- readthedocs-preview opendatacube end -->