### PR TITLE
CI: run code coverage earlier

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,14 @@ jobs:
             integration_tests"
         docker compose down
 
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+      with:
+        files: ./coverage.xml
+        disable_search: true
+        fail_ci_if_error: false
+        token: ${{ secrets.CODECOV_TOKEN }}
+
     - name: Install uv
       uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc # v6.4.3
 
@@ -81,11 +89,3 @@ jobs:
     - name: Upload package to PyPI on GitHub Release
       if: "github.repository_owner == 'opendatacube' && github.event.action == 'published'"
       uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # release/v1
-
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
-      with:
-        files: ./coverage.xml
-        disable_search: true
-        fail_ci_if_error: false
-        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### Reason for this pull request

Perform the code coverage action
as soon as there is coverage information
available.

This gives a contributor as much information
as possible from a single (failing)
CI-invocation on a pull request.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2076.org.readthedocs.build/en/2076/

<!-- readthedocs-preview opendatacube end -->