### PR TITLE
Consolidate stac/eo3 conversion logic

### DIFF
--- a/datacube/metadata/__init__.py
+++ b/datacube/metadata/__init__.py
@@ -7,8 +7,10 @@ Datacube metadata generation from STAC.
 """
 
 from ._eo3converter import infer_dc_product, stac2ds
+from ._stacconverter import ds2stac
 
 __all__ = (
+    "ds2stac",
     "infer_dc_product",
     "stac2ds",
 )

--- a/datacube/metadata/_eo3converter.py
+++ b/datacube/metadata/_eo3converter.py
@@ -185,6 +185,7 @@ def _to_eo3_properties(properties: dict[str, Any]) -> dict[str, Any]:
     prop = {
         STAC_TO_EO3_RENAMES.get(key, key): _to_eo3_type(key, val)
         for key, val in properties.items()
+        if not key.startswith("proj:")
     }
 
     if prop.get("odc:processing_datetime") is None:
@@ -194,10 +195,6 @@ def _to_eo3_properties(properties: dict[str, Any]) -> dict[str, Any]:
     if prop.get("odc:file_format") is None:
         prop["odc:file_format"] = "GeoTIFF"
 
-    for key in list(prop.keys()):
-        if key.startswith("proj:"):
-            prop.pop(key)
-
     return prop
 
 
@@ -206,7 +203,7 @@ def _to_dataset(
     properties: dict[str, Any],
     ds_uuid: uuid.UUID,
     product: Product,
-    geometry,
+    geometry: dict[str, Any] | None,
 ) -> Dataset:
     # pylint: disable=too-many-locals
 
@@ -266,7 +263,6 @@ def _to_dataset(
         crs = EPSG4326
 
     # lineage = properties.pop("odc:lineage", {})
-    geom = Geometry(geometry, 4326).to_crs(crs)
 
     ds_doc = {
         "$schema": "https://schemas.opendatacube.org/dataset",
@@ -274,12 +270,14 @@ def _to_dataset(
         "product": {"name": product.name.lower()},
         "crs": str(crs),
         "grids": grids,
-        "geometry": geom.json,
         "measurements": measurements,
         "properties": _to_eo3_properties(properties),
         "accessories": item.accessories,
         "lineage": {},  # TODO: properly handling lineage requires an Index
     }
+
+    if geometry is not None:
+        ds_doc["geometry"] = Geometry(geometry, 4326).to_crs(crs).json
 
     title = ds_doc["properties"].pop("title", None)
     if title is not None:

--- a/datacube/metadata/_eo3converter.py
+++ b/datacube/metadata/_eo3converter.py
@@ -11,10 +11,11 @@ Utilities for translating STAC Items to EO3 Datasets.
 import dataclasses
 import uuid
 from collections.abc import Iterable, Iterator, Sequence
+from datetime import datetime
 from functools import singledispatch
 from typing import Any
 
-from odc.geo import CRS
+from odc.geo import CRS, Geometry
 from odc.geo.geobox import GeoBox
 from odc.loader.types import (  # TODO: after loader 0.6.0 - add RasterSource
     BandKey,
@@ -34,7 +35,6 @@ from odc.stac.model import (
     RasterCollectionMetadata,
 )
 from pystac import Collection, Item
-from toolz import dicttoolz
 
 from datacube.index.abstract import default_metadata_type_docs
 from datacube.index.eo3 import prep_eo3
@@ -57,6 +57,7 @@ STAC_TO_EO3_RENAMES = {
     "view:azimuth": "eo:azimuth",
     "view:sun_azimuth": "eo:sun_azimuth",
     "view:sun_elevation": "eo:sun_elevation",
+    "created": "odc:processing_datetime",
 }
 
 (_eo3,) = (
@@ -160,12 +161,12 @@ def _compute_uuid(
 
 
 def _to_grid(gbox: GeoBox) -> dict[str, Any]:
-    return {"shape": gbox.shape.yx, "transform": gbox.transform[:6]}  # type: ignore[index]
+    return {"shape": list(gbox.shape.yx), "transform": list(gbox.transform)}  # type: ignore[index]
 
 
 def _to_eo3_properties(properties: dict[str, Any]) -> dict[str, Any]:
     """
-    Convert EO3 properties dictionary to the Stac equivalent.
+    Convert STAC properties dictionary to the EO3 equivalent.
     """
 
     def _to_eo3_type(key: str, value):
@@ -174,6 +175,10 @@ def _to_eo3_properties(properties: dict[str, Any]) -> dict[str, Any]:
                 return "_".join([i.upper() for i in value])
             else:
                 return None
+        elif key == "created" or "datetime" in key:
+            if isinstance(value, str):
+                return datetime.fromisoformat(value)
+            return value
         else:
             return value
 
@@ -181,16 +186,17 @@ def _to_eo3_properties(properties: dict[str, Any]) -> dict[str, Any]:
         STAC_TO_EO3_RENAMES.get(key, key): _to_eo3_type(key, val)
         for key, val in properties.items()
     }
-    creation_time = (
-        properties.get("odc:processing_datetime")
-        or properties.get("created")
-        or properties.get("datetime")
-    )
-    if prop.get("odc:processing_datetime") is None and creation_time:
-        prop["odc:processing_datetime"] = creation_time
+
+    if prop.get("odc:processing_datetime") is None:
+        # default to datetime value if no created
+        prop["odc:processing_datetime"] = properties.get("datetime")
 
     if prop.get("odc:file_format") is None:
         prop["odc:file_format"] = "GeoTIFF"
+
+    for key in list(prop.keys()):
+        if key.startswith("proj:"):
+            prop.pop(key)
 
     return prop
 
@@ -200,6 +206,7 @@ def _to_dataset(
     properties: dict[str, Any],
     ds_uuid: uuid.UUID,
     product: Product,
+    geometry,
 ) -> Dataset:
     # pylint: disable=too-many-locals
 
@@ -209,13 +216,20 @@ def _to_dataset(
     measurements: dict[str, dict[str, Any]] = {}
     crs: CRS | None = None
 
+    for key in ["proj:code", "proj:epsg", "proj:wkt2"]:
+        if key in properties:
+            crs = CRS(properties.get(key))
+
     for band_key, src in item.bands.items():
         name, idx = band_key
 
         m: dict[str, Any] = {"path": src.uri}
         if idx > 1:
             m["band"] = idx
-        measurements[name] = m
+        try:
+            measurements[product.canonical_measurement(name)] = m
+        except ValueError:
+            measurements[name] = m
 
         if not md.has_proj:
             continue
@@ -245,12 +259,13 @@ def _to_dataset(
 
         gbox = mk_1x1_geobox(item.geometry)
         grids["default"] = _to_grid(gbox)
-        crs = gbox.crs
+        crs = gbox.crs  # should this replace item proj:code if it exists?
 
     if crs is None:
         crs = EPSG4326
 
-    lineage = properties.pop("odc:lineage", {})
+    # lineage = properties.pop("odc:lineage", {})
+    geom = Geometry(geometry, 4326).to_crs(crs)
 
     ds_doc = {
         "$schema": "https://schemas.opendatacube.org/dataset",
@@ -258,15 +273,18 @@ def _to_dataset(
         "product": {"name": product.name.lower()},
         "crs": str(crs),
         "grids": grids,
-        "measurements": dicttoolz.keymap(
-            lambda k: product.canonical_measurement(k), measurements
-        ),
+        "geometry": geom.json,
+        "measurements": measurements,
         "properties": _to_eo3_properties(properties),
         "accessories": item.accessories,
-        "lineage": lineage,
+        "lineage": {},  # TODO: properly handling lineage requires an Index
     }
 
-    # Note: this bypasses consistency and lineage checks
+    title = ds_doc["properties"].pop("title", None)
+    if title is not None:
+        ds_doc["label"] = title
+
+    # TODO: this need to use Doc2Ds for consistency checks and lineage handling
     return Dataset(product, prep_eo3(ds_doc), uri=item.href)
 
 
@@ -289,7 +307,7 @@ def _item_to_ds(
     )
     _item = parse_item(item, md)
 
-    return _to_dataset(_item, item.properties, ds_uuid, product)
+    return _to_dataset(_item, item.properties, ds_uuid, product, item.geometry)
 
 
 def stac2ds(

--- a/datacube/metadata/_eo3converter.py
+++ b/datacube/metadata/_eo3converter.py
@@ -11,7 +11,6 @@ Utilities for translating STAC Items to EO3 Datasets.
 import dataclasses
 import uuid
 from collections.abc import Iterable, Iterator, Sequence
-from datetime import datetime
 from functools import singledispatch
 from typing import Any
 
@@ -40,25 +39,11 @@ from datacube.index.abstract import default_metadata_type_docs
 from datacube.index.eo3 import prep_eo3
 from datacube.model import Dataset, Product, metadata_from_doc
 
+from ._utils import stac_to_eo3_properties
+
 # uuid.uuid5(uuid.NAMESPACE_URL, "https://stacspec.org")
 UUID_NAMESPACE_STAC = uuid.UUID("55d26088-a6d0-5c77-bf9a-3a7f3c6a6dab")
 
-# Mapping between EO3 field names and STAC properties object field names
-# EO3 metadata was defined before STAC 1.0, so we used some extensions
-# that are now part of the standard instead
-STAC_TO_EO3_RENAMES = {
-    "end_datetime": "dtr:end_datetime",
-    "start_datetime": "dtr:start_datetime",
-    "gsd": "eo:gsd",
-    "instruments": "eo:instrument",
-    "platform": "eo:platform",
-    "constellation": "eo:constellation",
-    "view:off_nadir": "eo:off_nadir",
-    "view:azimuth": "eo:azimuth",
-    "view:sun_azimuth": "eo:sun_azimuth",
-    "view:sun_elevation": "eo:sun_elevation",
-    "created": "odc:processing_datetime",
-}
 
 (_eo3,) = (
     metadata_from_doc(d) for d in default_metadata_type_docs() if d.get("name") == "eo3"
@@ -161,41 +146,7 @@ def _compute_uuid(
 
 
 def _to_grid(gbox: GeoBox) -> dict[str, Any]:
-    return {"shape": list(gbox.shape.yx), "transform": list(gbox.transform[:])}  # type: ignore[index]
-
-
-def _to_eo3_properties(properties: dict[str, Any]) -> dict[str, Any]:
-    """
-    Convert STAC properties dictionary to the EO3 equivalent.
-    """
-
-    def _to_eo3_type(key: str, value):
-        if key == "instruments":
-            if len(value) > 0:
-                return "_".join([i.upper() for i in value])
-            else:
-                return None
-        elif key == "created" or "datetime" in key:
-            if isinstance(value, str):
-                return datetime.fromisoformat(value)
-            return value
-        else:
-            return value
-
-    prop = {
-        STAC_TO_EO3_RENAMES.get(key, key): _to_eo3_type(key, val)
-        for key, val in properties.items()
-        if not key.startswith("proj:")
-    }
-
-    if prop.get("odc:processing_datetime") is None:
-        # default to datetime value if no created
-        prop["odc:processing_datetime"] = properties.get("datetime")
-
-    if prop.get("odc:file_format") is None:
-        prop["odc:file_format"] = "GeoTIFF"
-
-    return prop
+    return {"shape": gbox.shape.yx, "transform": gbox.transform.to_shapely()}
 
 
 def _to_dataset(
@@ -244,7 +195,7 @@ def _to_dataset(
             continue
         assert isinstance(gbox, GeoBox)
 
-        if crs is None:
+        if crs is None and grid_name == "default":
             crs = gbox.crs
 
         if grid_name not in grids:
@@ -271,7 +222,7 @@ def _to_dataset(
         "crs": str(crs),
         "grids": grids,
         "measurements": measurements,
-        "properties": _to_eo3_properties(properties),
+        "properties": stac_to_eo3_properties(properties),
         "accessories": item.accessories,
         "lineage": {},  # TODO: properly handling lineage requires an Index
     }

--- a/datacube/metadata/_eo3converter.py
+++ b/datacube/metadata/_eo3converter.py
@@ -161,7 +161,7 @@ def _compute_uuid(
 
 
 def _to_grid(gbox: GeoBox) -> dict[str, Any]:
-    return {"shape": list(gbox.shape.yx), "transform": list(gbox.transform[:])}
+    return {"shape": list(gbox.shape.yx), "transform": list(gbox.transform[:])}  # type: ignore[index]
 
 
 def _to_eo3_properties(properties: dict[str, Any]) -> dict[str, Any]:
@@ -406,5 +406,5 @@ def infer_dc_product_from_collection(
     # unless configured to ignore projection info assume that it will be present
     ignore_proj = cfg.get(product.name, {}).get("ignore_proj", False)
     if not ignore_proj:
-        product._stac = dataclasses.replace(product._stac, has_proj=True)
+        product._stac = dataclasses.replace(product._stac, has_proj=True)  # type: ignore[type-var]
     return product

--- a/datacube/metadata/_eo3converter.py
+++ b/datacube/metadata/_eo3converter.py
@@ -279,7 +279,7 @@ def _to_dataset(
     if geometry is not None:
         ds_doc["geometry"] = Geometry(geometry, 4326).to_crs(crs).json
 
-    title = ds_doc["properties"].pop("title", None)
+    title = ds_doc["properties"].pop("title", None)  # type: ignore[attr-defined]
     if title is not None:
         ds_doc["label"] = title
 

--- a/datacube/metadata/_eo3converter.py
+++ b/datacube/metadata/_eo3converter.py
@@ -259,7 +259,8 @@ def _to_dataset(
 
         gbox = mk_1x1_geobox(item.geometry)
         grids["default"] = _to_grid(gbox)
-        crs = gbox.crs  # should this replace item proj:code if it exists?
+        if crs is None:
+            crs = gbox.crs
 
     if crs is None:
         crs = EPSG4326

--- a/datacube/metadata/_eo3converter.py
+++ b/datacube/metadata/_eo3converter.py
@@ -14,8 +14,6 @@ from collections.abc import Iterable, Iterator, Sequence
 from functools import singledispatch
 from typing import Any
 
-import pystac.collection
-import pystac.item
 from odc.geo import CRS
 from odc.geo.geobox import GeoBox
 from odc.loader.types import (  # TODO: after loader 0.6.0 - add RasterSource
@@ -35,6 +33,7 @@ from odc.stac.model import (
     ParsedItem,
     RasterCollectionMetadata,
 )
+from pystac import Collection, Item
 from toolz import dicttoolz
 
 from datacube.index.abstract import default_metadata_type_docs
@@ -111,9 +110,9 @@ def infer_dc_product(x: Any, cfg: ConversionConfig | None = None) -> Product:
     )
 
 
-@infer_dc_product.register(pystac.item.Item)
+@infer_dc_product.register(Item)
 def infer_dc_product_from_item(
-    item: pystac.item.Item, cfg: ConversionConfig | None = None
+    item: Item, cfg: ConversionConfig | None = None
 ) -> Product:
     """
     Infer Datacube product object from a STAC Item.
@@ -127,7 +126,7 @@ def infer_dc_product_from_item(
 
 
 def _compute_uuid(
-    item: pystac.item.Item, mode: str = "auto", extras: Sequence[str] | None = None
+    item: Item, mode: str = "auto", extras: Sequence[str] | None = None
 ) -> uuid.UUID:
     if mode == "native":
         return uuid.UUID(item.id)
@@ -162,6 +161,38 @@ def _compute_uuid(
 
 def _to_grid(gbox: GeoBox) -> dict[str, Any]:
     return {"shape": gbox.shape.yx, "transform": gbox.transform[:6]}  # type: ignore[index]
+
+
+def _to_eo3_properties(properties: dict[str, Any]) -> dict[str, Any]:
+    """
+    Convert EO3 properties dictionary to the Stac equivalent.
+    """
+
+    def _to_eo3_type(key: str, value):
+        if key == "instruments":
+            if len(value) > 0:
+                return "_".join([i.upper() for i in value])
+            else:
+                return None
+        else:
+            return value
+
+    prop = {
+        STAC_TO_EO3_RENAMES.get(key, key): _to_eo3_type(key, val)
+        for key, val in properties.items()
+    }
+    creation_time = (
+        properties.get("odc:processing_datetime")
+        or properties.get("created")
+        or properties.get("datetime")
+    )
+    if prop.get("odc:processing_datetime") is None and creation_time:
+        prop["odc:processing_datetime"] = creation_time
+
+    if prop.get("odc:file_format") is None:
+        prop["odc:file_format"] = "GeoTIFF"
+
+    return prop
 
 
 def _to_dataset(
@@ -219,24 +250,28 @@ def _to_dataset(
     if crs is None:
         crs = EPSG4326
 
+    lineage = properties.pop("odc:lineage", {})
+
     ds_doc = {
-        "id": str(ds_uuid),
         "$schema": "https://schemas.opendatacube.org/dataset",
+        "id": str(ds_uuid),
+        "product": {"name": product.name.lower()},
         "crs": str(crs),
         "grids": grids,
-        "measurements": measurements,
-        "properties": dicttoolz.keymap(
-            lambda k: STAC_TO_EO3_RENAMES.get(k, k), properties
+        "measurements": dicttoolz.keymap(
+            lambda k: product.canonical_measurement(k), measurements
         ),
+        "properties": _to_eo3_properties(properties),
         "accessories": item.accessories,
-        "lineage": {},
+        "lineage": lineage,
     }
 
+    # Note: this bypasses consistency and lineage checks
     return Dataset(product, prep_eo3(ds_doc), uri=item.href)
 
 
 def _item_to_ds(
-    item: pystac.item.Item, product: Product, cfg: ConversionConfig | None = None
+    item: Item, product: Product, cfg: ConversionConfig | None = None
 ) -> Dataset:
     """
     Construct Dataset object from STAC Item and previously constructed Product.
@@ -258,7 +293,7 @@ def _item_to_ds(
 
 
 def stac2ds(
-    items: Iterable[pystac.item.Item],
+    items: Iterable[Item],
     cfg: ConversionConfig | None = None,
     product_cache: dict[str, Product] | None = None,
 ) -> Iterator[Dataset]:
@@ -334,9 +369,9 @@ def stac2ds(
         yield _item_to_ds(item, product, cfg)
 
 
-@infer_dc_product.register(pystac.collection.Collection)
+@infer_dc_product.register(Collection)
 def infer_dc_product_from_collection(
-    collection: pystac.collection.Collection, cfg: ConversionConfig | None = None
+    collection: Collection, cfg: ConversionConfig | None = None
 ) -> Product:
     """
     Construct Datacube Product definition from STAC Collection.

--- a/datacube/metadata/_eo3converter.py
+++ b/datacube/metadata/_eo3converter.py
@@ -161,7 +161,7 @@ def _compute_uuid(
 
 
 def _to_grid(gbox: GeoBox) -> dict[str, Any]:
-    return {"shape": list(gbox.shape.yx), "transform": list(gbox.transform)}  # type: ignore[index]
+    return {"shape": list(gbox.shape.yx), "transform": list(gbox.transform[:])}
 
 
 def _to_eo3_properties(properties: dict[str, Any]) -> dict[str, Any]:
@@ -406,5 +406,5 @@ def infer_dc_product_from_collection(
     # unless configured to ignore projection info assume that it will be present
     ignore_proj = cfg.get(product.name, {}).get("ignore_proj", False)
     if not ignore_proj:
-        product._stac = dataclasses.replace(product._stac, has_proj=True)  # type: ignore[type-var]
+        product._stac = dataclasses.replace(product._stac, has_proj=True)
     return product

--- a/datacube/metadata/_stacconverter.py
+++ b/datacube/metadata/_stacconverter.py
@@ -176,13 +176,13 @@ def _stac_links(
 
 def _as_stac_instruments(value: str):
     """
-    >>> _as_stac_instruments('TM')
+    >>> _as_stac_instruments("TM")
     ['tm']
-    >>> _as_stac_instruments('OLI')
+    >>> _as_stac_instruments("OLI")
     ['oli']
-    >>> _as_stac_instruments('ETM+')
+    >>> _as_stac_instruments("ETM+")
     ['etm']
-    >>> _as_stac_instruments('OLI_TIRS')
+    >>> _as_stac_instruments("OLI_TIRS")
     ['oli', 'tirs']
     """
     return [i.strip("+-").lower() for i in value.split("_")]

--- a/datacube/metadata/_stacconverter.py
+++ b/datacube/metadata/_stacconverter.py
@@ -6,6 +6,7 @@ import datetime
 import math
 import mimetypes
 import warnings
+from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 from urllib.parse import urljoin
@@ -41,7 +42,7 @@ def _lineage_fields(dataset: Dataset) -> dict:
     """
     if dataset.sources:
         lineage_dict = {key: [str(ds.id)] for key, ds in dataset.sources.items()}
-    elif dataset.source_tree:
+    elif dataset.source_tree and dataset.source_tree.children:
         lineage_dict = {
             key: [str(child.dataset_id) for child in children]
             for key, children in dataset.source_tree.children.items()
@@ -106,7 +107,7 @@ def _asset_title_fields(asset_name: str) -> str | None:
         return None
 
 
-def _uri_resolve(location: str, path: str):
+def _uri_resolve(location: str | None, path: str):
     # ODC's method doesn't support empty locations. Fall back to the path alone.
     if not location:
         return path
@@ -119,7 +120,7 @@ def _stac_links(
     stac_url: str | None,
     self_url: str | None,
     collection_url: str | None,
-) -> list[Link]:
+) -> Generator[Any, Any, Any]:
     """
     Add links for ODC product into a STAC Item
     """
@@ -261,7 +262,7 @@ def ds2stac(
         if str(dataset.crs).startswith("EPSG"):
             proj.apply(epsg=dataset.crs.epsg, **_proj_fields(dataset.grids))
         else:
-            proj.apply(wkt=dataset.crs.wkt, **_proj_fields(dataset.grids))
+            proj.apply(wkt2=dataset.crs.wkt, **_proj_fields(dataset.grids))
 
     # To pass validation, only add 'view' extension when we're using it somewhere.
     if any(k.startswith("view:") for k in properties):
@@ -285,13 +286,12 @@ def ds2stac(
         band = Band.create(name)
         eo.apply(bands=[band])
 
-        if dataset._gs:
+        if dataset.crs:
             proj_fields = _proj_fields(
                 dataset.grids, measurement.get("grid", "default")
             )
             if proj_fields is not None:
                 proj = ProjectionExtension.ext(asset)
-                # Not sure how this handles None for an EPSG code
                 proj.apply(
                     shape=proj_fields["shape"],
                     transform=proj_fields["transform"],

--- a/datacube/metadata/_stacconverter.py
+++ b/datacube/metadata/_stacconverter.py
@@ -73,12 +73,12 @@ def _media_type(path: Path) -> str:
     """
     Add media type of the asset object
     """
-    mime_type = mimetypes.guess_type(path.name)[0]
     if path.suffix == ".sha1":
         return MediaType.TEXT
     elif path.suffix == ".yaml":
         return "text/yaml"
-    elif mime_type:
+    mime_type = mimetypes.guess_type(path.name)[0]
+    if mime_type:
         if mime_type == "image/tiff":
             return MediaType.COG
         else:
@@ -107,7 +107,7 @@ def _asset_title_fields(asset_name: str) -> str | None:
         return None
 
 
-def _uri_resolve(location: str | None, path: str):
+def _uri_resolve(location: str | None, path: str) -> str:
     # ODC's method doesn't support empty locations. Fall back to the path alone.
     if not location:
         return path
@@ -120,7 +120,7 @@ def _stac_links(
     stac_url: str | None,
     self_url: str | None,
     collection_url: str | None,
-) -> Generator[Any, Any, Any]:
+) -> Generator[Link, Any, Any]:
     """
     Add links for ODC product into a STAC Item
     """
@@ -172,10 +172,10 @@ def _stac_links(
         )
 
     if not collection_url and not stac_url:
-        warnings.warn("No collection provided for Stac Item.")
+        warnings.warn("No collection provided for STAC Item.")
 
 
-def _as_stac_instruments(value: str):
+def _as_stac_instruments(value: str) -> list[str]:
     """
     >>> _as_stac_instruments("TM")
     ['tm']

--- a/datacube/metadata/_stacconverter.py
+++ b/datacube/metadata/_stacconverter.py
@@ -291,7 +291,7 @@ def ds2stac(
                 dataset.grids, measurement.get("grid", "default")
             )
             if proj_fields is not None:
-                proj = ProjectionExtension.ext(asset)
+                proj = ProjectionExtension.ext(asset)  # type: ignore[arg-type]
                 proj.apply(
                     shape=proj_fields["shape"],
                     transform=proj_fields["transform"],

--- a/datacube/metadata/_stacconverter.py
+++ b/datacube/metadata/_stacconverter.py
@@ -2,7 +2,12 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-import datetime
+"""
+EO3 -> STAC utilities.
+
+Utilities for translating EO3 Datasets to STAC Items.
+"""
+
 import math
 import mimetypes
 import warnings
@@ -15,24 +20,11 @@ from pystac import Asset, Item, Link, MediaType
 from pystac.extensions.eo import Band, EOExtension
 from pystac.extensions.projection import ProjectionExtension
 from pystac.extensions.view import ViewExtension
-from pystac.utils import datetime_to_str
 
 import datacube.utils.uris as dc_uris
 from datacube.model import Dataset
 
-EO3_TO_STAC_RENAMES = {
-    "dtr:end_datetime": "end_datetime",
-    "dtr:start_datetime": "start_datetime",
-    "eo:gsd": "gsd",
-    "eo:instrument": "instruments",
-    "eo:platform": "platform",
-    "eo:constellation": "constellation",
-    "eo:off_nadir": "view:off_nadir",
-    "eo:azimuth": "view:azimuth",
-    "eo:sun_azimuth": "view:sun_azimuth",
-    "eo:sun_elevation": "view:sun_elevation",
-    "odc:processing_datetime": "created",
-}
+from ._utils import eo3_to_stac_properties
 
 
 def _lineage_fields(dataset: Dataset) -> dict:
@@ -172,51 +164,6 @@ def _stac_links(
 
     if not collection_url and not stac_url:
         warnings.warn("No collection provided for STAC Item.")
-
-
-def _as_stac_instruments(value: str) -> list[str]:
-    """
-    >>> _as_stac_instruments("TM")
-    ['tm']
-    >>> _as_stac_instruments("OLI")
-    ['oli']
-    >>> _as_stac_instruments("ETM+")
-    ['etm']
-    >>> _as_stac_instruments("OLI_TIRS")
-    ['oli', 'tirs']
-    """
-    return [i.strip("+-").lower() for i in value.split("_")]
-
-
-def _convert_value_to_stac_type(key: str, value):
-    """
-    Convert return type as per STAC specification
-    """
-    # In STAC spec, "instruments" have [String] type
-    if key == "eo:instrument":
-        return _as_stac_instruments(value)
-    # Convert the non-default datetimes to a string
-    elif isinstance(value, datetime.datetime) and key != "datetime":
-        return datetime_to_str(value)
-    else:
-        return value
-
-
-def eo3_to_stac_properties(dataset: Dataset, title: str | None = None) -> dict:
-    """
-    Convert EO3 properties dictionary to the Stac equivalent.
-    """
-    # Put the title at the top for document readability.
-    properties = {"title": title} if title else {}
-
-    properties.update(
-        {
-            EO3_TO_STAC_RENAMES.get(key, key): _convert_value_to_stac_type(key, val)
-            for key, val in dataset.properties.items()
-        },
-    )
-
-    return properties
 
 
 def ds2stac(

--- a/datacube/metadata/_stacconverter.py
+++ b/datacube/metadata/_stacconverter.py
@@ -1,0 +1,318 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2025 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+import datetime
+import math
+import mimetypes
+import warnings
+from pathlib import Path
+from typing import Any
+from urllib.parse import urljoin
+
+from pystac import Asset, Item, Link, MediaType
+from pystac.errors import STACError
+from pystac.extensions.eo import Band, EOExtension
+from pystac.extensions.projection import ProjectionExtension
+from pystac.extensions.view import ViewExtension
+from pystac.utils import datetime_to_str
+
+import datacube.utils.uris as dc_uris
+from datacube.model import Dataset
+
+EO3_TO_STAC_RENAMES = {
+    "dtr:end_datetime": "end_datetime",
+    "dtr:start_datetime": "start_datetime",
+    "eo:gsd": "gsd",
+    "eo:instrument": "instruments",
+    "eo:platform": "platform",
+    "eo:constellation": "constellation",
+    "eo:off_nadir": "view:off_nadir",
+    "eo:azimuth": "view:azimuth",
+    "eo:sun_azimuth": "view:sun_azimuth",
+    "eo:sun_elevation": "view:sun_elevation",
+    "odc:processing_datetime": "created",
+}
+
+
+def _lineage_fields(dataset: Dataset) -> dict:
+    """
+    Add custom lineage field to a STAC Item
+    """
+    if dataset.sources:
+        lineage_dict = {key: [str(ds.id)] for key, ds in dataset.sources.items()}
+    elif dataset.source_tree:
+        lineage_dict = {
+            key: [str(child.dataset_id) for child in children]
+            for key, children in dataset.source_tree.children.items()
+        }
+    else:
+        return {}
+    return {"odc:lineage": lineage_dict}
+
+
+def _proj_fields(grid: dict[str, Any], grid_name: str = "default") -> dict:
+    """
+    Get any proj (Stac projection extension) fields if we have them for the grid.
+    """
+    if not grid:
+        return {}
+
+    grid_info = grid.get(grid_name or "default")
+    if not grid_info:
+        return {}
+
+    return {
+        "shape": grid_info.get("shape"),
+        "transform": grid_info.get("transform"),
+    }
+
+
+def _media_type(path: Path) -> str:
+    """
+    Add media type of the asset object
+    """
+    mime_type = mimetypes.guess_type(path.name)[0]
+    if path.suffix == ".sha1":
+        return MediaType.TEXT
+    elif path.suffix == ".yaml":
+        return "text/yaml"
+    elif mime_type:
+        if mime_type == "image/tiff":
+            return MediaType.COG
+        else:
+            return mime_type
+    else:
+        return "application/octet-stream"
+
+
+def _asset_roles_fields(asset_name: str) -> list[str]:
+    """
+    Add roles of the asset object
+    """
+    if asset_name.startswith("thumbnail"):
+        return ["thumbnail"]
+    else:
+        return ["metadata"]
+
+
+def _asset_title_fields(asset_name: str) -> str | None:
+    """
+    Add title of the asset object
+    """
+    if asset_name.startswith("thumbnail"):
+        return "Thumbnail image"
+    else:
+        return None
+
+
+def _uri_resolve(location: str, path: str):
+    # ODC's method doesn't support empty locations. Fall back to the path alone.
+    if not location:
+        return path
+
+    return dc_uris.uri_resolve(location, path)
+
+
+def _stac_links(
+    dataset: Dataset,
+    stac_url: str | None,
+    self_url: str | None,
+    collection_url: str | None,
+) -> list[Link]:
+    """
+    Add links for ODC product into a STAC Item
+    """
+    # TODO: better logic for relative links
+    if dataset.uri:
+        if not self_url:
+            link = Link(
+                rel="self",
+                media_type=MediaType.JSON,
+                target=dataset.uri.replace("odc-metadata.yaml", "stac-item.json"),
+            )
+            yield link
+        if dataset.uri.endswith("yaml"):
+            yield Link(
+                title="ODC Dataset YAML",
+                rel="odc_yaml",
+                media_type="text/yaml",
+                target=dataset.uri,
+            )
+    if self_url:
+        yield Link(
+            rel="self",
+            media_type=MediaType.JSON,
+            target=self_url,
+        )
+
+    if collection_url:
+        yield Link(
+            rel="collection",
+            target=collection_url,
+        )
+    if stac_url:
+        if not collection_url:
+            yield Link(
+                rel="collection",
+                target=urljoin(stac_url, f"/stac/collections/{dataset.product.name}"),
+            )
+        yield Link(
+            title="ODC Product Overview",
+            rel="product_overview",
+            media_type="text/html",
+            target=urljoin(stac_url, f"product/{dataset.product.name}"),
+        )
+        yield Link(
+            title="ODC Dataset Overview",
+            rel="alternative",
+            media_type="text/html",
+            target=urljoin(stac_url, f"dataset/{dataset.id}"),
+        )
+
+    if not collection_url and not stac_url:
+        warnings.warn("No collection provided for Stac Item.")
+
+
+def _as_stac_instruments(value: str):
+    """
+    >>> _as_stac_instruments('TM')
+    ['tm']
+    >>> _as_stac_instruments('OLI')
+    ['oli']
+    >>> _as_stac_instruments('ETM+')
+    ['etm']
+    >>> _as_stac_instruments('OLI_TIRS')
+    ['oli', 'tirs']
+    """
+    return [i.strip("+-").lower() for i in value.split("_")]
+
+
+def _convert_value_to_stac_type(key: str, value):
+    """
+    Convert return type as per STAC specification
+    """
+    # In STAC spec, "instruments" have [String] type
+    if key == "eo:instrument":
+        return _as_stac_instruments(value)
+    # Convert the non-default datetimes to a string
+    elif isinstance(value, datetime.datetime) and key != "datetime":
+        return datetime_to_str(value)
+    else:
+        return value
+
+
+def eo3_to_stac_properties(dataset: Dataset, title: str | None = None) -> dict:
+    """
+    Convert EO3 properties dictionary to the Stac equivalent.
+    """
+    # Put the title at the top for document readability.
+    properties = {"title": title} if title else {}
+
+    properties.update(
+        {
+            EO3_TO_STAC_RENAMES.get(key, key): _convert_value_to_stac_type(key, val)
+            for key, val in dataset.properties.items()
+        },
+    )
+
+    return properties
+
+
+def ds2stac(
+    dataset: Dataset,
+    stac_url: str | None = None,
+    self_url: str | None = None,
+    collection_url: str | None = None,
+) -> Item:
+    if dataset.extent is not None:
+        wgs84_geometry = dataset.extent.to_crs("EPSG:4326", math.inf)
+
+        geometry = wgs84_geometry.json
+        bbox = wgs84_geometry.boundingbox.bbox
+    else:
+        geometry = None
+        bbox = None
+
+    properties = eo3_to_stac_properties(dataset, title=dataset.metadata.label)
+    properties.update(_lineage_fields(dataset))
+
+    dt = properties.get("datetime")
+
+    item = Item(
+        id=str(dataset.id),
+        datetime=dt,
+        properties=properties,
+        geometry=geometry,
+        bbox=bbox,
+        collection=dataset.product.name,
+    )
+
+    # Add links
+    for link in _stac_links(dataset, stac_url, self_url, collection_url):
+        item.links.append(link)
+
+    EOExtension.ext(item, add_if_missing=True)
+
+    if dataset.extent:
+        proj = ProjectionExtension.ext(item, add_if_missing=True)
+        if dataset.crs is None:
+            raise STACError("Projection extension requires a crs.")
+        if str(dataset.crs).startswith("EPSG"):
+            proj.apply(epsg=dataset.crs.epsg, **_proj_fields(dataset.grids))
+        else:
+            proj.apply(wkt=dataset.crs.wkt, **_proj_fields(dataset.grids))
+
+    # To pass validation, only add 'view' extension when we're using it somewhere.
+    if any(k.startswith("view:") for k in properties):
+        ViewExtension.ext(item, add_if_missing=True)
+
+    # Add assets that are data
+    for name, measurement in dataset.measurements.items():
+        if not dataset.uri and not measurement.get("path"):
+            # No URL to link to. URL is mandatory for Stac validation.
+            continue
+
+        asset = Asset(
+            href=_uri_resolve(dataset.uri, measurement["path"]),
+            media_type=_media_type(Path(measurement["path"])),
+            title=name,
+            roles=["data"],
+        )
+        eo = EOExtension.ext(asset)
+
+        # TODO: pull out more information about the band
+        band = Band.create(name)
+        eo.apply(bands=[band])
+
+        if dataset._gs:
+            proj_fields = _proj_fields(
+                dataset.grids, measurement.get("grid", "default")
+            )
+            if proj_fields is not None:
+                proj = ProjectionExtension.ext(asset)
+                # Not sure how this handles None for an EPSG code
+                proj.apply(
+                    shape=proj_fields["shape"],
+                    transform=proj_fields["transform"],
+                    epsg=dataset.crs.epsg,
+                )
+
+        item.add_asset(name, asset=asset)
+
+    # Add assets that are accessories
+    for name, accessory in dataset.accessories.items():
+        if not dataset.uri and not accessory.get("path"):
+            # No URL to link to. URL is mandatory for Stac validation.
+            continue
+
+        asset = Asset(
+            href=_uri_resolve(dataset.uri, accessory["path"]),
+            media_type=_media_type(Path(accessory["path"])),
+            title=_asset_title_fields(name),
+            roles=_asset_roles_fields(name),
+        )
+
+        item.add_asset(name, asset=asset)
+
+    return item

--- a/datacube/metadata/_stacconverter.py
+++ b/datacube/metadata/_stacconverter.py
@@ -12,7 +12,6 @@ from typing import Any
 from urllib.parse import urljoin
 
 from pystac import Asset, Item, Link, MediaType
-from pystac.errors import STACError
 from pystac.extensions.eo import Band, EOExtension
 from pystac.extensions.projection import ProjectionExtension
 from pystac.extensions.view import ViewExtension
@@ -226,14 +225,13 @@ def ds2stac(
     self_url: str | None = None,
     collection_url: str | None = None,
 ) -> Item:
-    if dataset.extent is not None:
-        wgs84_geometry = dataset.extent.to_crs("EPSG:4326", math.inf)
-
-        geometry = wgs84_geometry.json
-        bbox = wgs84_geometry.boundingbox.bbox
-    else:
+    if dataset.extent is None:
         geometry = None
         bbox = None
+    else:
+        wgs84_geometry = dataset.extent.to_crs("EPSG:4326", math.inf)
+        geometry = wgs84_geometry.json
+        bbox = wgs84_geometry.boundingbox.bbox
 
     properties = eo3_to_stac_properties(dataset, title=dataset.metadata.label)
     properties.update(_lineage_fields(dataset))
@@ -257,8 +255,7 @@ def ds2stac(
 
     if dataset.extent:
         proj = ProjectionExtension.ext(item, add_if_missing=True)
-        if dataset.crs is None:
-            raise STACError("Projection extension requires a crs.")
+        assert dataset.crs is not None  # for mypy - extent will be None if crs is None
         if str(dataset.crs).startswith("EPSG"):
             proj.apply(epsg=dataset.crs.epsg, **_proj_fields(dataset.grids))
         else:

--- a/datacube/metadata/_utils.py
+++ b/datacube/metadata/_utils.py
@@ -1,0 +1,113 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2025 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""
+Mirrored helper functions for STAC/EO3 conversion
+"""
+
+from datetime import datetime
+from typing import Any
+
+from pystac.utils import datetime_to_str
+
+from datacube.model import Dataset
+
+# Mapping between EO3 field names and STAC properties object field names
+# EO3 metadata was defined before STAC 1.0, so we used some extensions
+# that are now part of the standard instead
+STAC_TO_EO3_RENAMES = {
+    "end_datetime": "dtr:end_datetime",
+    "start_datetime": "dtr:start_datetime",
+    "gsd": "eo:gsd",
+    "instruments": "eo:instrument",
+    "platform": "eo:platform",
+    "constellation": "eo:constellation",
+    "view:off_nadir": "eo:off_nadir",
+    "view:azimuth": "eo:azimuth",
+    "view:sun_azimuth": "eo:sun_azimuth",
+    "view:sun_elevation": "eo:sun_elevation",
+    "created": "odc:processing_datetime",
+}
+
+EO3_TO_STAC_RENAMES = {v: k for k, v in STAC_TO_EO3_RENAMES.items()}
+
+
+def _as_stac_instruments(value: str) -> list[str]:
+    """
+    >>> _as_stac_instruments("TM")
+    ['tm']
+    >>> _as_stac_instruments("OLI")
+    ['oli']
+    >>> _as_stac_instruments("ETM+")
+    ['etm']
+    >>> _as_stac_instruments("OLI_TIRS")
+    ['oli', 'tirs']
+    """
+    return [i.strip("+-").lower() for i in value.split("_")]
+
+
+def _value_to_stac_type(key: str, value):
+    """
+    Convert return type as per STAC specification
+    """
+    # In STAC spec, "instruments" have [String] type
+    if key == "eo:instrument":
+        return _as_stac_instruments(value)
+    # Convert the non-default datetimes to a string
+    elif isinstance(value, datetime) and key != "datetime":
+        return datetime_to_str(value)
+    else:
+        return value
+
+
+def _value_to_eo3_type(key: str, value):
+    # TODO: remove once list field types are supported
+    if key == "instruments":
+        if len(value) > 0:
+            return "_".join([i.upper() for i in value])
+        else:
+            return None
+    elif key == "created" or "datetime" in key:
+        if isinstance(value, str):
+            return datetime.fromisoformat(value)
+        return value
+    else:
+        return value
+
+
+def eo3_to_stac_properties(dataset: Dataset, title: str | None = None) -> dict:
+    """
+    Convert EO3 properties dictionary to the Stac equivalent.
+    """
+    # Put the title at the top for document readability.
+    properties = {"title": title} if title else {}
+
+    properties.update(
+        {
+            EO3_TO_STAC_RENAMES.get(key, key): _value_to_stac_type(key, val)
+            for key, val in dataset.properties.items()
+        },
+    )
+
+    return properties
+
+
+def stac_to_eo3_properties(properties: dict[str, Any]) -> dict[str, Any]:
+    """
+    Convert STAC properties dictionary to the EO3 equivalent.
+    """
+    prop = {
+        STAC_TO_EO3_RENAMES.get(key, key): _value_to_eo3_type(key, val)
+        for key, val in properties.items()
+        if not key.startswith("proj:")
+    }
+
+    if prop.get("odc:processing_datetime") is None:
+        # default to datetime value if no created
+        prop["odc:processing_datetime"] = properties.get("datetime")
+
+    if prop.get("odc:file_format") is None:
+        prop["odc:file_format"] = "GeoTIFF"
+
+    return prop

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -409,6 +409,18 @@ class Dataset:
 
         return None
 
+    @property
+    def accessories(self) -> dict[str, Any]:
+        return self.metadata_doc.get("accessories", {})
+
+    @property
+    def grids(self) -> dict[str, Any]:
+        return self.metadata_doc["grids"]
+
+    @property
+    def properties(self) -> dict[str, Any]:
+        return self.metadata_doc["properties"]
+
     @override
     def __eq__(self, other) -> bool:
         if isinstance(other, Dataset):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ tests in this and sub packages.
 
 import os
 from pathlib import Path
+from typing import Any
 
 import pystac
 import pystac.collection
@@ -375,12 +376,12 @@ ODC_PRODUCT_FILE: str = "ard_ls8.odc-product.yaml"
 
 
 @pytest.fixture
-def partial_proj_stac():
+def partial_proj_stac() -> pystac.Item:
     return pystac.item.Item.from_file(str(TEST_DATA_FOLDER.joinpath(PARTIAL_PROJ_STAC)))
 
 
 @pytest.fixture
-def no_bands_stac(partial_proj_stac):
+def no_bands_stac(partial_proj_stac) -> pystac.Item:
     partial_proj_stac.assets.clear()
     return partial_proj_stac
 
@@ -393,64 +394,64 @@ def usgs_landsat_stac_v1():
 
 
 @pytest.fixture
-def sentinel_stac_ms():
+def sentinel_stac_ms() -> pystac.Item:
     return pystac.item.Item.from_file(str(TEST_DATA_FOLDER.joinpath(SENTINEL_STAC_MS)))
 
 
 @pytest.fixture
-def sentinel_stac_ms_with_raster_ext():
+def sentinel_stac_ms_with_raster_ext() -> pystac.Item:
     return pystac.item.Item.from_file(
         str(TEST_DATA_FOLDER.joinpath(SENTINEL_STAC_MS_RASTER_EXT))
     )
 
 
 @pytest.fixture
-def sentinel_stac_collection():
+def sentinel_stac_collection() -> pystac.Collection:
     return pystac.collection.Collection.from_file(
         str(TEST_DATA_FOLDER.joinpath(SENTINEL_STAC_COLLECTION))
     )
 
 
 @pytest.fixture
-def s2_l2a_stac():
+def s2_l2a_stac() -> pystac.Item:
     return pystac.item.Item.from_file(str(TEST_DATA_FOLDER.joinpath(S2_L2A_STAC)))
 
 
 @pytest.fixture
-def s2_l2a_product(eo3_metadata):
+def s2_l2a_product(eo3_metadata) -> Product:
     filepath = TEST_DATA_FOLDER.joinpath(S2_L2A_PRODUCT)
     (_, doc), *_ = read_documents(filepath)
     return Product(eo3_metadata, doc)
 
 
 @pytest.fixture
-def eo3_metadata_type():
+def eo3_metadata_type() -> MetadataType:
     filepath = TEST_DATA_FOLDER.joinpath(ODC_METADATA_FILE)
     (_, doc), *_ = read_documents(filepath)
     return metadata_from_doc(doc)
 
 
 @pytest.fixture
-def eo3_product(eo3_metadata_type: MetadataType):
+def eo3_product(eo3_metadata_type: MetadataType) -> Product:
     filepath = TEST_DATA_FOLDER.joinpath(ODC_PRODUCT_FILE)
     (_, doc), *_ = read_documents(filepath)
     return Product(eo3_metadata_type, doc)
 
 
 @pytest.fixture
-def odc_dataset_doc():
+def odc_dataset_doc() -> dict[str, Any]:
     filepath = TEST_DATA_FOLDER.joinpath(ODC_DATASET_FILE)
     with open(str(filepath)) as f:
         return next(iter(load_from_yaml(f, parse_dates=True)))
 
 
 @pytest.fixture
-def eo3_dataset(eo3_product, odc_dataset_doc):
+def eo3_dataset(eo3_product, odc_dataset_doc) -> Dataset:
     return Dataset(eo3_product, prep_eo3(odc_dataset_doc), uri=ODC_DATASET_FILE)
 
 
 @pytest.fixture
-def ds_legacy_sources(eo3_product, odc_dataset_doc):
+def ds_legacy_sources(eo3_product, odc_dataset_doc) -> Dataset:
     sample_source_def = {
         "$schema": "https://schemas.opendatacube.org/dataset",
         "id": "b5f234fe-bba8-5483-9bc0-250360d429cf",
@@ -477,7 +478,7 @@ def ds_legacy_sources(eo3_product, odc_dataset_doc):
 
 
 @pytest.fixture
-def ds_ext_lineage(eo3_product, odc_dataset_doc):
+def ds_ext_lineage(eo3_product, odc_dataset_doc) -> Dataset:
     ds = Dataset(
         eo3_product,
         prep_eo3(odc_dataset_doc, remap_lineage=False),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -476,6 +476,7 @@ def ds_legacy_sources(eo3_product, odc_dataset_doc):
     )
 
 
+@pytest.fixture
 def ds_ext_lineage(eo3_product, odc_dataset_doc):
     ds = Dataset(
         eo3_product,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,8 +22,15 @@ from odc.geo.geobox import GeoBox
 
 from datacube import Datacube
 from datacube.index.eo3 import prep_eo3
-from datacube.model import Dataset, Measurement, MetadataType, Product
-from datacube.utils.documents import read_documents
+from datacube.model import (
+    Dataset,
+    LineageTree,
+    Measurement,
+    MetadataType,
+    Product,
+    metadata_from_doc,
+)
+from datacube.utils.documents import load_from_yaml, read_documents
 
 AWS_ENV_VARS = [
     "AWS_ACCESS_KEY_ID",
@@ -360,6 +367,11 @@ SENTINEL_STAC_MS_RASTER_EXT: str = (
     "S2B_MSIL2A_20190629T212529_R043_T06VVN_20201006T080531_raster_ext.json"
 )
 USGS_LANDSAT_STAC_v1: str = "LC08_L2SP_028030_20200114_20200824_02_T1_SR.json"
+S2_L2A_STAC: str = "s2_l2a.stac-item.json"
+S2_L2A_PRODUCT: str = "s2_l2a.odc-product.yaml"
+ODC_DATASET_FILE: str = "ga_ls8c_ard_3-1-0_088080_2020-05-25_final.odc-metadata.yaml"
+ODC_METADATA_FILE: str = "eo3_landsat_ard.odc-type.yaml"
+ODC_PRODUCT_FILE: str = "ard_ls8.odc-product.yaml"
 
 
 @pytest.fixture
@@ -397,3 +409,78 @@ def sentinel_stac_collection():
     return pystac.collection.Collection.from_file(
         str(TEST_DATA_FOLDER.joinpath(SENTINEL_STAC_COLLECTION))
     )
+
+
+@pytest.fixture
+def s2_l2a_stac():
+    return pystac.item.Item.from_file(str(TEST_DATA_FOLDER.joinpath(S2_L2A_STAC)))
+
+
+@pytest.fixture
+def s2_l2a_product(eo3_metadata):
+    filepath = TEST_DATA_FOLDER.joinpath(S2_L2A_PRODUCT)
+    (_, doc), *_ = read_documents(filepath)
+    return Product(eo3_metadata, doc)
+
+
+@pytest.fixture
+def eo3_metadata_type():
+    filepath = TEST_DATA_FOLDER.joinpath(ODC_METADATA_FILE)
+    (_, doc), *_ = read_documents(filepath)
+    return metadata_from_doc(doc)
+
+
+@pytest.fixture
+def eo3_product(eo3_metadata_type: MetadataType):
+    filepath = TEST_DATA_FOLDER.joinpath(ODC_PRODUCT_FILE)
+    (_, doc), *_ = read_documents(filepath)
+    return Product(eo3_metadata_type, doc)
+
+
+@pytest.fixture
+def odc_dataset_doc():
+    filepath = TEST_DATA_FOLDER.joinpath(ODC_DATASET_FILE)
+    with open(str(filepath)) as f:
+        return next(iter(load_from_yaml(f, parse_dates=True)))
+
+
+@pytest.fixture
+def eo3_dataset(eo3_product, odc_dataset_doc):
+    return Dataset(eo3_product, prep_eo3(odc_dataset_doc), uri=ODC_DATASET_FILE)
+
+
+@pytest.fixture
+def ds_legacy_sources(eo3_product, odc_dataset_doc):
+    sample_source_def = {
+        "$schema": "https://schemas.opendatacube.org/dataset",
+        "id": "b5f234fe-bba8-5483-9bc0-250360d429cf",
+        "product": {"name": eo3_product.name},
+        "crs": "epsg:3857",
+        "properties": {
+            "datetime": "2020-04-20 00:26:43Z",
+            "odc:processing_datetime": "2020-05-16 10:56:18Z",
+        },
+        "grids": {
+            "default": {
+                "shape": [100, 200],
+                "transform": [10, 0, 100000, 0, -10, 200000, 0, 0, 1],
+            }
+        },
+    }
+    source_ds = Dataset(eo3_product, sample_source_def)
+    return Dataset(
+        eo3_product,
+        prep_eo3(odc_dataset_doc),
+        sources={"level1": source_ds},
+        uri=ODC_DATASET_FILE,
+    )
+
+
+def ds_ext_lineage(eo3_product, odc_dataset_doc):
+    ds = Dataset(
+        eo3_product,
+        prep_eo3(odc_dataset_doc, remap_lineage=False),
+        uri=ODC_DATASET_FILE,
+    )
+    ds.source_tree = LineageTree.from_eo3_doc(ds.metadata_doc, home="src_home")
+    return ds

--- a/tests/data/ard_ls8.odc-product.yaml
+++ b/tests/data/ard_ls8.odc-product.yaml
@@ -1,0 +1,180 @@
+---
+name: ga_ls8c_ard_3
+description: Geoscience Australia Landsat 8 Operational Land Imager and Thermal Infra-Red Scanner Analysis Ready Data Collection 3
+metadata_type: eo3_landsat_ard
+
+license: CC-BY-4.0
+
+metadata:
+  product:
+    name: ga_ls8c_ard_3
+  properties:
+     eo:platform: landsat-8
+     odc:producer: ga.gov.au
+     odc:product_family: ard
+
+measurements:
+  # NBART
+  - name: nbart_coastal_aerosol
+    aliases:
+      - nbart_band01
+      - coastal_aerosol
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_blue
+    aliases:
+      - nbart_band02
+      - blue
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_green
+    aliases:
+      - nbart_band03
+      - green
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_red
+    aliases:
+      - nbart_band04
+      - red
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_nir
+    aliases:
+      - nbart_band05
+      - nir
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_swir_1
+    aliases:
+      - nbart_band06
+      - swir_1
+      # Requested for backwards compatibility with previous collection
+      - swir1
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_swir_2
+    aliases:
+      - nbart_band07
+      - swir_2
+      # Requested for backwards compatibility with previous collection
+      - swir2
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_panchromatic
+    aliases:
+      - nbart_band08
+      - panchromatic
+    dtype: int16
+    nodata: -999
+    units: '1'
+
+    # Observation Attributes
+  - name: oa_fmask
+    aliases:
+      - fmask
+    dtype: uint8
+    nodata: 0
+    units: '1'
+    flags_definition:
+      fmask:
+        bits: [0, 1, 2, 3, 4, 5, 6, 7]
+        description: Fmask
+        values:
+          '0': nodata
+          '1': valid
+          '2': cloud
+          '3': shadow
+          '4': snow
+          '5': water
+  - name: oa_nbart_contiguity
+    aliases:
+      - nbart_contiguity
+    dtype: uint8
+    nodata: 255
+    units: '1'
+    flags_definition:
+      contiguous:
+        bits: [0]
+        values:
+          '1': true
+          '0': false
+  - name: oa_azimuthal_exiting
+    aliases:
+      - azimuthal_exiting
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_azimuthal_incident
+    aliases:
+      - azimuthal_incident
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_combined_terrain_shadow
+    aliases:
+      - combined_terrain_shadow
+    dtype: uint8
+    nodata: 255
+    units: '1'
+  - name: oa_exiting_angle
+    aliases:
+      - exiting_angle
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_incident_angle
+    aliases:
+      - incident_angle
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_relative_azimuth
+    aliases:
+      - relative_azimuth
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_relative_slope
+    aliases:
+      - relative_slope
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_satellite_azimuth
+    aliases:
+      - satellite_azimuth
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_satellite_view
+    aliases:
+      - satellite_view
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_solar_azimuth
+    aliases:
+      - solar_azimuth
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_solar_zenith
+    aliases:
+      - solar_zenith
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_time_delta
+    aliases:
+      - time_delta
+    dtype: float32
+    nodata: .nan
+    units: '1'

--- a/tests/data/eo3_landsat_ard.odc-type.yaml
+++ b/tests/data/eo3_landsat_ard.odc-type.yaml
@@ -1,0 +1,298 @@
+---
+name: eo3_landsat_ard
+description: EO3 for ARD Landsat Collection 3
+dataset:
+  id: [id]  # No longer configurable in newer ODCs.
+  sources: [lineage, source_datasets]  # No longer configurable in newer ODCs.
+
+  grid_spatial: [grid_spatial, projection]
+  measurements: [measurements]
+  creation_dt: [properties, 'odc:processing_datetime']
+  label: [label]
+  format: [properties, 'odc:file_format']
+
+  search_fields:
+    platform:
+      description: Platform code
+      offset: [properties, 'eo:platform']
+      indexed: false
+
+    instrument:
+      description: Instrument name
+      offset: [properties, 'eo:instrument']
+      indexed: false
+
+    product_family:
+      description: Product family code
+      offset: [properties, 'odc:product_family']
+      indexed: false
+
+    region_code:
+      description: >
+        Spatial reference code from the provider.
+        For Landsat region_code is a scene path row:
+                '{:03d}{:03d}.format(path,row)'
+        For Sentinel it is MGRS code.
+        In general it is a unique string identifier
+        that datasets covering roughly the same spatial
+        region share.
+
+      offset: [properties, 'odc:region_code']
+
+    crs_raw:
+      description: The raw CRS string as it appears in metadata
+      offset: ['crs']
+      indexed: false
+
+    dataset_maturity:
+      description: One of - final|interim|nrt  (near real time)
+      offset: [properties, 'dea:dataset_maturity']
+
+    gqa:
+      description: GQA Circular error probable (90%)
+      type: double
+      offset: [properties, 'gqa:cep90']
+
+    cloud_cover:
+      description: Cloud cover percentage [0, 100]
+      type: double
+      offset: [properties, 'eo:cloud_cover']
+
+    time:
+      description: Acquisition time range
+      type: datetime-range
+      min_offset:
+        - [properties, 'dtr:start_datetime']
+        - [properties, datetime]
+      max_offset:
+        - [properties, 'dtr:end_datetime']
+        - [properties, datetime]
+
+    # LonLat bounding box, generated on the fly from:
+    #  `grids`, `crs` and `geometry` of the new metadata format
+    #
+    # Bounding box is defined by two ranges:
+    #   [lon.begin, lon.end] -- Longitude
+    #   [lat.begin, lat.end] -- Latitude
+    #
+    # Note that STAC is using `bbox` for the same thing as following:
+    #
+    #     bbox: [left, bottom, right, top]
+    #              0      1      2     3
+    #             lon    lat    lon   lat
+    #
+    # But MetadataType does not support integer index keys, so...
+    #   BoundingBox: [lon.begin, lat.begin, lon.end, lat.end]
+
+    lon:
+      description: Longitude range
+      type: double-range
+      min_offset:
+        - [extent, lon, begin]
+      max_offset:
+        - [extent, lon, end]
+
+    lat:
+      description: Latitude range
+      type: double-range
+      min_offset:
+        - [extent, lat, begin]
+      max_offset:
+        - [extent, lat, end]
+
+    landsat_product_id:
+      description: Landsat Product ID
+      indexed: false
+      offset:
+        - properties
+        - landsat:landsat_product_id
+
+    # semi-auto generated below
+    eo_gsd:
+      description: Ground sample distance, meters
+      indexed: false
+      offset:
+        - properties
+        - eo:gsd
+      type: double
+    eo_sun_azimuth:
+      description: 'TODO: <eo:sun_azimuth>'
+      indexed: false
+      offset:
+        - properties
+        - eo:sun_azimuth
+      type: double
+    eo_sun_elevation:
+      description: 'TODO: <eo:sun_elevation>'
+      indexed: false
+      offset:
+        - properties
+        - eo:sun_elevation
+      type: double
+    fmask_clear:
+      description: 'TODO: <fmask:clear>'
+      indexed: false
+      offset:
+        - properties
+        - fmask:clear
+      type: double
+    fmask_cloud_shadow:
+      description: 'TODO: <fmask:cloud_shadow>'
+      indexed: false
+      offset:
+        - properties
+        - fmask:cloud_shadow
+      type: double
+    fmask_snow:
+      description: 'TODO: <fmask:snow>'
+      indexed: false
+      offset:
+        - properties
+        - fmask:snow
+      type: double
+    fmask_water:
+      description: 'TODO: <fmask:water>'
+      indexed: false
+      offset:
+        - properties
+        - fmask:water
+      type: double
+    gqa_abs_iterative_mean_x:
+      description: 'TODO: <gqa:abs_iterative_mean_x>'
+      indexed: false
+      offset:
+        - properties
+        - gqa:abs_iterative_mean_x
+      type: double
+    gqa_abs_iterative_mean_xy:
+      description: 'TODO: <gqa:abs_iterative_mean_xy>'
+      indexed: false
+      offset:
+        - properties
+        - gqa:abs_iterative_mean_xy
+      type: double
+    gqa_abs_iterative_mean_y:
+      description: 'TODO: <gqa:abs_iterative_mean_y>'
+      indexed: false
+      offset:
+        - properties
+        - gqa:abs_iterative_mean_y
+      type: double
+    gqa_abs_x:
+      description: 'TODO: <gqa:abs_x>'
+      indexed: false
+      offset:
+        - properties
+        - gqa:abs_x
+      type: double
+    gqa_abs_xy:
+      description: 'TODO: <gqa:abs_xy>'
+      indexed: false
+      offset:
+        - properties
+        - gqa:abs_xy
+      type: double
+    gqa_abs_y:
+      description: 'TODO: <gqa:abs_y>'
+      indexed: false
+      offset:
+        - properties
+        - gqa:abs_y
+      type: double
+    gqa_cep90:
+      description: 'TODO: <gqa:cep90>'
+      indexed: false
+      offset:
+        - properties
+        - gqa:cep90
+      type: double
+    gqa_iterative_mean_x:
+      description: 'TODO: <gqa:iterative_mean_x>'
+      indexed: false
+      offset:
+        - properties
+        - gqa:iterative_mean_x
+      type: double
+    gqa_iterative_mean_xy:
+      description: 'TODO: <gqa:iterative_mean_xy>'
+      indexed: false
+      offset:
+        - properties
+        - gqa:iterative_mean_xy
+      type: double
+    gqa_iterative_mean_y:
+      description: 'TODO: <gqa:iterative_mean_y>'
+      indexed: false
+      offset:
+        - properties
+        - gqa:iterative_mean_y
+      type: double
+    gqa_iterative_stddev_x:
+      description: 'TODO: <gqa:iterative_stddev_x>'
+      indexed: false
+      offset:
+        - properties
+        - gqa:iterative_stddev_x
+      type: double
+    gqa_iterative_stddev_xy:
+      description: 'TODO: <gqa:iterative_stddev_xy>'
+      indexed: false
+      offset:
+        - properties
+        - gqa:iterative_stddev_xy
+      type: double
+    gqa_iterative_stddev_y:
+      description: 'TODO: <gqa:iterative_stddev_y>'
+      indexed: false
+      offset:
+        - properties
+        - gqa:iterative_stddev_y
+      type: double
+    gqa_mean_x:
+      description: 'TODO: <gqa:mean_x>'
+      indexed: false
+      offset:
+        - properties
+        - gqa:mean_x
+      type: double
+    gqa_mean_xy:
+      description: 'TODO: <gqa:mean_xy>'
+      indexed: false
+      offset:
+        - properties
+        - gqa:mean_xy
+      type: double
+    gqa_mean_y:
+      description: 'TODO: <gqa:mean_y>'
+      indexed: false
+      offset:
+        - properties
+        - gqa:mean_y
+      type: double
+    gqa_stddev_x:
+      description: 'TODO: <gqa:stddev_x>'
+      indexed: false
+      offset:
+        - properties
+        - gqa:stddev_x
+      type: double
+    gqa_stddev_xy:
+      description: 'TODO: <gqa:stddev_xy>'
+      indexed: false
+      offset:
+        - properties
+        - gqa:stddev_xy
+      type: double
+    gqa_stddev_y:
+      description: 'TODO: <gqa:stddev_y>'
+      indexed: false
+      offset:
+        - properties
+        - gqa:stddev_y
+      type: double
+    landsat_scene_id:
+      description: Landsat Scene ID
+      indexed: false
+      offset:
+        - properties
+        - landsat:landsat_scene_id

--- a/tests/data/ga_ls8c_ard_3-1-0_088080_2020-05-25_final.odc-metadata.yaml
+++ b/tests/data/ga_ls8c_ard_3-1-0_088080_2020-05-25_final.odc-metadata.yaml
@@ -1,0 +1,160 @@
+---
+# Dataset
+$schema: https://schemas.opendatacube.org/dataset
+id: 2aa69fcf-aa55-4747-9d95-3652f9fe79b0
+
+label: ga_ls8c_ard_3-1-0_088080_2020-05-25_final
+product:
+  name: ga_ls8c_ard_3
+  href: https://collections.dea.ga.gov.au/product/ga_ls8c_ard_3
+
+
+crs: epsg:32656
+geometry:
+  type: Polygon
+  coordinates: [[[572743.2722121085, -3077151.309749513], [572745.0, -3077145.0],
+      [572969.4472838908, -3077198.798209872], [573250.996461604, -3077257.9131992455],
+      [758606.0005942872, -3121687.9141904702], [759791.1380343756, -3121972.947862498],
+      [759832.5, -3122002.5], [714367.0886436494, -3312160.9887643186], [714322.5,
+        -3312262.5], [714228.5968569319, -3312239.9605382206], [714225.0, -3312255.0],
+      [527767.9988114258, -3267524.1716190595], [527167.7239312489, -3267374.1042750045],
+      [527095.752540109, -3267322.682433342], [527032.5, -3267307.5], [528337.9117568319,
+        -3261784.0095614507], [541042.9139480147, -3208729.0004160986], [553732.9148397002,
+        -3155853.9967016927], [572107.9166454426, -3079413.9891924215], [572647.9478624978,
+        -3077178.8619656246], [572677.5, -3077137.5], [572743.2722121085, -3077151.309749513]]]
+grids:
+  default:
+    shape: [7841, 7781]
+    transform: [30.0, 0.0, 526785.0, 0.0, -30.0, -3077085.0, 0.0, 0.0, 1.0]
+  panchromatic:
+    shape: [15681, 15561]
+    transform: [15.0, 0.0, 526792.5, 0.0, -15.0, -3077092.5, 0.0, 0.0, 1.0]
+
+properties:
+  datetime: 2020-05-25 23:35:47.745731Z
+  dea:dataset_maturity: final
+  dtr:end_datetime: 2020-05-25 23:36:02.557719Z
+  dtr:start_datetime: 2020-05-25 23:35:32.815426Z
+  eo:cloud_cover: 42.42102985910952
+  eo:gsd: 15.0  # Ground sample distance (m)
+  eo:instrument: OLI_TIRS
+  eo:platform: landsat-8
+  eo:sun_azimuth: 34.22994171
+  eo:sun_elevation: 31.7895917
+  fmask:clear: 1.0427704509544131
+  fmask:cloud: 42.42102985910952
+  fmask:cloud_shadow: 2.919727915379625
+  fmask:snow: 0.00034972190505407335
+  fmask:water: 53.61612205265139
+  gqa:abs_iterative_mean_x: 0.17
+  gqa:abs_iterative_mean_xy: 0.24
+  gqa:abs_iterative_mean_y: 0.16
+  gqa:abs_x: 0.28
+  gqa:abs_xy: 0.4
+  gqa:abs_y: 0.28
+  gqa:cep90: .nan
+  gqa:iterative_mean_x: 0.03
+  gqa:iterative_mean_xy: 0.12
+  gqa:iterative_mean_y: 0.12
+  gqa:iterative_stddev_x: 0.21
+  gqa:iterative_stddev_xy: 0.26
+  gqa:iterative_stddev_y: 0.15
+  gqa:mean_x: -0.08
+  gqa:mean_xy: 0.15
+  gqa:mean_y: 0.12
+  gqa:stddev_x: 0.42
+  gqa:stddev_xy: 0.58
+  gqa:stddev_y: 0.4
+  landsat:collection_category: T1
+  landsat:collection_number: 1
+  landsat:landsat_product_id: LC08_L1TP_088080_20200525_20200608_01_T1
+  landsat:landsat_scene_id: LC80880802020146LGN00
+  landsat:wrs_path: 88
+  landsat:wrs_row: 80
+  odc:dataset_version: 3.1.0
+  odc:file_format: GeoTIFF
+  odc:processing_datetime: 2020-06-18 07:07:06.303867Z
+  odc:producer: ga.gov.au
+  odc:product_family: ard
+  odc:region_code: '088080'
+
+measurements:
+  nbar_blue:
+    path: ga_ls8c_nbar_3-1-0_088080_2020-05-25_final_band02.tif
+  nbar_coastal_aerosol:
+    path: ga_ls8c_nbar_3-1-0_088080_2020-05-25_final_band01.tif
+  nbar_green:
+    path: ga_ls8c_nbar_3-1-0_088080_2020-05-25_final_band03.tif
+  nbar_nir:
+    path: ga_ls8c_nbar_3-1-0_088080_2020-05-25_final_band05.tif
+  nbar_panchromatic:
+    path: ga_ls8c_nbar_3-1-0_088080_2020-05-25_final_band08.tif
+    grid: panchromatic
+  nbar_red:
+    path: ga_ls8c_nbar_3-1-0_088080_2020-05-25_final_band04.tif
+  nbar_swir_1:
+    path: ga_ls8c_nbar_3-1-0_088080_2020-05-25_final_band06.tif
+  nbar_swir_2:
+    path: ga_ls8c_nbar_3-1-0_088080_2020-05-25_final_band07.tif
+  nbart_blue:
+    path: ga_ls8c_nbart_3-1-0_088080_2020-05-25_final_band02.tif
+  nbart_coastal_aerosol:
+    path: ga_ls8c_nbart_3-1-0_088080_2020-05-25_final_band01.tif
+  nbart_green:
+    path: ga_ls8c_nbart_3-1-0_088080_2020-05-25_final_band03.tif
+  nbart_nir:
+    path: ga_ls8c_nbart_3-1-0_088080_2020-05-25_final_band05.tif
+  nbart_panchromatic:
+    path: ga_ls8c_nbart_3-1-0_088080_2020-05-25_final_band08.tif
+    grid: panchromatic
+  nbart_red:
+    path: ga_ls8c_nbart_3-1-0_088080_2020-05-25_final_band04.tif
+  nbart_swir_1:
+    path: ga_ls8c_nbart_3-1-0_088080_2020-05-25_final_band06.tif
+  nbart_swir_2:
+    path: ga_ls8c_nbart_3-1-0_088080_2020-05-25_final_band07.tif
+  oa_azimuthal_exiting:
+    path: ga_ls8c_oa_3-1-0_088080_2020-05-25_final_azimuthal-exiting.tif
+  oa_azimuthal_incident:
+    path: ga_ls8c_oa_3-1-0_088080_2020-05-25_final_azimuthal-incident.tif
+  oa_combined_terrain_shadow:
+    path: ga_ls8c_oa_3-1-0_088080_2020-05-25_final_combined-terrain-shadow.tif
+  oa_exiting_angle:
+    path: ga_ls8c_oa_3-1-0_088080_2020-05-25_final_exiting-angle.tif
+  oa_fmask:
+    path: ga_ls8c_oa_3-1-0_088080_2020-05-25_final_fmask.tif
+  oa_incident_angle:
+    path: ga_ls8c_oa_3-1-0_088080_2020-05-25_final_incident-angle.tif
+  oa_nbar_contiguity:
+    path: ga_ls8c_oa_3-1-0_088080_2020-05-25_final_nbar-contiguity.tif
+  oa_nbart_contiguity:
+    path: ga_ls8c_oa_3-1-0_088080_2020-05-25_final_nbart-contiguity.tif
+  oa_relative_azimuth:
+    path: ga_ls8c_oa_3-1-0_088080_2020-05-25_final_relative-azimuth.tif
+  oa_relative_slope:
+    path: ga_ls8c_oa_3-1-0_088080_2020-05-25_final_relative-slope.tif
+  oa_satellite_azimuth:
+    path: ga_ls8c_oa_3-1-0_088080_2020-05-25_final_satellite-azimuth.tif
+  oa_satellite_view:
+    path: ga_ls8c_oa_3-1-0_088080_2020-05-25_final_satellite-view.tif
+  oa_solar_azimuth:
+    path: ga_ls8c_oa_3-1-0_088080_2020-05-25_final_solar-azimuth.tif
+  oa_solar_zenith:
+    path: ga_ls8c_oa_3-1-0_088080_2020-05-25_final_solar-zenith.tif
+  oa_time_delta:
+    path: ga_ls8c_oa_3-1-0_088080_2020-05-25_final_time-delta.tif
+
+accessories:
+  thumbnail:nbar:
+    path: ga_ls8c_nbar_3-1-0_088080_2020-05-25_final_thumbnail.jpg
+  thumbnail:nbart:
+    path: ga_ls8c_nbart_3-1-0_088080_2020-05-25_final_thumbnail.jpg
+  checksum:sha1:
+    path: ga_ls8c_ard_3-1-0_088080_2020-05-25_final.sha1
+  metadata:processor:
+    path: ga_ls8c_ard_3-1-0_088080_2020-05-25_final.proc-info.yaml
+
+lineage:
+  level1:
+  - b5f234fe-bba8-5483-9bc0-250360d429cf
+...

--- a/tests/data/s2_l2a.odc-product.yaml
+++ b/tests/data/s2_l2a.odc-product.yaml
@@ -1,0 +1,117 @@
+---
+name: s2_l2a
+description: Sentinel-2a and Sentinel-2b imagery, processed to Level
+  2A (Surface Reflectance) and converted to Cloud Optimized GeoTIFFs
+metadata_type: eo3
+
+metadata:
+  product:
+    name: s2_l2a
+
+measurements:
+  - name: "coastal"
+    aliases: [band_01, B01, coastal_aerosol]
+    units: "1"
+    dtype: uint16
+    nodata: 0
+
+  - name: "blue"
+    aliases: [band_02, B02]
+    units: "1"
+    dtype: uint16
+    nodata: 0
+
+  - name: "green"
+    aliases: [band_03, B03, green]
+    units: "1"
+    dtype: uint16
+    nodata: 0
+
+  - name: "red"
+    aliases: [band_04, B04, red]
+    units: "1"
+    dtype: uint16
+    nodata: 0
+
+  - name: "rededge1"
+    aliases: [band_05, B05, red_edge_1]
+    units: "1"
+    dtype: uint16
+    nodata: 0
+
+  - name: "rededge2"
+    aliases: [band_06, B06, red_edge_2]
+    units: "1"
+    dtype: uint16
+    nodata: 0
+
+  - name: "rededge3"
+    aliases: [band_07, B07, red_edge_3]
+    units: "1"
+    dtype: uint16
+    nodata: 0
+
+  - name: "nir"
+    aliases: [band_08, B08, nir, nir_1]
+    units: "1"
+    dtype: uint16
+    nodata: 0
+
+  - name: "nir08"
+    aliases: [band_8a, B8A, nir_narrow, nir_2]
+    units: "1"
+    dtype: uint16
+    nodata: 0
+
+  - name: "nir09"
+    aliases: [band_09, B09, water_vapour]
+    units: "1"
+    dtype: uint16
+    nodata: 0
+
+  - name: "swir16"
+    aliases: [band_11, B11, swir_1, swir_16]
+    units: "1"
+    dtype: uint16
+    nodata: 0
+
+  - name: "swir22"
+    aliases: [band_12, B12, swir_2, swir_22]
+    units: "1"
+    dtype: uint16
+    nodata: 0
+
+  - name: "scl"
+    aliases: [mask, SCL, qa]
+    units: "1"
+    dtype: uint8
+    nodata: 0
+    flags_definition:
+      qa:
+        bits: [0, 1, 2, 3, 4, 5, 6, 7]
+        description: Sen2Cor Scene Classification
+        values:
+          0: no data
+          1: saturated or defective
+          2: dark area pixels
+          3: cloud shadows
+          4: vegetation
+          5: bare soils
+          6: water
+          7: unclassified
+          8: cloud medium probability
+          9: cloud high probability
+          10: thin cirrus
+          11: snow or ice
+
+  - name: "aot"
+    aliases: [aerosol_optical_thickness, AOT]
+    units: "1"
+    dtype: uint16
+    nodata: 0
+
+  - name: "wvp"
+    aliases: [scene_average_water_vapour, WVP]
+    units: "1"
+    dtype: uint16
+    nodata: 0

--- a/tests/data/s2_l2a.stac-item.json
+++ b/tests/data/s2_l2a.stac-item.json
@@ -1,0 +1,503 @@
+{
+  "id": "S2B_MSIL2A_20250803T225109_R001_T15XVL_20250803T232015",
+  "bbox": [-99.3781161, 80.9292576, -95.6513494, 81.9330544],
+  "type": "Feature",
+  "links": [
+    {
+      "rel": "collection",
+      "type": "application/json",
+      "href": "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-2-l2a"
+    },
+    {
+      "rel": "parent",
+      "type": "application/json",
+      "href": "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-2-l2a"
+    },
+    {
+      "rel": "root",
+      "type": "application/json",
+      "href": "https://planetarycomputer.microsoft.com/api/stac/v1/"
+    },
+    {
+      "rel": "self",
+      "type": "application/geo+json",
+      "href": "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-2-l2a/items/S2B_MSIL2A_20250803T225109_R001_T15XVL_20250803T232015"
+    },
+    {
+      "rel": "license",
+      "href": "https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice"
+    },
+    {
+      "rel": "preview",
+      "href": "https://planetarycomputer.microsoft.com/api/data/v1/item/map?collection=sentinel-2-l2a&item=S2B_MSIL2A_20250803T225109_R001_T15XVL_20250803T232015",
+      "title": "Map of item",
+      "type": "text/html"
+    }
+  ],
+  "assets": {
+    "AOT": {
+      "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/15/X/VL/2025/08/03/S2B_MSIL2A_20250803T225109_N0511_R001_T15XVL_20250803T232015.SAFE/GRANULE/L2A_T15XVL_A043928_20250803T225111/IMG_DATA/R10m/T15XVL_20250803T225109_AOT_10m.tif",
+      "proj:bbox": [399960, 8990220, 509760, 9100020],
+      "proj:shape": [10980, 10980],
+      "proj:transform": [10, 0, 399960, 0, -10, 9100020],
+      "gsd": 10,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "title": "Aerosol optical thickness (AOT)"
+    },
+    "B01": {
+      "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/15/X/VL/2025/08/03/S2B_MSIL2A_20250803T225109_N0511_R001_T15XVL_20250803T232015.SAFE/GRANULE/L2A_T15XVL_A043928_20250803T225111/IMG_DATA/R60m/T15XVL_20250803T225109_B01_60m.tif",
+      "proj:bbox": [399960, 8990220, 509760, 9100020],
+      "proj:shape": [1830, 1830],
+      "proj:transform": [60, 0, 399960, 0, -60, 9100020],
+      "gsd": 60,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "title": "Band 1 - Coastal aerosol - 60m",
+      "eo:bands": [
+        {
+          "name": "B01",
+          "common_name": "coastal",
+          "description": "Band 1 - Coastal aerosol",
+          "center_wavelength": 0.443,
+          "full_width_half_max": 0.027
+        }
+      ]
+    },
+    "B02": {
+      "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/15/X/VL/2025/08/03/S2B_MSIL2A_20250803T225109_N0511_R001_T15XVL_20250803T232015.SAFE/GRANULE/L2A_T15XVL_A043928_20250803T225111/IMG_DATA/R10m/T15XVL_20250803T225109_B02_10m.tif",
+      "proj:bbox": [399960, 8990220, 509760, 9100020],
+      "proj:shape": [10980, 10980],
+      "proj:transform": [10, 0, 399960, 0, -10, 9100020],
+      "gsd": 10,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "title": "Band 2 - Blue - 10m",
+      "eo:bands": [
+        {
+          "name": "B02",
+          "common_name": "blue",
+          "description": "Band 2 - Blue",
+          "center_wavelength": 0.49,
+          "full_width_half_max": 0.098
+        }
+      ]
+    },
+    "B03": {
+      "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/15/X/VL/2025/08/03/S2B_MSIL2A_20250803T225109_N0511_R001_T15XVL_20250803T232015.SAFE/GRANULE/L2A_T15XVL_A043928_20250803T225111/IMG_DATA/R10m/T15XVL_20250803T225109_B03_10m.tif",
+      "proj:bbox": [399960, 8990220, 509760, 9100020],
+      "proj:shape": [10980, 10980],
+      "proj:transform": [10, 0, 399960, 0, -10, 9100020],
+      "gsd": 10,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "title": "Band 3 - Green - 10m",
+      "eo:bands": [
+        {
+          "name": "B03",
+          "common_name": "green",
+          "description": "Band 3 - Green",
+          "center_wavelength": 0.56,
+          "full_width_half_max": 0.045
+        }
+      ]
+    },
+    "B04": {
+      "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/15/X/VL/2025/08/03/S2B_MSIL2A_20250803T225109_N0511_R001_T15XVL_20250803T232015.SAFE/GRANULE/L2A_T15XVL_A043928_20250803T225111/IMG_DATA/R10m/T15XVL_20250803T225109_B04_10m.tif",
+      "proj:bbox": [399960, 8990220, 509760, 9100020],
+      "proj:shape": [10980, 10980],
+      "proj:transform": [10, 0, 399960, 0, -10, 9100020],
+      "gsd": 10,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "title": "Band 4 - Red - 10m",
+      "eo:bands": [
+        {
+          "name": "B04",
+          "common_name": "red",
+          "description": "Band 4 - Red",
+          "center_wavelength": 0.665,
+          "full_width_half_max": 0.038
+        }
+      ]
+    },
+    "B05": {
+      "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/15/X/VL/2025/08/03/S2B_MSIL2A_20250803T225109_N0511_R001_T15XVL_20250803T232015.SAFE/GRANULE/L2A_T15XVL_A043928_20250803T225111/IMG_DATA/R20m/T15XVL_20250803T225109_B05_20m.tif",
+      "proj:bbox": [399960, 8990220, 509760, 9100020],
+      "proj:shape": [5490, 5490],
+      "proj:transform": [20, 0, 399960, 0, -20, 9100020],
+      "gsd": 20,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "title": "Band 5 - Vegetation red edge 1 - 20m",
+      "eo:bands": [
+        {
+          "name": "B05",
+          "common_name": "rededge",
+          "description": "Band 5 - Vegetation red edge 1",
+          "center_wavelength": 0.704,
+          "full_width_half_max": 0.019
+        }
+      ]
+    },
+    "B06": {
+      "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/15/X/VL/2025/08/03/S2B_MSIL2A_20250803T225109_N0511_R001_T15XVL_20250803T232015.SAFE/GRANULE/L2A_T15XVL_A043928_20250803T225111/IMG_DATA/R20m/T15XVL_20250803T225109_B06_20m.tif",
+      "proj:bbox": [399960, 8990220, 509760, 9100020],
+      "proj:shape": [5490, 5490],
+      "proj:transform": [20, 0, 399960, 0, -20, 9100020],
+      "gsd": 20,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "title": "Band 6 - Vegetation red edge 2 - 20m",
+      "eo:bands": [
+        {
+          "name": "B06",
+          "common_name": "rededge",
+          "description": "Band 6 - Vegetation red edge 2",
+          "center_wavelength": 0.74,
+          "full_width_half_max": 0.018
+        }
+      ]
+    },
+    "B07": {
+      "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/15/X/VL/2025/08/03/S2B_MSIL2A_20250803T225109_N0511_R001_T15XVL_20250803T232015.SAFE/GRANULE/L2A_T15XVL_A043928_20250803T225111/IMG_DATA/R20m/T15XVL_20250803T225109_B07_20m.tif",
+      "proj:bbox": [399960, 8990220, 509760, 9100020],
+      "proj:shape": [5490, 5490],
+      "proj:transform": [20, 0, 399960, 0, -20, 9100020],
+      "gsd": 20,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "title": "Band 7 - Vegetation red edge 3 - 20m",
+      "eo:bands": [
+        {
+          "name": "B07",
+          "common_name": "rededge",
+          "description": "Band 7 - Vegetation red edge 3",
+          "center_wavelength": 0.783,
+          "full_width_half_max": 0.028
+        }
+      ]
+    },
+    "B08": {
+      "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/15/X/VL/2025/08/03/S2B_MSIL2A_20250803T225109_N0511_R001_T15XVL_20250803T232015.SAFE/GRANULE/L2A_T15XVL_A043928_20250803T225111/IMG_DATA/R10m/T15XVL_20250803T225109_B08_10m.tif",
+      "proj:bbox": [399960, 8990220, 509760, 9100020],
+      "proj:shape": [10980, 10980],
+      "proj:transform": [10, 0, 399960, 0, -10, 9100020],
+      "gsd": 10,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "title": "Band 8 - NIR - 10m",
+      "eo:bands": [
+        {
+          "name": "B08",
+          "common_name": "nir",
+          "description": "Band 8 - NIR",
+          "center_wavelength": 0.842,
+          "full_width_half_max": 0.145
+        }
+      ]
+    },
+    "B09": {
+      "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/15/X/VL/2025/08/03/S2B_MSIL2A_20250803T225109_N0511_R001_T15XVL_20250803T232015.SAFE/GRANULE/L2A_T15XVL_A043928_20250803T225111/IMG_DATA/R60m/T15XVL_20250803T225109_B09_60m.tif",
+      "proj:bbox": [399960, 8990220, 509760, 9100020],
+      "proj:shape": [1830, 1830],
+      "proj:transform": [60, 0, 399960, 0, -60, 9100020],
+      "gsd": 60,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "title": "Band 9 - Water vapor - 60m",
+      "eo:bands": [
+        {
+          "name": "B09",
+          "description": "Band 9 - Water vapor",
+          "center_wavelength": 0.945,
+          "full_width_half_max": 0.026
+        }
+      ]
+    },
+    "B11": {
+      "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/15/X/VL/2025/08/03/S2B_MSIL2A_20250803T225109_N0511_R001_T15XVL_20250803T232015.SAFE/GRANULE/L2A_T15XVL_A043928_20250803T225111/IMG_DATA/R20m/T15XVL_20250803T225109_B11_20m.tif",
+      "proj:bbox": [399960, 8990220, 509760, 9100020],
+      "proj:shape": [5490, 5490],
+      "proj:transform": [20, 0, 399960, 0, -20, 9100020],
+      "gsd": 20,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "title": "Band 11 - SWIR (1.6) - 20m",
+      "eo:bands": [
+        {
+          "name": "B11",
+          "common_name": "swir16",
+          "description": "Band 11 - SWIR (1.6)",
+          "center_wavelength": 1.61,
+          "full_width_half_max": 0.143
+        }
+      ]
+    },
+    "B12": {
+      "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/15/X/VL/2025/08/03/S2B_MSIL2A_20250803T225109_N0511_R001_T15XVL_20250803T232015.SAFE/GRANULE/L2A_T15XVL_A043928_20250803T225111/IMG_DATA/R20m/T15XVL_20250803T225109_B12_20m.tif",
+      "proj:bbox": [399960, 8990220, 509760, 9100020],
+      "proj:shape": [5490, 5490],
+      "proj:transform": [20, 0, 399960, 0, -20, 9100020],
+      "gsd": 20,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "title": "Band 12 - SWIR (2.2) - 20m",
+      "eo:bands": [
+        {
+          "name": "B12",
+          "common_name": "swir22",
+          "description": "Band 12 - SWIR (2.2)",
+          "center_wavelength": 2.19,
+          "full_width_half_max": 0.242
+        }
+      ]
+    },
+    "B8A": {
+      "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/15/X/VL/2025/08/03/S2B_MSIL2A_20250803T225109_N0511_R001_T15XVL_20250803T232015.SAFE/GRANULE/L2A_T15XVL_A043928_20250803T225111/IMG_DATA/R20m/T15XVL_20250803T225109_B8A_20m.tif",
+      "proj:bbox": [399960, 8990220, 509760, 9100020],
+      "proj:shape": [5490, 5490],
+      "proj:transform": [20, 0, 399960, 0, -20, 9100020],
+      "gsd": 20,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "title": "Band 8A - Vegetation red edge 4 - 20m",
+      "eo:bands": [
+        {
+          "name": "B8A",
+          "common_name": "rededge",
+          "description": "Band 8A - Vegetation red edge 4",
+          "center_wavelength": 0.865,
+          "full_width_half_max": 0.033
+        }
+      ]
+    },
+    "SCL": {
+      "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/15/X/VL/2025/08/03/S2B_MSIL2A_20250803T225109_N0511_R001_T15XVL_20250803T232015.SAFE/GRANULE/L2A_T15XVL_A043928_20250803T225111/IMG_DATA/R20m/T15XVL_20250803T225109_SCL_20m.tif",
+      "proj:bbox": [399960, 8990220, 509760, 9100020],
+      "proj:shape": [5490, 5490],
+      "proj:transform": [20, 0, 399960, 0, -20, 9100020],
+      "gsd": 20,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "title": "Scene classfication map (SCL)"
+    },
+    "WVP": {
+      "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/15/X/VL/2025/08/03/S2B_MSIL2A_20250803T225109_N0511_R001_T15XVL_20250803T232015.SAFE/GRANULE/L2A_T15XVL_A043928_20250803T225111/IMG_DATA/R10m/T15XVL_20250803T225109_WVP_10m.tif",
+      "proj:bbox": [399960, 8990220, 509760, 9100020],
+      "proj:shape": [10980, 10980],
+      "proj:transform": [10, 0, 399960, 0, -10, 9100020],
+      "gsd": 10,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "title": "Water vapour (WVP)"
+    },
+    "visual": {
+      "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/15/X/VL/2025/08/03/S2B_MSIL2A_20250803T225109_N0511_R001_T15XVL_20250803T232015.SAFE/GRANULE/L2A_T15XVL_A043928_20250803T225111/IMG_DATA/R10m/T15XVL_20250803T225109_TCI_10m.tif",
+      "proj:bbox": [399960, 8990220, 509760, 9100020],
+      "proj:shape": [10980, 10980],
+      "proj:transform": [10, 0, 399960, 0, -10, 9100020],
+      "gsd": 10,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "title": "True color image",
+      "eo:bands": [
+        {
+          "name": "B04",
+          "common_name": "red",
+          "description": "Band 4 - Red",
+          "center_wavelength": 0.665,
+          "full_width_half_max": 0.038
+        },
+        {
+          "name": "B03",
+          "common_name": "green",
+          "description": "Band 3 - Green",
+          "center_wavelength": 0.56,
+          "full_width_half_max": 0.045
+        },
+        {
+          "name": "B02",
+          "common_name": "blue",
+          "description": "Band 2 - Blue",
+          "center_wavelength": 0.49,
+          "full_width_half_max": 0.098
+        }
+      ]
+    },
+    "safe-manifest": {
+      "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/15/X/VL/2025/08/03/S2B_MSIL2A_20250803T225109_N0511_R001_T15XVL_20250803T232015.SAFE/manifest.safe",
+      "type": "application/xml",
+      "roles": [
+        "metadata"
+      ],
+      "title": "SAFE manifest"
+    },
+    "granule-metadata": {
+      "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/15/X/VL/2025/08/03/S2B_MSIL2A_20250803T225109_N0511_R001_T15XVL_20250803T232015.SAFE/GRANULE/L2A_T15XVL_A043928_20250803T225111/MTD_TL.xml",
+      "type": "application/xml",
+      "roles": [
+        "metadata"
+      ],
+      "title": "Granule metadata"
+    },
+    "inspire-metadata": {
+      "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/15/X/VL/2025/08/03/S2B_MSIL2A_20250803T225109_N0511_R001_T15XVL_20250803T232015.SAFE/INSPIRE.xml",
+      "type": "application/xml",
+      "roles": [
+        "metadata"
+      ],
+      "title": "INSPIRE metadata"
+    },
+    "product-metadata": {
+      "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/15/X/VL/2025/08/03/S2B_MSIL2A_20250803T225109_N0511_R001_T15XVL_20250803T232015.SAFE/MTD_MSIL2A.xml",
+      "type": "application/xml",
+      "roles": [
+        "metadata"
+      ],
+      "title": "Product metadata"
+    },
+    "datastrip-metadata": {
+      "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/15/X/VL/2025/08/03/S2B_MSIL2A_20250803T225109_N0511_R001_T15XVL_20250803T232015.SAFE/DATASTRIP/DS_2BPS_20250803T232015_S20250803T225111/MTD_DS.xml",
+      "type": "application/xml",
+      "roles": [
+        "metadata"
+      ],
+      "title": "Datastrip metadata"
+    },
+    "tilejson": {
+      "title": "TileJSON with default rendering",
+      "href": "https://planetarycomputer.microsoft.com/api/data/v1/item/tilejson.json?collection=sentinel-2-l2a&item=S2B_MSIL2A_20250803T225109_R001_T15XVL_20250803T232015&assets=visual&asset_bidx=visual%7C1%2C2%2C3&nodata=0&format=png",
+      "type": "application/json",
+      "roles": [
+        "tiles"
+      ]
+    },
+    "rendered_preview": {
+      "title": "Rendered preview",
+      "rel": "preview",
+      "href": "https://planetarycomputer.microsoft.com/api/data/v1/item/preview.png?collection=sentinel-2-l2a&item=S2B_MSIL2A_20250803T225109_R001_T15XVL_20250803T232015&assets=visual&asset_bidx=visual%7C1%2C2%2C3&nodata=0&format=png",
+      "roles": [
+        "overview"
+      ],
+      "type": "image/png"
+    }
+  },
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [-95.7207461, 81.9330544],
+        [-95.7175848, 81.9198353],
+        [-95.714592, 81.9198432],
+        [-95.7145829, 81.9198041],
+        [-95.7113321, 81.9198118],
+        [-95.7112463, 81.9194438],
+        [-95.7000091, 81.9194705],
+        [-95.6810645, 81.7751521],
+        [-95.6740592, 81.7206909],
+        [-95.6703544, 81.6906599],
+        [-95.6893414, 81.6906125],
+        [-95.6893388, 81.6905824],
+        [-95.6900303, 81.6905806],
+        [-95.6724947, 81.4878624],
+        [-95.6708262, 81.4878668],
+        [-95.6708191, 81.4877821],
+        [-95.6691274, 81.487786],
+        [-95.6691138, 81.4876264],
+        [-95.6551688, 81.4876586],
+        [-95.6513494, 81.2595475],
+        [-95.6679109, 81.2595062],
+        [-95.6679114, 81.2594959],
+        [-95.6685152, 81.2594943],
+        [-95.6775964, 81.0559949],
+        [-95.6756058, 81.0560003],
+        [-95.6756109, 81.055884],
+        [-95.6728261, 81.0558906],
+        [-95.6728354, 81.0556862],
+        [-95.6703378, 81.0556921],
+        [-95.6703397, 81.0556465],
+        [-95.6617027, 81.0556671],
+        [-95.6699929, 80.9503382],
+        [-98.6928391, 80.9292576],
+        [-99.3781161, 81.907481],
+        [-95.7207461, 81.9330544]
+      ]
+    ]
+  },
+  "collection": "s2_l2a",
+  "properties": {
+    "datetime": "2025-08-03T22:51:09.024000Z",
+    "platform": "Sentinel-2B",
+    "proj:epsg": 32615,
+    "instruments": [
+      "msi"
+    ],
+    "s2:mgrs_tile": "15XVL",
+    "constellation": "Sentinel 2",
+    "s2:granule_id": "S2B_OPER_MSI_L2A_TL_2BPS_20250803T232015_A043928_T15XVL_N05.11",
+    "eo:cloud_cover": 90.512687,
+    "s2:datatake_id": "GS2B_20250803T225109_043928_N05.11",
+    "s2:product_uri": "S2B_MSIL2A_20250803T225109_N0511_R001_T15XVL_20250803T232015.SAFE",
+    "s2:datastrip_id": "S2B_OPER_MSI_L2A_DS_2BPS_20250803T232015_S20250803T225111_N05.11",
+    "s2:product_type": "S2MSI2A",
+    "sat:orbit_state": "ascending",
+    "s2:datatake_type": "INS-NOBS",
+    "s2:generation_time": "2025-08-03T23:20:15.000000Z",
+    "sat:relative_orbit": 1,
+    "s2:water_percentage": 0.244149,
+    "s2:mean_solar_zenith": 69.4111936146107,
+    "s2:mean_solar_azimuth": 248.259348809602,
+    "s2:processing_baseline": "05.11",
+    "s2:snow_ice_percentage": 9.243122,
+    "s2:vegetation_percentage": 0.000039,
+    "s2:thin_cirrus_percentage": 18.115379,
+    "s2:cloud_shadow_percentage": 0,
+    "s2:nodata_pixel_percentage": 49.230048,
+    "s2:unclassified_percentage": 0,
+    "s2:not_vegetated_percentage": 0,
+    "s2:degraded_msi_data_percentage": 0.0057,
+    "s2:high_proba_clouds_percentage": 34.519255,
+    "s2:reflectance_conversion_factor": 0.970545213164858,
+    "s2:medium_proba_clouds_percentage": 37.878054,
+    "s2:saturated_defective_pixel_percentage": 0
+  },
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+  ],
+  "stac_version": "1.0.0"
+}

--- a/tests/test_eo3converter.py
+++ b/tests/test_eo3converter.py
@@ -178,7 +178,7 @@ def test_item_to_ds_no_proj(sentinel_stac_ms: pystac.Item) -> None:
     assert item.geometry is not None
     geom = Geometry(item.geometry, "EPSG:4326")
     ds = _item_to_ds(item, product, STAC_CFG)
-    assert ds.crs == "EPSG:4326"
+    assert ds.crs == "EPSG:32606"
     assert ds.extent is not None
     assert ds.extent.contains(geom)
     assert native_geobox(ds).shape == (1, 1)
@@ -322,3 +322,11 @@ def test_roundtrip(eo3_dataset: Dataset, eo3_product: Product):
     assert to_eo3.grids["default"] == eo3_dataset.grids["default"]
     # there's no way to conserve grid names when converting to stac, but values should still be the same
     assert to_eo3.grids["g15"] == eo3_dataset.grids["panchromatic"]
+    assert to_eo3.crs == eo3_dataset.crs
+    assert to_eo3.extent.area == pytest.approx(eo3_dataset.extent.area, abs=0.001)
+    assert all(
+        x == pytest.approx(y)
+        for x, y in zip(
+            rt_doc["geometry"]["coordinates"][0], orig_doc["geometry"]["coordinates"][0]
+        )
+    )

--- a/tests/test_eo3converter.py
+++ b/tests/test_eo3converter.py
@@ -171,6 +171,7 @@ def test_item_to_ds_no_proj(sentinel_stac_ms: pystac.Item) -> None:
     item0 = sentinel_stac_ms
     item = item0.clone()
     item.stac_extensions.remove(ProjectionExtension.get_schema_uri())
+    del item.properties["proj:code"]
     assert has_proj_ext(item) is False
 
     product = infer_dc_product(item, STAC_CFG)
@@ -178,7 +179,7 @@ def test_item_to_ds_no_proj(sentinel_stac_ms: pystac.Item) -> None:
     assert item.geometry is not None
     geom = Geometry(item.geometry, "EPSG:4326")
     ds = _item_to_ds(item, product, STAC_CFG)
-    assert ds.crs == "EPSG:32606"
+    assert ds.crs == "EPSG:4326"
     assert ds.extent is not None
     assert ds.extent.contains(geom)
     assert native_geobox(ds).shape == (1, 1)

--- a/tests/test_eo3converter.py
+++ b/tests/test_eo3converter.py
@@ -5,6 +5,7 @@
 # pylint: disable=unused-argument,unused-variable,missing-module-docstring,wrong-import-position,import-error
 # pylint: disable=redefined-outer-name,protected-access,import-outside-toplevel
 
+import os
 import uuid
 from typing import Any
 
@@ -229,7 +230,7 @@ def test_issue_n6(usgs_landsat_stac_v1: pystac.Item) -> None:
 
 def test_partial_proj(partial_proj_stac: pystac.Item) -> None:
     (ds,) = list(stac2ds([partial_proj_stac]))
-    assert ds.metadata_doc["grids"]["default"]["shape"] == (1, 1)
+    assert ds.metadata_doc["grids"]["default"]["shape"] == [1, 1]
 
 
 def test_noassets_case(no_bands_stac: Any) -> None:
@@ -287,7 +288,9 @@ def test_ds2stac(eo3_dataset: Dataset):
     assert output_stac["links"] == [
         {
             "rel": "self",
-            "href": eo3_dataset.uri.replace("odc-metadata.yaml", "stac-item.json"),
+            "href": os.path.abspath(eo3_dataset.uri).replace(
+                "odc-metadata.yaml", "stac-item.json"
+            ),
             "type": "application/json",
         },
         {

--- a/tests/test_eo3converter.py
+++ b/tests/test_eo3converter.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import pystac
 import pytest
+from affine import Affine
 from odc.geo.geom import Geometry
 from odc.stac._mdtools import RasterCollectionMetadata, has_proj_ext, has_raster_ext
 from pystac.extensions.eo import EOExtension
@@ -231,7 +232,7 @@ def test_issue_n6(usgs_landsat_stac_v1: pystac.Item) -> None:
 
 def test_partial_proj(partial_proj_stac: pystac.Item) -> None:
     (ds,) = list(stac2ds([partial_proj_stac]))
-    assert ds.metadata_doc["grids"]["default"]["shape"] == [1, 1]
+    assert ds.metadata_doc["grids"]["default"]["shape"] == (1, 1)
 
 
 def test_noassets_case(no_bands_stac: Any) -> None:
@@ -304,6 +305,38 @@ def test_ds2stac(eo3_dataset: Dataset):
     ]
 
 
+def test_ds2stac_links(eo3_dataset: Dataset):
+    eo3_dataset.uri = None
+    output_stac = ds2stac(
+        eo3_dataset,
+        self_url="https://localhost/stac/eo3_dataset.json",
+        stac_url="https://localhost/",
+    ).to_dict()
+    assert output_stac["links"] == [
+        {
+            "rel": "self",
+            "href": "https://localhost/stac/eo3_dataset.json",
+            "type": "application/json",
+        },
+        {
+            "rel": "collection",
+            "href": f"https://localhost/stac/collections/{eo3_dataset.product.name}",
+        },
+        {
+            "title": "ODC Product Overview",
+            "rel": "product_overview",
+            "type": "text/html",
+            "href": f"https://localhost/product/{eo3_dataset.product.name}",
+        },
+        {
+            "title": "ODC Dataset Overview",
+            "rel": "alternative",
+            "type": "text/html",
+            "href": f"https://localhost/dataset/{eo3_dataset.id}",
+        },
+    ]
+
+
 def test_sources(ds_legacy_sources: Dataset, ds_ext_lineage: Dataset):
     assert ds2stac(ds_legacy_sources).to_dict()["properties"]["odc:lineage"] == {
         "level1": ["b5f234fe-bba8-5483-9bc0-250360d429cf"]
@@ -314,21 +347,41 @@ def test_sources(ds_legacy_sources: Dataset, ds_ext_lineage: Dataset):
 
 
 def test_roundtrip(eo3_dataset: Dataset, eo3_product: Product):
-    to_stac = ds2stac(eo3_dataset)
-    to_eo3 = _item_to_ds(to_stac, eo3_product)
-    orig_doc = eo3_dataset.metadata_doc
-    rt_doc = to_eo3.metadata_doc
+    original = eo3_dataset
+    roundtrip = _item_to_ds(ds2stac(eo3_dataset), eo3_product)
+    orig_doc = original.metadata_doc
+    rt_doc = roundtrip.metadata_doc
+
     assert set(rt_doc.keys()) == set(orig_doc.keys())
-    assert set(to_eo3.properties.keys()) == set(eo3_dataset.properties.keys())
-    assert len(to_eo3.grids) == 2
-    assert to_eo3.grids["default"] == eo3_dataset.grids["default"]
+    assert set(roundtrip.properties.keys()) == set(original.properties.keys())
+
+    assert len(roundtrip.grids) == 2
+    assert (
+        list(roundtrip.grids["default"]["shape"]) == original.grids["default"]["shape"]
+    )
+    # assert list(roundtrip.grids["default"]["transform"]) == original.grids["default"]["transform"][:6]
+    assert (
+        roundtrip.grids["default"]["transform"]
+        == Affine(*original.grids["default"]["transform"]).to_shapely()
+    )
     # there's no way to conserve grid names when converting to stac, but values should still be the same
-    assert to_eo3.grids["g15"] == eo3_dataset.grids["panchromatic"]
-    assert to_eo3.crs == eo3_dataset.crs
-    assert to_eo3.extent.area == pytest.approx(eo3_dataset.extent.area, abs=0.001)
+    assert (
+        list(roundtrip.grids["g15"]["shape"]) == original.grids["panchromatic"]["shape"]
+    )
+    assert (
+        roundtrip.grids["g15"]["transform"]
+        == Affine(*original.grids["panchromatic"]["transform"]).to_shapely()
+    )
+
+    assert roundtrip.crs == original.crs
+    assert roundtrip.extent.area == pytest.approx(original.extent.area, abs=0.001)
     assert all(
         x == pytest.approx(y)
         for x, y in zip(
             rt_doc["geometry"]["coordinates"][0], orig_doc["geometry"]["coordinates"][0]
         )
     )
+
+    assert set(roundtrip.measurements.keys()) == set(original.measurements.keys())
+    assert roundtrip.measurements["nbar_panchromatic"]["grid"] == "g15"
+    assert set(roundtrip.accessories.keys()) == set(original.accessories.keys())

--- a/tests/test_eo3converter.py
+++ b/tests/test_eo3converter.py
@@ -281,6 +281,7 @@ def test_accessories(sentinel_stac_ms: pystac.Item) -> None:
 
 
 def test_ds2stac(eo3_dataset: Dataset):
+    assert eo3_dataset.uri is not None
     output_stac = ds2stac(eo3_dataset).to_dict()
     assert output_stac["properties"]["instruments"] == ["oli", "tirs"]
     assert set(output_stac["assets"].keys()) == set(

--- a/tests/test_eo3converter.py
+++ b/tests/test_eo3converter.py
@@ -9,9 +9,6 @@ import uuid
 from typing import Any
 
 import pystac
-import pystac.asset
-import pystac.collection
-import pystac.item
 import pytest
 from odc.geo.geom import Geometry
 from odc.stac._mdtools import RasterCollectionMetadata, has_proj_ext, has_raster_ext
@@ -20,16 +17,17 @@ from pystac.extensions.item_assets import ItemAssetsExtension
 from pystac.extensions.projection import ProjectionExtension
 from toolz import dicttoolz
 
-from datacube.metadata import infer_dc_product, stac2ds
+from datacube.metadata import ds2stac, infer_dc_product, stac2ds
 from datacube.metadata._eo3converter import _compute_uuid, _item_to_ds
+from datacube.model import Dataset, Product
 from datacube.testutils.io import native_geobox
 
 from .common import NO_WARN_CFG, STAC_CFG, mk_stac_item
 
 
 def test_infer_product_collection(
-    sentinel_stac_collection: pystac.collection.Collection,
-    sentinel_stac_ms_with_raster_ext: pystac.item.Item,
+    sentinel_stac_collection: pystac.Collection,
+    sentinel_stac_ms_with_raster_ext: pystac.Item,
 ) -> None:
     assert has_raster_ext(sentinel_stac_collection) is True
     product = infer_dc_product(sentinel_stac_collection)
@@ -74,7 +72,7 @@ def test_infer_product_collection(
         infer_dc_product([])
 
 
-def test_infer_product_item(sentinel_stac_ms: pystac.item.Item) -> None:
+def test_infer_product_item(sentinel_stac_ms: pystac.Item) -> None:
     item = sentinel_stac_ms
 
     assert item.collection_id in STAC_CFG
@@ -97,14 +95,14 @@ def test_infer_product_item(sentinel_stac_ms: pystac.item.Item) -> None:
     )
 
     _stac = dicttoolz.dissoc(sentinel_stac_ms.to_dict(), "collection")
-    item_no_collection = pystac.item.Item.from_dict(_stac)
+    item_no_collection = pystac.Item.from_dict(_stac)
     assert item_no_collection.collection_id is None
 
     product = infer_dc_product(item_no_collection)
 
 
 def test_infer_product_raster_ext(
-    sentinel_stac_ms_with_raster_ext: pystac.item.Item,
+    sentinel_stac_ms_with_raster_ext: pystac.Item,
 ) -> None:
     item = sentinel_stac_ms_with_raster_ext.clone()
     assert has_raster_ext(item) is True
@@ -126,7 +124,7 @@ def test_infer_product_raster_ext(
     } == set(product.measurements)
 
 
-def test_item_to_ds(sentinel_stac_ms: pystac.item.Item) -> None:
+def test_item_to_ds(sentinel_stac_ms: pystac.Item) -> None:
     item0 = sentinel_stac_ms
     item = item0.clone()
 
@@ -168,7 +166,7 @@ def test_item_to_ds(sentinel_stac_ms: pystac.item.Item) -> None:
     infer_dc_product(item, NO_WARN_CFG)
 
 
-def test_item_to_ds_no_proj(sentinel_stac_ms: pystac.item.Item) -> None:
+def test_item_to_ds_no_proj(sentinel_stac_ms: pystac.Item) -> None:
     item0 = sentinel_stac_ms
     item = item0.clone()
     item.stac_extensions.remove(ProjectionExtension.get_schema_uri())
@@ -239,7 +237,7 @@ def test_noassets_case(no_bands_stac: Any) -> None:
     assert len(ds.measurements) == 0
 
 
-def test_product_cache(sentinel_stac_ms: pystac.item.Item) -> None:
+def test_product_cache(sentinel_stac_ms: pystac.Item) -> None:
     item = sentinel_stac_ms
     # simulate a product that was not created via infer_dc_product
     # (and therefore did not have the stac attr set)
@@ -248,3 +246,76 @@ def test_product_cache(sentinel_stac_ms: pystac.item.Item) -> None:
     # make sure it doesn't error when product_cache is provided
     (ds,) = stac2ds([item], STAC_CFG, {product.name: product})
     assert ds.id
+
+
+def test_values_converted(s2_l2a_stac, s2_l2a_product) -> None:
+    # check that values that need to be converted are correct
+    (ds,) = stac2ds([s2_l2a_stac], STAC_CFG, {s2_l2a_product.name: s2_l2a_product})
+    assert ds.id
+    # instruments list converted to string
+    assert ds.metadata.instrument == "MSI"
+    # missing properties are filled in
+    assert ds.metadata.format == "GeoTIFF"
+    # aliased measurements are converted to their canonical names
+    assert set(s2_l2a_product.measurements.keys()).issubset(ds.measurements.keys())
+
+
+def test_accessories(sentinel_stac_ms: pystac.Item) -> None:
+    # check accessories are correctly retrieved from assets
+    expected_accs = [
+        "preview",
+        "safe-manifest",
+        "granule-metadata",
+        "inspire-metadata",
+        "product-metadata",
+        "datastrip-metadata",
+        "tilejson",
+        "rendered_preview",
+    ]
+    item = sentinel_stac_ms
+    product = infer_dc_product(item, STAC_CFG)
+    ds = _item_to_ds(item, product, STAC_CFG)
+    assert set(ds.metadata_doc["accessories"].keys()) == set(expected_accs)
+
+
+def test_ds2stac(eo3_dataset: Dataset):
+    output_stac = ds2stac(eo3_dataset).to_dict()
+    assert output_stac["properties"]["instruments"] == ["oli", "tirs"]
+    assert set(output_stac["assets"].keys()) == set(
+        list(eo3_dataset.measurements.keys()) + list(eo3_dataset.accessories.keys())
+    )
+    assert output_stac["links"] == [
+        {
+            "rel": "self",
+            "href": eo3_dataset.uri.replace("odc-metadata.yaml", "stac-item.json"),
+            "type": "application/json",
+        },
+        {
+            "rel": "odc_yaml",
+            "href": eo3_dataset.uri,
+            "type": "text/yaml",
+            "title": "ODC Dataset YAML",
+        },
+    ]
+
+
+def test_sources(ds_legacy_sources: Dataset, ds_ext_lineage: Dataset):
+    assert ds2stac(ds_legacy_sources).to_dict()["properties"]["odc:lineage"] == {
+        "level1": ["b5f234fe-bba8-5483-9bc0-250360d429cf"]
+    }
+    assert ds2stac(ds_ext_lineage).to_dict()["properties"]["odc:lineage"] == {
+        "level1": ["b5f234fe-bba8-5483-9bc0-250360d429cf"]
+    }
+
+
+def test_roundtrip(eo3_dataset: Dataset, eo3_product: Product):
+    to_stac = ds2stac(eo3_dataset)
+    to_eo3 = _item_to_ds(to_stac, eo3_product)
+    orig_doc = eo3_dataset.metadata_doc
+    rt_doc = to_eo3.metadata_doc
+    assert set(rt_doc.keys()) == set(orig_doc.keys())
+    assert set(to_eo3.properties.keys()) == set(eo3_dataset.properties.keys())
+    assert len(to_eo3.grids) == 2
+    assert to_eo3.grids["default"] == eo3_dataset.grids["default"]
+    # there's no way to conserve grid names when converting to stac, but values should still be the same
+    assert to_eo3.grids["g15"] == eo3_dataset.grids["panchromatic"]


### PR DESCRIPTION
### Reason for this pull request

Following on from #2027, port over stac/eo3 conversion logic from `eo-datasets` and `odc-apps-dc-tools` into `datacube.metadata`.


### Proposed changes

- Flesh out `stac2ds` logic by combining it with some of the logic from `stac_transform` in `dc-tools`
- Adapt logic from `eo-datasets` to create `ds2stac` for converting from EO3 to STAC
- Expose the accessories, properties, and grids dicts as Dataset properties for easy access, as they come in use with stac logic (and potentially elsewhere) and are not otherwise accessible via `.metadata`



 - [ ] Closes #xxxx
 - [x] Tests added / passed
 - [x] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2077.org.readthedocs.build/en/2077/

<!-- readthedocs-preview opendatacube end -->