### PR TITLE
docs: build with uv

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,17 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.12"
+  jobs:
+    post_checkout:
+      - git fetch --prune --unshallow
+    pre_create_environment:
+       - asdf plugin add uv
+       - asdf install uv latest
+       - asdf global uv latest
+    create_environment:
+       - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
+    install:
+       - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --frozen --group doc
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -18,9 +29,3 @@ sphinx:
 # If using Sphinx, optionally build your docs in additional formats such as PDF
 # formats:
 #    - pdf
-
-python:
-  install:
-    - requirements: docs/requirements.txt
-    - method: pip
-      path: .

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,6 +5,7 @@
 import os
 import sys
 
+sys.path.insert(0, os.path.abspath("."))
 sys.path.insert(0, os.path.abspath("../.."))
 
 # Configuration file for the Sphinx documentation builder.


### PR DESCRIPTION
### Reason for this pull request

Use uv instead of pip to build the documentation at ReadTheDocs. This speeds up the doc build and eliminates the need for a separate requirements.txt in `docs/`.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2082.org.readthedocs.build/en/2082/

<!-- readthedocs-preview opendatacube end -->