### PR TITLE
Ensure MetadataType  models can always be pickled to support Dask loading

### DIFF
--- a/datacube/index/memory/_metadata_types.py
+++ b/datacube/index/memory/_metadata_types.py
@@ -155,9 +155,8 @@ class MetadataTypeResource(AbstractMetadataTypeResource):
 
     @staticmethod
     def _make(definition: Mapping[str, Any], id_=None) -> MetadataType:
-        return MetadataType(
-            definition, dataset_search_fields=get_dataset_fields(definition), id_=id_
-        )
+        # Note this is an index-specific implementation of get_dataset_fields, not the default
+        return MetadataType(definition, search_field_extractor=get_dataset_fields, id_=id_)
 
     @staticmethod
     def clone(orig: MetadataType) -> MetadataType:

--- a/datacube/index/memory/_metadata_types.py
+++ b/datacube/index/memory/_metadata_types.py
@@ -156,7 +156,9 @@ class MetadataTypeResource(AbstractMetadataTypeResource):
     @staticmethod
     def _make(definition: Mapping[str, Any], id_=None) -> MetadataType:
         # Note this is an index-specific implementation of get_dataset_fields, not the default
-        return MetadataType(definition, search_field_extractor=get_dataset_fields, id_=id_)
+        return MetadataType(
+            definition, search_field_extractor=get_dataset_fields, id_=id_
+        )
 
     @staticmethod
     def clone(orig: MetadataType) -> MetadataType:

--- a/datacube/index/memory/index.py
+++ b/datacube/index/memory/index.py
@@ -166,9 +166,7 @@ class MemoryIndexDriver(AbstractIndexDriver):
         :param definition:
         """
         MetadataType.validate(definition)  # type: ignore
-        return MetadataType(
-            definition, dataset_search_fields=Index.get_dataset_fields(definition)
-        )
+        return MetadataType(definition, search_field_extractor=Index.get_dataset_fields)
 
 
 def index_driver_init() -> MemoryIndexDriver:

--- a/datacube/index/null/index.py
+++ b/datacube/index/null/index.py
@@ -152,9 +152,7 @@ class NullIndexDriver(AbstractIndexDriver):
         :param definition:
         """
         MetadataType.validate(definition)  # type: ignore
-        return MetadataType(
-            definition, dataset_search_fields=Index.get_dataset_fields(definition)
-        )
+        return MetadataType(definition, search_field_extractor=Index.get_dataset_fields)
 
 
 def index_driver_init() -> NullIndexDriver:

--- a/datacube/index/postgis/_metadata_types.py
+++ b/datacube/index/postgis/_metadata_types.py
@@ -281,8 +281,4 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
 
     def _make(self, definition: dict, id_: int | None = None) -> MetadataType:
         MetadataType.validate_eo3(definition)
-        return MetadataType(
-            definition,
-            dataset_search_fields=self._db.get_dataset_fields(definition),
-            id_=id_,
-        )
+        return MetadataType(definition, search_field_extractor=self._db.get_dataset_fields, id_=id_)

--- a/datacube/index/postgis/_metadata_types.py
+++ b/datacube/index/postgis/_metadata_types.py
@@ -281,4 +281,6 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
 
     def _make(self, definition: dict, id_: int | None = None) -> MetadataType:
         MetadataType.validate_eo3(definition)
-        return MetadataType(definition, search_field_extractor=self._db.get_dataset_fields, id_=id_)
+        return MetadataType(
+            definition, search_field_extractor=self._db.get_dataset_fields, id_=id_
+        )

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -273,9 +273,7 @@ class PostgisIndexDriver(AbstractIndexDriver):
         """
         # TODO: Validate metadata is ODCv2 compliant - e.g. either non-raster or EO3.
         MetadataType.validate(definition)  # type: ignore
-        return MetadataType(
-            definition, dataset_search_fields=Index.get_dataset_fields(definition)
-        )
+        return MetadataType(definition, search_field_extractor=Index.get_dataset_fields)
 
     @staticmethod
     @override

--- a/datacube/index/postgres/_metadata_types.py
+++ b/datacube/index/postgres/_metadata_types.py
@@ -284,6 +284,6 @@ class MetadataTypeResource(AbstractMetadataTypeResource, IndexResourceAddIn):
         """
         return MetadataType(
             definition,
-            dataset_search_fields=self._db.get_dataset_fields(definition),
+            search_field_extractor=self._db.get_dataset_fields,
             id_=id_,
         )

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -232,9 +232,7 @@ class PostgresIndexDriver(AbstractIndexDriver):
         :param definition:
         """
         MetadataType.validate(definition)  # type: ignore
-        return MetadataType(
-            definition, dataset_search_fields=Index.get_dataset_fields(definition)
-        )
+        return MetadataType(definition, search_field_extractor=Index.get_dataset_fields)
 
     @staticmethod
     @override

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 import math
 from collections import OrderedDict
-from collections.abc import Generator, Iterable, Iterator, Mapping, Sequence
+from collections.abc import Callable, Generator, Iterable, Iterator, Mapping, Sequence
 from datetime import datetime
 from pathlib import Path
 from typing import Any, TypeAlias
@@ -614,13 +614,16 @@ class MetadataType:
     def __init__(
         self,
         definition: Mapping[str, Any],
-        dataset_search_fields: Mapping[str, Field] | None = None,
+        search_field_extractor: Callable[[Mapping[str, Any]], Mapping[str, Field]]
+        | None = None,
         id_: int | None = None,
     ) -> None:
-        if dataset_search_fields is None:
-            dataset_search_fields = get_dataset_fields(definition)
+        # Build fields using a named extractor function for pickleability
+        if search_field_extractor is None:
+            search_field_extractor = get_dataset_fields
         self.definition = definition
-        self.dataset_fields = dataset_search_fields
+        self.search_field_extractor = search_field_extractor
+        self.dataset_fields = self.search_field_extractor(self.definition)
         self.id = id_
 
     @property
@@ -638,6 +641,21 @@ class MetadataType:
     def validate_eo3(cls, doc) -> None:
         cls.validate(doc)  # type: ignore[attr-defined]
         validate_eo3_compatible_type(doc)
+
+    # Fields defined using SQLAlchemy ORM are not pickleable,
+    # so use a named (and therefore pickleable) extraction function
+    def __getstate__(self) -> Mapping[str, Any]:
+        return {
+            "definition": self.definition,
+            "id": self.id,
+            "search_field_extractor": self.search_field_extractor,
+        }
+
+    def __setstate__(self, state: Mapping[str, Any]) -> None:
+        self.definition = state["definition"]
+        self.id = state["id"]
+        self.search_field_extractor = state["search_field_extractor"]
+        self.dataset_fields = self.search_field_extractor(self.definition)
 
     @override
     def __eq__(self, other: Any) -> bool:
@@ -1272,10 +1290,8 @@ def metadata_from_doc(doc: Mapping[str, Any]) -> MetadataType:
     useful when there is a need to interpret dataset metadata documents
     according to metadata spec.
     """
-    from .fields import get_dataset_fields
-
     MetadataType.validate(doc)  # type: ignore[attr-defined]
-    return MetadataType(doc, get_dataset_fields(doc))
+    return MetadataType(doc)
 
 
 ExtraDimensionSlices: TypeAlias = dict[str, float | tuple[float, float]]

--- a/datacube/model/fields.py
+++ b/datacube/model/fields.py
@@ -231,4 +231,6 @@ def get_dataset_fields(metadata_definition: Mapping[str, Any]) -> dict[str, Fiel
     implementation.
     """
     fields = toolz.get_in(["dataset", "search_fields"], metadata_definition, {})
-    return {n: parse_search_field(doc, name=n) for n, doc in fields.items()}
+    return {
+        n: parse_search_field(doc, name=n) for n, doc in fields.items()
+    }

--- a/datacube/model/fields.py
+++ b/datacube/model/fields.py
@@ -231,6 +231,4 @@ def get_dataset_fields(metadata_definition: Mapping[str, Any]) -> dict[str, Fiel
     implementation.
     """
     fields = toolz.get_in(["dataset", "search_fields"], metadata_definition, {})
-    return {
-        n: parse_search_field(doc, name=n) for n, doc in fields.items()
-    }
+    return {n: parse_search_field(doc, name=n) for n, doc in fields.items()}

--- a/integration_tests/index/test_memory_index.py
+++ b/integration_tests/index/test_memory_index.py
@@ -43,6 +43,7 @@ def test_mem_user_resource(mem_index_fresh: Datacube) -> None:
     assert ("odc_user", "test_user_1", "Test1") in users
     assert ("agdc_user", "test_user_2", "Test2") in users
     # Test create_user errors
+
     with pytest.raises(ValueError) as e:
         mem_index_fresh.index.users.create_user(
             "test_user_2", "password123", "agdc_user", "Test2"

--- a/tests/api/test_virtual.py
+++ b/tests/api/test_virtual.py
@@ -62,7 +62,6 @@ def example_metadata_type():
                 "sources": ["lineage", "source_datasets"],
             },
         },
-        dataset_search_fields={},
     )
 
 

--- a/tests/index/test_api_index_dataset.py
+++ b/tests/index/test_api_index_dataset.py
@@ -123,8 +123,7 @@ _EXAMPLE_METADATA_TYPE = MetadataType(
             "measurements": ["image", "bands"],
             "sources": ["lineage", "source_datasets"],
         },
-    },
-    dataset_search_fields={},
+    }
 )
 
 _EXAMPLE_PRODUCT = Product(

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -661,7 +661,6 @@ _EXAMPLE_METADATA_TYPE = MetadataType(
             "format": ["format", "name"],
         },
     },
-    dataset_search_fields={},
 )
 
 _EXAMPLE_PRODUCT = Product(

--- a/tests/test_metadata_fields.py
+++ b/tests/test_metadata_fields.py
@@ -52,6 +52,7 @@ dataset:
 """)
 
 SAMPLE_DOC = yaml.safe_load("""---
+id: usually_a_uuid_str
 x_string_path: some_string
 x_double_path: 6.283185307179586
 x_integer_path: 4466778

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -431,17 +431,8 @@ def test_metadata_type() -> None:
                 "format": ["format", "name"],
             },
         },
-        dataset_search_fields={},
     )
 
-    assert "eo" in str(m)
-    assert "eo" in repr(m)
-    assert m.name == "eo"
-    assert m.description is None
-    assert m.dataset_reader({}) is not None
-
-    # again but without dataset_search_fields
-    m = MetadataType(m.definition)
     assert "eo" in str(m)
     assert "eo" in repr(m)
     assert m.name == "eo"

--- a/tests/test_utils_docs.py
+++ b/tests/test_utils_docs.py
@@ -173,7 +173,6 @@ def test_without_lineage_sources() -> None:
                 "format": ["format", "name"],
             },
         },
-        dataset_search_fields={},
     )
 
     test_doc = mk_sample(10)


### PR DESCRIPTION
### Reason for this pull request

As raised by @alexgleith in the re-opened #1913 , pickling errors occur when performing a Dask load using the legacy loader driver and datasets returned by the postgis index driver.

The problem is that Metadata Type models (within the Dataset model) returned by the postgis driver are not pickleable.  This is because MetadataTypes contain driver-specific `Field` objects which are unpickleable in the postgis driver because they use the newer ORM-style schema definitions.

### Proposed changes

- Change to the `MetadataType` constructor to take a function that constructs the Field dictionary from the yaml definition, instead of passing the Fields in directly to the constructor.  This is a safe change as users are already strongly advised to use the various helper methods in the API to construct `MetadataType` objects and to NOT use the `MetadataType` constructor directly.  (This MUST be a proper named function, not a lambda, or we are back where we started.)
- `MetadataType.__setstate__()` and `__getstate__()` methods that construct the Field dictionary dynamically from the function passed to the constuctor, thus restoring pickleability to all MetadataTypes.
- Update the various helper methods mentioned above to use the new constructor correctly.
- Corresponding changes to tests

IMO this is overall cleaner than what we had before, but acknowledge we can do better in the longer term:

Future further refactoring should be performed so that `MetadataType` models only carry generic non-driver-specific fields, with the relevant index driver generating its own driver-specific Fields dynamically as needed, but we can hold those changes over for a future PR as this is a critical bug.

In draft so I can review test coverage and see if we need some new tests.

 - [x] Closes #1913
 - [x] Tests added / passed
 - [x] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2083.org.readthedocs.build/en/2083/

<!-- readthedocs-preview opendatacube end -->