### PR TITLE
dockerignore: update with more patterns

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,102 +1,76 @@
-.appveyor
-.circleci
-.github
-.travis
-.pre-commit-config.yaml
-.readthedocs.yaml
-.mergify.yml
-integration_tests
-tests
-!tests/drivers/fail_drivers
-
-# Files that are only used by docker compose.
+# Files that are only used by docker/docker compose.
+docker-compose.yaml
+docker-compose.*.yaml
 docker-compose.yml
+docker-compose.*.yml
+.docker
+.dockerignore
+conda-environment.yml
 docker/assets/create-pg-databases.sh
 
 # Byte-compiled / optimized / DLL files
 **/__pycache__
 **/*.py[cod]
 
-# C extensions
-**/*.so
-
-# Distribution / packaging
-.Python
-env/
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
+# CI / distribution / packaging
+**/*.egg-info
+.github
+.git-blame-ignore-revs
+.gitignore
+.mergify.yml
+.pre-commit-config.yaml
+.readthedocs.yaml
+.stylelintrc
 .venv
-**/*.egg-info/
-.installed.cfg
-**/*.egg
-conda-environment.yml
-
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Test / coverage reports
-htmlcov/
-.tox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-.hypothesis
-.pytest_cache
-.mypy_cache
+.yamllint
+build
+datacube/_version.py
+dist
+license-template.txt
 pylintrc
+
+# Test and coverage reports
+**/htmlcov
+**/.tox
+**/.coverage
+**/.coveragerc
+**/.coverage.*
+**/.cache
+**/nosetests.xml
+**/coverage.xml
+**/*.cover
+**/.hypothesis
+.editorconfig
+.mypy_cache
+.pytest_cache
 .ruff_cache
+check-code.sh
+integration_tests
+odc_search_profile.py
+tests
+!tests/drivers/fail_drivers
+
+# Django stuff:
+**/*.log
+
+# Documentation
+*.md
+*.png
+*.rst
+docs
+LICENSE
 spellcheck.yaml
 wordlist.txt
 
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-
-# Sphinx documentation
-docs/build/
-
 # PyBuilder
-target/
-.idea/
+**/target
 
 # iPython Notebook
-.ipynb_checkpoints
+**/.ipynb_checkpoints
 
 # Mac OS X
-.DS_Store
+**/.DS_Store
 
-# Generated Documentation
-**/generate/
-docs/notebooks/
-
-#Local Visual Studio Code configurations
-.vscode/
-.env
-
-CONTRIBUTING.md
-code-of-conduct.md
-.editorconfig
-LICENSE
-README.rst
+# IDE settings
+.idea
+.vscode


### PR DESCRIPTION
### Reason for this pull request

This should improve the build time
since there is less context to be
transferred, and also improve the Docker
cache hit rates.

This mostly aligns the file with the dockerignores
from Explorer and OWS.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2084.org.readthedocs.build/en/2084/

<!-- readthedocs-preview opendatacube end -->