### PR TITLE
docs: autogenerate version

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,9 +18,22 @@ sys.path.insert(0, os.path.abspath("../.."))
 project = "Open Data Cube"
 copyright = "2015-2025, ODC Contributors"
 author = "Open Data Cube"
-version = "1.9"
-# FIXME: obtain real version by running git
-release = "version"
+
+# Getting the version requires importing a couple of symbols from datacube._version.
+# Importing from datacube interferes with autodoc_mock_imports, which in turn causes
+# a build failure, so adjust sys.path and do a direct import of _version, and then
+# restore sys.path to its previous value.
+version_path = os.path.abspath("../../datacube")
+sys.path.insert(0, version_path)
+
+import _version
+
+version = f"{_version.__version_tuple__[0]}.{_version.__version_tuple__[1]}"
+# The full version, including alpha/beta/rc tags.
+release = _version.__version__
+
+sys.path.remove(version_path)
+# Direct import trickery done, sys.path has been restored.
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,7 +169,11 @@ filterwarnings = [
 ]
 
 [tool.ruff]
-extend-exclude = ["datacube/drivers/postgis/alembic/versions"]
+extend-exclude = [
+    "datacube/_version.py",
+    "datacube/drivers/postgis/alembic/versions",
+    "docs/source/conf.py",
+]
 
 [tool.ruff.lint]
 select = [
@@ -209,9 +213,6 @@ extend-ignore-names = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-# Generated files, exclude from linting.
-"datacube/_version.py" = ["I", "UP"]
-"docs/source/conf.py" = ["A"]
 # SQLAlchemy has overloaded ==, so use that (or is_) to compare with None.
 "datacube/drivers/postgis/_api.py" = ["E711"]
 "datacube/drivers/postgis/_schema.py" = ["E711"]


### PR DESCRIPTION
### Reason for this pull request

This prevents the documentation
version from getting out of sync.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2085.org.readthedocs.build/en/2085/

<!-- readthedocs-preview opendatacube end -->