### PR TITLE
Make configure_s3_access driver aware

### DIFF
--- a/datacube/utils/aws/__init__.py
+++ b/datacube/utils/aws/__init__.py
@@ -19,6 +19,7 @@ from botocore.client import BaseClient
 from botocore.config import Config
 from botocore.credentials import Credentials, ReadOnlyCredentials
 from botocore.session import Session
+from odc.loader._rio import configure_s3_access as rio_configure_s3_access
 from sqlalchemy.engine.url import URL
 
 from datacube.utils.generic import thread_local_cache
@@ -479,6 +480,7 @@ def configure_s3_access(
     requester_pays: bool = False,
     cloud_defaults: bool = True,
     client=None,
+    driver: str | None = None,
     **gdal_opts,
 ) -> Credentials | None:
     """Credentialize for S3 bucket access or configure public access.
@@ -508,6 +510,18 @@ def configure_s3_access(
 
     :returns: credentials object or ``None`` if ``aws_unsigned=True``
     """
+    if driver == "rio":
+        # rio driver has a different approach to RIO configuration.
+        # The approaches may be reconcilable in future, but probably not worth the effort.
+        return rio_configure_s3_access(
+            profile=profile,
+            region_name=region_name,
+            aws_unsigned=aws_unsigned,
+            requester_pays=requester_pays,
+            cloud_defaults=cloud_defaults,
+            **gdal_opts,
+        )
+
     from ..rio import set_default_rio_config
 
     aws, creds = get_aws_settings(

--- a/datacube/utils/rio/_rio.py
+++ b/datacube/utils/rio/_rio.py
@@ -10,8 +10,10 @@ from typing import Literal
 
 import rasterio
 import rasterio.env
+from deprecat import deprecat
 from rasterio.session import AWSSession, DummySession
 
+from datacube.migration import ODC2DeprecationWarning
 from datacube.utils.generic import thread_local_cache
 
 _CFG_LOCK = threading.Lock()
@@ -156,6 +158,11 @@ def set_default_rio_config(aws=None, cloud_defaults: bool = False, **kwargs) -> 
         )
 
 
+@deprecat(
+    reason="This method is deprecated. Use datacube.utils.aws.configure_s3_access instead.",
+    version="1.9.7",
+    category=ODC2DeprecationWarning,
+)
 def configure_s3_access(
     profile: str | None = None,
     region_name: str = "auto",

--- a/tests/test_utils_rio.py
+++ b/tests/test_utils_rio.py
@@ -9,10 +9,10 @@ import moto
 import pytest
 
 from datacube.testutils import write_files
+from datacube.utils.aws import configure_s3_access
 from datacube.utils.rio import (
     activate_from_config,
     activate_rio_env,
-    configure_s3_access,
     deactivate_rio_env,
     get_rio_env,
     set_default_rio_config,

--- a/tests/test_utils_rio.py
+++ b/tests/test_utils_rio.py
@@ -154,6 +154,7 @@ def test_rio_configure_aws_access(monkeypatch, without_aws_env, dask_client) -> 
     monkeypatch.setenv("AWS_DEFAULT_REGION", "fake-region")
 
     creds = configure_s3_access()
+    assert creds is not None
     cc = creds.get_frozen_credentials()
     assert cc.access_key == "fake-key-id"
     assert cc.secret_key == "fake-secret"
@@ -177,6 +178,7 @@ def test_rio_configure_aws_access(monkeypatch, without_aws_env, dask_client) -> 
     client = dask_client
 
     creds = configure_s3_access(client=client)
+    assert creds is not None
     cc = creds.get_frozen_credentials()
     assert cc.access_key == "fake-key-id"
     assert cc.secret_key == "fake-secret"


### PR DESCRIPTION
### Reason for this pull request

As noted in #2081, switching between the legacy and rio drivers results in having to change the way RIO is configured for cloud access.

It is probably possible to get the legacy and rio drivers sharing the same configuration layer eventually, but not in this PR.

### Proposed changes

- Formally deprecate the `datacube.utils.rio.configure_s3_access` method, which just a partial wrapper around the utils.aws version (and has been deprecated in the docstring forever) and migrate tests to use the preferred location.
-  Add an optional `driver` argument to `configure_s3_access`.  When it is set to "rio", the call is forwarded to the odc-loader version.



 - [x] Closes #2081
 - [x] Tests added / passed
 - [x] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2087.org.readthedocs.build/en/2087/

<!-- readthedocs-preview opendatacube end -->