### PR TITLE
Update broken installation docs.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ Developer setup
 
 Install test dependencies using:
 
-   ``pip install --upgrade -e '.[test]'``
+   ``pip install --upgrade -e '.[dev]'``
 
 If install for these fails, please lodge them as issues.
 

--- a/docs/source/installation/setup/macosx.rst
+++ b/docs/source/installation/setup/macosx.rst
@@ -52,7 +52,7 @@ Verify it all works
 Install additional test dependencies::
 
     cd datacube-core
-    pip install --upgrade -e '.[test]'
+    pip install --upgrade -e '.[dev]'
 
 Run the integration tests::
 

--- a/docs/source/installation/setup/ubuntu.rst
+++ b/docs/source/installation/setup/ubuntu.rst
@@ -72,7 +72,7 @@ Verify it all works
 Install additional test dependencies::
 
     cd datacube-core
-    pip install --upgrade -e '.[test]'
+    pip install --upgrade -e '.[dev]'
 
 Run the integration tests::
 

--- a/docs/source/installation/setup/windows.rst
+++ b/docs/source/installation/setup/windows.rst
@@ -40,7 +40,7 @@ Install required python packages and create an ``odc`` conda environment.
 
 Python::
 
-   conda create --name odc_env python=3.8 datacube
+   conda create --name odc_env python=3.12 datacube
 
 Activate ``odc`` python environment::
 


### PR DESCRIPTION
### Reason for this pull request

As per #2028


### Proposed changes

- Advise `pip install -e .[dev]` instead of `pip install -e .[test]` in installation instructions as the latter no longer exists



 - [x] Closes #2028
 - [n/a ] Tests added / passed
 - [x] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2091.org.readthedocs.build/en/2091/

<!-- readthedocs-preview opendatacube end -->