### PR TITLE
CI: fixate time stamp for image layers (reproducible docker builds)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,11 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
+    - name: Get Git commit timestamps
+      run: |
+        TIMESTAMP=$(git log -1 --pretty=%ct pyproject.toml uv.lock datacube examples)
+        echo "TIMESTAMP=$TIMESTAMP" >> $GITHUB_ENV
+
     - name: Build Docker
       uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
       with:
@@ -50,6 +55,8 @@ jobs:
         load: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
+      env:
+        SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}
 
     - name: Verify and Run Tests
       run: |


### PR DESCRIPTION
### Reason for this pull request

Set the timestamp of the layers in
the Docker image according to:

https://docs.docker.com/build/ci/github-actions/reproducible-builds/

We improve on that solution by
just getting the time of the last
commit for the package-related
files, so timestamps change
less often.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2094.org.readthedocs.build/en/2094/

<!-- readthedocs-preview opendatacube end -->