### PR TITLE
Use datetime instead of dateutil

### DIFF
--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -100,8 +100,8 @@ class Query:
         Use by accessing :attr:`search_terms`:
 
         >>> query.search_terms['time']  # doctest: +NORMALIZE_WHITESPACE
-        Range(begin=datetime.datetime(2001, 1, 1, 0, 0, tzinfo=tzutc()), \
-        end=datetime.datetime(2002, 1, 1, 23, 59, 59, 999999, tzinfo=tzutc()))
+        Range(begin=datetime.datetime(2001, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), \
+        end=datetime.datetime(2002, 1, 1, 23, 59, 59, 999999, tzinfo=datetime.timezone.utc))
 
         By passing in an ``index``, the search parameters will be validated as existing on the ``product``,
         and a spatial search appropriate for the index driver can be extracted.

--- a/datacube/index/fields.py
+++ b/datacube/index/fields.py
@@ -6,9 +6,8 @@
 Common datatypes for DB drivers.
 """
 
-from datetime import date, datetime, time
+from datetime import date, datetime, time, timezone
 
-from dateutil.tz import UTC
 from typing_extensions import override
 
 from datacube.model import Not, Range
@@ -66,8 +65,8 @@ def as_expression(field: Field, value) -> Expression:
         return as_expression(
             field,
             Range(
-                datetime.combine(value, time.min.replace(tzinfo=UTC)),
-                datetime.combine(value, time.max.replace(tzinfo=UTC)),
+                datetime.combine(value, time.min.replace(tzinfo=timezone.utc)),
+                datetime.combine(value, time.max.replace(tzinfo=timezone.utc)),
             ),
         )
     return field == value

--- a/datacube/utils/dates.py
+++ b/datacube/utils/dates.py
@@ -10,7 +10,7 @@ Includes sequence generation functions to be used by statistics apps
 """
 
 from collections.abc import Iterator
-from datetime import date, datetime, tzinfo
+from datetime import date, datetime, timezone, tzinfo
 
 import dateutil
 import dateutil.parser
@@ -18,7 +18,6 @@ import numpy as np
 import xarray as xr
 from dateutil.relativedelta import relativedelta
 from dateutil.rrule import DAILY, MONTHLY, YEARLY, rrule
-from dateutil.tz import UTC
 
 FREQS: dict[str, int] = {"y": YEARLY, "m": MONTHLY, "d": DAILY}
 DURATIONS = {"y": "years", "m": "months", "d": "days"}
@@ -76,11 +75,11 @@ def normalise_dt(dt: str | datetime) -> datetime:
     if isinstance(dt, str):
         dt = parse_time(dt)
     if dt.tzinfo is not None:
-        dt = dt.astimezone(UTC).replace(tzinfo=None)
+        dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
     return dt
 
 
-def tz_aware(dt: datetime, default: tzinfo = UTC) -> datetime:
+def tz_aware(dt: datetime, default: tzinfo = timezone.utc) -> datetime:
     """Ensure a datetime is timezone aware, defaulting to UTC or a user-selected default"""
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=default)
@@ -90,8 +89,8 @@ def tz_aware(dt: datetime, default: tzinfo = UTC) -> datetime:
 def tz_as_utc(dt: datetime) -> datetime:
     """Ensure a datetime has a UTC timezone"""
     if dt.tzinfo is None:
-        return dt.replace(tzinfo=UTC)
-    return dt.astimezone(UTC)
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
 
 
 def mk_time_coord(

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -9,12 +9,12 @@ Module
 import datetime
 import warnings
 from collections import namedtuple
+from datetime import timezone
 from typing import Any
 
 import pytest
 import yaml
 from antimeridian import FixWindingWarning
-from dateutil.tz import UTC
 
 import datacube.scripts.cli_app
 import datacube.scripts.search_tool
@@ -572,7 +572,7 @@ def test_search_returning_eo3(
     assert format_ == "GeoTIFF"
 
     # It's always UTC in the document
-    expected_time = creation_time.astimezone(UTC).replace(tzinfo=None)
+    expected_time = creation_time.astimezone(timezone.utc).replace(tzinfo=None)
     assert expected_time.isoformat() == ls8_eo3_dataset.metadata.creation_dt
     assert label == ls8_eo3_dataset.metadata.label
 
@@ -932,8 +932,8 @@ def test_count_time_groups(index: Index, ls8_eo3_dataset: Dataset) -> None:
             "1 day",
             product=ls8_eo3_dataset.product.name,
             time=Range(
-                datetime.datetime(2016, 5, 11, tzinfo=UTC),
-                datetime.datetime(2016, 5, 13, tzinfo=UTC),
+                datetime.datetime(2016, 5, 11, tzinfo=timezone.utc),
+                datetime.datetime(2016, 5, 13, tzinfo=timezone.utc),
             ),
         )
     )
@@ -942,15 +942,15 @@ def test_count_time_groups(index: Index, ls8_eo3_dataset: Dataset) -> None:
     assert timeline == [
         (
             Range(
-                datetime.datetime(2016, 5, 11, tzinfo=UTC),
-                datetime.datetime(2016, 5, 12, tzinfo=UTC),
+                datetime.datetime(2016, 5, 11, tzinfo=timezone.utc),
+                datetime.datetime(2016, 5, 12, tzinfo=timezone.utc),
             ),
             0,
         ),
         (
             Range(
-                datetime.datetime(2016, 5, 12, tzinfo=UTC),
-                datetime.datetime(2016, 5, 13, tzinfo=UTC),
+                datetime.datetime(2016, 5, 12, tzinfo=timezone.utc),
+                datetime.datetime(2016, 5, 13, tzinfo=timezone.utc),
             ),
             1,
         ),

--- a/integration_tests/index/test_search_legacy.py
+++ b/integration_tests/index/test_search_legacy.py
@@ -9,13 +9,13 @@ Module
 import copy
 import datetime
 import uuid
+from datetime import timezone
 from decimal import Decimal
 from typing import Any
 from uuid import UUID
 
 import pytest
 import yaml
-from dateutil.tz import UTC
 from odc.geo import CRS
 from sqlalchemy.dialects.postgresql.ranges import Range as SQLARange
 
@@ -586,7 +586,7 @@ def test_search_returning(
     assert format_ == "PSEUDOMD"
 
     # It's always UTC in the document
-    expected_time = creation_time.astimezone(UTC).replace(tzinfo=None)
+    expected_time = creation_time.astimezone(timezone.utc).replace(tzinfo=None)
     assert expected_time.isoformat() == pseudo_ls8_dataset.metadata_doc["creation_dt"]
     assert label == pseudo_ls8_dataset.metadata_doc["ga_label"]
 

--- a/tests/scripts/test_search_tool.py
+++ b/tests/scripts/test_search_tool.py
@@ -7,9 +7,9 @@ Module
 """
 
 import datetime
+from datetime import timezone
 from os import terminal_size
 
-from dateutil.tz import UTC
 from sqlalchemy.dialects.postgresql import Range as PgRange
 
 from datacube.index.fields import Field
@@ -38,7 +38,7 @@ def test_csv_serialise() -> None:
         [
             {"f1": 12, "f2": PgRange(1.0, 2.0)},
             {
-                "f1": datetime.datetime(2014, 7, 26, 23, 48, 0, tzinfo=UTC),
+                "f1": datetime.datetime(2014, 7, 26, 23, 48, 0, tzinfo=timezone.utc),
                 "f2": PgRange(-1.0, 2.0),
             },
             {"f1": datetime.datetime(2014, 7, 26, 23, 48, 0), "f2": "landsat"},
@@ -61,7 +61,7 @@ def test_pretty_serialise() -> None:
         [
             {"f1": 12, "field 2": PgRange(1.0, 2.0)},
             {
-                "f1": datetime.datetime(2014, 7, 26, 23, 48, 0, tzinfo=UTC),
+                "f1": datetime.datetime(2014, 7, 26, 23, 48, 0, tzinfo=timezone.utc),
                 "field 2": PgRange(-1.0, 2.0),
             },
             {"f1": datetime.datetime(2014, 7, 26, 23, 48, 0), "field 2": "landsat"},

--- a/tests/test_utils_dates.py
+++ b/tests/test_utils_dates.py
@@ -2,13 +2,12 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from datetime import datetime
+from datetime import datetime, timezone
 
 import numpy as np
 import pytest
 from dateutil.relativedelta import relativedelta
 from dateutil.rrule import DAILY, MONTHLY, YEARLY
-from dateutil.tz import UTC
 
 from datacube.utils.dates import (
     mk_time_coord,
@@ -63,7 +62,7 @@ def test_tz_aware() -> None:
 
     dt_notz = parse_time("2020-11-15T15:11:56.23456")
     assert dt_notz.tzinfo is None
-    assert tz_aware(parse_time("2020-11-15T15:11:56.23456")).tzinfo == UTC
+    assert tz_aware(parse_time("2020-11-15T15:11:56.23456")).tzinfo == timezone.utc
     assert (
         tz_aware(parse_time("2020-11-15T15:11:56.23456"), default=dt_tz.tzinfo).tzinfo
         == dt_tz.tzinfo

--- a/tests/ui/test_expression_parsing.py
+++ b/tests/ui/test_expression_parsing.py
@@ -2,9 +2,7 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from datetime import datetime
-
-from dateutil.tz import UTC
+from datetime import datetime, timezone
 
 from datacube.model import Range
 from datacube.ui import parse_expressions
@@ -81,15 +79,15 @@ def test_parse_uri_expression() -> None:
 def test_parse_dates() -> None:
     assert parse_expressions("time in 2014-03-02") == {
         "time": Range(
-            begin=datetime(2014, 3, 2, 0, 0, tzinfo=UTC),
-            end=datetime(2014, 3, 2, 23, 59, 59, 999999, tzinfo=UTC),
+            begin=datetime(2014, 3, 2, 0, 0, tzinfo=timezone.utc),
+            end=datetime(2014, 3, 2, 23, 59, 59, 999999, tzinfo=timezone.utc),
         )
     }
 
     assert parse_expressions("time in 2014-3-2") == {
         "time": Range(
-            begin=datetime(2014, 3, 2, 0, 0, tzinfo=UTC),
-            end=datetime(2014, 3, 2, 23, 59, 59, 999999, tzinfo=UTC),
+            begin=datetime(2014, 3, 2, 0, 0, tzinfo=timezone.utc),
+            end=datetime(2014, 3, 2, 23, 59, 59, 999999, tzinfo=timezone.utc),
         )
     }
 
@@ -98,8 +96,8 @@ def test_parse_dates() -> None:
     # for backwards compatibility.
     march_2014 = {
         "time": Range(
-            begin=datetime(2014, 3, 1, 0, 0, tzinfo=UTC),
-            end=datetime(2014, 3, 31, 23, 59, 59, 999999, tzinfo=UTC),
+            begin=datetime(2014, 3, 1, 0, 0, tzinfo=timezone.utc),
+            end=datetime(2014, 3, 31, 23, 59, 59, 999999, tzinfo=timezone.utc),
         )
     }
     assert parse_expressions("time in 2014-03") == march_2014
@@ -107,8 +105,8 @@ def test_parse_dates() -> None:
 
     implied_feb_march_2014 = {
         "time": Range(
-            begin=datetime(2014, 2, 1, 0, 0, tzinfo=UTC),
-            end=datetime(2014, 3, 31, 23, 59, 59, 999999, tzinfo=UTC),
+            begin=datetime(2014, 2, 1, 0, 0, tzinfo=timezone.utc),
+            end=datetime(2014, 3, 31, 23, 59, 59, 999999, tzinfo=timezone.utc),
         )
     }
     assert parse_expressions("time in [2014-02, 2014-03]") == implied_feb_march_2014
@@ -117,8 +115,8 @@ def test_parse_dates() -> None:
 def test_parse_date_ranges() -> None:
     eighth_march_2014 = {
         "time": Range(
-            datetime(2014, 3, 8, tzinfo=UTC),
-            datetime(2014, 3, 8, 23, 59, 59, 999999, tzinfo=UTC),
+            datetime(2014, 3, 8, tzinfo=timezone.utc),
+            datetime(2014, 3, 8, 23, 59, 59, 999999, tzinfo=timezone.utc),
         )
     }
     assert parse_expressions("time in 2014-03-08") == eighth_march_2014
@@ -126,8 +124,8 @@ def test_parse_date_ranges() -> None:
 
     march_2014 = {
         "time": Range(
-            datetime(2014, 3, 1, tzinfo=UTC),
-            datetime(2014, 3, 31, 23, 59, 59, 999999, tzinfo=UTC),
+            datetime(2014, 3, 1, tzinfo=timezone.utc),
+            datetime(2014, 3, 31, 23, 59, 59, 999999, tzinfo=timezone.utc),
         )
     }
     assert parse_expressions("time in 2014-03") == march_2014
@@ -135,8 +133,8 @@ def test_parse_date_ranges() -> None:
     # Leap year, 28 days
     feb_2014 = {
         "time": Range(
-            datetime(2014, 2, 1, tzinfo=UTC),
-            datetime(2014, 2, 28, 23, 59, 59, 999999, tzinfo=UTC),
+            datetime(2014, 2, 1, tzinfo=timezone.utc),
+            datetime(2014, 2, 28, 23, 59, 59, 999999, tzinfo=timezone.utc),
         )
     }
     assert parse_expressions("time in 2014-02") == feb_2014
@@ -145,8 +143,8 @@ def test_parse_date_ranges() -> None:
     # Entire year
     year_2014 = {
         "time": Range(
-            datetime(2014, 1, 1, tzinfo=UTC),
-            datetime(2014, 12, 31, 23, 59, 59, 999999, tzinfo=UTC),
+            datetime(2014, 1, 1, tzinfo=timezone.utc),
+            datetime(2014, 12, 31, 23, 59, 59, 999999, tzinfo=timezone.utc),
         )
     }
     assert parse_expressions("time in 2014") == year_2014


### PR DESCRIPTION
### Reason for this pull request

Switch to using the standard library
for the UTC timezone in the remaining
places that still use dateutil.

Short-term this does not provide
any benefit, but it makes it clear
which parts of the code that require
functionality beyond that of
the standard library.


### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2114.org.readthedocs.build/en/2114/

<!-- readthedocs-preview opendatacube end -->