### PR TITLE
Make handling of coords in create_storage backwards compatible

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -790,7 +790,7 @@ class Datacube:
         # 2D defaults
         # retrieve dims from coords if DataArray
         dims_default: tuple[Hashable, ...] = ()
-        if coords is not None:
+        if coords:
             coords_value = next(iter(coords.values()))
             if isinstance(coords_value, xarray.DataArray):
                 dims_default = coords_value.dims + geobox.dimensions
@@ -799,12 +799,12 @@ class Datacube:
             dims_default = (() if coords is None else coords.dims) + geobox.dimensions
 
         shape_default = (
-            ()
-            if coords is None
-            else tuple(c.size for k, c in coords.items() if k in dims_default)
+            tuple(c.size for k, c in coords.items() if k in dims_default)
+            if coords
+            else ()
         ) + geobox.shape
         coords_default: OrderedDict[str, xarray.DataArray] = OrderedDict()
-        if coords is not None:
+        if coords:
             coords_default.update([(str(k), v) for k, v in coords.items()])
         coords_default.update(
             [(str(k), v) for k, v in xr_coords(geobox, spatial_ref).items()]

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -791,19 +791,19 @@ class Datacube:
         if isinstance(coords, dict):
             warnings.warn(
                 "The coords argument to Datacube.create_storage is now expected "
-                "as a DataArrayCoordinates object instead of a dict.",
+                "as a DataArrayCoordinates object or None instead of a dict.",
                 ODC2DeprecationWarning,
             )
             coords = None if coords == {} else DataArrayCoordinates(*coords.values())
 
-        dims_default = (coords.dims if coords else ()) + geobox.dimensions
+        dims_default = (() if coords is None else coords.dims) + geobox.dimensions
         shape_default = (
-            tuple(c.size for k, c in coords.items() if k in dims_default)
-            if coords
-            else ()
+            ()
+            if coords is None
+            else tuple(c.size for k, c in coords.items() if k in dims_default)
         ) + geobox.shape.yx
         coords_default: OrderedDict[str, xarray.DataArray] = OrderedDict()
-        if coords:
+        if coords is not None:
             coords_default.update([(str(k), v) for k, v in coords.items()])
         coords_default.update(
             [(str(k), v) for k, v in xr_coords(geobox, spatial_ref).items()]

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -788,21 +788,20 @@ class Datacube:
         #  - 3D dims must fit between (t) and (y, x) or (lat, lon)
 
         # 2D defaults
-        # retrieve dims from coords if DataArray
-        dims_default: tuple[Hashable, ...] = ()
-        if coords:
-            coords_value = next(iter(coords.values()))
-            if isinstance(coords_value, xarray.DataArray):
-                dims_default = coords_value.dims + geobox.dimensions
+        if isinstance(coords, dict):
+            warnings.warn(
+                "The coords argument to Datacube.create_storage is now expected "
+                "as a DataArrayCoordinates object instead of a dict.",
+                ODC2DeprecationWarning,
+            )
+            coords = None if coords == {} else DataArrayCoordinates(*coords.values())
 
-        if not dims_default:
-            dims_default = (() if coords is None else coords.dims) + geobox.dimensions
-
+        dims_default = (coords.dims if coords else ()) + geobox.dimensions
         shape_default = (
             tuple(c.size for k, c in coords.items() if k in dims_default)
             if coords
             else ()
-        ) + geobox.shape
+        ) + geobox.shape.yx
         coords_default: OrderedDict[str, xarray.DataArray] = OrderedDict()
         if coords:
             coords_default.update([(str(k), v) for k, v in coords.items()])


### PR DESCRIPTION
### Reason for this pull request

The change to the parameter type of `coords` in `create_storage` is not backwards compatible, and the corresponding logic can produce an unintuitive error.


### Proposed changes

- Add a deprecation warning so users are aware of the type change
- Maintain backwards compatibility by converting `coords` if needed



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2126.org.readthedocs.build/en/2126/

<!-- readthedocs-preview opendatacube end -->