### PR TITLE
Only permit UUID for dataset IDs

### DIFF
--- a/datacube/index/abstract/_types.py
+++ b/datacube/index/abstract/_types.py
@@ -34,12 +34,12 @@ class BatchStatus(NamedTuple):
     safe: Iterable[str] | None = None
 
 
-# Non-strict Dataset ID representation
+# Former non-strict Dataset ID representation.
 
-DSID: TypeAlias = str | UUID
+DSID: TypeAlias = UUID
 
 
-def dsid_to_uuid(dsid: DSID) -> UUID:
+def dsid_to_uuid(dsid: str | DSID) -> UUID:
     """
     Convert non-strict dataset ID representation to strict UUID
     """

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -7,6 +7,7 @@ import datetime
 import json
 import logging
 import sys
+import uuid
 from collections import OrderedDict
 from collections.abc import Iterable, Iterator, Mapping, MutableMapping, Sequence
 from textwrap import dedent
@@ -798,10 +799,14 @@ def count_cmd(
     is_flag=True,
     default=False,
 )
-@click.argument("ids", nargs=-1)
+@click.argument("ids", nargs=-1, type=click.UUID)
 @ui.pass_index()
 def archive_cmd(
-    index: Index, archive_derived: bool, dry_run: bool, all_ds: bool, ids: list[str]
+    index: Index,
+    archive_derived: bool,
+    dry_run: bool,
+    all_ds: bool,
+    ids: Sequence[uuid.UUID],
 ) -> None:
     if not ids and not all_ds:
         echo("Error: no datasets provided\n", err=True)
@@ -814,10 +819,7 @@ def archive_cmd(
             index.datasets.get_all_dataset_ids(archived=False), True
         )
     else:
-        datasets_for_archive = {
-            UUID(dataset_id): exists
-            for dataset_id, exists in zip(ids, index.datasets.bulk_has(ids))
-        }
+        datasets_for_archive = dict(zip(ids, index.datasets.bulk_has(ids)))
 
         if False in datasets_for_archive.values():
             for dataset_id, exists in datasets_for_archive.items():
@@ -874,7 +876,7 @@ def archive_cmd(
     is_flag=True,
     default=False,
 )
-@click.argument("ids", nargs=-1)
+@click.argument("ids", nargs=-1, type=click.UUID)
 @ui.pass_index()
 def restore_cmd(
     index: Index,
@@ -882,7 +884,7 @@ def restore_cmd(
     derived_tolerance_seconds: int,
     dry_run: bool,
     all_ds: bool,
-    ids: list[str],
+    ids: Sequence[uuid.UUID],
 ) -> None:
     if not ids and not all_ds:
         echo("Error: no datasets provided\n", err=True)
@@ -900,7 +902,7 @@ def restore_cmd(
             sys.exit(-1)
 
         to_process = (
-            _get_derived_set(index, UUID(id_)) if restore_derived else {target_dataset}
+            _get_derived_set(index, id_) if restore_derived else {target_dataset}
         )
         _LOG.debug("%s selected", len(to_process))
 
@@ -947,10 +949,10 @@ def restore_cmd(
     default=False,
     help="Allow active datasets to be deleted (default: false)",
 )
-@click.argument("ids", nargs=-1)
+@click.argument("ids", nargs=-1, type=click.UUID)
 @ui.pass_index()
 def purge_cmd(
-    index: Index, dry_run: bool, all_ds: bool, force: bool, ids: list[str]
+    index: Index, dry_run: bool, all_ds: bool, force: bool, ids: Sequence[uuid.UUID]
 ) -> None:
     if not ids and not all_ds:
         echo("Error: no datasets provided\n", err=True)
@@ -962,10 +964,7 @@ def purge_cmd(
             index.datasets.get_all_dataset_ids(archived=True), True
         )
     else:
-        datasets_for_purge = {
-            UUID(dataset_id): exists
-            for dataset_id, exists in zip(ids, index.datasets.bulk_has(ids))
-        }
+        datasets_for_purge = dict(zip(ids, index.datasets.bulk_has(ids)))
 
         # Check for non-existent datasets
         if False in datasets_for_purge.values():

--- a/datacube/scripts/spindex.py
+++ b/datacube/scripts/spindex.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 import sys
+import uuid
 from collections.abc import Sequence
 
 import click
@@ -116,12 +117,16 @@ def list_spindex(index) -> None:
     "--dataset",
     "-d",
     multiple=True,
+    type=click.UUID,
     help="The id of a dataset to update the spatial index for (can be used multiple times for multiple datasets)",
 )
 @click.argument("srids", nargs=-1)
 @ui.pass_index()
 def update(
-    index: Index, product: Sequence[str], dataset: Sequence[str], srids: Sequence[str]
+    index: Index,
+    product: Sequence[str],
+    dataset: Sequence[uuid.UUID],
+    srids: Sequence[str],
 ) -> None:
     if not index.supports_spatial_indexes:
         echo(

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -273,40 +273,40 @@ def test_index_duplicate_dataset(index: Index, cfg_env, ls8_eo3_dataset) -> None
 
 def test_has_dataset(index: Index, ls8_eo3_dataset: Dataset) -> None:
     assert index.datasets.has(ls8_eo3_dataset.id)
-    assert index.datasets.has(str(ls8_eo3_dataset.id))
+    assert index.datasets.has(str(ls8_eo3_dataset.id))  # type: ignore[arg-type]
 
     assert not index.datasets.has(UUID("f226a278-e422-11e6-b501-185e0f80a5c0"))
-    assert not index.datasets.has("f226a278-e422-11e6-b501-185e0f80a5c0")
+    assert not index.datasets.has("f226a278-e422-11e6-b501-185e0f80a5c0")  # type: ignore[arg-type]
 
     assert index.datasets.bulk_has(
         [ls8_eo3_dataset.id, UUID("f226a278-e422-11e6-b501-185e0f80a5c0")]
     ) == [True, False]
     assert index.datasets.bulk_has(
-        [str(ls8_eo3_dataset.id), "f226a278-e422-11e6-b501-185e0f80a5c0"]
+        [str(ls8_eo3_dataset.id), "f226a278-e422-11e6-b501-185e0f80a5c0"]  # type: ignore[list-item]
     ) == [True, False]
 
 
 def test_get_dataset(index: Index, ls8_eo3_dataset: Dataset) -> None:
     assert index.datasets.has(ls8_eo3_dataset.id)
-    assert index.datasets.has(str(ls8_eo3_dataset.id))
+    assert index.datasets.has(str(ls8_eo3_dataset.id))  # type: ignore[arg-type]
 
     assert index.datasets.bulk_has(
-        [ls8_eo3_dataset.id, "f226a278-e422-11e6-b501-185e0f80a5c0"]
+        [ls8_eo3_dataset.id, "f226a278-e422-11e6-b501-185e0f80a5c0"]  # type: ignore[list-item]
     ) == [True, False]
 
     for tr in (lambda x: x, lambda x: str(x)):
-        ds = index.datasets.get(tr(ls8_eo3_dataset.id))
+        ds = index.datasets.get(tr(ls8_eo3_dataset.id))  # type: ignore[arg-type]
         assert ds is not None
         assert ds.id == ls8_eo3_dataset.id
 
-        (ds,) = index.datasets.bulk_get([tr(ls8_eo3_dataset.id)])
+        (ds,) = index.datasets.bulk_get([tr(ls8_eo3_dataset.id)])  # type: ignore[list-item]
         assert ds.id == ls8_eo3_dataset.id
 
     assert (
         index.datasets.bulk_get(
             [
-                "f226a278-e422-11e6-b501-185e0f80a5c0",
-                "f226a278-e422-11e6-b501-185e0f80a5c1",
+                "f226a278-e422-11e6-b501-185e0f80a5c0",  # type: ignore[list-item]
+                "f226a278-e422-11e6-b501-185e0f80a5c1",  # type: ignore[list-item]
             ]
         )
         == []
@@ -733,7 +733,7 @@ def test_index_dataset_with_location(
         ]
 
         # test order using datasets.get(), it has custom query as it turns out
-        d = index.datasets.get(test_uuid)
+        d = index.datasets.get(test_uuid)  # type: ignore[arg-type]
         assert d is not None
         assert d._uris == [
             "file:///a",
@@ -755,7 +755,7 @@ def test_index_dataset_with_location(
             "file:///a",
             "file:///b",
         ]
-        d = index.datasets.get(test_uuid)
+        d = index.datasets.get(test_uuid)  # type: ignore[arg-type]
         assert d is not None
         assert d.uris == [  # Test of deprecated functionality
             "file:///c",

--- a/integration_tests/index/test_null_index.py
+++ b/integration_tests/index/test_null_index.py
@@ -90,10 +90,10 @@ def test_null_product_resource(null_config: ODCEnvironment) -> None:
 def test_null_dataset_resource(null_config: ODCEnvironment) -> None:
     with Datacube(env=null_config, validate_connection=True) as dc:
         assert dc.index.datasets.get(test_uuid) is None
-        assert dc.index.datasets.bulk_get([test_uuid, "foo"]) == []
+        assert dc.index.datasets.bulk_get([test_uuid, "foo"]) == []  # type: ignore[list-item]
         assert dc.index.datasets.get_derived(test_uuid) == []
         assert not dc.index.datasets.has(test_uuid)
-        assert dc.index.datasets.bulk_has([test_uuid, "foo"]) == [False, False]
+        assert dc.index.datasets.bulk_has([test_uuid, "foo"]) == [False, False]  # type: ignore[list-item]
         with pytest.raises(NotImplementedError):
             dc.index.datasets.add(MagicMock())
         with pytest.raises(NotImplementedError):
@@ -101,11 +101,11 @@ def test_null_dataset_resource(null_config: ODCEnvironment) -> None:
         with pytest.raises(NotImplementedError):
             dc.index.datasets.update(MagicMock())
         with pytest.raises(NotImplementedError):
-            dc.index.datasets.archive([test_uuid, "foo"])
+            dc.index.datasets.archive([test_uuid, "foo"])  # type: ignore[list-item]
         with pytest.raises(NotImplementedError):
-            dc.index.datasets.restore([test_uuid, "foo"])
+            dc.index.datasets.restore([test_uuid, "foo"])  # type: ignore[list-item]
         with pytest.raises(NotImplementedError):
-            dc.index.datasets.purge([test_uuid, "foo"])
+            dc.index.datasets.purge([test_uuid, "foo"])  # type: ignore[list-item]
 
         assert empty(dc.index.datasets.get_all_dataset_ids(True))
         assert dc.index.datasets.get_location(test_uuid) is None

--- a/integration_tests/index/test_search_legacy.py
+++ b/integration_tests/index/test_search_legacy.py
@@ -94,10 +94,11 @@ def pseudo_ls8_dataset(index: Index, pseudo_ls8_type):
             pseudo_ls8_type.id,
         )
         was_inserted = was_inserted and connection.insert_dataset_location(
-            id_, "file://tmp/a/b/c"
+            id_,  # type: ignore[arg-type]
+            "file://tmp/a/b/c",
         )
     assert was_inserted
-    d = index.datasets.get(id_)
+    d = index.datasets.get(id_)  # type: ignore[arg-type]
     assert d is not None
     # The dataset should have been matched to the telemetry type.
     assert d.product.id == pseudo_ls8_type.id
@@ -147,10 +148,11 @@ def pseudo_ls8_dataset2(index: Index, pseudo_ls8_type):
             pseudo_ls8_type.id,
         )
         was_inserted = was_inserted and connection.insert_dataset_location(
-            id_, "file://tmp/d/e/f"
+            id_,  # type: ignore[arg-type]
+            "file://tmp/d/e/f",
         )
     assert was_inserted
-    d = index.datasets.get(id_)
+    d = index.datasets.get(id_)  # type: ignore[arg-type]
     assert d is not None
     # The dataset should have been matched to the telemetry type.
     assert d.product.id == pseudo_ls8_type.id
@@ -177,7 +179,7 @@ def pseudo_ls8_dataset3(
     with index._active_connection() as connection:
         was_inserted = connection.insert_dataset(dataset_doc, id_, pseudo_ls8_type.id)
     assert was_inserted
-    d = index.datasets.get(id_)
+    d = index.datasets.get(id_)  # type: ignore[arg-type]
     assert d is not None
     # The dataset should have been matched to the telemetry type.
     assert d.product.id == pseudo_ls8_type.id
@@ -202,7 +204,7 @@ def pseudo_ls8_dataset4(
     with index._active_connection() as connection:
         was_inserted = connection.insert_dataset(dataset_doc, id_, pseudo_ls8_type.id)
         assert was_inserted
-        d = index.datasets.get(id_)
+        d = index.datasets.get(id_)  # type: ignore[arg-type]
         assert d is not None
         # The dataset should have been matched to the telemetry type.
         assert d.product.id == pseudo_ls8_type.id
@@ -787,7 +789,7 @@ def test_get_dataset_with_children(
     assert list(sources.sources) == []
 
     # It should also work with a string id
-    d = index.datasets.get(str(id_), include_sources=True)
+    d = index.datasets.get(str(id_), include_sources=True)  # type: ignore[arg-type]
     assert d is not None
     sources = d.sources
     assert sources is not None


### PR DESCRIPTION
### Reason for this pull request

The type annotated functions
in datacube-core makes it easy
for downstream users to find
any problem spots and update them.

Add type ignores in all the tests so
the string UUID continues to work
while people migrate.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2127.org.readthedocs.build/en/2127/

<!-- readthedocs-preview opendatacube end -->