### PR TITLE
drivers: set preserve_rowcount

### DIFF
--- a/datacube/drivers/postgis/_connections.py
+++ b/datacube/drivers/postgis/_connections.py
@@ -286,7 +286,7 @@ class PostGisDb:
         Low level context manager, use <index_resource>._db_connection instead
         """
         with self._engine.connect().execution_options(
-            isolation_level="AUTOCOMMIT"
+            isolation_level="AUTOCOMMIT", preserve_rowcount=True
         ) as connection:
             try:
                 yield _api.PostgisDbAPI(self, connection)

--- a/datacube/drivers/postgres/_connections.py
+++ b/datacube/drivers/postgres/_connections.py
@@ -222,7 +222,7 @@ class PostgresDb:
         Low level context manager, use <index_resource>._db_connection instead
         """
         with self._engine.connect().execution_options(
-            isolation_level="AUTOCOMMIT"
+            isolation_level="AUTOCOMMIT", preserve_rowcount=True
         ) as connection:
             try:
                 yield _api.PostgresDbAPI(connection)

--- a/integration_tests/index/test_lineage.py
+++ b/integration_tests/index/test_lineage.py
@@ -28,7 +28,7 @@ def test_lineage_home_api(index) -> None:
     for home in index.lineage.get_homes(*a_uuids).values():
         assert home == "eggs"
     assert index.lineage.get_homes(*b_uuids) == {}
-    assert index.lineage.set_home("eggs", *a_uuids, allow_updates=True) == 0
+    assert index.lineage.set_home("eggs", *a_uuids, allow_updates=True) == 10
     assert index.lineage.set_home("eggs", *b_uuids, allow_updates=True) == 10
 
     # Test clear_home with actual work done.


### PR DESCRIPTION
### Reason for this pull request

This attribute is normally only preserved
for update and delete statements, but our
drivers use it for insert as well, so
turn on the SQLAlchemy feature for it.

https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Connection.execution_options.params.preserve_rowcount

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2135.org.readthedocs.build/en/2135/

<!-- readthedocs-preview opendatacube end -->