### PR TITLE
test_config_docs: remove Python 2 support

### DIFF
--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -479,9 +479,8 @@ def test_product_delete_cli(
     assert "is already in the database" not in add.output
 
 
-def _to_yaml(ls5_telem_doc):
-    # Need to explicitly allow unicode in Py2
-    return yaml.safe_dump(ls5_telem_doc, allow_unicode=True)
+def _to_yaml(ls5_telem_doc) -> str | bytes | None:
+    return yaml.safe_dump(ls5_telem_doc)
 
 
 def test_update_metadata_type(


### PR DESCRIPTION


### Reason for this pull request

Everything is unicode in Python 3,
so remove this old comment and parameter.


### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2139.org.readthedocs.build/en/2139/

<!-- readthedocs-preview opendatacube end -->