### PR TITLE
test_config_tool: enable test for postgis

### DIFF
--- a/integration_tests/test_config_tool.py
+++ b/integration_tests/test_config_tool.py
@@ -149,30 +149,29 @@ def test_db_init_noop(clirunner, cfg_env, ls8_eo3_product) -> None:
     assert "eo3 " in result.output
 
 
-@pytest.mark.parametrize("datacube_env_name", ("datacube",))
-def test_db_init_rebuild(clirunner, cfg_env, ls5_telem_type) -> None:
+def test_db_init_rebuild(clirunner, cfg_env, ls8_eo3_product) -> None:
     if cfg_env._name == "datacube":
         from datacube.drivers.postgres import _dynamic
         from datacube.drivers.postgres.sql import SCHEMA_NAME
 
         # Set field creation logging to debug since we assert on debug output.
         _dynamic._LOG.setLevel(logging.DEBUG)
-    else:
-        from datacube.drivers.postgis.sql import SCHEMA_NAME
     # Run on an existing database.
     result = clirunner(["-v", "-E", cfg_env._name, "system", "init", "--rebuild"])
     assert "Updated." in result.output
-    # It should have recreated views and indexes.
-    assert f"Dropping index: dix_{ls5_telem_type.name}" in result.output
-    assert f"Creating index: dix_{ls5_telem_type.name}" in result.output
-    assert (
-        f"Dropping view: {SCHEMA_NAME}.dv_{ls5_telem_type.name}_dataset"
-        in result.output
-    )
-    assert (
-        f"Creating view: {SCHEMA_NAME}.dv_{ls5_telem_type.name}_dataset"
-        in result.output
-    )
+    # These debug log messages are not present in the Postgis driver.
+    if cfg_env._name == "datacube":
+        # It should have recreated views and indexes.
+        assert f"Dropping index: dix_{ls8_eo3_product.name}" in result.output
+        assert f"Creating index: dix_{ls8_eo3_product.name}" in result.output
+        assert (
+            f"Dropping view: {SCHEMA_NAME}.dv_{ls8_eo3_product.name}_dataset"
+            in result.output
+        )
+        assert (
+            f"Creating view: {SCHEMA_NAME}.dv_{ls8_eo3_product.name}_dataset"
+            in result.output
+        )
 
 
 def test_db_init(clirunner, index) -> None:


### PR DESCRIPTION
### Reason for this pull request

Switch the test to use the ls8_eo3_product
so the metadata validation performed with
Postgis can pass, and enable the test with
Postgis.

The asserted log messages are never printed
by the Postgis driver, so make the asserts
conditional on the environment and only
test them on the Postgres driver.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2140.org.readthedocs.build/en/2140/

<!-- readthedocs-preview opendatacube end -->