### PR TITLE
STAC/EO3 conversion improvements

### DIFF
--- a/datacube/metadata/__init__.py
+++ b/datacube/metadata/__init__.py
@@ -7,10 +7,12 @@ Datacube metadata generation from STAC.
 """
 
 from ._eo3converter import infer_dc_product, stac2ds
-from ._stacconverter import ds2stac
+from ._stacconverter import ds2stac, ds_doc_to_stac, infer_eo3_product
 
 __all__ = (
     "ds2stac",
+    "ds_doc_to_stac",
     "infer_dc_product",
+    "infer_eo3_product",
     "stac2ds",
 )

--- a/datacube/metadata/_eo3converter.py
+++ b/datacube/metadata/_eo3converter.py
@@ -35,19 +35,13 @@ from odc.stac.model import (
 )
 from pystac import Collection, Item
 
-from datacube.index.abstract import default_metadata_type_docs
 from datacube.index.eo3 import prep_eo3
-from datacube.model import Dataset, Product, metadata_from_doc
+from datacube.model import Dataset, Product
 
-from ._utils import stac_to_eo3_properties
+from ._utils import EO3_MD_TYPE, stac_to_eo3_properties
 
 # uuid.uuid5(uuid.NAMESPACE_URL, "https://stacspec.org")
 UUID_NAMESPACE_STAC = uuid.UUID("55d26088-a6d0-5c77-bf9a-3a7f3c6a6dab")
-
-
-(_eo3,) = (
-    metadata_from_doc(d) for d in default_metadata_type_docs() if d.get("name") == "eo3"
-)
 
 
 def _to_product(md: RasterCollectionMetadata) -> Product:
@@ -85,7 +79,7 @@ def _to_product(md: RasterCollectionMetadata) -> Product:
             for band_key, band in md.meta.bands.items()  # TODO: use .raster_bands() after loader 0.6.0
         ],
     }
-    return Product(_eo3, doc, stac=md)
+    return Product(EO3_MD_TYPE, doc, stac=md)
 
 
 @singledispatch
@@ -166,6 +160,7 @@ def _to_dataset(
     for key in ["proj:code", "proj:epsg", "proj:wkt2"]:
         if key in properties:
             crs = CRS(properties.get(key))
+            break
 
     for band_key, src in item.bands.items():
         name, idx = band_key

--- a/datacube/metadata/_stacconverter.py
+++ b/datacube/metadata/_stacconverter.py
@@ -12,6 +12,7 @@ import math
 import mimetypes
 import warnings
 from collections.abc import Generator
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 from urllib.parse import urljoin
@@ -22,9 +23,11 @@ from pystac.extensions.projection import ProjectionExtension
 from pystac.extensions.view import ViewExtension
 
 import datacube.utils.uris as dc_uris
-from datacube.model import Dataset
+from datacube.index.eo3 import is_doc_eo3, prep_eo3
+from datacube.model import Dataset, Product
 
-from ._utils import eo3_to_stac_properties
+from ..migration import ODC2DeprecationWarning
+from ._utils import EO3_MD_TYPE, EO_MD_TYPE, eo3_to_stac_properties
 
 
 def _lineage_fields(dataset: Dataset) -> dict:
@@ -180,6 +183,8 @@ def ds2stac(
     properties.update(_lineage_fields(dataset))
 
     dt = properties.get("datetime")
+    if isinstance(dt, str):
+        dt = datetime.fromisoformat(dt)
 
     item = Item(
         id=str(dataset.id),
@@ -256,3 +261,48 @@ def ds2stac(
         item.add_asset(name, asset=asset)
 
     return item
+
+
+def infer_eo3_product(metadata_doc: dict) -> Product:
+    # Create a basic Product from a dataset metadata_doc
+    name = metadata_doc["product"]["name"]
+    doc = {
+        "name": name,
+        "metadata_type": "eo3",
+        "metadata": {"product": {"name": name}},
+        "measurements": [{"name": key} for key in metadata_doc["measurements"]],
+    }
+    return Product(EO3_MD_TYPE, doc)
+
+
+def infer_eo_product(metadata_doc: dict) -> Product:
+    name = metadata_doc["product_type"]
+    doc = {
+        "name": name,
+        "metadata_type": "eo",
+        "metadata": {"product_type": name},
+        "measurements": [{"name": key} for key in metadata_doc["image"]["bands"]],
+    }
+    return Product(EO_MD_TYPE, doc)
+
+
+def ds_doc_to_stac(
+    metadata_doc: dict,
+    uri: str | None = None,
+    stac_url: str | None = None,
+    self_url: str | None = None,
+    collection_url: str | None = None,
+) -> Item:
+    warnings.warn("It is strongly preferred to use ds2stac if possible.")
+    if is_doc_eo3(metadata_doc):
+        product = infer_eo3_product(metadata_doc)
+        dataset = Dataset(product, prep_eo3(metadata_doc), uri=uri)
+    else:
+        warnings.warn(
+            "Support for legacy eo datasets is deprecated and will require an "
+            "eo3-style properties dict to be added to the metadata.",
+            ODC2DeprecationWarning,
+        )
+        product = infer_eo_product(metadata_doc)
+        dataset = Dataset(product, metadata_doc, uri=uri)
+    return ds2stac(dataset, stac_url, self_url, collection_url)

--- a/datacube/metadata/_utils.py
+++ b/datacube/metadata/_utils.py
@@ -11,7 +11,8 @@ from typing import Any
 
 from pystac.utils import datetime_to_str
 
-from datacube.model import Dataset
+from datacube.index.abstract import default_metadata_type_docs
+from datacube.model import Dataset, metadata_from_doc
 
 # Mapping between EO3 field names and STAC properties object field names
 # EO3 metadata was defined before STAC 1.0, so we used some extensions
@@ -31,6 +32,12 @@ STAC_TO_EO3_RENAMES = {
 }
 
 EO3_TO_STAC_RENAMES = {v: k for k, v in STAC_TO_EO3_RENAMES.items()}
+
+_default_md_types = {
+    d.get("name"): metadata_from_doc(d) for d in default_metadata_type_docs()
+}
+EO3_MD_TYPE = _default_md_types["eo3"]
+EO_MD_TYPE = _default_md_types["eo"]
 
 
 def _as_stac_instruments(value: str) -> list[str]:

--- a/tests/test_eo3converter.py
+++ b/tests/test_eo3converter.py
@@ -19,7 +19,13 @@ from pystac.extensions.item_assets import ItemAssetsExtension
 from pystac.extensions.projection import ProjectionExtension
 from toolz import dicttoolz
 
-from datacube.metadata import ds2stac, infer_dc_product, stac2ds
+from datacube.metadata import (
+    ds2stac,
+    ds_doc_to_stac,
+    infer_dc_product,
+    infer_eo3_product,
+    stac2ds,
+)
 from datacube.metadata._eo3converter import _compute_uuid, _item_to_ds
 from datacube.model import Dataset, Product
 from datacube.testutils.io import native_geobox
@@ -385,3 +391,51 @@ def test_roundtrip(eo3_dataset: Dataset, eo3_product: Product):
     assert set(roundtrip.measurements.keys()) == set(original.measurements.keys())
     assert roundtrip.measurements["nbar_panchromatic"]["grid"] == "g15"
     assert set(roundtrip.accessories.keys()) == set(original.accessories.keys())
+
+
+def test_infer_eo3_product(odc_dataset_doc) -> None:
+    product = infer_eo3_product(odc_dataset_doc)
+    assert product.definition == {
+        "name": "ga_ls8c_ard_3",
+        "metadata_type": "eo3",
+        "metadata": {"product": {"name": "ga_ls8c_ard_3"}},
+        "measurements": [
+            {"name": "nbar_blue"},
+            {"name": "nbar_coastal_aerosol"},
+            {"name": "nbar_green"},
+            {"name": "nbar_nir"},
+            {"name": "nbar_panchromatic"},
+            {"name": "nbar_red"},
+            {"name": "nbar_swir_1"},
+            {"name": "nbar_swir_2"},
+            {"name": "nbart_blue"},
+            {"name": "nbart_coastal_aerosol"},
+            {"name": "nbart_green"},
+            {"name": "nbart_nir"},
+            {"name": "nbart_panchromatic"},
+            {"name": "nbart_red"},
+            {"name": "nbart_swir_1"},
+            {"name": "nbart_swir_2"},
+            {"name": "oa_azimuthal_exiting"},
+            {"name": "oa_azimuthal_incident"},
+            {"name": "oa_combined_terrain_shadow"},
+            {"name": "oa_exiting_angle"},
+            {"name": "oa_fmask"},
+            {"name": "oa_incident_angle"},
+            {"name": "oa_nbar_contiguity"},
+            {"name": "oa_nbart_contiguity"},
+            {"name": "oa_relative_azimuth"},
+            {"name": "oa_relative_slope"},
+            {"name": "oa_satellite_azimuth"},
+            {"name": "oa_satellite_view"},
+            {"name": "oa_solar_azimuth"},
+            {"name": "oa_solar_zenith"},
+            {"name": "oa_time_delta"},
+        ],
+    }
+
+
+def test_dsdoc_to_stac(odc_dataset_doc, eo3_dataset) -> None:
+    from_doc = ds_doc_to_stac(odc_dataset_doc, uri=eo3_dataset.uri)
+    from_ds = ds2stac(eo3_dataset)
+    assert from_doc.to_dict() == from_ds.to_dict()


### PR DESCRIPTION
### Reason for this pull request

Various additions and fixes to the STAC/EO3 conversion logic to address identified issues and refactoring difficulties


### Proposed changes
- Implement `ds_doc_to_stac`, to enable conversion from a raw metadata document when a `Dataset` object isn't available 
- Avoid code/epsg value being overwritten if wkt2 is also present in the STAC docuemnt
- Ensure `pystac.Item.datetime` is provided as a `datetime` object and not a string



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2146.org.readthedocs.build/en/2146/

<!-- readthedocs-preview opendatacube end -->