### PR TITLE
More STAC/EO3 logic fixes

### DIFF
--- a/datacube/metadata/_eo3converter.py
+++ b/datacube/metadata/_eo3converter.py
@@ -139,7 +139,7 @@ def _compute_uuid(
 
 
 def _to_grid(gbox: GeoBox) -> dict[str, Any]:
-    return {"shape": gbox.shape.yx, "transform": gbox.transform.to_shapely()}
+    return {"shape": gbox.shape.yx, "transform": gbox.transform[:6]}
 
 
 def _to_dataset(
@@ -228,7 +228,7 @@ def _to_dataset(
     if title is not None:
         ds_doc["label"] = title
 
-    # TODO: this need to use Doc2Ds for consistency checks and lineage handling
+    # TODO: this needs to use Doc2Ds for consistency checks and lineage handling
     return Dataset(product, prep_eo3(ds_doc), uri=item.href)
 
 

--- a/datacube/metadata/_eo3converter.py
+++ b/datacube/metadata/_eo3converter.py
@@ -139,7 +139,7 @@ def _compute_uuid(
 
 
 def _to_grid(gbox: GeoBox) -> dict[str, Any]:
-    return {"shape": gbox.shape.yx, "transform": gbox.transform[:6]}
+    return {"shape": gbox.shape.yx, "transform": gbox.transform[:6]}  # type: ignore[index]
 
 
 def _to_dataset(

--- a/datacube/metadata/_stacconverter.py
+++ b/datacube/metadata/_stacconverter.py
@@ -12,7 +12,6 @@ import math
 import mimetypes
 import warnings
 from collections.abc import Generator
-from datetime import datetime
 from pathlib import Path
 from typing import Any
 from urllib.parse import urljoin
@@ -25,6 +24,7 @@ from pystac.extensions.view import ViewExtension
 import datacube.utils.uris as dc_uris
 from datacube.index.eo3 import is_doc_eo3, prep_eo3
 from datacube.model import Dataset, Product
+from datacube.utils import parse_time
 
 from ..migration import ODC2DeprecationWarning
 from ._utils import EO3_MD_TYPE, EO_MD_TYPE, eo3_to_stac_properties
@@ -184,7 +184,7 @@ def ds2stac(
 
     dt = properties.get("datetime")
     if isinstance(dt, str):
-        dt = datetime.fromisoformat(dt)
+        dt = parse_time(dt)
 
     item = Item(
         id=str(dataset.id),

--- a/datacube/metadata/_utils.py
+++ b/datacube/metadata/_utils.py
@@ -13,6 +13,7 @@ from pystac.utils import datetime_to_str
 
 from datacube.index.abstract import default_metadata_type_docs
 from datacube.model import Dataset, metadata_from_doc
+from datacube.utils import parse_time
 
 # Mapping between EO3 field names and STAC properties object field names
 # EO3 metadata was defined before STAC 1.0, so we used some extensions
@@ -75,7 +76,7 @@ def _value_to_eo3_type(key: str, value):
         return None
     if key == "created" or "datetime" in key:
         if isinstance(value, str):
-            return datetime.fromisoformat(value)
+            return parse_time(value)
         return value
     return value
 

--- a/tests/test_eo3converter.py
+++ b/tests/test_eo3converter.py
@@ -11,7 +11,6 @@ from typing import Any
 
 import pystac
 import pytest
-from affine import Affine
 from odc.geo.geom import Geometry
 from odc.stac._mdtools import RasterCollectionMetadata, has_proj_ext, has_raster_ext
 from pystac.extensions.eo import EOExtension
@@ -365,18 +364,17 @@ def test_roundtrip(eo3_dataset: Dataset, eo3_product: Product):
     assert (
         list(roundtrip.grids["default"]["shape"]) == original.grids["default"]["shape"]
     )
-    # assert list(roundtrip.grids["default"]["transform"]) == original.grids["default"]["transform"][:6]
     assert (
-        roundtrip.grids["default"]["transform"]
-        == Affine(*original.grids["default"]["transform"]).to_shapely()
+        list(roundtrip.grids["default"]["transform"])
+        == original.grids["default"]["transform"][:6]
     )
     # there's no way to conserve grid names when converting to stac, but values should still be the same
     assert (
         list(roundtrip.grids["g15"]["shape"]) == original.grids["panchromatic"]["shape"]
     )
     assert (
-        roundtrip.grids["g15"]["transform"]
-        == Affine(*original.grids["panchromatic"]["transform"]).to_shapely()
+        list(roundtrip.grids["g15"]["transform"])
+        == original.grids["panchromatic"]["transform"][:6]
     )
 
     assert roundtrip.crs == original.crs


### PR DESCRIPTION
### Reason for this pull request

Resolve downstream errors from stac/eo3 conversion logic.


### Proposed changes

- Use `parse_time` instead of `datetime.fromisoformat` to handle ISO 8601 date formats with python 3.10
- Don't use `to_shapely` to keep the order of the transform matrix consistent



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2150.org.readthedocs.build/en/2150/

<!-- readthedocs-preview opendatacube end -->