### PR TITLE
postgis: use parse_time for dates

### DIFF
--- a/datacube/drivers/postgis/_fields.py
+++ b/datacube/drivers/postgis/_fields.py
@@ -26,7 +26,7 @@ from datacube import utils
 from datacube.drivers.postgis._schema import Dataset, search_field_index_map
 from datacube.model import Range
 from datacube.model.fields import _AVAILABLE_TYPES, Expression, Field
-from datacube.utils import cached_property, get_doc_offset
+from datacube.utils import cached_property, get_doc_offset, parse_time
 from datacube.utils.changes import Offset
 from datacube.utils.dates import tz_as_utc
 
@@ -409,9 +409,9 @@ class DateDocField(SimpleDocField):
         raise ValueError(f"Value not readable as date: {value!r}")
 
     @override
-    def normalise_value(self, value):
+    def normalise_value(self, value: str | datetime) -> datetime:
         if isinstance(value, str):
-            value = datetime.fromisoformat(value)
+            value = parse_time(value)
         return tz_as_utc(value)
 
     @override

--- a/datacube/utils/dates.py
+++ b/datacube/utils/dates.py
@@ -9,7 +9,7 @@ Includes sequence generation functions to be used by statistics apps
 
 """
 
-from collections.abc import Iterator
+from collections.abc import Generator
 from datetime import date, datetime, timezone, tzinfo
 
 import dateutil
@@ -25,7 +25,7 @@ DURATIONS = {"y": "years", "m": "months", "d": "days"}
 
 def date_sequence(
     start: date | None, end: date | int | None, stats_duration: str, step_size: str
-) -> Iterator:
+) -> Generator[tuple]:
     """
     Generate a sequence of time span tuples
 
@@ -46,7 +46,7 @@ def date_sequence(
             yield start_date, start_date + stats_duration
 
 
-def parse_interval(interval):
+def parse_interval(interval) -> tuple:
     count, units = _split_duration(interval)
     try:
         return count, FREQS[units]
@@ -66,7 +66,7 @@ def parse_duration(duration):
     return relativedelta(**delta)
 
 
-def _split_duration(duration):
+def _split_duration(duration) -> tuple:
     return int(duration[:-1]), duration[-1:]
 
 


### PR DESCRIPTION
### Reason for this pull request

Inspired by #2150.

Python 3.10's fromisoformat does not
fully support ISO 8601 dates.

Also add a commit with some partial
type signatures for date.py.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2152.org.readthedocs.build/en/2152/

<!-- readthedocs-preview opendatacube end -->