### PR TITLE
Group dependabot updates to GHA Actions Versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      actions-deps:
+        patterns:
+          - "*"
   - package-ecosystem: docker
     directory: "/docker"
     schedule:


### PR DESCRIPTION
### Reason for this pull request

Try and minimise PR spam like:
<img width="908" height="216" alt="image" src="https://github.com/user-attachments/assets/1bc8921f-5163-4f43-8b02-bdabedcc508d" />


### Proposed changes
Group all the updates to GitHub actions versions together, so that we get at most 1 per week to review and merge.

<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2164.org.readthedocs.build/en/2164/

<!-- readthedocs-preview opendatacube end -->