### PR TITLE
Fix docs rendering on configuration page

### DIFF
--- a/docs/source/installation/database/configuration.rst
+++ b/docs/source/installation/database/configuration.rst
@@ -260,34 +260,38 @@ remaining configuration options only apply to the ``postgres`` and
 
 .. confval:: db_database
 
-   **Only used for the 'postgres' and 'postgis' index drivers.**
+   .. admonition::
+      Only used for the 'postgres' and 'postgis' index drivers.
 
-   **Only used if :confval:`db_url` is not set.**
+      Only used if :confval:`db_url` is not set.
 
    The name of the database to connect to.  Defaults to ``"datacube"``.
 
 .. confval:: db_hostname
 
-   **Only used for the 'postgres' and 'postgis' index drivers.**
+   .. admonition::
+      Only used for the 'postgres' and 'postgis' index drivers.
 
-   **Only used if :confval:`db_url` is not set.**
+      Only used if :confval:`db_url` is not set.
 
    The hostname to connect to.  May be set to an empty string, in which case a
    local socket is used. Defaults to ``"localhost"`` if not set at all.
 
 .. confval:: db_port
 
-   **Only used for the 'postgres' and 'postgis' index drivers.**
+   .. admonition::
+      Only used for the 'postgres' and 'postgis' index drivers.
 
-   **Only used if :confval:`db_url` is not set.**
+      Only used if :confval:`db_url` is not set.
 
    The TCP port to connect to.  Defaults to 5432.  Not used when connecting over a local socket.
 
 .. confval:: db_username
 
-   **Only used for the 'postgres' and 'postgis' index drivers.**
+   .. admonition::
+      Only used for the 'postgres' and 'postgis' index drivers.
 
-   **Only used if :confval:`db_url` is not set.**
+      Only used if :confval:`db_url` is not set.
 
    The username to use when connecting to the database. Defaults to the
    username of the logged-in user on UNIX-like systems.


### PR DESCRIPTION
Restructured text doesn't like markup within markup, in this case specifying text roles inside of bold text.

On [the docs configuration page](https://opendatacube.readthedocs.io/en/latest/installation/database/configuration.html#confval-db_database). Instead of poor rendering and no link like:
<img width="510" height="118" alt="image" src="https://github.com/user-attachments/assets/545c7891-b427-4a72-b713-c1ea9e212ec8" />

We willl get:
<img width="766" height="132" alt="image" src="https://github.com/user-attachments/assets/05775bf4-7bfe-47e6-aa30-1ba29a2bc860" />




<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2167.org.readthedocs.build/en/2167/

<!-- readthedocs-preview opendatacube end -->