### PR TITLE
drivers: remove SQLAlchemy 1.4 workaround

### DIFF
--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -13,7 +13,7 @@ from alembic import command, config
 from alembic.migration import MigrationContext
 from alembic.runtime.environment import EnvironmentContext
 from alembic.script import ScriptDirectory
-from sqlalchemy import MetaData, inspect, text
+from sqlalchemy import Connection, MetaData, inspect, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.schema import CreateSchema
 from sqlalchemy.sql.ddl import DropSchema
@@ -286,10 +286,8 @@ def has_schema(engine) -> bool:
     return SCHEMA_NAME in inspector.get_schema_names()
 
 
-def drop_db(connection) -> None:
-    # if_exists parameter seems to not be working in SQLA1.4?
-    if has_schema(connection.engine):
-        connection.execute(DropSchema(SCHEMA_NAME, cascade=True, if_exists=True))
+def drop_db(connection: Connection) -> None:
+    connection.execute(DropSchema(SCHEMA_NAME, cascade=True, if_exists=True))
 
 
 def to_pg_role(role) -> str:

--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -8,7 +8,7 @@ Core SQL schema settings.
 
 import logging
 
-from sqlalchemy import MetaData, inspect, text
+from sqlalchemy import Connection, MetaData, inspect, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.schema import CreateSchema, DropSchema
 
@@ -296,10 +296,8 @@ def has_schema(engine) -> bool:
     return SCHEMA_NAME in inspector.get_schema_names()
 
 
-def drop_db(connection) -> None:
-    # if_exists parameter seems to not be working in SQLA1.4?
-    if has_schema(connection.engine):
-        connection.execute(DropSchema(SCHEMA_NAME, cascade=True, if_exists=True))
+def drop_db(connection: Connection) -> None:
+    connection.execute(DropSchema(SCHEMA_NAME, cascade=True, if_exists=True))
 
 
 def to_pg_role(role: str) -> str:

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -615,7 +615,6 @@ def reset_db(cfg_env: ODCEnvironment, tz=None) -> PostgresDb | PostGisDb:
 def cleanup_db(cfg_env: ODCEnvironment, db: PostgresDb | PostGisDb) -> None:
     with db._engine.connect() as connection:
         if cfg_env._name in ("datacube", "default", "postgres"):
-            # with db.begin() as c:  # Drop SCHEMA
             pgres_core.drop_db(connection)
         else:
             pgis_core.drop_db(connection)


### PR DESCRIPTION
### Reason for this pull request

The if_exists parameter seems to work
in SQLAlchemy 2.0, so remove the has_schema
check and just run DropSchema directly.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2168.org.readthedocs.build/en/2168/

<!-- readthedocs-preview opendatacube end -->