### PR TITLE
CI: speed up Conda workflows

### DIFF
--- a/.github/workflows/test-conda-build.yml
+++ b/.github/workflows/test-conda-build.yml
@@ -48,12 +48,14 @@ jobs:
         with:
           environment-file: conda-environment.yml
           auto-update-conda: true
+          condarc-file: condarc.yml
           python-version: ${{ matrix.python-version}}
       - uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
         if: steps.conda1.outcome == 'failure'
         with:
           environment-file: conda-environment.yml
           auto-update-conda: true
+          condarc-file: condarc.yml
           python-version: ${{ matrix.python-version}}
 
       - name: Get pip cache dir

--- a/.github/workflows/test-conda-build.yml
+++ b/.github/workflows/test-conda-build.yml
@@ -55,6 +55,20 @@ jobs:
           auto-update-conda: true
           python-version: ${{ matrix.python-version}}
 
+      - name: Get pip cache dir
+        id: pip-cache
+        shell: bash
+        run: |
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+
+      - name: pip cache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: Bash
         shell: bash -l {0}
         run: |

--- a/.github/workflows/test-conda-build.yml
+++ b/.github/workflows/test-conda-build.yml
@@ -23,6 +23,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
           os: ["ubuntu-latest", "macos-latest", "windows-latest"]
           python-version: ["3.10", "3.11", "3.12", "3.13"]

--- a/.github/workflows/test-conda-build.yml
+++ b/.github/workflows/test-conda-build.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           path: ~/conda_pkgs_dir
           key:
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
+            ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ env.CACHE_NUMBER }}-${{
             hashFiles('conda-environment.yml') }}
 
       - uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0

--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -41,4 +41,3 @@ dependencies:
   - odc-geo >=0.4.8
   - odc-loader <=0.5.1
   - odc-stac >= 0.4.0
-  - minizip ==4.0.6

--- a/condarc.yml
+++ b/condarc.yml
@@ -1,0 +1,1 @@
+use_local: True

--- a/condarc.yml
+++ b/condarc.yml
@@ -1,1 +1,2 @@
+default_threads: 2
 use_local: True


### PR DESCRIPTION
### Reason for this pull request

Use a separate cache for each Python version, and make Conda use that cache instead of downloading all packages each invocation.

Configure Conda to use 2 threads for the solving which should speed things up a bit.

Also stop cancelling the Conda jobs when one of them fails since they fail intermittently most of the time, and unpin minizip that was pinned during the 1.9 development phase.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2169.org.readthedocs.build/en/2169/

<!-- readthedocs-preview opendatacube end -->