### PR TITLE
drivers: use has_schema method

### DIFF
--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -281,9 +281,8 @@ def has_role(conn, role_name: str) -> bool:
     )
 
 
-def has_schema(engine) -> bool:
-    inspector = inspect(engine)
-    return SCHEMA_NAME in inspector.get_schema_names()
+def has_schema(engine: Engine, schema_name: str = SCHEMA_NAME) -> bool:
+    return inspect(engine).has_schema(schema_name)
 
 
 def drop_db(connection: Connection) -> None:

--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -291,9 +291,8 @@ def has_role(conn, role_name: str) -> bool:
     return bool(res)
 
 
-def has_schema(engine) -> bool:
-    inspector = inspect(engine)
-    return SCHEMA_NAME in inspector.get_schema_names()
+def has_schema(engine: Engine, schema_name: str = SCHEMA_NAME) -> bool:
+    return inspect(engine).has_schema(schema_name)
 
 
 def drop_db(connection: Connection) -> None:


### PR DESCRIPTION


### Reason for this pull request

The inspector has a method for
querying about the existence
of a schema, so use that instead
of scanning the result of getting
all schema names.

Explorer also checks for schemas,
so give the function an argument
for the schema name so Explorer
does not have to re-implement
the same logic.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2172.org.readthedocs.build/en/2172/

<!-- readthedocs-preview opendatacube end -->