### PR TITLE
drivers: deprecate drop_db function

### DIFF
--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -13,6 +13,7 @@ from alembic import command, config
 from alembic.migration import MigrationContext
 from alembic.runtime.environment import EnvironmentContext
 from alembic.script import ScriptDirectory
+from deprecat import deprecat
 from sqlalchemy import Connection, MetaData, inspect, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.schema import CreateSchema
@@ -25,6 +26,7 @@ from datacube.drivers.postgis.sql import (
     UPDATE_TIMESTAMP_SQL,
     escape_pg_identifier,
 )
+from datacube.migration import ODC2DeprecationWarning
 
 USER_ROLES = ("odc_user", "odc_manage", "odc_admin")
 
@@ -285,8 +287,18 @@ def has_schema(engine: Engine, schema_name: str = SCHEMA_NAME) -> bool:
     return inspect(engine).has_schema(schema_name)
 
 
+def drop_schema(connection: Connection, schema_name: str = SCHEMA_NAME) -> None:
+    connection.execute(DropSchema(schema_name, cascade=True, if_exists=True))
+
+
+@deprecat(
+    reason="The 'drop_db' function has been deprecated. "
+    "Please use 'drop_schema' instead.",
+    version="1.9.10",
+    category=ODC2DeprecationWarning,
+)
 def drop_db(connection: Connection) -> None:
-    connection.execute(DropSchema(SCHEMA_NAME, cascade=True, if_exists=True))
+    drop_schema(connection)
 
 
 def to_pg_role(role) -> str:

--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -8,6 +8,7 @@ Core SQL schema settings.
 
 import logging
 
+from deprecat import deprecat
 from sqlalchemy import Connection, MetaData, inspect, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.schema import CreateSchema, DropSchema
@@ -24,6 +25,7 @@ from datacube.drivers.postgres.sql import (
     escape_pg_identifier,
     pg_column_exists,
 )
+from datacube.migration import ODC2DeprecationWarning
 
 USER_ROLES = ("agdc_user", "agdc_ingest", "agdc_manage", "agdc_admin")
 
@@ -295,8 +297,18 @@ def has_schema(engine: Engine, schema_name: str = SCHEMA_NAME) -> bool:
     return inspect(engine).has_schema(schema_name)
 
 
+def drop_schema(connection: Connection, schema_name: str = SCHEMA_NAME) -> None:
+    connection.execute(DropSchema(schema_name, cascade=True, if_exists=True))
+
+
+@deprecat(
+    reason="The 'drop_db' function has been deprecated. "
+    "Please use 'drop_schema' instead.",
+    version="1.9.10",
+    category=ODC2DeprecationWarning,
+)
 def drop_db(connection: Connection) -> None:
-    connection.execute(DropSchema(SCHEMA_NAME, cascade=True, if_exists=True))
+    drop_schema(connection)
 
 
 def to_pg_role(role: str) -> str:

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -597,7 +597,7 @@ def reset_db(cfg_env: ODCEnvironment, tz=None) -> PostgresDb | PostGisDb:
         # Drop tables so our tests have a clean db.
         # with db.begin() as c:  # Creates a new PostgresDbAPI, by passing a new connection to it
         with db._engine.connect() as connection:
-            pgres_core.drop_db(connection)
+            pgres_core.drop_schema(connection)
             if tz:
                 connection.execute(
                     text(f"alter database {db_name} set timezone = {tz!r}")
@@ -610,7 +610,7 @@ def reset_db(cfg_env: ODCEnvironment, tz=None) -> PostgresDb | PostGisDb:
             cfg_env, application_name="test-run", validate_connection=False
         )
         with db._engine.connect() as connection:
-            pgis_core.drop_db(connection)
+            pgis_core.drop_schema(connection)
             if tz:
                 connection.execute(
                     text(f"alter database {db_name} set timezone = {tz!r}")
@@ -622,9 +622,9 @@ def reset_db(cfg_env: ODCEnvironment, tz=None) -> PostgresDb | PostGisDb:
 def cleanup_db(cfg_env: ODCEnvironment, db: PostgresDb | PostGisDb) -> None:
     with db._engine.connect() as connection:
         if cfg_env._name in ("datacube", "default", "postgres", "datacube3"):
-            pgres_core.drop_db(connection)
+            pgres_core.drop_schema(connection)
         else:
-            pgis_core.drop_db(connection)
+            pgis_core.drop_schema(connection)
     db.close()
 
 

--- a/integration_tests/test_config_tool.py
+++ b/integration_tests/test_config_tool.py
@@ -176,12 +176,12 @@ def test_db_init_rebuild(clirunner, cfg_env, ls8_eo3_product) -> None:
 
 def test_db_init(clirunner, index) -> None:
     if index._db.driver_name == "postgis":
-        from datacube.drivers.postgis._core import drop_db, has_schema
+        from datacube.drivers.postgis._core import drop_schema, has_schema
     else:
-        from datacube.drivers.postgres._core import drop_db, has_schema
+        from datacube.drivers.postgres._core import drop_schema, has_schema
 
     with index._db._connect() as connection:
-        drop_db(connection._connection)
+        drop_schema(connection._connection)
 
         assert not has_schema(index._db._engine)
 


### PR DESCRIPTION
### Reason for this pull request

The function drops the schema, so
deprecate it and add a drop_schema
function instead.

While changing the API, also add
a parameter with the schema name
so Explorer can use this instead
of having its own implementation.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2174.org.readthedocs.build/en/2174/

<!-- readthedocs-preview opendatacube end -->