### PR TITLE
Remove f-strings without placeholders

### DIFF
--- a/datacube/index/abstract/_users.py
+++ b/datacube/index/abstract/_users.py
@@ -33,7 +33,7 @@ class AbstractUserResource(ABC):
         Create a new user
         :param username: username of the new user
         :param password: password of the new user
-        :param role: default role of the the new user
+        :param role: default role of the new user
         :param description: optional description for the new user
         """
 

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -929,7 +929,7 @@ class Product:
                         spectral_definition.get("response")
                     ):
                         raise ValueError(
-                            f"spectral_definition_map: wavelength should be the same length as response "
+                            "spectral_definition_map: wavelength should be the same length as response "
                             f"in the product definition for spectral definition at index {idx}."
                         )
 
@@ -1496,8 +1496,7 @@ class ExtraDimensions:
     def __str__(self) -> str:
         return (
             f"ExtraDimensions(extra_dim={dict(self._dims)}, dim_slice={self._dim_slice} "
-            f"coords={self._coords} "
-            f")"
+            f"coords={self._coords})"
         )
 
     @override

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -1434,7 +1434,7 @@ class ExtraDimensions:
         """Returns the index for slicing on a dimension
 
         :param dim: The name of the dimension
-        :return: A slice for the the requested dimension.
+        :return: A slice for the requested dimension.
         """
         dim_slice = self.measurements_index(dim)
         return slice(*dim_slice)
@@ -1443,7 +1443,7 @@ class ExtraDimensions:
         """Returns the index for slicing on a dimension as a tuple.
 
         :param dim: The name of the dimension
-        :return: A tuple for the the requested dimension.
+        :return: A tuple for the requested dimension.
         """
         if dim not in self._dim_slice:
             raise ValueError(f"Dimension {dim} not found.")

--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -857,7 +857,7 @@ def clip_lon180(geom: Geometry, tol: float = 1e-6) -> Geometry:
 
     .. note:: This will only do "right thing" for chopped geometries,
         expectation is that all the points are to one side of lon=180
-        line, or in the the capture zone of lon=(+/-)180
+        line, or in the capture zone of lon=(+/-)180
     """
     thresh = 180 - tol
 


### PR DESCRIPTION
### Reason for this pull request

While fixing this, I noticed a bunch of double "the the" in doc strings, so put a commit in for fixing that as well.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2185.org.readthedocs.build/en/2185/

<!-- readthedocs-preview opendatacube end -->