### PR TITLE
documents: handle failed download

### DIFF
--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -183,8 +183,8 @@ def read_documents(*paths, uri: bool = False) -> Generator[tuple[str, dict]]:
 
 
 def parse_doc_stream(
-    doc_stream: Sequence[tuple[str, str | bytes]],
-    on_error: Callable[[str, str | bytes], None] | None = None,
+    doc_stream: Sequence[tuple[str, str | bytes | None]],
+    on_error: Callable[[str, str | bytes | None], None] | None = None,
     transform: Callable[[Mapping[str, Any]], Mapping[str, Any]] | None = None,
 ) -> Generator[tuple[str, Mapping[str, Any] | None]]:
     """
@@ -203,6 +203,8 @@ def parse_doc_stream(
     """
     for uri, doc in doc_stream:
         try:
+            if doc is None:
+                raise Exception(f"No document for {uri}")
             metadata = json.loads(doc) if uri.endswith(".json") else parse_yaml(doc)
             if transform is not None:
                 metadata = transform(metadata)


### PR DESCRIPTION
### Reason for this pull request

This function is used by odc-tools,
and the doc_stream can have None
as document when S3 fails, and that
causes json.loads to raise a TypeError
which is not caught by the except
clause.

Fix the type annotation and throw
an error locally when doc is None
so the on_error handler is invoked
properly.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2189.org.readthedocs.build/en/2189/

<!-- readthedocs-preview opendatacube end -->