### PR TITLE
Reduce product.grid_spec warning volume

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -171,7 +171,8 @@ class Datacube:
                 if col == "crs":
                     return load_hints.get("output_crs", None)
                 return load_hints.get(col, None)
-            return getattr(product.grid_spec, col, None)
+            with warnings.catch_warnings(action="ignore", category=DeprecationWarning):
+                return getattr(product.grid_spec, col, None)
 
         # Read properties from each datacube product
         cols = [
@@ -562,7 +563,8 @@ class Datacube:
             resolution = _handle_legacy_resolution(resolution)
 
         load_hints = datacube_product.load_hints()
-        grid_spec = None if load_hints is not None else datacube_product.grid_spec
+        with warnings.catch_warnings(action="ignore", category=DeprecationWarning):
+            grid_spec = None if load_hints is not None else datacube_product.grid_spec
 
         geobox = output_geobox(
             like=like,

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -171,8 +171,7 @@ class Datacube:
                 if col == "crs":
                     return load_hints.get("output_crs", None)
                 return load_hints.get(col, None)
-            with warnings.catch_warnings(action="ignore", category=DeprecationWarning):
-                return getattr(product.grid_spec, col, None)
+            return getattr(product.grid_spec, col, None)
 
         # Read properties from each datacube product
         cols = [
@@ -563,8 +562,7 @@ class Datacube:
             resolution = _handle_legacy_resolution(resolution)
 
         load_hints = datacube_product.load_hints()
-        with warnings.catch_warnings(action="ignore", category=DeprecationWarning):
-            grid_spec = None if load_hints is not None else datacube_product.grid_spec
+        grid_spec = None if load_hints is not None else datacube_product.grid_spec
 
         geobox = output_geobox(
             like=like,

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -1087,7 +1087,10 @@ DatasetType = Product
 
 
 @deprecat(
-    reason="This version of GridSpec has been deprecated. Please use the GridSpec class defined in odc-geo.",
+    reason="This version of GridSpec has been deprecated. Please use the GridSpec class defined in odc-geo.\n"
+    "Note that in odc-geo GridSpec, tile_size has been renamed tile_shape and should be provided in pixels, "
+    "resolution is expected in (X, Y) order or simply X if using square pixels with inverted Y axis, "
+    "and origin (if provided) must be an instance of odc.geo.XY",
     version="1.9.0",
     category=ODC2DeprecationWarning,
 )
@@ -1125,17 +1128,8 @@ class GridSpec:
         origin: tuple[float, float] | None = None,
     ) -> None:
         self.crs = crs
-        _LOG.warning(
-            "In odc-geo GridSpec, tile_size has been renamed tile_shape and should be provided in pixels."
-        )
         self.tile_size = tile_size
-        _LOG.warning(
-            "In odc-geo GridSpec, resolution is expected in (X, Y) order, "
-            "or simply X if using square pixels with inverted Y axis."
-        )
         self.resolution = resolution
-        if origin is not None:
-            _LOG.warning("In odc-geo GridSpec, origin is expected in (X, Y) order.")
         self.origin = origin or (0.0, 0.0)
 
     @override


### PR DESCRIPTION
### Reason for this pull request

See #2190 


### Proposed changes

- Instead of multiple logger warnings, put all info into the GridSpec deprecat warning



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2191.org.readthedocs.build/en/2191/

<!-- readthedocs-preview opendatacube end -->