### PR TITLE
tests: test with single time zone

### DIFF
--- a/integration_tests/index/test_update_columns.py
+++ b/integration_tests/index/test_update_columns.py
@@ -56,6 +56,7 @@ def drop_column(conn, table: str, column: str) -> None:
     )
 
 
+@pytest.mark.parametrize("uninitialised_postgres_db", ("UTC",), indirect=True)
 @pytest.mark.parametrize("datacube_env_name", ("datacube", "datacube3"))
 def test_added_column(clirunner, uninitialised_postgres_db) -> None:
     # Run on an empty database.
@@ -81,6 +82,7 @@ def test_added_column(clirunner, uninitialised_postgres_db) -> None:
         assert not check_trigger(connection, _schema.DATASET_LOCATION.name)
 
 
+@pytest.mark.parametrize("uninitialised_postgres_db", ("UTC",), indirect=True)
 @pytest.mark.parametrize("datacube_env_name", ("datacube", "datacube3"))
 def test_readd_column(clirunner, uninitialised_postgres_db) -> None:
     # Run on an empty database. drop columns and re-add


### PR DESCRIPTION
### Reason for this pull request

These tests just check for existence
of columns in tables, so run them for
a single time zone.

Refs #2193

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2194.org.readthedocs.build/en/2194/

<!-- readthedocs-preview opendatacube end -->