### PR TITLE
CI: remove pyspell job

### DIFF
--- a/.github/workflows/doc-qa.yaml
+++ b/.github/workflows/doc-qa.yaml
@@ -17,15 +17,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pyspell:
-    timeout-minutes: 15
-    runs-on: ubuntu-latest
-    steps:
-      # Spellcheck
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          fetch-depth: 0
-
   doctor-rst:
     timeout-minutes: 15
     name: Lint (DOCtor-RST)


### PR DESCRIPTION
### Reason for this pull request

This job only checks out the repository
and is then considered done, so remove
it.

This saves us one CI runner for pull
requests and merges.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2201.org.readthedocs.build/en/2201/

<!-- readthedocs-preview opendatacube end -->