### PR TITLE
Resolve virtual product odc-geo reprojection incompatibility

### DIFF
--- a/datacube/virtual/impl.py
+++ b/datacube/virtual/impl.py
@@ -1129,7 +1129,9 @@ def reproject_band(
 ) -> xarray.DataArray:
     """Reproject a single measurement to the geobox."""
     if not hasattr(band.data, "dask") or dask_chunks is None:
-        data = reproject_array(band.data, band.nodata, band.geobox, geobox, resampling)
+        data = reproject_array(
+            band.data, band.nodata, band.odc.geobox, geobox, resampling
+        )
         return wrap_in_dataarray(data, band, geobox, dims)
 
     dask_name = f"warp_{band.name}-{uuid.uuid4().hex}"
@@ -1145,7 +1147,7 @@ def reproject_band(
     for tile_index in numpy.ndindex(gt.shape):  # type: ignore[call-overload]
         sub_geobox = gt[tile_index]
         # find the input array slice from the output geobox
-        reproject_roi = compute_reproject_roi(band.geobox, sub_geobox, padding=1)
+        reproject_roi = compute_reproject_roi(band.odc.geobox, sub_geobox, padding=1)
 
         # find the chunk from the input array with the slice index
         subset_band = band[(..., *reproject_roi.roi_src)].chunk(-1)
@@ -1191,7 +1193,8 @@ def reproject_band(
 
 def reproject_array(src, nodata, s_geobox, d_geobox, resampling):
     """Reproject a numpy array."""
-    dst = numpy.full(d_geobox.shape, fill_value=nodata, dtype=src.dtype)
+    # add time dimension to the shape to match src dims
+    dst = numpy.full((1, *d_geobox.shape), fill_value=nodata, dtype=src.dtype)
     rio_reproject(
         src=src,
         dst=dst,

--- a/datacube/virtual/impl.py
+++ b/datacube/virtual/impl.py
@@ -1193,8 +1193,9 @@ def reproject_band(
 
 def reproject_array(src, nodata, s_geobox, d_geobox, resampling):
     """Reproject a numpy array."""
-    # add time dimension to the shape to match src dims
-    dst = numpy.full((1, *d_geobox.shape), fill_value=nodata, dtype=src.dtype)
+    # add time dimension to the shape to match src dims if needed
+    dst_shape = (1, *d_geobox.shape) if src.ndim == 3 else d_geobox.shape
+    dst = numpy.full(dst_shape, fill_value=nodata, dtype=src.dtype)
     rio_reproject(
         src=src,
         dst=dst,

--- a/tests/api/test_virtual.py
+++ b/tests/api/test_virtual.py
@@ -533,7 +533,6 @@ def test_register(dc, query) -> None:
     assert "bluegreen" in data
 
 
-@pytest.mark.skip(reason="odc-geo implementation of rio_reproject is a breaking change")
 def test_reproject(dc, query, catalog) -> None:
     reproject_utm = catalog["reproject_utm"]
 


### PR DESCRIPTION
### Reason for this pull request

The odc-geo implementation of `rio_reproject` was a breaking change for virtual product loading as it requires the `src` and `dst` ndarrays to have the same number of dimensions.

### Proposed changes

- Add time dimension to the `dst` ndarray shape to match the `src` dims



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2202.org.readthedocs.build/en/2202/

<!-- readthedocs-preview opendatacube end -->