### PR TITLE
Revert "Make dateutil an optional dependency"

### DIFF
--- a/datacube/utils/dates.py
+++ b/datacube/utils/dates.py
@@ -12,9 +12,14 @@ Includes sequence generation functions to be used by statistics apps
 from collections.abc import Generator
 from datetime import date, datetime, timezone, tzinfo
 
+import dateutil
+import dateutil.parser
 import numpy as np
 import xarray as xr
+from dateutil.relativedelta import relativedelta
+from dateutil.rrule import DAILY, MONTHLY, YEARLY, rrule
 
+FREQS: dict[str, int] = {"y": YEARLY, "m": MONTHLY, "d": DAILY}
 DURATIONS = {"y": "years", "m": "months", "d": "days"}
 
 
@@ -33,8 +38,6 @@ def date_sequence(
     :param step_size: How far apart should the start dates be
     :return: sequence of (start_date, end_date) tuples
     """
-    from dateutil.rrule import rrule
-
     interval, freq = parse_interval(step_size)
     stats_duration = parse_duration(stats_duration)
     for start_date in rrule(freq, interval=interval, dtstart=start, until=end):
@@ -44,9 +47,6 @@ def date_sequence(
 
 
 def parse_interval(interval) -> tuple:
-    from dateutil.rrule import DAILY, MONTHLY, YEARLY
-
-    FREQS: dict[str, int] = {"y": YEARLY, "m": MONTHLY, "d": DAILY}  # noqa: N806
     count, units = _split_duration(interval)
     try:
         return count, FREQS[units]
@@ -57,8 +57,6 @@ def parse_interval(interval) -> tuple:
 
 
 def parse_duration(duration):
-    from dateutil.relativedelta import relativedelta
-
     count, units = _split_duration(duration)
     try:
         delta = {DURATIONS[units]: count}
@@ -120,8 +118,6 @@ def parse_time(time: str | datetime) -> datetime:
 
             return parse_datetime(time)
         except (ImportError, ValueError):  # pragma: no cover
-            from dateutil.parser import parse
-
-            return parse(time)
+            return dateutil.parser.parse(time)
 
     return time

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     'packaging',
     'pandas',
     'pyproj>=2.5',
+    'python-dateutil',
     'pyyaml',
     'rasterio>=1.3.11',  # Deleted Numpy version in 1.3.10
     'ruamel.yaml',
@@ -67,7 +68,6 @@ Chat = "https://discord.com/invite/4hhBQVas5U"
 
 [project.optional-dependencies]
 performance = ['ciso8601', 'bottleneck']
-dateutil = ['python-dateutil']
 distributed = ['distributed', 'dask[distributed]']
 s3 = ['boto3', 'botocore']
 netcdf = ['netcdf4']
@@ -76,7 +76,7 @@ psycopg3 = ['psycopg']
 
 [dependency-groups]
 dev = [
-    'datacube[dateutil,netcdf,postgres,psycopg3]',
+    'datacube[netcdf,postgres,psycopg3]',
     # Test requirements
     'click>=8.2', # Only the tests need >=8.2, everything else works with older click.
     'hypothesis',

--- a/uv.lock
+++ b/uv.lock
@@ -859,6 +859,7 @@ dependencies = [
     { name = "pandas" },
     { name = "pyproj", version = "3.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pyproj", version = "3.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "python-dateutil" },
     { name = "pyyaml" },
     { name = "rasterio" },
     { name = "ruamel-yaml" },
@@ -870,9 +871,6 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-dateutil = [
-    { name = "python-dateutil" },
-]
 distributed = [
     { name = "dask", extra = ["distributed"] },
     { name = "distributed" },
@@ -902,7 +900,7 @@ dev = [
     { name = "boto3-stubs" },
     { name = "botocore-stubs" },
     { name = "click" },
-    { name = "datacube", extra = ["dateutil", "netcdf", "postgres", "psycopg3"] },
+    { name = "datacube", extra = ["netcdf", "postgres", "psycopg3"] },
     { name = "hypothesis" },
     { name = "ipython", version = "8.37.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "ipython", version = "9.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -976,7 +974,7 @@ requires-dist = [
     { name = "psycopg", marker = "extra == 'psycopg3'" },
     { name = "psycopg2", marker = "extra == 'postgres'" },
     { name = "pyproj", specifier = ">=2.5" },
-    { name = "python-dateutil", marker = "extra == 'dateutil'" },
+    { name = "python-dateutil" },
     { name = "pyyaml" },
     { name = "rasterio", specifier = ">=1.3.11" },
     { name = "ruamel-yaml" },
@@ -985,7 +983,7 @@ requires-dist = [
     { name = "toolz" },
     { name = "xarray", specifier = ">=0.9" },
 ]
-provides-extras = ["performance", "dateutil", "distributed", "s3", "netcdf", "postgres", "psycopg3"]
+provides-extras = ["performance", "distributed", "s3", "netcdf", "postgres", "psycopg3"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -994,7 +992,7 @@ dev = [
     { name = "boto3-stubs" },
     { name = "botocore-stubs" },
     { name = "click", specifier = ">=8.2" },
-    { name = "datacube", extras = ["dateutil", "netcdf", "postgres", "psycopg3"] },
+    { name = "datacube", extras = ["netcdf", "postgres", "psycopg3"] },
     { name = "hypothesis" },
     { name = "ipython" },
     { name = "moto", specifier = ">=5.0" },
@@ -1297,7 +1295,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.12'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [


### PR DESCRIPTION

### Reason for this pull request

Not sure how I missed it, but the parse_time
function is used in many places, so revert
this.

This reverts commit 7d1ea9d398cf3a9c3d502e4bc7102a92d346a365.

Fixes #2207

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2206.org.readthedocs.build/en/2206/

<!-- readthedocs-preview opendatacube end -->