### PR TITLE
tests: include error message for cli

### DIFF
--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -370,7 +370,7 @@ def test_product_update_cli(
     assert str(f'Updated "{extended_eo3_product_doc["name"]}"') in result.output
     fresh = get_current(index, extended_eo3_product_doc)
     assert documents_equal(fresh, extended_eo3_product_doc)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
 
     # Try to add an unknown property: this should be forbidden by validation of dataset-type-schema.yaml
     modified_doc = copy.deepcopy(extended_eo3_product_doc)
@@ -382,7 +382,7 @@ def test_product_update_cli(
     # The error message differs between jsonschema versions, but should always mention the invalid property name.
     assert "newly_added_property" in result.output
     # Return error code for failure!
-    assert result.exit_code == 1
+    assert result.exit_code == 1, f"Output: {result.output}"
     fresh = get_current(index, extended_eo3_product_doc)
     assert documents_equal(fresh, extended_eo3_product_doc)
 
@@ -396,7 +396,7 @@ def test_product_update_cli(
     result = run_update_product(file_path, expect_success=False)
     assert "Unsafe change in metadata.42 from missing to 'hello'" in result.output
     # Return error code for failure!
-    assert result.exit_code == 1
+    assert result.exit_code == 1, f"Output: {result.output}"
     # Unchanged
     fresh = get_current(index, extended_eo3_product_doc)
     assert documents_equal(fresh, extended_eo3_product_doc)
@@ -404,7 +404,7 @@ def test_product_update_cli(
     # But if we set allow-unsafe==True, this one will work.
     result = run_update_product(file_path, allow_unsafe=True)
     assert "Unsafe change in metadata.42 from missing to 'hello'" in result.output
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
     # Has changed, and our key is now a string (json only allows string keys)
     modified_doc = copy.deepcopy(extended_eo3_product_doc)
     modified_doc["metadata"]["42"] = "hello"
@@ -447,7 +447,7 @@ def test_product_delete_cli(
     assert "1 out of 2 products successfully deleted" in runner.output
     assert "ga_ls_wo_3 could not be deleted" not in runner.output
     assert "ga_ls8c_ard_3 could not be deleted" in runner.output
-    assert runner.exit_code == 0
+    assert runner.exit_code == 0, f"Output: {runner.output}"
 
     index.products.get_by_name_unsafe.cache_clear()  # type: ignore[attr-defined]
     assert index.products.get_by_name("ga_ls8c_ard_3") is not None
@@ -462,7 +462,7 @@ def test_product_delete_cli(
         ["product", "delete", "ga_ls8c_ard_3", "--force"], verbose_flag=False
     )
     assert "Completed product deletion" in runner.output
-    assert runner.exit_code == 0
+    assert runner.exit_code == 0, f"Output: {runner.output}"
 
     runner = clirunner(
         ["dataset", "archive", "4a30d008-4e82-4d67-99af-28bc1629f766"],

--- a/integration_tests/index/test_pluggable_indexes.py
+++ b/integration_tests/index/test_pluggable_indexes.py
@@ -20,4 +20,4 @@ def test_system_init(uninitialised_postgres_db, clirunner) -> None:
 
     if result.exit_code != 0:
         print(result.output)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -999,7 +999,7 @@ def test_search_cli_basic(clirunner: Any, ls8_eo3_dataset: Dataset) -> None:
     )
     assert str(ls8_eo3_dataset.id) in result.output
     assert str(ls8_eo3_dataset.metadata_type.name) in result.output
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
 
     result = clirunner(
         ["dataset", "search"],
@@ -1007,7 +1007,7 @@ def test_search_cli_basic(clirunner: Any, ls8_eo3_dataset: Dataset) -> None:
     )
     assert str(ls8_eo3_dataset.id) in result.output
     assert str(ls8_eo3_dataset.product.name) in result.output
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
 
 
 def test_cli_info_eo3(

--- a/integration_tests/index/test_search_legacy.py
+++ b/integration_tests/index/test_search_legacy.py
@@ -980,7 +980,9 @@ def test_cli_missing_info(clirunner, index) -> None:
         expect_success=False,
         verbose_flag=False,
     )
-    assert result.exit_code == 1, "Should return exit status when dataset is missing"
+    assert result.exit_code == 1, (
+        f"Should return exit status when dataset is missing. Output: {result.output}"
+    )
     assert result.stderr.endswith(f"{id_} missing\n")
 
 

--- a/integration_tests/test_cli_output.py
+++ b/integration_tests/test_cli_output.py
@@ -9,7 +9,7 @@ def test_cli_product_subcommand(index_empty, clirunner, dataset_add_configs) -> 
     runner = clirunner(["product", "update"], verbose_flag=False, expect_success=False)
     assert "Usage:  [OPTIONS] [FILES]" in runner.output
     assert "Update existing products." in runner.output
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
     runner = clirunner(
         ["product", "update", dataset_add_configs.empty_file],
@@ -17,22 +17,22 @@ def test_cli_product_subcommand(index_empty, clirunner, dataset_add_configs) -> 
         expect_success=False,
     )
     assert "All files are empty, exit" in runner.output
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
     runner = clirunner(["product", "add"], verbose_flag=False, expect_success=False)
     assert "Usage:  [OPTIONS] [FILES]" in runner.output
     assert "Add or update products in" in runner.output
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
     runner = clirunner(["product", "list"], verbose_flag=False)
     assert "Usage:  [OPTIONS] [FILES]" not in runner.output
-    assert runner.exit_code == 0
+    assert runner.exit_code == 0, f"Output: {runner.output}"
 
     runner = clirunner(
         ["product", "show", "ga_ls8c_ard_3"], verbose_flag=False, expect_success=False
     )
     assert "No products" not in runner.output
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
     runner = clirunner(
         ["product", "add", dataset_add_configs.empty_file],
@@ -40,7 +40,7 @@ def test_cli_product_subcommand(index_empty, clirunner, dataset_add_configs) -> 
         expect_success=False,
     )
     assert "All files are empty, exit" in runner.output
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
     runner = clirunner(["product", "delete"], verbose_flag=False, expect_success=False)
     assert "Usage:  [OPTIONS] [PRODUCT_NAMES]" in runner.output
@@ -50,14 +50,14 @@ def test_cli_product_subcommand(index_empty, clirunner, dataset_add_configs) -> 
         ["product", "delete", "ga_ls8c_ard_3"], verbose_flag=False, expect_success=False
     )
     assert '"ga_ls8c_ard_3" is not a valid Product name' in runner.output
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
 
 def test_cli_metadata_subcommand(index_empty, clirunner, dataset_add_configs) -> None:
     runner = clirunner(["metadata", "update"], verbose_flag=False, expect_success=False)
     assert "Usage:  [OPTIONS] [FILES]" in runner.output
     assert "Update existing metadata types." in runner.output
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
     runner = clirunner(
         ["metadata", "update", dataset_add_configs.empty_file],
@@ -65,12 +65,12 @@ def test_cli_metadata_subcommand(index_empty, clirunner, dataset_add_configs) ->
         expect_success=False,
     )
     assert "All files are empty, exit" in runner.output
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
     runner = clirunner(["metadata", "add"], verbose_flag=False, expect_success=False)
     assert "Usage:  [OPTIONS] [FILES]" in runner.output
     assert "Add or update metadata types in" in runner.output
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
     runner = clirunner(
         ["metadata", "add", dataset_add_configs.empty_file],
@@ -78,7 +78,7 @@ def test_cli_metadata_subcommand(index_empty, clirunner, dataset_add_configs) ->
         expect_success=False,
     )
     assert "All files are empty, exit" in runner.output
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
 
 @pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")
@@ -99,25 +99,25 @@ def test_cli_dataset_subcommand(
     )
     assert "Usage:  [OPTIONS] [DATASET_PATHS]" in runner.output
     assert "Add datasets" in runner.output
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
     runner = clirunner(["dataset", "update"], verbose_flag=False, expect_success=False)
     assert "0 successful, 0 failed" not in runner.output
     assert "Usage:  [OPTIONS] [DATASET_PATHS]" in runner.output
     assert "Update datasets" in runner.output
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
     runner = clirunner(["dataset", "info"], verbose_flag=False, expect_success=False)
     assert "Usage:  [OPTIONS] [IDS]" in runner.output
     assert "Display dataset information" in runner.output
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
     runner = clirunner(
         ["dataset", "uri-search"], verbose_flag=False, expect_success=False
     )
     assert "Usage:  [OPTIONS] [PATHS]" in runner.output
     assert "Search by dataset locations" in runner.output
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
     # Insert datasets
     for path in eo3_dataset_paths:
@@ -127,7 +127,7 @@ def test_cli_dataset_subcommand(
         ["dataset", "find-duplicates"], verbose_flag=False, expect_success=False
     )
     assert "Error: must provide field names to match on" in runner.output
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
     runner = clirunner(
         ["dataset", "find-duplicates", "region_code", "fake_field"],
@@ -137,7 +137,7 @@ def test_cli_dataset_subcommand(
     assert (
         "Error: no products found with fields region_code, fake_field" in runner.output
     )
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
     runner = clirunner(
         [
@@ -157,13 +157,13 @@ def test_cli_dataset_subcommand(
         "Error: specified products ga_ls_wo_3 do not contain all required fields"
         in runner.output
     )
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
     runner = clirunner(
         ["dataset", "find-duplicates", "region_code", "uri"], verbose_flag=False
     )
     assert "No potential duplicates found." in runner.output
-    assert runner.exit_code == 0
+    assert runner.exit_code == 0, f"Output: {runner.output}"
 
     runner = clirunner(
         ["dataset", "find-duplicates", "region_code", "dataset_maturity"],
@@ -172,27 +172,27 @@ def test_cli_dataset_subcommand(
     assert "No potential duplicates found." not in runner.output
     assert "region_code: 090086\ndataset_maturity: final" in runner.output
     assert "region_code: '101077'\ndataset_maturity: final" in runner.output
-    assert runner.exit_code == 0
+    assert runner.exit_code == 0, f"Output: {runner.output}"
 
     runner = clirunner(
         ["dataset", "count", "--count-only", "ga_ls8c_ard_3", "ga_ls_wo_3"],
         verbose_flag=False,
     )
     assert runner.output == "5\n"
-    assert runner.exit_code == 0
+    assert runner.exit_code == 0, f"Output: {runner.output}"
 
     runner = clirunner(
         ["dataset", "count", "ga_ls8c_ard_3", "ga_ls_wo_3"], verbose_flag=False
     )
     assert "product: ga_ls8c_ard_3\ncount: 4" in runner.output
-    assert runner.exit_code == 0
+    assert runner.exit_code == 0, f"Output: {runner.output}"
 
     runner = clirunner(
         ["dataset", "count", "ga_ls8c_ard_3", "--query", 'region_code="090086"'],
         verbose_flag=False,
     )
     assert "count: 2" in runner.output
-    assert runner.exit_code == 0
+    assert runner.exit_code == 0, f"Output: {runner.output}"
 
     runner = clirunner(
         ["dataset", "count", "--count-only", "--period", "1 month", "ga_ls8c_ard_3"],
@@ -202,7 +202,7 @@ def test_cli_dataset_subcommand(
     assert (
         "Error: cannot return total count when requesting time slicing" in runner.output
     )
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
     runner = clirunner(
         [
@@ -217,7 +217,7 @@ def test_cli_dataset_subcommand(
         verbose_flag=False,
     )
     assert "time: '2013-01-01'\ncount: 2" in runner.output
-    assert runner.exit_code == 0
+    assert runner.exit_code == 0, f"Output: {runner.output}"
 
     clirunner(
         ["dataset", "archive", "c21648b1-a6fa-4de0-9dc3-9c445d8b295a"],
@@ -239,49 +239,49 @@ def test_cli_dataset_subcommand(
         ["dataset", "search", "foo"], verbose_flag=False, expect_success=False
     )
     assert "Invalid expression" in runner.output
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
     runner = clirunner(
         ["dataset", "search", "product=ga_ls8c_ard_3", 'region_code="090086"'],
         verbose_flag=False,
     )
     assert "id: 4a30d008-4e82-4d67-99af-28bc1629f766" in runner.output
-    assert runner.exit_code == 0
+    assert runner.exit_code == 0, f"Output: {runner.output}"
 
     runner = clirunner(["dataset", "archive"], verbose_flag=False, expect_success=False)
     assert "Completed dataset archival." not in runner.output
     assert "Usage:  [OPTIONS] [IDS]" in runner.output
     assert "Archive datasets" in runner.output
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
     runner = clirunner(["dataset", "archive", "--all"], verbose_flag=False)
     assert "Archiving dataset:" in runner.output
     assert "Completed dataset archival." in runner.output
     assert "Usage:  [OPTIONS] [IDS]" not in runner.output
     assert "Archive datasets" not in runner.output
-    assert runner.exit_code == 0
+    assert runner.exit_code == 0, f"Output: {runner.output}"
 
     runner = clirunner(["dataset", "restore"], verbose_flag=False, expect_success=False)
     assert "Usage:  [OPTIONS] [IDS]" in runner.output
     assert "Restore datasets" in runner.output
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
     runner = clirunner(["dataset", "restore", "--all"], verbose_flag=False)
     assert "restoring" in runner.output
     assert "Usage:  [OPTIONS] [IDS]" not in runner.output
     assert "Restore datasets" not in runner.output
-    assert runner.exit_code == 0
+    assert runner.exit_code == 0, f"Output: {runner.output}"
 
     runner = clirunner(["dataset", "purge"], verbose_flag=False, expect_success=False)
     assert "Completed dataset purge." not in runner.output
     assert "Usage:  [OPTIONS] [IDS]" in runner.output
     assert "Purge archived datasets" in runner.output
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
     runner = clirunner(["dataset", "purge", "--all"], verbose_flag=False)
     assert "Completed dataset purge." in runner.output
     assert "Usage:  [OPTIONS] [IDS]" not in runner.output
-    assert runner.exit_code == 0
+    assert runner.exit_code == 0, f"Output: {runner.output}"
 
 
 @pytest.mark.filterwarnings("ignore::antimeridian.FixWindingWarning")

--- a/integration_tests/test_cli_spatial_indexes.py
+++ b/integration_tests/test_cli_spatial_indexes.py
@@ -13,43 +13,43 @@ def test_cli_spatial_indexes(index: Index, clirunner) -> None:
     runner = clirunner(["spindex", "list"], verbose_flag=False)
     assert "EPSG:4326" in runner.output
     assert "EPSG:3577" not in runner.output
-    assert runner.exit_code == 0
+    assert runner.exit_code == 0, f"Output: {runner.output}"
 
     runner = clirunner(["spindex", "create", "epsg:3577"], verbose_flag=False)
-    assert runner.exit_code == 0
+    assert runner.exit_code == 0, f"Output: {runner.output}"
 
     # Double creation succeeds silently
     runner = clirunner(["spindex", "create", "3577"], verbose_flag=False)
-    assert runner.exit_code == 0
+    assert runner.exit_code == 0, f"Output: {runner.output}"
 
     runner = clirunner(["spindex", "update", "3577"], verbose_flag=False)
-    assert runner.exit_code == 0
+    assert runner.exit_code == 0, f"Output: {runner.output}"
 
     runner = clirunner(
         ["spindex", "update", "EPSG:3857"], verbose_flag=False, expect_success=False
     )
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
     runner = clirunner(["spindex", "list"], verbose_flag=False)
     assert "EPSG:4326" in runner.output
     assert "EPSG:3577" in runner.output
-    assert runner.exit_code == 0
+    assert runner.exit_code == 0, f"Output: {runner.output}"
 
     runner = clirunner(
         ["spindex", "drop", "3577"], verbose_flag=False, expect_success=False
     )
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
     runner = clirunner(["spindex", "drop", "--force", "3577"], verbose_flag=False)
-    assert runner.exit_code == 0
+    assert runner.exit_code == 0, f"Output: {runner.output}"
 
     runner = clirunner(["spindex", "list"], verbose_flag=False)
     assert "EPSG:4326" in runner.output
     assert "EPSG:3577" not in runner.output
-    assert runner.exit_code == 0
+    assert runner.exit_code == 0, f"Output: {runner.output}"
 
     # Drop non-existent spindex ignored.
     runner = clirunner(["spindex", "drop", "--force", "3577"], verbose_flag=False)
-    assert runner.exit_code == 0
+    assert runner.exit_code == 0, f"Output: {runner.output}"
 
 
 @pytest.mark.parametrize("datacube_env_name", ("postgis", "postgis3"))
@@ -57,62 +57,62 @@ def test_cli_spatial_index_create_and_update(index: Index, clirunner) -> None:
     runner = clirunner(["spindex", "list"], verbose_flag=False)
     assert "EPSG:4326" in runner.output
     assert "EPSG:3577" not in runner.output
-    assert runner.exit_code == 0
+    assert runner.exit_code == 0, f"Output: {runner.output}"
 
     runner = clirunner(["spindex", "create", "--update", "3577"], verbose_flag=False)
-    assert runner.exit_code == 0
+    assert runner.exit_code == 0, f"Output: {runner.output}"
 
     runner = clirunner(["spindex", "list"], verbose_flag=False)
     assert "EPSG:4326" in runner.output
     assert "EPSG:3577" in runner.output
-    assert runner.exit_code == 0
+    assert runner.exit_code == 0, f"Output: {runner.output}"
 
     runner = clirunner(
         ["spindex", "drop", "3577"], verbose_flag=False, expect_success=False
     )
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
     runner = clirunner(["spindex", "drop", "--force", "3577"], verbose_flag=False)
-    assert runner.exit_code == 0
+    assert runner.exit_code == 0, f"Output: {runner.output}"
 
 
 @pytest.mark.parametrize("datacube_env_name", ("datacube", "datacube3"))
 def test_cli_spatial_indexes_on_non_supporting_index(index: Index, clirunner) -> None:
     runner = clirunner(["spindex", "list"], verbose_flag=False, expect_success=False)
     assert "does not support spatial indexes" in runner.output
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
     runner = clirunner(
         ["spindex", "create", "3577"], verbose_flag=False, expect_success=False
     )
     assert "does not support spatial indexes" in runner.output
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
     runner = clirunner(
         ["spindex", "update", "3577"], verbose_flag=False, expect_success=False
     )
     assert "does not support spatial indexes" in runner.output
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
     runner = clirunner(
         ["spindex", "drop", "3577"], verbose_flag=False, expect_success=False
     )
     assert "does not support spatial indexes" in runner.output
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
 
 @pytest.mark.parametrize("datacube_env_name", ("postgis", "postgis3"))
 def test_cli_spatial_indexes_no_srids(index: Index, clirunner) -> None:
     runner = clirunner(["spindex", "create"], verbose_flag=False, expect_success=False)
     assert "Must supply at least one CRS" in runner.output
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
     runner = clirunner(["spindex", "update"], verbose_flag=False, expect_success=False)
     assert "Must supply at least one CRS" in runner.output
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
     runner = clirunner(["spindex", "drop"], verbose_flag=False, expect_success=False)
     assert "Must supply at least one CRS" in runner.output
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
 
 
 @pytest.mark.parametrize("datacube_env_name", ("postgis", "postgis3"))
@@ -120,17 +120,17 @@ def test_cli_spatial_indexes_bad_srid(index: Index, clirunner) -> None:
     runner = clirunner(
         ["spindex", "create", "1"], verbose_flag=False, expect_success=False
     )
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
     runner = clirunner(
         ["spindex", "create", "--update", "1"], verbose_flag=False, expect_success=False
     )
     assert "Skipping update" in runner.output
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
     runner = clirunner(
         ["spindex", "update", "1"], verbose_flag=False, expect_success=False
     )
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"
     runner = clirunner(
         ["spindex", "drop", "1"], verbose_flag=False, expect_success=False
     )
-    assert runner.exit_code == 1
+    assert runner.exit_code == 1, f"Output: {runner.output}"

--- a/integration_tests/test_config_tool.py
+++ b/integration_tests/test_config_tool.py
@@ -51,7 +51,7 @@ def test_add_example_dataset_types(
             print(f"Adding mapping {mapping_path}")
 
             result = clirunner(["-v", "product", "add", mapping_path])
-            assert result.exit_code == 0
+            assert result.exit_code == 0, f"Output: {result.output}"
 
             mappings_count = _dataset_type_count(index)
             assert mappings_count > existing_mappings, (
@@ -60,15 +60,15 @@ def test_add_example_dataset_types(
             existing_mappings = mappings_count
 
         result = clirunner(["-v", "metadata", "show", "-f", "json", "eo"])
-        assert result.exit_code == 0
+        assert result.exit_code == 0, f"Output: {result.output}"
 
     # EO3 test examples
     result = clirunner(["-v", "metadata", "add", ext_eo3_mdt_path])
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
 
     for path in eo3_product_paths:
         result = clirunner(["-v", "product", "add", path])
-        assert result.exit_code == 0
+        assert result.exit_code == 0, f"Output: {result.output}"
 
         mappings_count = _dataset_type_count(index)
         assert mappings_count > existing_mappings, (
@@ -77,16 +77,16 @@ def test_add_example_dataset_types(
         existing_mappings = mappings_count
 
     result = clirunner(["-v", "metadata", "show", "-f", "json", "eo3"])
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
 
     result = clirunner(["-v", "metadata", "list"])
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
 
     result = clirunner(["-v", "metadata", "show"])
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
 
     result = clirunner(["-v", "product", "list"])
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
 
     expect_result = 0 if existing_mappings > 0 else 1
     result = clirunner(["-v", "product", "show"], expect_success=(expect_result == 0))
@@ -96,13 +96,13 @@ def test_add_example_dataset_types(
         result = clirunner(
             ["-v", "product", "show", "-f", "json"], expect_success=False
         )
-        assert result.exit_code == 1
+        assert result.exit_code == 1, f"Output: {result.output}"
 
         result = clirunner(["-v", "product", "show", "-f", "json", "ga_ls8c_ard_3"])
-        assert result.exit_code == 0
+        assert result.exit_code == 0, f"Output: {result.output}"
 
         result = clirunner(["-v", "product", "show", "-f", "yaml", "ga_ls8c_ard_3"])
-        assert result.exit_code == 0
+        assert result.exit_code == 0, f"Output: {result.output}"
 
 
 def test_error_returned_on_invalid(clirunner, index) -> None:
@@ -135,7 +135,7 @@ def test_list_users_does_not_fail(clirunner, cfg_env, index) -> None:
     # (They are host-global, not specific to the database)
     # So we're just checking that it doesn't fail (and the SQL etc is well formed)
     result = clirunner(["user", "list"])
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
 
 
 def test_db_init_noop(clirunner, cfg_env, ls8_eo3_product) -> None:
@@ -201,7 +201,7 @@ def test_add_no_such_product(clirunner, index) -> None:
     result = clirunner(
         ["dataset", "add", "--dtype", "no_such_product", "/tmp"], expect_success=False
     )
-    assert result.exit_code != 0
+    assert result.exit_code != 0, f"Output: {result.output}"
     assert "DEPRECATED option detected" in result.output
     assert "ERROR Supplied product name" in result.output
 

--- a/integration_tests/test_dataset_add.py
+++ b/integration_tests/test_dataset_add.py
@@ -255,7 +255,7 @@ def test_dataset_add(dataset_add_configs, index_empty, clirunner) -> None:
     p = dataset_add_configs
     index = index_empty
     r = clirunner(["dataset", "add", p.datasets], expect_success=False)
-    assert r.exit_code != 0
+    assert r.exit_code != 0, f"Output: {r.output}"
     assert "Found no matching products" in r.output
 
     clirunner(["metadata", "add", p.metadata])
@@ -318,11 +318,11 @@ def test_dataset_add(dataset_add_configs, index_empty, clirunner) -> None:
     )
 
     assert "ERROR Supplied product name" in r.output
-    assert r.exit_code != 0
+    assert r.exit_code != 0, f"Output: {r.output}"
 
     # test dataset add eo3
     r = clirunner(["dataset", "add", p.datasets_eo3])
-    assert r.exit_code == 0
+    assert r.exit_code == 0, f"Output: {r.output}"
 
     ds_eo3 = load_dataset_definition(p.datasets_eo3)
     assert ds_eo3 is not None
@@ -565,7 +565,7 @@ def test_dataset_archive_dry_run(dataset_add_configs, index_empty, clirunner) ->
     single_invalid_uuid = clirunner(
         ["dataset", "archive", "--dry-run", non_existent_uuid], expect_success=False
     )
-    assert single_invalid_uuid.exit_code is -1
+    assert single_invalid_uuid.exit_code is -1, f"Output: {single_invalid_uuid.output}"
     assert non_existent_uuid in single_invalid_uuid.output
     assert index.datasets.has(ds.id) is True
 
@@ -576,7 +576,7 @@ def test_dataset_archive_dry_run(dataset_add_configs, index_empty, clirunner) ->
         expect_success=False,
     )
     assert non_existent_uuid in valid_and_invalid_uuid.output
-    assert single_invalid_uuid.exit_code is -1
+    assert single_invalid_uuid.exit_code is -1, f"Output: {single_invalid_uuid.output}"
     assert index.datasets.has(ds.id) is True
 
     valid_and_invalid_uuid = clirunner(
@@ -590,7 +590,7 @@ def test_dataset_archive_dry_run(dataset_add_configs, index_empty, clirunner) ->
         ],
         expect_success=False,
     )
-    assert single_invalid_uuid.exit_code is -1
+    assert single_invalid_uuid.exit_code is -1, f"Output: {single_invalid_uuid.output}"
     assert non_existent_uuid in valid_and_invalid_uuid.output
     assert index.datasets.has(ds.id) is True
 

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -54,7 +54,7 @@ def assert_click_command(command, args) -> None:
     result = CliRunner().invoke(command, args=args, catch_exceptions=False)
     print(result.output)
     assert not result.exception
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
 
 
 def limit_num_measurements(dataset_type):


### PR DESCRIPTION
### Reason for this pull request

Asserting on the exit code is robust,
but it's difficult to understand why
tests fail when they fail, so add
the CLI output to the assert message.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2211.org.readthedocs.build/en/2211/

<!-- readthedocs-preview opendatacube end -->