### PR TITLE
postgis: create spatial_* as odc_admin

### DIFF
--- a/datacube/drivers/postgis/_connections.py
+++ b/datacube/drivers/postgis/_connections.py
@@ -236,11 +236,14 @@ class PostGisDb:
             assert self._spindexes is not None  # for type checker
         return self._spindexes
 
-    def create_spatial_index(self, crs: CRS) -> type[SpatialIndex] | None:
+    def create_spatial_index(
+        self, crs: CRS, with_permissions: bool
+    ) -> type[SpatialIndex] | None:
         """
         Create a spatial index across the database, for the named CRS.
 
         :param crs:
+        :param with_permissions: Whether to create db permissions.
         :return:
         """
         try:
@@ -248,7 +251,7 @@ class PostGisDb:
             spidx = self.spindexes.get(crs_id)
             if spidx is None:
                 spidx = spindex_for_crs(crs)
-                ensure_spindex(self._engine, spidx, crs_id)
+                ensure_spindex(self._engine, spidx, crs_id, with_permissions)
                 self._refresh_spindexes()
         except ValueError:
             _LOG.warning("Could not dynamically model an index for CRS %s", crs._str)

--- a/datacube/drivers/postgis/_spatial.py
+++ b/datacube/drivers/postgis/_spatial.py
@@ -21,7 +21,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, mapped_column
 from sqlalchemy.sql.ddl import DropTable
 
-from ._core import METADATA
+from ._core import METADATA, _get_quoted_connection_info
 from ._schema import Base, Dataset, SpatialIndex, SpatialIndexRecord, orm_registry
 from .sql import SCHEMA_NAME
 
@@ -142,7 +142,9 @@ def spindex_for_record(rec: SpatialIndexRecord) -> type[SpatialIndex]:
     return spindex_for_epsg(rec.srid)
 
 
-def ensure_spindex(engine: Engine, sp_idx: type[SpatialIndex], crs_id: int) -> None:
+def ensure_spindex(
+    engine: Engine, sp_idx: type[SpatialIndex], crs_id: int, with_permissions: bool
+) -> None:
     """Ensure a Spatial Index exists in a particular database."""
     with Session(engine) as session:
         results = session.execute(
@@ -151,24 +153,29 @@ def ensure_spindex(engine: Engine, sp_idx: type[SpatialIndex], crs_id: int) -> N
         for _ in results:
             # SpatialIndexRecord exists - actual index assumed to exist too.
             return
+        _, quoted_user = _get_quoted_connection_info(session.connection())
+        if with_permissions:
+            session.execute(text("set role odc_admin"))
+            session.commit()
         # SpatialIndexRecord doesn't exist - create the index table...
         orm_registry.metadata.create_all(engine, [sp_idx.__table__])  # type: ignore[attr-defined]
         # ... and add a SpatialIndexRecord
         session.add(SpatialIndexRecord(srid=crs_id, table_name=sp_idx.__tablename__))  # type: ignore[attr-defined]
         session.commit()
         session.flush()
-        # Permissions Management
-        for command in [
-            # Read access to odc_user
-            f"grant select on {SCHEMA_NAME}.{sp_idx.__tablename__} to odc_user;",  # type: ignore[attr-defined]
-            # Insert access to odc_manage
-            f"grant insert on {SCHEMA_NAME}.{sp_idx.__tablename__} to odc_manage;",  # type: ignore[attr-defined]
-            # Full access to odc_admin
-            f"grant all on {SCHEMA_NAME}.{sp_idx.__tablename__} to odc_admin;",  # type: ignore[attr-defined]
-        ]:
-            session.execute(text(command))
-        # Grant statements in PostgreSQL behave like transactions, so commit them.
-        session.commit()
+        if with_permissions:
+            for command in [
+                # Read access to odc_user
+                f"grant select on {SCHEMA_NAME}.{sp_idx.__tablename__} to odc_user;",  # type: ignore[attr-defined]
+                # Insert access to odc_manage
+                f"grant insert on {SCHEMA_NAME}.{sp_idx.__tablename__} to odc_manage;",  # type: ignore[attr-defined]
+                # Full access to odc_admin
+                f"grant all on {SCHEMA_NAME}.{sp_idx.__tablename__} to odc_admin;",  # type: ignore[attr-defined]
+            ]:
+                session.execute(text(command))
+            session.execute(text(f"set role {quoted_user}"))
+            # Grant statements in PostgreSQL behave like transactions, so commit them.
+            session.commit()
 
 
 def drop_spindex(engine: Engine, sp_idx: type[SpatialIndex], crs_id: int) -> bool:

--- a/datacube/index/abstract/_index.py
+++ b/datacube/index/abstract/_index.py
@@ -143,7 +143,7 @@ class AbstractIndex(ABC):
 
     # Spatial Index API
 
-    def create_spatial_index(self, crs: CRS) -> bool:
+    def create_spatial_index(self, crs: CRS, with_permissions: bool) -> bool:
         """
         Create a spatial index for a CRS.
 
@@ -154,6 +154,7 @@ class AbstractIndex(ABC):
         Only implemented by index drivers with supports_spatial_indexes set to True.
 
         :param crs: The coordinate reference system to create a spatial index for.
+        :param with_permissions: Whether to create db permissions.
         :return: True if the spatial index was successfully created (or already exists)
         """
         if not self.supports_spatial_indexes:
@@ -234,6 +235,7 @@ class AbstractIndex(ABC):
         batch_size: int = 1000,
         skip_lineage: bool = False,
         lineage_only: bool = False,
+        with_permissions: bool = True,
     ) -> Mapping[str, BatchStatus]:
         """
         Clone an existing index into this one.
@@ -270,6 +272,7 @@ class AbstractIndex(ABC):
         :param batch_size: Maximum number of objects to write to the database in one go.
         :param skip_lineage: Skip lineage in cloned result.
         :param lineage_only: Only clone lineage.
+        :param with_permissions: Whether to create db permissions.
         :return: Dictionary containing a BatchStatus named tuple for "metadata_types", "products"
                  and "datasets", and optionally "lineage".
         """
@@ -278,7 +281,7 @@ class AbstractIndex(ABC):
             if self.supports_spatial_indexes and origin_index.supports_spatial_indexes:
                 for crs in origin_index.spatial_indexes(refresh=True):
                     report_to_user(f"Creating spatial index for CRS {crs}")
-                    self.create_spatial_index(crs)
+                    self.create_spatial_index(crs, with_permissions)
                 self.update_spatial_index(
                     list(origin_index.spatial_indexes(refresh=False))
                 )

--- a/datacube/index/memory/index.py
+++ b/datacube/index/memory/index.py
@@ -138,7 +138,7 @@ class Index(AbstractIndex):
         pass
 
     @override
-    def create_spatial_index(self, crs: CRS) -> bool:
+    def create_spatial_index(self, crs: CRS, with_permissions: bool) -> bool:
         _LOG.warning("memory index driver does not support spatio-temporal indexes")
         return False
 

--- a/datacube/index/null/index.py
+++ b/datacube/index/null/index.py
@@ -124,7 +124,7 @@ class Index(AbstractIndex):
         pass
 
     @override
-    def create_spatial_index(self, crs: CRS) -> bool:
+    def create_spatial_index(self, crs: CRS, with_permissions: bool) -> bool:
         _LOG.warning("null driver does not support spatio-temporal indexes")
         return False
 

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -162,7 +162,9 @@ class Index(AbstractIndex):
                 )
 
         if is_new and with_default_spatial_index:
-            self.create_spatial_index(CRS("EPSG:4326"))
+            self.create_spatial_index(
+                CRS("EPSG:4326"), with_permissions=with_permissions
+            )
 
         return is_new
 
@@ -188,8 +190,8 @@ class Index(AbstractIndex):
         return PostgisTransaction(self._db, self.index_id)
 
     @override
-    def create_spatial_index(self, crs: CRS) -> bool:
-        sp_idx = self._db.create_spatial_index(crs)
+    def create_spatial_index(self, crs: CRS, with_permissions: bool) -> bool:
+        sp_idx = self._db.create_spatial_index(crs, with_permissions)
         return sp_idx is not None
 
     @override

--- a/datacube/scripts/spindex.py
+++ b/datacube/scripts/spindex.py
@@ -26,6 +26,12 @@ def system() -> None:
 
 @system.command("create", help="Create unpopulated spatial index for particular CRSes")
 @click.option(
+    "--init-users/--no-init-users",
+    is_flag=True,
+    default=True,
+    help="Include user roles and grants. (default: true)",
+)
+@click.option(
     "--update/--no-update",
     "-u",
     is_flag=True,
@@ -35,7 +41,7 @@ def system() -> None:
 )
 @click.argument("srids", nargs=-1)
 @ui.pass_index()
-def create(index: Index, update: bool, srids: Sequence[str]) -> None:
+def create(index: Index, init_users: bool, update: bool, srids: Sequence[str]) -> None:
     if not index.supports_spatial_indexes:
         echo(
             "The active index driver does not support spatial indexes. "
@@ -64,7 +70,7 @@ def create(index: Index, update: bool, srids: Sequence[str]) -> None:
         if crs in index.spatial_indexes():
             # A spatial index for crs already exists: skip silently
             confirmed.append(crs)
-        elif index.create_spatial_index(crs):
+        elif index.create_spatial_index(crs, with_permissions=init_users):
             # Creation succeeded
             confirmed.append(crs)
         else:

--- a/integration_tests/index/test_postgis_index.py
+++ b/integration_tests/index/test_postgis_index.py
@@ -25,11 +25,12 @@ def test_create_drop_spatial_index(index: Index) -> None:
         CRS(
             'GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137,298.257223563]]'
             ',PRIMEM["Weird",22.3],UNIT["Degree",0.017453292519943295]]'
-        )
+        ),
+        True,
     )
     assert list(index.spatial_indexes()) == [CRS("epsg:4326")]
-    assert index.create_spatial_index(CRS("epsg:3577"))
-    assert index.create_spatial_index(CRS("WGS-84"))
+    assert index.create_spatial_index(CRS("epsg:3577"), True)
+    assert index.create_spatial_index(CRS("WGS-84"), True)
     assert set(index.spatial_indexes()) == {CRS("epsg:3577"), CRS("epsg:4326")}
     assert set(index.spatial_indexes(refresh=True)) == {
         CRS("epsg:3577"),
@@ -45,7 +46,7 @@ def test_create_drop_spatial_index(index: Index) -> None:
 def test_spatial_index_maintain(
     index: Index, ls8_eo3_product, eo3_ls8_dataset_doc
 ) -> None:
-    index.create_spatial_index(CRS("EPSG:3577"))
+    index.create_spatial_index(CRS("EPSG:3577"), True)
     assert set(index.spatial_indexes(refresh=True)) == {
         CRS("EPSG:3577"),
         CRS("EPSG:4326"),
@@ -74,7 +75,7 @@ def test_spatial_index_populate(
     ls8_eo3_dataset4,
     wo_eo3_dataset,
 ) -> None:
-    index.create_spatial_index(CRS("EPSG:3577"))
+    index.create_spatial_index(CRS("EPSG:3577"), True)
     assert set(index.spatial_indexes(refresh=True)) == {
         CRS("EPSG:3577"),
         CRS("EPSG:4326"),
@@ -115,7 +116,7 @@ def test_spatial_index_crs_validity(
     # TODO: potentially include africa_eo3_dataset2 in this test
     epsg4326 = CRS("EPSG:4326")
     epsg3577 = CRS("EPSG:3577")
-    index.create_spatial_index(epsg3577)
+    index.create_spatial_index(epsg3577, True)
     assert set(index.spatial_indexes(refresh=True)) == {epsg4326, epsg3577}
     assert index.update_spatial_index(crses=[epsg3577]) == 2
 
@@ -249,7 +250,7 @@ def test_spatial_extent(
     # TODO: include africa_eo3_dataset2 in this test
     epsg4326 = CRS("EPSG:4326")
     epsg3577 = CRS("EPSG:3577")
-    index.create_spatial_index(epsg3577)
+    index.create_spatial_index(epsg3577, True)
     index.update_spatial_index(crses=[epsg3577])
 
     with pytest.raises(KeyError):
@@ -301,7 +302,7 @@ def test_spatial_search(
 ) -> None:
     epsg4326 = CRS("EPSG:4326")
     epsg3577 = CRS("EPSG:3577")
-    index.create_spatial_index(epsg3577)
+    index.create_spatial_index(epsg3577, True)
     index.update_spatial_index(crses=[epsg3577])
     # Test old style lat/lon search
     dss = index.datasets.search(

--- a/integration_tests/index/test_search_legacy.py
+++ b/integration_tests/index/test_search_legacy.py
@@ -1193,7 +1193,7 @@ def test_spatial_index_api_defaults(index: Index) -> None:
         index.spatial_indexes()
     assert "does not support the Spatial Index API" in str(e.value)
     with pytest.raises(NotImplementedError) as e:
-        index.create_spatial_index(CRS("epsg:3577"))
+        index.create_spatial_index(CRS("epsg:3577"), True)
     assert "does not support the Spatial Index API" in str(e.value)
     with pytest.raises(NotImplementedError) as e:
         index.update_spatial_index([CRS("epsg:3577")])


### PR DESCRIPTION
### Reason for this pull request

Perform a set role before creating
spatial_* tables, so they get
the same permissions as the other
odc tables.

Fixes #1959 

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2224.org.readthedocs.build/en/2224/

<!-- readthedocs-preview opendatacube end -->