### PR TITLE
docs: Fix Build Warnings - Don't double publish the same API autosummary methods/classes

### DIFF
--- a/docs/source/api/indexed-data/dataset-querying.rst
+++ b/docs/source/api/indexed-data/dataset-querying.rst
@@ -12,7 +12,6 @@ When connected to an ODC Database, these methods are available for searching and
 .. currentmodule:: datacube.index.abstract.AbstractDatasetResource
 
 .. autosummary::
-   :toctree: generate/
 
    get
    search

--- a/docs/source/api/indexed-data/dataset-writing.rst
+++ b/docs/source/api/indexed-data/dataset-writing.rst
@@ -13,7 +13,6 @@ When connected to an ODC Database, these methods are available for adding, updat
 .. currentmodule:: datacube.index.abstract.AbstractDatasetResource
 
 .. autosummary::
-   :toctree: generate/
 
    add
    add_location

--- a/docs/source/api/indexed-data/product-querying.rst
+++ b/docs/source/api/indexed-data/product-querying.rst
@@ -13,7 +13,6 @@ When connected to an ODC Database, these methods are available for discovering i
 
 .. autosummary::
    :nosignatures:
-   :toctree: generate/
 
    can_update
    get

--- a/docs/source/api/indexed-data/product-writing.rst
+++ b/docs/source/api/indexed-data/product-writing.rst
@@ -14,7 +14,6 @@ When connected to an ODC Database, these methods are available for altering info
 
 .. autosummary::
    :nosignatures:
-   :toctree: generate/
 
    from_doc
    add


### PR DESCRIPTION
## Before Merging

I'm pretty sure this is all good and will fix the annoying build warnings, but, I want to check the RTD preview since it includes a diff view of changes pages to make sure we haven't lost anything in the process.

## Summary
Drop the :toctree: option on the method tables in:

- dataset-writing
- dataset-querying
- product-writing
- product-querying


The autosummary tables still link to the canonical module docs but no longer create extra stub pages that collided with the module-generated ones.



<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2235.org.readthedocs.build/en/2235/

<!-- readthedocs-preview opendatacube end -->