### PR TITLE
docs: use :signatures: none

### DIFF
--- a/docs/source/api/cfg.rst
+++ b/docs/source/api/cfg.rst
@@ -10,7 +10,7 @@ Executive Summary
 .. currentmodule:: datacube.cfg
 
 .. autosummary::
-   :nosignatures:
+   :signatures: none
    :toctree: generate/
 
    ODCConfig.get_environment

--- a/docs/source/api/indexed-data/discovery.rst
+++ b/docs/source/api/indexed-data/discovery.rst
@@ -7,7 +7,7 @@ When connected to an ODC Database, these methods are available for discovering i
 .. currentmodule:: datacube
 
 .. autosummary::
-   :nosignatures:
+   :signatures: none
    :toctree: generate/
 
    Datacube.list_products

--- a/docs/source/api/indexed-data/loading.rst
+++ b/docs/source/api/indexed-data/loading.rst
@@ -5,7 +5,7 @@ Data Loading
 .. currentmodule:: datacube
 
 .. autosummary::
-   :nosignatures:
+   :signatures: none
    :toctree: generate/
 
    Datacube.load

--- a/docs/source/api/indexed-data/product-querying.rst
+++ b/docs/source/api/indexed-data/product-querying.rst
@@ -12,7 +12,7 @@ When connected to an ODC Database, these methods are available for discovering i
 .. currentmodule:: datacube.index.abstract.AbstractProductResource
 
 .. autosummary::
-   :nosignatures:
+   :signatures: none
 
    can_update
    get

--- a/docs/source/api/indexed-data/product-writing.rst
+++ b/docs/source/api/indexed-data/product-writing.rst
@@ -13,7 +13,7 @@ When connected to an ODC Database, these methods are available for altering info
 .. currentmodule:: datacube.index.abstract.AbstractProductResource
 
 .. autosummary::
-   :nosignatures:
+   :signatures: none
 
    from_doc
    add


### PR DESCRIPTION
### Reason for this pull request

The :nosignatures: clause is
supserseded by :signatures: none
according to the documentation,
so use that.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2236.org.readthedocs.build/en/2236/

<!-- readthedocs-preview opendatacube end -->