### PR TITLE
dataset: only confirm without --all

### DIFF
--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -968,10 +968,10 @@ def purge_cmd(
                     echo(f"No dataset found with id: {dataset_id}", err=True)
             sys.exit(-1)
 
-    if sys.stdin.isatty() and force:
-        click.confirm(
-            "Warning: you may be deleting active datasets. Proceed?", abort=True
-        )
+        if sys.stdin.isatty() and force:
+            click.confirm(
+                "Warning: you may be deleting active datasets. Proceed?", abort=True
+            )
 
     if not dry_run:
         # Perform purge


### PR DESCRIPTION
### Reason for this pull request

If the user passes -all, the database
provides the list of archived datasets,
so there is no need to scare the user
about potentially deleting active
datasets.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2244.org.readthedocs.build/en/2244/

<!-- readthedocs-preview opendatacube end -->