### PR TITLE
Cleanup of database user and permission management in postgis driver 

### DIFF
--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -84,9 +84,8 @@ def get_connection_info(connection: Connection) -> tuple[str, str]:
     row = connection.execute(
         text("select quote_ident(current_database()), quote_ident(current_user)")
     ).fetchone()
-    assert (
-        row is not None
-    )  # Mypy doesn't understand that the above SQL always returns a row.
+    # Mypy doesn't understand that the above SQL always returns a row.
+    assert row is not None
     db, user = row
     return db, user
 
@@ -121,6 +120,7 @@ def ensure_db(engine: Engine, with_permissions: bool = True) -> bool:
             c.commit()
 
         if is_new:
+            # If NOT new, it is up to the caller to update with alembic
             sqla_txn = c.begin()
             if with_permissions:
                 # Switch to 'odc_admin', so that all items are owned by them.
@@ -148,7 +148,6 @@ def ensure_db(engine: Engine, with_permissions: bool = True) -> bool:
             command.stamp(alembic_cfg, "head")
             if with_permissions:
                 c.execute(text(f"set role {quoted_user}"))
-        # If not new, caller updates with alembic
 
         if with_permissions:
             _LOG.info("Adding role grants.")

--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -8,7 +8,7 @@ Core SQL schema settings.
 
 import logging
 import os
-from typing import Iterable
+from collections.abc import Iterable
 
 from alembic import command, config
 from alembic.migration import MigrationContext
@@ -84,7 +84,9 @@ def get_connection_info(connection: Connection) -> tuple[str, str]:
     row = connection.execute(
         text("select quote_ident(current_database()), quote_ident(current_user)")
     ).fetchone()
-    assert row is not None  # Mypy doesn't understand that the above SQL always returns a row.
+    assert (
+        row is not None
+    )  # Mypy doesn't understand that the above SQL always returns a row.
     db, user = row
     return db, user
 
@@ -253,7 +255,11 @@ def _ensure_extension(conn: Connection, extension_name: str = "POSTGIS") -> None
 
 
 def _ensure_role(
-    conn: Connection, name: str, inherits_from: str | None = None, add_user: bool = False, create_db: bool = False
+    conn: Connection,
+    name: str,
+    inherits_from: str | None = None,
+    add_user: bool = False,
+    create_db: bool = False,
 ) -> None:
     if has_role(conn, name):
         _LOG.debug("Role exists: %s", name)

--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -8,6 +8,7 @@ Core SQL schema settings.
 
 import logging
 import os
+from typing import Iterable
 
 from alembic import command, config
 from alembic.migration import MigrationContext
@@ -74,14 +75,21 @@ def schema_qualified(name: str) -> str:
     return f"{SCHEMA_NAME}.{name}"
 
 
-def _get_quoted_connection_info(connection) -> tuple:
-    db, user = connection.execute(
+def get_connection_info(connection: Connection) -> tuple[str, str]:
+    """
+    Obtain information about an open database connection
+    :param connection: An SQLAlchemy connection
+    :return: A tuple consisting of the database name and the user name of the connection
+    """
+    row = connection.execute(
         text("select quote_ident(current_database()), quote_ident(current_user)")
     ).fetchone()
+    assert row is not None  # Mypy doesn't understand that the above SQL always returns a row.
+    db, user = row
     return db, user
 
 
-def ensure_db(engine, with_permissions: bool = True) -> bool:
+def ensure_db(engine: Engine, with_permissions: bool = True) -> bool:
     """
     Initialise the db if needed.
 
@@ -92,7 +100,7 @@ def ensure_db(engine, with_permissions: bool = True) -> bool:
     is_new = not has_schema(engine)
     with engine.connect() as c:
         #  NB. Using default SQLA2.0 auto-begin commit-as-you-go behaviour
-        quoted_db_name, quoted_user = _get_quoted_connection_info(c)
+        quoted_db_name, quoted_user = get_connection_info(c)
 
         _ensure_extension(c, "POSTGIS")
         c.commit()
@@ -175,7 +183,7 @@ def ensure_db(engine, with_permissions: bool = True) -> bool:
     return is_new
 
 
-def database_exists(engine) -> bool:
+def database_exists(engine: Engine) -> bool:
     """
     Have they init'd this database?
     """
@@ -239,13 +247,13 @@ def update_schema(engine: Engine) -> None:
         command.upgrade(cfg, "head")
 
 
-def _ensure_extension(conn, extension_name: str = "POSTGIS") -> None:
+def _ensure_extension(conn: Connection, extension_name: str = "POSTGIS") -> None:
     sql = text(f"create extension if not exists {extension_name}")
     conn.execute(sql)
 
 
 def _ensure_role(
-    conn, name: str, inherits_from=None, add_user: bool = False, create_db: bool = False
+    conn: Connection, name: str, inherits_from: str | None = None, add_user: bool = False, create_db: bool = False
 ) -> None:
     if has_role(conn, name):
         _LOG.debug("Role exists: %s", name)
@@ -261,7 +269,7 @@ def _ensure_role(
     conn.execute(text(" ".join(sql)))
 
 
-def grant_role(conn, role, users) -> None:
+def grant_role(conn: Connection, role: str, users: Iterable[str]) -> None:
     if role not in USER_ROLES:
         raise ValueError(f"Unknown role {role!r}. Expected one of {USER_ROLES!r}")
 
@@ -278,7 +286,7 @@ def grant_role(conn, role, users) -> None:
     )
 
 
-def has_role(conn, role_name: str) -> bool:
+def has_role(conn: Connection, role_name: str) -> bool:
     return bool(
         conn.execute(
             text(f"SELECT rolname FROM pg_roles WHERE rolname='{role_name}'")
@@ -304,7 +312,7 @@ def drop_db(connection: Connection) -> None:
     drop_schema(connection)
 
 
-def to_pg_role(role) -> str:
+def to_pg_role(role: str) -> str:
     """
     Convert a role name to a name for use in PostgreSQL
 

--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -131,13 +131,14 @@ def ensure_db(engine, with_permissions: bool = True) -> bool:
             _LOG.info("Creating triggers.")
             install_timestamp_trigger(c)
             sqla_txn.commit()
-            if with_permissions:
-                c.execute(text(f"set role {quoted_user}"))
             c.commit()
             # Stamp with latest Alembic revision
             alembic_cfg = config.Config(ALEMBIC_INI_LOCATION)
             alembic_cfg.attributes["connection"] = c
             command.stamp(alembic_cfg, "head")
+            if with_permissions:
+                c.execute(text(f"set role {quoted_user}"))
+        # If not new, caller updates with alembic
 
         if with_permissions:
             _LOG.info("Adding role grants.")
@@ -145,7 +146,7 @@ def ensure_db(engine, with_permissions: bool = True) -> bool:
             c.execute(
                 text(f"grant select on all tables in schema {SCHEMA_NAME} to odc_user")
             )
-
+            c.execute(text("grant odc_user to odc_manage"))
             c.execute(
                 text(
                     f"grant insert on {SCHEMA_NAME}.dataset,"
@@ -167,6 +168,8 @@ def ensure_db(engine, with_permissions: bool = True) -> bool:
             )
             # Allow creation of indexes, views
             c.execute(text(f"grant create on schema {SCHEMA_NAME} to odc_manage"))
+            # Belt and braces to cover corner cases
+            c.execute(text("grant odc_manage to odc_admin"))
             c.commit()
 
     return is_new

--- a/datacube/drivers/postgis/_spatial.py
+++ b/datacube/drivers/postgis/_spatial.py
@@ -21,7 +21,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, mapped_column
 from sqlalchemy.sql.ddl import DropTable
 
-from ._core import METADATA, _get_quoted_connection_info
+from ._core import METADATA, get_connection_info
 from ._schema import Base, Dataset, SpatialIndex, SpatialIndexRecord, orm_registry
 from .sql import SCHEMA_NAME
 
@@ -153,7 +153,7 @@ def ensure_spindex(
         for _ in results:
             # SpatialIndexRecord exists - actual index assumed to exist too.
             return
-        _, quoted_user = _get_quoted_connection_info(session.connection())
+        _, quoted_user = get_connection_info(session.connection())
         if with_permissions:
             session.execute(text("set role odc_admin"))
             session.commit()

--- a/datacube/drivers/postgis/alembic/README.md
+++ b/datacube/drivers/postgis/alembic/README.md
@@ -1,4 +1,16 @@
 This is the Alembic environment for the ODC postgis environment.
 
-Example of how to run alembic to generate an upgrade from inside the Docker container:
+Example of how to run alembic to generate an upgrade from inside the Docker container (after updating the schema)
 `uv run alembic -c datacube/drivers/postgis/alembic.ini -x env=postgis revision --autogenerate -m "Commit message"`
+
+(skip `--autogenerate` if you want a manual migration file)
+
+Upgrade to latest, or downgrade to previous
+`alembic upgrade head`
+`alembic downgrade -1`
+
+Current state of database:
+`alembic current`
+
+List all migrations
+`alembic history`

--- a/datacube/drivers/postgis/alembic/versions/01fa1abedd6d_create_empty_alembic_migration_for_.py
+++ b/datacube/drivers/postgis/alembic/versions/01fa1abedd6d_create_empty_alembic_migration_for_.py
@@ -72,10 +72,16 @@ def upgrade() -> None:
     for table in tables:
         conn.execute(sa.text(f"alter table {SCHEMA_NAME}.{table} owner to odc_admin"))
 
+    # Enforce hierarchical permissions
+    conn.execute(sa.text("grant odc_user to odc_manage"))
+    conn.execute(sa.text("grant odc_manage to odc_admin"))
+
 
 def downgrade() -> None:
     # Ownership of the affected tables was previously "uncontrolled" and simply belonged
     # to the user who first ran `datacube system init`.
-    # The downgrade process could not guarantee previous ownership was restored, so leave
-    # as a no-op.
-    pass
+    # The downgrade process could not guarantee previous ownership was restored, so skip.
+    # Remove hierarchical permissions
+    conn = op.get_bind()
+    conn.execute(sa.text("revoke odc_manage from odc_admin"))
+    conn.execute(sa.text("revoke odc_user from odc_manage"))

--- a/datacube/drivers/postgis/alembic/versions/01fa1abedd6d_create_empty_alembic_migration_for_.py
+++ b/datacube/drivers/postgis/alembic/versions/01fa1abedd6d_create_empty_alembic_migration_for_.py
@@ -28,11 +28,13 @@ def confirm_user_can_transfer(
         conn: sa.Connection,
         schema: str,
         tables: list[str]) -> str:
-    from datacube.drivers.postgis._core import _get_quoted_connection_info
-    _, user = _get_quoted_connection_info(conn)
-    _, is_super = conn.execute(
+    from datacube.drivers.postgis._core import get_connection_info
+    _, user = get_connection_info(conn)
+    row = conn.execute(
         sa.text(f"select rolname , rolsuper from pg_roles WHERE rolname = '{user}'")
     ).fetchone()
+    assert row is not None  # Mypy doesn't understand that the above SQL always returns a row.
+    _, is_super = row
     if is_super:
         # We are a superuser, we can do anything.
         return user
@@ -80,7 +82,8 @@ def upgrade() -> None:
 def downgrade() -> None:
     # Ownership of the affected tables was previously "uncontrolled" and simply belonged
     # to the user who first ran `datacube system init`.
-    # The downgrade process could not guarantee previous ownership was restored, so skip.
+    # The downgrade process therefore cannot guarantee previous ownership was restored, so skip.
+    #
     # Remove hierarchical permissions
     conn = op.get_bind()
     conn.execute(sa.text("revoke odc_manage from odc_admin"))

--- a/datacube/drivers/postgis/alembic/versions/01fa1abedd6d_create_empty_alembic_migration_for_.py
+++ b/datacube/drivers/postgis/alembic/versions/01fa1abedd6d_create_empty_alembic_migration_for_.py
@@ -52,7 +52,7 @@ def confirm_user_can_transfer(
 
 def tables_to_transfer(conn: sa.Connection, schema: str) -> list[str]:
     """
-    Return list of tables (in the odc schema) to ensure belong to odc_admin
+    Return list of tables in the odc schema that may not yet belong to odc_admin
 
     :param conn:
     :return: list of table names

--- a/datacube/drivers/postgis/alembic/versions/01fa1abedd6d_create_empty_alembic_migration_for_.py
+++ b/datacube/drivers/postgis/alembic/versions/01fa1abedd6d_create_empty_alembic_migration_for_.py
@@ -1,6 +1,6 @@
 # This file is part of the Open Data Cube, see https://opendatacube.org for more information
 #
-# Copyright (c) 2015-2023 ODC Contributors
+# Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 """Permissions cleanup
 

--- a/datacube/drivers/postgis/alembic/versions/01fa1abedd6d_create_empty_alembic_migration_for_.py
+++ b/datacube/drivers/postgis/alembic/versions/01fa1abedd6d_create_empty_alembic_migration_for_.py
@@ -1,0 +1,81 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2023 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Permissions cleanup
+
+Revision ID: 01fa1abedd6d
+Revises: d27eed82e1f6
+Create Date: 2025-11-04 09:02:19.111741
+
+"""
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from alembic.util.exc import CommandError
+
+from datacube.model import SCHEMA_PATH
+
+# revision identifiers, used by Alembic.
+revision: str = '01fa1abedd6d'
+down_revision: str | None = 'd27eed82e1f6'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def confirm_user_can_transfer(
+        conn: sa.Connection,
+        schema: str,
+        tables: list[str]) -> str:
+    from datacube.drivers.postgis._core import _get_quoted_connection_info
+    _, user = _get_quoted_connection_info(conn)
+    _, is_super = conn.execute(
+        sa.text(f"select rolname , rolsuper from pg_roles WHERE rolname = '{user}'")
+    ).fetchone()
+    if is_super:
+        # We are a superuser, we can do anything.
+        return user
+    for row in conn.execute(sa.text(
+        f"select tablename, tableowner from pg_tables where schemaname = '{schema}' "
+        f"and tablename in {tuple(tables)}"
+    )):
+        # tableowner is target_user - no change required
+        # tableowner is the current user - should be able to transfer
+        if row.tableowner not in ('odc_admin', user):
+            raise CommandError("Insufficient permissions to upgrade to schema revision 01fa1abedd6d.\n"
+                               f"Try running as a database superuser or as {row.tableowner}.")
+    return user
+
+
+def tables_to_transfer(conn: sa.Connection, schema: str) -> list[str]:
+    """
+    Return list of tables (in the odc schema) to ensure belong to odc_admin
+
+    :param conn:
+    :return: list of table names
+    """
+    tables = ["alembic_version",]
+    for row in conn.execute(sa.text(f"select table_name from {schema}.spatial_indicies")):
+        tables.append(f"{row.table_name}")
+    return tables
+
+
+def upgrade() -> None:
+    from datacube.drivers.postgis._core import SCHEMA_NAME
+    conn = op.get_bind()
+    # Obtain list of tables that potentially need ownership transferred to odc_admin
+    tables = tables_to_transfer(conn, SCHEMA_NAME)
+    # Check we have necessary permissions to do the ownership transfer
+    user = confirm_user_can_transfer(conn, SCHEMA_NAME, tables)
+    # Transfer ownership of alembic tables to odc_admin
+    for table in tables:
+        conn.execute(sa.text(f"alter table {SCHEMA_NAME}.{table} owner to odc_admin"))
+
+
+def downgrade() -> None:
+    # Ownership of the affected tables was previously "uncontrolled" and simply belonged
+    # to the user who first ran `datacube system init`.
+    # The downgrade process could not guarantee previous ownership was restored, so leave
+    # as a no-op.
+    pass

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -252,7 +252,7 @@ def index_cmd(
             index,
             auto_add_lineage=auto_add_lineage and not ignore_lineage,
             dry_run=dry_run,
-            archive_less_mature=archive_less_mature,
+            archive_less_mature=500 if archive_less_mature else False
         )
 
     # If outputting directly to terminal, show a progress bar.

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -252,7 +252,7 @@ def index_cmd(
             index,
             auto_add_lineage=auto_add_lineage and not ignore_lineage,
             dry_run=dry_run,
-            archive_less_mature=500 if archive_less_mature else False
+            archive_less_mature=500 if archive_less_mature else False,
         )
 
     # If outputting directly to terminal, show a progress bar.

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -252,7 +252,8 @@ def index_cmd(
             index,
             auto_add_lineage=auto_add_lineage and not ignore_lineage,
             dry_run=dry_run,
-            archive_less_mature=500 if archive_less_mature else False,
+            # Convert from bool to int to avoid warnings
+            archive_less_mature=500 if archive_less_mature else None,
         )
 
     # If outputting directly to terminal, show a progress bar.


### PR DESCRIPTION
### Reason for this pull request

@pjonsson 's PR #2224 raised some related database user and permission managment issues in the postgis driver that needed addressing

### Proposed changes

- Alembic tables are created belonging to the `odc-admin` user
- Roles are now granted hierarchically.  (odc_user -> odc_manage -> odc_admin)  This probably not strictly required for core, but will make consistent user and permissions management in OWS easier.
- An Alembic migration has been created to correct table ownership and role inheritance in older databases.

To apply the changes to an existing postgis database, simply run `datacube -E env system init`.  Note that the database user associated with `env` will need to be either a database superuser or the same user that originally ran `datacube system init` to create the database.

Subsequent alembic migrations should be able to run as any user with the `odc_admin` role.

 - [x] Tests added / passed
 - [x] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2245.org.readthedocs.build/en/2245/

<!-- readthedocs-preview opendatacube end -->