### PR TITLE
cli: return failure from dataset update command

### DIFF
--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -391,48 +391,32 @@ def update_cmd(
             # TODO:
             pass
 
-        if not dry_run:
-            try:
+        try:
+            if dry_run:
+                update, safe, unsafe = index.datasets.can_update(
+                    dataset, updates_allowed=updates_allowed
+                )
+                echo(
+                    f"Can{'' if update else 'not'} update {dataset.id}: "
+                    f"{len(unsafe)} unsafe changes, {len(safe)} safe changes"
+                )
+            else:
                 index.datasets.update(
                     dataset,
                     updates_allowed=updates_allowed,
                     archive_less_mature=archive_less_mature,
                 )
+                update = True
+            if update:
                 update_loc(dataset, existing_ds)
-                success += 1
                 echo(f"Updated {dataset.id}")
-            except ValueError as e:
-                fail += 1
-                echo(f"Failed to update {dataset.id}: {e}")
-        else:
-            if update_dry_run(index, updates_allowed, dataset):
-                update_loc(dataset, existing_ds)
                 success += 1
             else:
                 fail += 1
+        except ValueError as e:
+            fail += 1
+            echo(f"{'Cannot' if dry_run else 'Failed to'} update {dataset.id}: {e}")
     echo(f"{success} successful, {fail} failed")
-
-
-def update_dry_run(
-    index: Index, updates_allowed: Mapping[Offset, AllowPolicy] | None, dataset: Dataset
-) -> bool:
-    try:
-        can_update, safe_changes, unsafe_changes = index.datasets.can_update(
-            dataset, updates_allowed=updates_allowed
-        )
-    except ValueError as e:
-        echo(f"Cannot update {dataset.id}: {e}")
-        return False
-
-    if can_update:
-        echo(
-            f"Can update {dataset.id}: {len(unsafe_changes)} unsafe changes, {len(safe_changes)} safe changes"
-        )
-    else:
-        echo(
-            f"Cannot update {dataset.id}: {len(unsafe_changes)} unsafe changes, {len(safe_changes)} safe changes"
-        )
-    return can_update
 
 
 def build_dataset_info(

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -382,10 +382,11 @@ def update_cmd(
 
     success, fail = 0, 0
     doc_stream = ui_path_doc_stream(dataset_paths, logger=_LOG, uri=True)
-    doc_stream = remap_uri_from_doc(doc_stream)
 
-    for dataset, existing_ds in load_datasets_for_update(doc_stream, index):
-        _LOG.info("Matched %s", dataset)
+    for ds, existing_ds in load_datasets_for_update(
+        remap_uri_from_doc(doc_stream), index
+    ):
+        _LOG.info("Matched %s", ds)
 
         if location_policy != "keep" and existing_ds.has_multiple_uris():
             # TODO:
@@ -394,28 +395,28 @@ def update_cmd(
         try:
             if dry_run:
                 update, safe, unsafe = index.datasets.can_update(
-                    dataset, updates_allowed=updates_allowed
+                    ds, updates_allowed=updates_allowed
                 )
                 echo(
-                    f"Can{'' if update else 'not'} update {dataset.id}: "
+                    f"Can{'' if update else 'not'} update {ds.id}: "
                     f"{len(unsafe)} unsafe changes, {len(safe)} safe changes"
                 )
             else:
                 index.datasets.update(
-                    dataset,
+                    ds,
                     updates_allowed=updates_allowed,
                     archive_less_mature=archive_less_mature,
                 )
                 update = True
             if update:
-                update_loc(dataset, existing_ds)
-                echo(f"Updated {dataset.id}")
+                update_loc(ds, existing_ds)
+                echo(f"Updated {ds.id}")
                 success += 1
             else:
                 fail += 1
         except ValueError as e:
             fail += 1
-            echo(f"{'Cannot' if dry_run else 'Failed to'} update {dataset.id}: {e}")
+            echo(f"{'Cannot' if dry_run else 'Failed to'} update {ds.id}: {e}")
     echo(f"{success} successful, {fail} failed")
 
 

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -422,6 +422,7 @@ def update_cmd(
             fail += 1
             echo(f"{'Cannot' if dry_run else 'Failed to'} update {ds.id}: {e}")
     echo(f"{success} successful, {fail} failed")
+    sys.exit(0 if fail == 0 else 1)
 
 
 def build_dataset_info(

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -344,7 +344,7 @@ def update_cmd(
 
         if existing_ds.has_multiple_uris():
             _LOG.warning("Refusing to %s old location, there are several", action_name)
-            return None
+            return False
 
         if new_ds.has_multiple_uris():
             raise ValueError("More than one uri in new dataset")
@@ -409,9 +409,13 @@ def update_cmd(
                 )
                 update = True
             if update:
-                update_loc(ds, existing_ds)
-                echo(f"Updated {ds.id}")
-                success += 1
+                updated = update_loc(ds, existing_ds)
+                if updated is False:
+                    echo(f"Could not update location for dataset: {ds.id}")
+                    fail += 1
+                else:
+                    echo(f"Updated {ds.id}")
+                    success += 1
             else:
                 fail += 1
         except ValueError as e:

--- a/integration_tests/test_cli_output.py
+++ b/integration_tests/test_cli_output.py
@@ -321,7 +321,9 @@ def test_read_and_update_metadata_product_dataset_command(
         assert "WARNING Dataset" in rerun_add.output
         assert "is already in the database" in rerun_add.output
 
-    update = clirunner(["dataset", "update", eo3_dataset_update_path])
+    update = clirunner(
+        ["dataset", "update", eo3_dataset_update_path], expect_success=False
+    )
     assert "Unsafe changes in" in update.output
     assert "0 successful, 1 failed" in update.output
 


### PR DESCRIPTION
### Reason for this pull request

This started as a cleanup, but after some inlining it became clear that not all failures are counted, and even when the failures are counted that information is not propagated to the caller.

Count all types of failures, and return a non-zero exit code when there are failures.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2254.org.readthedocs.build/en/2254/

<!-- readthedocs-preview opendatacube end -->