### PR TITLE
PERF: Statically import parse_datetime

### DIFF
--- a/datacube/utils/dates.py
+++ b/datacube/utils/dates.py
@@ -19,6 +19,11 @@ import xarray as xr
 from dateutil.relativedelta import relativedelta
 from dateutil.rrule import DAILY, MONTHLY, YEARLY, rrule
 
+try:
+    from ciso8601 import parse_datetime
+except ImportError:
+    parse_datetime = datetime.fromisoformat
+
 FREQS: dict[str, int] = {"y": YEARLY, "m": MONTHLY, "d": DAILY}
 DURATIONS = {"y": "years", "m": "months", "d": "days"}
 
@@ -114,10 +119,7 @@ def parse_time(time: str | datetime) -> datetime:
     """
     if isinstance(time, str):
         try:
-            from ciso8601 import parse_datetime  # pylint: disable=wrong-import-position
-
             return parse_datetime(time)
-        except (ImportError, ValueError):  # pragma: no cover
+        except ValueError:
             return dateutil.parser.parse(time)
-
     return time


### PR DESCRIPTION
### Reason for this pull request

When `ciso8601` is not installed, there is a performance hit from attempting to import the module each time it is called.


### Proposed changes

- Statically import at the top of the module so it only happens once.

 - [x] Pull Request Title will make sense in ODC Release Notes


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2257.org.readthedocs.build/en/2257/

<!-- readthedocs-preview opendatacube end -->