### PR TITLE
CI: use anchors for paths

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         python-version: ["3.12"]
         lintcommand:
-          - "pylint -j 2 datacube"
+          - "pylint -j 4 datacube"
           - "mypy datacube examples integration_tests tests"
     name: Linting
     steps:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,19 +2,18 @@ name: lint
 
 on:
   pull_request:
-    paths:
-      - '**'
-
-  push:
-    branches:
-      - develop
-    paths:
+    paths: &paths
       - '**'
       - '!.github/**'
       - '.github/workflows/lint.yaml'
       - '!docker/**'
       - '!docs/**'
       - '!contrib/**'
+
+  push:
+    branches:
+      - develop
+    paths: *paths
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
### Reason for this pull request

The path lists are usually meant
to be identical, so use the new yaml
anchors to ensure that.

Also switch to using 4 cores in the lint
job since the CI runners have 4 cores
nowadays.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2258.org.readthedocs.build/en/2258/

<!-- readthedocs-preview opendatacube end -->