### PR TITLE
Cleanup user role granting

### DIFF
--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -1186,7 +1186,9 @@ class PostgisDbAPI:
         role_str: str,
         description: str | None = None,
     ) -> None:
-        role = UserRole.to_pg_role(role_str)
+        if role_str not in UserRole.all_roles():
+            raise ValueError(f"Invalid role: {role_str}")
+        role = UserRole.to_pg_role(role_str)  # type: ignore[arg-type]
         username = escape_pg_identifier(self._connection, username)
         sql = text(f"create user {username} password :password in role {role.value}")
         self._connection.execute(sql, {"password": password})
@@ -1203,7 +1205,7 @@ class PostgisDbAPI:
         """
         Grant a role to a user.
         """
-        pg_role = UserRole.to_pg_role(role_str)
+        pg_role = UserRole.to_pg_role(role_str)  # type: ignore[arg-type]
 
         for user in users:
             if not _core.has_user(self._connection, user):

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -47,6 +47,7 @@ from datacube.utils.uris import split_uri
 
 from ...utils.changes import Offset
 from . import _core
+from ._core import UserRole
 from ._fields import (
     DateDocField,
     DateRangeDocField,
@@ -1176,14 +1177,18 @@ class PostgisDbAPI:
         """)
         )
         for row in result:
-            yield _core.from_pg_role(row.role_name), row.user_name, row.description
+            yield UserRole(row.role_name).simple_str(), row.user_name, row.description
 
     def create_user(
-        self, username: str, password: str, role, description: str | None = None
+        self,
+        username: str,
+        password: str,
+        role_str: str,
+        description: str | None = None,
     ) -> None:
-        pg_role = _core.to_pg_role(role)
+        role = UserRole.to_pg_role(role_str)
         username = escape_pg_identifier(self._connection, username)
-        sql = text(f"create user {username} password :password in role {pg_role}")
+        sql = text(f"create user {username} password :password in role {role.value}")
         self._connection.execute(sql, {"password": password})
         if description:
             sql = text(f"comment on role {username} is :description")
@@ -1194,14 +1199,14 @@ class PostgisDbAPI:
             sql = text(f"drop role {escape_pg_identifier(self._connection, username)}")
             self._connection.execute(sql)
 
-    def grant_role(self, role: str, users: Iterable[str]) -> None:
+    def grant_role(self, role_str: str, users: Iterable[str]) -> None:
         """
         Grant a role to a user.
         """
-        pg_role = _core.to_pg_role(role)
+        pg_role = UserRole.to_pg_role(role_str)
 
         for user in users:
-            if not _core.has_role(self._connection, user):
+            if not _core.has_user(self._connection, user):
                 raise ValueError(f"Unknown user {user!r}")
 
         _core.grant_role(self._connection, pg_role, users)

--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -49,7 +49,7 @@ class UserRole(Enum):
     @classmethod
     def all_roles(cls) -> Iterable[str]:
         for role in cls:
-            yield role.value
+            yield role.simple_str()
 
     def higher_roles(self) -> list["UserRole"]:
         if self == UserRole.USER:

--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -11,7 +11,7 @@ import enum
 import logging
 import os
 from collections.abc import Iterable
-from typing import Union
+from typing import Generator, Literal, Union
 
 import sqlalchemy
 from alembic import command, config
@@ -40,18 +40,18 @@ class UserRole(enum.Enum):
     ADMIN = "odc_admin"
 
     @classmethod
-    def to_pg_role(cls, role_str: str) -> "UserRole":
+    def to_pg_role(cls, role_str: Literal["user", "manage", "admin"]) -> "UserRole":
         return cls("odc_" + role_str.lower())
 
     def simple_str(self) -> str:
         return self.value.split("_")[1]
 
     @classmethod
-    def all_roles(cls) -> Iterable[str]:
+    def all_roles(cls) -> Generator[str]:
         for role in cls:
             yield role.value
 
-    def higher_roles(self) -> Iterable["UserRole"]:
+    def higher_roles(self) -> list["UserRole"]:
         if self == UserRole.USER:
             return [UserRole.MANAGE, UserRole.ADMIN]
         if self == UserRole.MANAGE:

--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -6,10 +6,14 @@
 Core SQL schema settings.
 """
 
+import contextlib
+import enum
 import logging
 import os
 from collections.abc import Iterable
+from typing import Union
 
+import sqlalchemy
 from alembic import command, config
 from alembic.migration import MigrationContext
 from alembic.runtime.environment import EnvironmentContext
@@ -29,7 +33,41 @@ from datacube.drivers.postgis.sql import (
 )
 from datacube.migration import ODC2DeprecationWarning
 
-USER_ROLES = ("odc_user", "odc_manage", "odc_admin")
+
+class UserRole(enum.Enum):
+    USER = "odc_user"
+    MANAGE = "odc_manage"
+    ADMIN = "odc_admin"
+
+    @classmethod
+    def to_pg_role(cls, role_str: str) -> "UserRole":
+        return cls("odc_" + role_str.lower())
+
+    def simple_str(self) -> str:
+        return self.value.split("_")[1]
+
+    @classmethod
+    def all_roles(cls) -> Iterable[str]:
+        for role in cls:
+            yield role.value
+
+    def higher_roles(self) -> Iterable["UserRole"]:
+        if self == UserRole.USER:
+            return [UserRole.MANAGE, UserRole.ADMIN]
+        if self == UserRole.MANAGE:
+            return [UserRole.ADMIN]
+        return []
+
+    def inherits_from(self) -> Union["UserRole", None]:
+        if self == UserRole.ADMIN:
+            return UserRole.MANAGE
+        if self == UserRole.MANAGE:
+            return UserRole.USER
+        return None
+
+    def create_user(self) -> bool:
+        return self == UserRole.ADMIN
+
 
 SQL_NAMING_CONVENTIONS = {
     "ix": "ix_%(column_0_label)s",
@@ -108,9 +146,8 @@ def ensure_db(engine: Engine, with_permissions: bool = True) -> bool:
 
         if with_permissions:
             _LOG.info("Ensuring user roles.")
-            _ensure_role(c, "odc_user")
-            _ensure_role(c, "odc_manage", inherits_from="odc_user")
-            _ensure_role(c, "odc_admin", inherits_from="odc_manage", add_user=True)
+            for role in UserRole:
+                _ensure_role(c, role)
 
             c.execute(
                 text(f"""
@@ -253,45 +290,39 @@ def _ensure_extension(conn: Connection, extension_name: str = "POSTGIS") -> None
     conn.execute(sql)
 
 
-def _ensure_role(
-    conn: Connection,
-    name: str,
-    inherits_from: str | None = None,
-    add_user: bool = False,
-    create_db: bool = False,
-) -> None:
-    if has_role(conn, name):
-        _LOG.debug("Role exists: %s", name)
+def _ensure_role(conn: Connection, role: UserRole) -> None:
+    if has_user(conn, role.value):
+        _LOG.debug("Role exists: %s", role.value)
         return
 
     sql = [
-        f"create role {name} nologin inherit",
-        "createrole" if add_user else "nocreaterole",
-        "createdb" if create_db else "nocreatedb",
+        f"create role {role.value} nologin inherit",
+        "createrole" if role.create_user() else "nocreaterole",
     ]
-    if inherits_from:
-        sql.append("in role " + inherits_from)
+    if (inherit := role.inherits_from()) is not None:
+        sql.append("in role " + inherit.value)
     conn.execute(text(" ".join(sql)))
 
 
-def grant_role(conn: Connection, role: str, users: Iterable[str]) -> None:
-    if role not in USER_ROLES:
-        raise ValueError(f"Unknown role {role!r}. Expected one of {USER_ROLES!r}")
-
+def grant_role(conn: Connection, role: UserRole, users: Iterable[str]) -> None:
     users = [escape_pg_identifier(conn, user) for user in users]
-    conn.execute(
-        text(
-            "revoke {roles} from {users}".format(
-                users=", ".join(users), roles=", ".join(USER_ROLES)
+    with contextlib.suppress(sqlalchemy.exc.ProgrammingError):
+        # Ignore failure to revoke roles that we don't have permission to revoke.
+        # e.g. because they were granted by a superuser.
+        conn.execute(
+            text(
+                "revoke {roles} from {users}".format(
+                    users=", ".join(users), roles=", ".join(UserRole.all_roles())
+                )
             )
         )
-    )
+
     conn.execute(
-        text("grant {role} to {users}".format(users=", ".join(users), role=role))
+        text("grant {role} to {users}".format(users=", ".join(users), role=role.value))
     )
 
 
-def has_role(conn: Connection, role_name: str) -> bool:
+def has_user(conn: Connection, role_name: str) -> bool:
     return bool(
         conn.execute(
             text(f"SELECT rolname FROM pg_roles WHERE rolname='{role_name}'")
@@ -315,44 +346,3 @@ def drop_schema(connection: Connection, schema_name: str = SCHEMA_NAME) -> None:
 )
 def drop_db(connection: Connection) -> None:
     drop_schema(connection)
-
-
-def to_pg_role(role: str) -> str:
-    """
-    Convert a role name to a name for use in PostgreSQL
-
-    There is a short list of valid ODC role names, and they are given
-    a prefix inside of PostgreSQL.
-
-    Why are we even doing this? Can't we use the same names internally and externally?
-
-    >>> to_pg_role("user")
-    'odc_user'
-    >>> to_pg_role("fake")
-    Traceback (most recent call last):
-    ...
-    ValueError: Unknown role 'fake'. Expected one of ...
-    """
-    pg_role = "odc_" + role.lower()
-    if pg_role not in USER_ROLES:
-        raise ValueError(
-            f"Unknown role {role!r}. Expected one of {[r.split('_')[1] for r in USER_ROLES]!r}"
-        )
-    return pg_role
-
-
-def from_pg_role(pg_role: str) -> str:
-    """
-    Convert a PostgreSQL role name back to an ODC name.
-
-    >>> from_pg_role("odc_admin")
-    'admin'
-    >>> from_pg_role("fake")
-    Traceback (most recent call last):
-    ...
-    ValueError: Not a pg role: 'fake'. Expected one of ...
-    """
-    if pg_role not in USER_ROLES:
-        raise ValueError(f"Not a pg role: {pg_role!r}. Expected one of {USER_ROLES!r}")
-
-    return pg_role.split("_")[1]

--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -312,7 +312,8 @@ def grant_role(conn: Connection, role: UserRole, users: Iterable[str]) -> None:
         conn.execute(
             text(
                 "revoke {roles} from {users}".format(
-                    users=", ".join(users), roles=", ".join(UserRole.all_roles())
+                    users=", ".join(users),
+                    roles=", ".join(r.value for r in UserRole.higher_roles(role)),
                 )
             )
         )

--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -7,13 +7,12 @@ Core SQL schema settings.
 """
 
 import contextlib
-import enum
 import logging
 import os
 from collections.abc import Iterable
+from enum import Enum
 from typing import Generator, Literal, Union
 
-import sqlalchemy
 from alembic import command, config
 from alembic.migration import MigrationContext
 from alembic.runtime.environment import EnvironmentContext
@@ -21,6 +20,7 @@ from alembic.script import ScriptDirectory
 from deprecat import deprecat
 from sqlalchemy import Connection, MetaData, inspect, text
 from sqlalchemy.engine import Engine
+from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.schema import CreateSchema
 from sqlalchemy.sql.ddl import DropSchema
 
@@ -34,7 +34,7 @@ from datacube.drivers.postgis.sql import (
 from datacube.migration import ODC2DeprecationWarning
 
 
-class UserRole(enum.Enum):
+class UserRole(Enum):
     USER = "odc_user"
     MANAGE = "odc_manage"
     ADMIN = "odc_admin"
@@ -306,7 +306,7 @@ def _ensure_role(conn: Connection, role: UserRole) -> None:
 
 def grant_role(conn: Connection, role: UserRole, users: Iterable[str]) -> None:
     users = [escape_pg_identifier(conn, user) for user in users]
-    with contextlib.suppress(sqlalchemy.exc.ProgrammingError):
+    with contextlib.suppress(ProgrammingError):
         # Ignore failure to revoke roles that we don't have permission to revoke.
         # e.g. because they were granted by a superuser.
         conn.execute(

--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -65,7 +65,7 @@ class UserRole(enum.Enum):
             return UserRole.USER
         return None
 
-    def create_user(self) -> bool:
+    def can_create_user(self) -> bool:
         return self == UserRole.ADMIN
 
 
@@ -297,7 +297,7 @@ def _ensure_role(conn: Connection, role: UserRole) -> None:
 
     sql = [
         f"create role {role.value} nologin inherit",
-        "createrole" if role.create_user() else "nocreaterole",
+        "createrole" if role.can_create_user() else "nocreaterole",
     ]
     if (inherit := role.inherits_from()) is not None:
         sql.append("in role " + inherit.value)

--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -9,7 +9,7 @@ Core SQL schema settings.
 import contextlib
 import logging
 import os
-from collections.abc import Iterable
+from collections.abc import Generator, Iterable
 from enum import Enum
 from typing import Literal, Union
 
@@ -47,7 +47,7 @@ class UserRole(Enum):
         return self.value.split("_")[1]
 
     @classmethod
-    def all_roles(cls) -> Iterable[str]:
+    def all_roles(cls) -> Generator[str]:
         for role in cls:
             yield role.simple_str()
 

--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -44,7 +44,7 @@ class UserRole(Enum):
         return cls("odc_" + role_str.lower())
 
     def simple_str(self) -> str:
-        return self.value.split("_")[1]
+        return self.value.split("_", 1)[1]
 
     @classmethod
     def all_roles(cls) -> Generator[str]:

--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -11,7 +11,7 @@ import logging
 import os
 from collections.abc import Iterable
 from enum import Enum
-from typing import Generator, Literal, Union
+from typing import Literal, Union
 
 from alembic import command, config
 from alembic.migration import MigrationContext
@@ -47,7 +47,7 @@ class UserRole(Enum):
         return self.value.split("_")[1]
 
     @classmethod
-    def all_roles(cls) -> Generator[str]:
+    def all_roles(cls) -> Iterable[str]:
         for role in cls:
             yield role.value
 

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -51,6 +51,7 @@ from datacube.utils.uris import split_uri
 
 from . import _core
 from . import _dynamic as dynamic
+from ._core import UserRole
 from ._fields import (  # noqa: F401
     DateDocField,
     DateRangeDocField,
@@ -1347,14 +1348,18 @@ class PostgresDbAPI:
         """)
         )
         for row in result:
-            yield _core.from_pg_role(row.role_name), row.user_name, row.description
+            yield UserRole(row.role_name).simple_str(), row.user_name, row.description
 
     def create_user(
-        self, username: str, password: str, role: str, description: str | None = None
+        self,
+        username: str,
+        password: str,
+        role_str: str,
+        description: str | None = None,
     ) -> None:
-        pg_role = _core.to_pg_role(role)
+        role = UserRole.to_pg_role(role_str)
         username = escape_pg_identifier(self._connection, username)
-        sql = text(f"create user {username} password :password in role {pg_role}")
+        sql = text(f"create user {username} password :password in role {role.value}")
         self._connection.execute(sql, {"password": password})
         if description:
             sql = text(f"comment on role {username} is :description")
@@ -1365,17 +1370,17 @@ class PostgresDbAPI:
             sql = text(f"drop role {escape_pg_identifier(self._connection, username)}")
             self._connection.execute(sql)
 
-    def grant_role(self, role: str, users: Iterable[str]) -> None:
+    def grant_role(self, role_str: str, users: Iterable[str]) -> None:
         """
         Grant a role to a user.
         """
-        pg_role = _core.to_pg_role(role)
+        role = UserRole.to_pg_role(role_str)
 
         for user in users:
-            if not _core.has_role(self._connection, user):
+            if not _core.has_user(self._connection, user):
                 raise ValueError(f"Unknown user {user!r}")
 
-        _core.grant_role(self._connection, pg_role, users)
+        _core.grant_role(self._connection, role, users)
 
     def find_most_recent_change(self, product_id: int):
         """

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -1357,7 +1357,9 @@ class PostgresDbAPI:
         role_str: str,
         description: str | None = None,
     ) -> None:
-        role = UserRole.to_pg_role(role_str)
+        if role_str not in UserRole.all_roles():
+            raise ValueError(f"Invalid role: {role_str}")
+        role = UserRole.to_pg_role(role_str)  # type: ignore[arg-type]
         username = escape_pg_identifier(self._connection, username)
         sql = text(f"create user {username} password :password in role {role.value}")
         self._connection.execute(sql, {"password": password})
@@ -1374,7 +1376,9 @@ class PostgresDbAPI:
         """
         Grant a role to a user.
         """
-        role = UserRole.to_pg_role(role_str)
+        if role_str not in UserRole.all_roles():
+            raise ValueError(f"Invalid role: {role_str}")
+        role = UserRole.to_pg_role(role_str)  # type: ignore[arg-type]
 
         for user in users:
             if not _core.has_user(self._connection, user):

--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -41,8 +41,7 @@ class UserRole(Enum):
 
     @classmethod
     def to_pg_role(
-            cls,
-            role_str: Literal["user", "ingest", "manage", "admin"]
+        cls, role_str: Literal["user", "ingest", "manage", "admin"]
     ) -> "UserRole":
         return cls("agdc_" + role_str.lower())
 

--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -8,7 +8,7 @@ Core SQL schema settings.
 
 import contextlib
 import logging
-from collections.abc import Iterable
+from collections.abc import Generator, Iterable
 from enum import Enum
 from typing import Literal, Union
 
@@ -49,7 +49,7 @@ class UserRole(Enum):
         return self.value.split("_")[1]
 
     @classmethod
-    def all_roles(cls) -> Iterable[str]:
+    def all_roles(cls) -> Generator[str]:
         for role in cls:
             yield role.simple_str()
 

--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -46,7 +46,7 @@ class UserRole(Enum):
         return cls("agdc_" + role_str.lower())
 
     def simple_str(self) -> str:
-        return self.value.split("_")[1]
+        return self.value.split("_", 1)[1]
 
     @classmethod
     def all_roles(cls) -> Generator[str]:

--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -6,8 +6,13 @@
 Core SQL schema settings.
 """
 
+import contextlib
+import enum
 import logging
+from collections.abc import Iterable
+from typing import Union
 
+import sqlalchemy
 from deprecat import deprecat
 from sqlalchemy import Connection, MetaData, inspect, text
 from sqlalchemy.engine import Engine
@@ -27,7 +32,46 @@ from datacube.drivers.postgres.sql import (
 )
 from datacube.migration import ODC2DeprecationWarning
 
-USER_ROLES = ("agdc_user", "agdc_ingest", "agdc_manage", "agdc_admin")
+
+class UserRole(enum.Enum):
+    USER = "agdc_user"
+    INGEST = "agdc_ingest"
+    MANAGE = "agdc_manage"
+    ADMIN = "agdc_admin"
+
+    @classmethod
+    def to_pg_role(cls, role_str: str) -> "UserRole":
+        return cls("agdc_" + role_str.lower())
+
+    def simple_str(self) -> str:
+        return self.value.split("_")[1]
+
+    @classmethod
+    def all_roles(cls) -> Iterable[str]:
+        for role in cls:
+            yield role.value
+
+    def higher_roles(self) -> Iterable["UserRole"]:
+        if self == UserRole.USER:
+            return [UserRole.INGEST, UserRole.MANAGE, UserRole.ADMIN]
+        if self == UserRole.INGEST:
+            return [UserRole.MANAGE, UserRole.ADMIN]
+        if self == UserRole.MANAGE:
+            return [UserRole.ADMIN]
+        return []
+
+    def inherits_from(self) -> Union["UserRole", None]:
+        if self == UserRole.ADMIN:
+            return UserRole.MANAGE
+        if self == UserRole.MANAGE:
+            return UserRole.INGEST
+        if self == UserRole.INGEST:
+            return UserRole.USER
+        return None
+
+    def create_user(self) -> bool:
+        return self == UserRole.ADMIN
+
 
 SQL_NAMING_CONVENTIONS = {
     "ix": "ix_%(column_0_label)s",
@@ -123,10 +167,8 @@ def ensure_db(engine, with_permissions: bool = True) -> bool:
 
         if with_permissions:
             _LOG.info("Ensuring user roles.")
-            _ensure_role(c, "agdc_user")
-            _ensure_role(c, "agdc_ingest", inherits_from="agdc_user")
-            _ensure_role(c, "agdc_manage", inherits_from="agdc_ingest")
-            _ensure_role(c, "agdc_admin", inherits_from="agdc_manage", add_user=True)
+            for role in UserRole:
+                _ensure_role(c, role)
 
             c.execute(
                 text(f"""
@@ -253,41 +295,37 @@ def update_schema(engine: Engine) -> None:
             _LOG.info("No schema updates required.")
 
 
-def _ensure_role(
-    conn, name: str, inherits_from=None, add_user: bool = False, create_db: bool = False
-) -> None:
-    if has_role(conn, name):
-        _LOG.debug("Role exists: %s", name)
+def _ensure_role(conn, role: UserRole) -> None:
+    if has_user(conn, role.value):
+        _LOG.debug("Role exists: %s", role.value)
         return
 
     sql = [
-        f"create role {name} nologin inherit",
-        "createrole" if add_user else "nocreaterole",
-        "createdb" if create_db else "nocreatedb",
+        f"create role {role.value} nologin inherit",
+        "createrole" if role.create_user() else "nocreaterole",
     ]
-    if inherits_from:
-        sql.append("in role " + inherits_from)
+    if (inherit := role.inherits_from()) is not None:
+        sql.append("in role " + inherit.value)
     conn.execute(text(" ".join(sql)))
 
 
-def grant_role(conn, role, users) -> None:
-    if role not in USER_ROLES:
-        raise ValueError(f"Unknown role {role!r}. Expected one of {USER_ROLES!r}")
-
+def grant_role(conn, role: UserRole, users) -> None:
     users = [escape_pg_identifier(conn, user) for user in users]
-    conn.execute(
-        text(
-            "revoke {roles} from {users}".format(
-                users=", ".join(users), roles=", ".join(USER_ROLES)
+    with contextlib.suppress(sqlalchemy.exc.ProgrammingError):
+        conn.execute(
+            text(
+                "revoke {roles} from {users}".format(
+                    users=", ".join(users),
+                    roles=", ".join(r.value for r in UserRole.higher_roles(role)),
+                )
             )
         )
-    )
     conn.execute(
-        text("grant {role} to {users}".format(users=", ".join(users), role=role))
+        text("grant {role} to {users}".format(users=", ".join(users), role=role.value))
     )
 
 
-def has_role(conn, role_name: str) -> bool:
+def has_user(conn, role_name: str) -> bool:
     res = conn.execute(
         text(f"SELECT rolname FROM pg_roles WHERE rolname='{role_name}'")
     ).fetchall()
@@ -310,44 +348,3 @@ def drop_schema(connection: Connection, schema_name: str = SCHEMA_NAME) -> None:
 )
 def drop_db(connection: Connection) -> None:
     drop_schema(connection)
-
-
-def to_pg_role(role: str) -> str:
-    """
-    Convert a role name to a name for use in PostgreSQL
-
-    There is a short list of valid ODC role names, and they are given
-    a prefix inside of PostgreSQL.
-
-    Why are we even doing this? Can't we use the same names internally and externally?
-
-    >>> to_pg_role("ingest")
-    'agdc_ingest'
-    >>> to_pg_role("fake")
-    Traceback (most recent call last):
-    ...
-    ValueError: Unknown role 'fake'. Expected one of ...
-    """
-    pg_role = "agdc_" + role.lower()
-    if pg_role not in USER_ROLES:
-        raise ValueError(
-            f"Unknown role {role!r}. Expected one of {[r.split('_')[1] for r in USER_ROLES]!r}"
-        )
-    return pg_role
-
-
-def from_pg_role(pg_role: str) -> str:
-    """
-    Convert a PostgreSQL role name back to an ODC name.
-
-    >>> from_pg_role("agdc_admin")
-    'admin'
-    >>> from_pg_role("fake")
-    Traceback (most recent call last):
-    ...
-    ValueError: Not a pg role: 'fake'. Expected one of ...
-    """
-    if pg_role not in USER_ROLES:
-        raise ValueError(f"Not a pg role: {pg_role!r}. Expected one of {USER_ROLES!r}")
-
-    return pg_role.split("_")[1]

--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -10,7 +10,7 @@ import contextlib
 import logging
 from collections.abc import Iterable
 from enum import Enum
-from typing import Generator, Literal, Union
+from typing import Literal, Union
 
 from deprecat import deprecat
 from sqlalchemy import Connection, MetaData, inspect, text
@@ -50,7 +50,7 @@ class UserRole(Enum):
         return self.value.split("_")[1]
 
     @classmethod
-    def all_roles(cls) -> Generator[str]:
+    def all_roles(cls) -> Iterable[str]:
         for role in cls:
             yield role.value
 

--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -51,7 +51,7 @@ class UserRole(Enum):
     @classmethod
     def all_roles(cls) -> Iterable[str]:
         for role in cls:
-            yield role.value
+            yield role.simple_str()
 
     def higher_roles(self) -> list["UserRole"]:
         if self == UserRole.USER:

--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -7,15 +7,15 @@ Core SQL schema settings.
 """
 
 import contextlib
-import enum
 import logging
 from collections.abc import Iterable
+from enum import Enum
 from typing import Generator, Literal, Union
 
-import sqlalchemy
 from deprecat import deprecat
 from sqlalchemy import Connection, MetaData, inspect, text
 from sqlalchemy.engine import Engine
+from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.schema import CreateSchema, DropSchema
 
 from datacube.drivers.postgres.sql import (
@@ -33,7 +33,7 @@ from datacube.drivers.postgres.sql import (
 from datacube.migration import ODC2DeprecationWarning
 
 
-class UserRole(enum.Enum):
+class UserRole(Enum):
     USER = "agdc_user"
     INGEST = "agdc_ingest"
     MANAGE = "agdc_manage"
@@ -312,9 +312,9 @@ def _ensure_role(conn, role: UserRole) -> None:
     conn.execute(text(" ".join(sql)))
 
 
-def grant_role(conn, role: UserRole, users) -> None:
+def grant_role(conn: Connection, role: UserRole, users: Iterable[str]) -> None:
     users = [escape_pg_identifier(conn, user) for user in users]
-    with contextlib.suppress(sqlalchemy.exc.ProgrammingError):
+    with contextlib.suppress(ProgrammingError):
         conn.execute(
             text(
                 "revoke {roles} from {users}".format(

--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -10,7 +10,7 @@ import contextlib
 import enum
 import logging
 from collections.abc import Iterable
-from typing import Union
+from typing import Generator, Literal, Union
 
 import sqlalchemy
 from deprecat import deprecat
@@ -40,18 +40,21 @@ class UserRole(enum.Enum):
     ADMIN = "agdc_admin"
 
     @classmethod
-    def to_pg_role(cls, role_str: str) -> "UserRole":
+    def to_pg_role(
+            cls,
+            role_str: Literal["user", "ingest", "manage", "admin"]
+    ) -> "UserRole":
         return cls("agdc_" + role_str.lower())
 
     def simple_str(self) -> str:
         return self.value.split("_")[1]
 
     @classmethod
-    def all_roles(cls) -> Iterable[str]:
+    def all_roles(cls) -> Generator[str]:
         for role in cls:
             yield role.value
 
-    def higher_roles(self) -> Iterable["UserRole"]:
+    def higher_roles(self) -> list["UserRole"]:
         if self == UserRole.USER:
             return [UserRole.INGEST, UserRole.MANAGE, UserRole.ADMIN]
         if self == UserRole.INGEST:

--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -72,7 +72,7 @@ class UserRole(enum.Enum):
             return UserRole.USER
         return None
 
-    def create_user(self) -> bool:
+    def can_create_user(self) -> bool:
         return self == UserRole.ADMIN
 
 
@@ -305,7 +305,7 @@ def _ensure_role(conn, role: UserRole) -> None:
 
     sql = [
         f"create role {role.value} nologin inherit",
-        "createrole" if role.create_user() else "nocreaterole",
+        "createrole" if role.can_create_user() else "nocreaterole",
     ]
     if (inherit := role.inherits_from()) is not None:
         sql.append("in role " + inherit.value)


### PR DESCRIPTION
### Reason for this pull request

While debugging the OWS user management overhaul I noticed some issues with the core user interface.

When granting a role to a user, all previous roles are revoked.  This can fail if e.g. the role was granted by a superuser and the user doing the current grant is NOT a superuser - even if the user already has the relevant role.

Fixed in both postgres and postgis drivers.

### Proposed changes

- Use an Enum for handling user roles.
- Only revoke roles with more privileges than the ones being granted.
- Ignore db errors on revokes.



 - [ ] Closes #xxxx
 - [x] Tests added / passed
 - [x] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2268.org.readthedocs.build/en/2268/

<!-- readthedocs-preview opendatacube end -->