### PR TITLE
Validate Product measurement nodata type

### DIFF
--- a/datacube/index/abstract/_products.py
+++ b/datacube/index/abstract/_products.py
@@ -53,6 +53,7 @@ class AbstractProductResource(ABC):
         """
         # This column duplication is getting out of hand:
         Product.validate(definition)  # type: ignore[attr-defined]   # validate method added by decorator
+        Product.validate_measurements(definition)
         # Validate extra dimension metadata
         Product.validate_extra_dims(definition)
 

--- a/datacube/index/memory/_products.py
+++ b/datacube/index/memory/_products.py
@@ -41,6 +41,9 @@ class ProductResource(AbstractProductResource):
     @override
     def add(self, product: Product, allow_table_lock: bool = False) -> Product | None:
         Product.validate(product.definition)  # type: ignore[attr-defined]
+        Product.validate_measurements(product.definition)
+        Product.validate_extra_dims(product.definition)
+
         existing = self.get_by_name(product.name)
         if existing:
             _LOG.warning(
@@ -75,6 +78,8 @@ class ProductResource(AbstractProductResource):
         allow_table_lock: bool = False,
     ) -> tuple[bool, Iterable[Change], Iterable[Change]]:
         Product.validate(product.definition)  # type: ignore[attr-defined]
+        Product.validate_measurements(product.definition)
+        Product.validate_extra_dims(product.definition)
 
         existing = self.get_by_name(product.name)
         if not existing:

--- a/datacube/index/postgis/_products.py
+++ b/datacube/index/postgis/_products.py
@@ -68,6 +68,8 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
         :param product: Product to add
         """
         Product.validate(product.definition)  # type: ignore[attr-defined]
+        Product.validate_measurements(product.definition)
+        Product.validate_extra_dims(product.definition)
 
         existing = self.get_by_name(product.name)
         if existing:
@@ -147,6 +149,8 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
             If false, creation will be slower and cannot be done in a transaction.
         """
         Product.validate(product.definition)  # type: ignore[attr-defined]
+        Product.validate_measurements(product.definition)
+        Product.validate_extra_dims(product.definition)
 
         existing = self.get_by_name(product.name)
         if not existing:

--- a/datacube/index/postgres/_products.py
+++ b/datacube/index/postgres/_products.py
@@ -68,6 +68,8 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
         :param product: Product to add
         """
         Product.validate(product.definition)  # type: ignore[attr-defined]
+        Product.validate_measurements(product.definition)
+        Product.validate_extra_dims(product.definition)
 
         existing = self.get_by_name(product.name)
         if existing:
@@ -134,6 +136,8 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
             If false, creation will be slower and cannot be done in a transaction.
         """
         Product.validate(product.definition)  # type: ignore[attr-defined]
+        Product.validate_measurements(product.definition)
+        Product.validate_extra_dims(product.definition)
 
         existing = self.get_by_name(product.name)
         if not existing:

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -18,6 +18,7 @@ from typing import Any, TypeAlias
 from urllib.parse import urlparse
 from uuid import UUID
 
+import numpy as np
 from affine import Affine
 from typing_extensions import override
 
@@ -870,6 +871,17 @@ class Product:
 
         del gs_params["tile_shape"]
         return GridSpec(crs=crs, **gs_params)
+
+    @staticmethod
+    def validate_measurements(definition: Mapping[str, Any]) -> None:
+        for m in definition.get("measurements", []):
+            try:
+                np.dtype(m["dtype"]).type(m["nodata"])
+            except ValueError:
+                raise ValueError(
+                    f"The Product defines a Measurement {m['name']} with a nodata value "
+                    "that does not correspond with its dtype."
+                ) from None
 
     @staticmethod
     def validate_extra_dims(definition: Mapping[str, Any]) -> None:

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 import math
+import warnings
 from collections import OrderedDict
 from collections.abc import Callable, Generator, Iterable, Iterator, Mapping, Sequence
 from datetime import datetime
@@ -875,13 +876,16 @@ class Product:
     @staticmethod
     def validate_measurements(definition: Mapping[str, Any]) -> None:
         for m in definition.get("measurements", []):
-            try:
-                np.dtype(m["dtype"]).type(m["nodata"])
-            except ValueError:
-                raise ValueError(
-                    f"The Product defines a Measurement {m['name']} with a nodata value "
-                    "that does not correspond with its dtype."
-                ) from None
+            with warnings.catch_warnings():
+                # numpy has deprecated the conversion of out-of-bound integers but does not yet error
+                warnings.simplefilter("error", DeprecationWarning)
+                try:
+                    np.dtype(m["dtype"]).type(m["nodata"])
+                except (ValueError, DeprecationWarning):
+                    raise ValueError(
+                        f"The Product defines a Measurement {m['name']} with a nodata value "
+                        "that does not correspond with its dtype."
+                    ) from None
 
     @staticmethod
     def validate_extra_dims(definition: Mapping[str, Any]) -> None:

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -877,11 +877,11 @@ class Product:
     def validate_measurements(definition: Mapping[str, Any]) -> None:
         for m in definition.get("measurements", []):
             with warnings.catch_warnings():
-                # numpy has deprecated the conversion of out-of-bound integers but does not yet error
+                # numpy<2 deprecates but doesn't error on conversion of out-of-bound integers
                 warnings.simplefilter("error", DeprecationWarning)
                 try:
                     np.dtype(m["dtype"]).type(m["nodata"])
-                except (ValueError, DeprecationWarning):
+                except (ValueError, OverflowError, DeprecationWarning):
                     raise ValueError(
                         f"The Product defines a Measurement {m['name']} with a nodata value "
                         "that does not correspond with its dtype."

--- a/tests/index/test_validate_product.py
+++ b/tests/index/test_validate_product.py
@@ -116,3 +116,17 @@ def test_rejects_invalid_measurements(invalid_product_measurement) -> None:
     mapping["measurements"] = {"10": invalid_product_measurement}
     with pytest.raises(InvalidDocException):
         Product.validate(mapping)  # type: ignore[attr-defined]
+
+
+def test_nodata_validation() -> None:
+    product = deepcopy(only_mandatory_fields)
+    product["measurements"] = [{"name": "_nan", "dtype": "uint8", "nodata": "NaN"}]
+    with pytest.raises(ValueError):
+        Product.validate_measurements(product)
+
+    product["measurements"] = [{"name": "_nan", "dtype": "uint8", "nodata": -100}]
+    with pytest.raises(ValueError):
+        Product.validate_measurements(product)
+
+    product["measurements"] = [{"name": "_nan", "dtype": "float32", "nodata": "NaN"}]
+    assert Product.validate_measurements(product) is None

--- a/tests/index/test_validate_product.py
+++ b/tests/index/test_validate_product.py
@@ -7,13 +7,14 @@ Module
 """
 
 from copy import deepcopy
+from typing import Any
 
 import pytest
 
 from datacube.model import Product
 from datacube.utils import InvalidDocException
 
-only_mandatory_fields = {
+only_mandatory_fields: dict[str, Any] = {
     "name": "ls7_nbar",
     "description": "description",
     "metadata_type": "eo",

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -217,6 +217,21 @@ def test_product_nodata_nan() -> None:
     assert product.measurements["_neg_inf"].nodata == -numpy.inf
 
 
+def test_product_nodata_validation() -> None:
+    product_def = mk_sample_product(
+        "test",
+        measurements=[
+            {"name": "_nan", "dtype": "uint8", "nodata": "NaN"},
+        ],
+    ).definition
+    with pytest.raises(ValueError):
+        Product.validate_measurements(product_def)
+    product_def["measurements"] = [
+        {"name": "_nan", "dtype": "float32", "nodata": "NaN"}
+    ]
+    assert Product.validate_measurements(product_def) is None
+
+
 def test_product_scale_factor() -> None:
     product = mk_sample_product(
         "test", measurements=[{"name": "red", "scale_factor": 33, "add_offset": -5}]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -217,21 +217,6 @@ def test_product_nodata_nan() -> None:
     assert product.measurements["_neg_inf"].nodata == -numpy.inf
 
 
-def test_product_nodata_validation() -> None:
-    product_def = mk_sample_product(
-        "test",
-        measurements=[
-            {"name": "_nan", "dtype": "uint8", "nodata": "NaN"},
-        ],
-    ).definition
-    with pytest.raises(ValueError):
-        Product.validate_measurements(product_def)
-    product_def["measurements"] = [
-        {"name": "_nan", "dtype": "float32", "nodata": "NaN"}
-    ]
-    assert Product.validate_measurements(product_def) is None
-
-
 def test_product_scale_factor() -> None:
     product = mk_sample_product(
         "test", measurements=[{"name": "red", "scale_factor": 33, "add_offset": -5}]


### PR DESCRIPTION
### Reason for this pull request

Addresses #2230 


### Proposed changes

- Add a Product validation method to check that a Measurement's nodata value aligns with its dtype



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2277.org.readthedocs.build/en/2277/

<!-- readthedocs-preview opendatacube end -->