### PR TITLE
Bump fallback version and update whats_new.rst for 1.9.11 release

### DIFF
--- a/docs/source/about/whats_new.rst
+++ b/docs/source/about/whats_new.rst
@@ -43,11 +43,9 @@ What's Changed
 * Update fallback version by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2216
 * CI: fetch tags for release by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2217
 * Dockerfile: install psql 18 by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2222
-* build(deps): bump the actions-deps group with 2 updates by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2223
 * Convert EO datasets and products to EO3 by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2179
 * postgis: create spatial_* as odc_admin by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2224
 * Update eo-datasets repo URL by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2225
-* build(deps): bump astral-sh/uv from 0.9.5 to 0.9.6 in /docker by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2229
 * Update to latest JSON schema version by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2226
 * Various minor cleanups by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2227
 * metadata-type-schema: improve validation by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2228
@@ -72,7 +70,6 @@ What's Changed
 * eo3converter: pass along asset_absolute_paths by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2264
 * drivers: add/fix type signatures by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2266
 * postgis: fix search parameters by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2267
-* build(deps): bump the actions-deps group with 3 updates by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2270
 * Cleanup user role granting by @SpacemanPaul in https://github.com/opendatacube/datacube-core/pull/2268
 * Fix status badge links by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2273
 * Bump fallback version and update whats_new.rst for 1.9.11 release @SpacemanPaul in https://github.com/opendatacube/datacube-core/pull/2278
@@ -82,6 +79,8 @@ Automated updates
 
 * [pre-commit.ci] pre-commit autoupdate by @pre-commit-ci[bot] in https://github.com/opendatacube/datacube-core/pull/2221
 * build(deps): bump astral-sh/uv from 0.9.4 to 0.9.5 in /docker by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2218
+* build(deps): bump the actions-deps group with 2 updates by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2223
+* build(deps): bump astral-sh/uv from 0.9.5 to 0.9.6 in /docker by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2229
 * build(deps): bump astral-sh/uv from 0.9.6 to 0.9.7 in /docker by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2233
 * [pre-commit.ci] pre-commit autoupdate by @pre-commit-ci[bot] in https://github.com/opendatacube/datacube-core/pull/2239
 * build(deps): bump github/codeql-action from 4.31.0 to 4.31.2 in the actions-deps group by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2240
@@ -94,6 +93,7 @@ Automated updates
 * build(deps): bump astral-sh/uv from 0.9.9 to 0.9.10 in /docker by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2261
 * build(deps): bump astral-sh/uv from 0.9.10 to 0.9.11 in /docker by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2263
 * [pre-commit.ci] pre-commit autoupdate by @pre-commit-ci[bot] in https://github.com/opendatacube/datacube-core/pull/2269
+* build(deps): bump the actions-deps group with 3 updates by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2270
 * build(deps): bump astral-sh/uv from 0.9.11 to 0.9.12 in /docker by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2271
 * build(deps): bump astral-sh/uv from 0.9.12 to 0.9.13 in /docker by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2272
 * [pre-commit.ci] pre-commit autoupdate by @pre-commit-ci[bot] in https://github.com/opendatacube/datacube-core/pull/2274

--- a/docs/source/about/whats_new.rst
+++ b/docs/source/about/whats_new.rst
@@ -8,6 +8,177 @@ What's New
 Next Release
 ============
 
+v1.9.10 (21 October 2025)
+=========================
+
+This release fixes issues with the load function and resolves an incompatibility with odc-geo reprojection. It
+also introduces initial psycopg3 support, migrates some functionality from odc-tools, and includes cleanup to
+code, tests, docs, and CI setup.
+
+What's Changed
+--------------
+
+ - Group dependabot updates to GHA Actions Versions by @omad in https://github.com/opendatacube/datacube-core/pull/2164
+ - storage: rework function for MyPy by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2158
+ - pytest: output test times by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2165
+ - storage: move num2numpy call by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2157
+ - product: add missing space by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2166
+ - tests: always import boto3/moto by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2159
+ - Add more type signatures by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2154
+ - Fix docs rendering on configuration page by @omad in https://github.com/opendatacube/datacube-core/pull/2167
+ - drivers: remove SQLAlchemy 1.4 workaround by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2168
+ - drivers: use has_schema method by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2172
+ - CI: speed up Conda workflows by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2169
+ - Update fallback version by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2170
+ - Add experimental psycopg3 support by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2120
+ - drivers: deprecate drop_db function by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2174
+ - Migrate code from odc-cloud: Sync AWS Functions by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2175
+ - Migrate code from odc-io modules by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2176
+ - Tests: Speed up eo3converter test by mocking AWS services by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2177
+ - Miscellaneous docs and pre-commit fixes by @omad in https://github.com/opendatacube/datacube-core/pull/2180
+ - Update Ruff version in pre-commit by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2184
+ - Remove f-strings without placeholders by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2185
+ - Reduce product.grid_spec warning volume by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2191
+ - Make dateutil an optional dependency by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2199
+ - CI: remove pyspell job by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2201
+ - CI: stop building with Conda by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2200
+ - drivers: use SQLAlchemy inspector by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2195
+ - tests: test with single time zone by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2194
+ - Revert "Make dateutil an optional dependency" by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2206
+ - Pass Exception to error callback by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2208
+ - tests: include error message for cli by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2211
+ - Resolve unexpected load behaviours by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2192
+ - Dockerfile: update to latest uv by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2212
+ - Resolve virtual product odc-geo reprojection incompatibility by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2202
+
+Automated Updates
+-----------------
+
+ - https://github.com/opendatacube/datacube-core/pull/2161
+ - https://github.com/opendatacube/datacube-core/pull/2162
+ - https://github.com/opendatacube/datacube-core/pull/2163
+ - https://github.com/opendatacube/datacube-core/pull/2171
+ - https://github.com/opendatacube/datacube-core/pull/2173
+ - https://github.com/opendatacube/datacube-core/pull/2182
+ - https://github.com/opendatacube/datacube-core/pull/2181
+ - https://github.com/opendatacube/datacube-core/pull/2197
+ - https://github.com/opendatacube/datacube-core/pull/2198
+ - https://github.com/opendatacube/datacube-core/pull/2203
+ - https://github.com/opendatacube/datacube-core/pull/2204
+ - https://github.com/opendatacube/datacube-core/pull/2209
+ - https://github.com/opendatacube/datacube-core/pull/2210
+ - https://github.com/opendatacube/datacube-core/pull/2214
+ - https://github.com/opendatacube/datacube-core/pull/2215
+ - https://github.com/opendatacube/datacube-core/pull/2213
+
+Full Changelog: https://github.com/opendatacube/datacube-core/compare/1.9.9...1.9.10
+
+Includes contributions from @pjonsson, @omad, and @Ariana-B
+
+The Open Data Cube Steering Council thanks and acknowledges the ongoing support of Geoscience Australia, CSIRO, and RISE.
+
+v1.9.9 (2 September 2025)
+=========================
+
+his release includes more fixes and improvements to STAC/EO3 conversion, documentation updates, and various code,
+testing, and CI cleanup.
+
+What's Changed
+--------------
+
+ -  CI: make twine check strict by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2133
+ -  Tutorial for odc-stac by @caitlinadams in https://github.com/opendatacube/datacube-core/pull/2055
+ -  Add cyprus datacube by @whatnick in https://github.com/opendatacube/datacube-core/pull/2092
+ -  Add some more type signatures by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2128
+ -  cli: use UUID for dataset IDs by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2131
+ -  index: use dsid_to_uuid function by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2132
+ -  drivers: pass regular parameters by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2134
+ -  drivers: set preserve_rowcount by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2135
+ -  lineage: add type annotation by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2136
+ -  Replace the automatic spell checker tool. by @omad in https://github.com/opendatacube/datacube-core/pull/2097
+ -  test_config_docs: remove Python 2 support by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2139
+ -  STAC/EO3 conversion improvements by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2146
+ -  MANIFEST.in: graft model/schemas by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2148
+ -  More STAC/EO3 logic fixes by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2150
+ -  test_search_eo3: expect right type by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2138
+ -  postgis: validate doc definition by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2141
+ -  test_config_tool: enable test for postgis by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2140
+ -  documents: add parse_doc_stream by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2147
+ -  Use stacklevel on warnings to expose their call site and make sure they're displayed by @omad in https://github.com/opendatacube/datacube-core/pull/2151
+ -  postgis: use parse_time for dates by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2152
+ -  Add some type annotations by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2153
+ -  Tweak STAC link handling by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2156
+
+Automated Updates
+-----------------
+
+ - https://github.com/opendatacube/datacube-core/pull/2137
+ - https://github.com/opendatacube/datacube-core/pull/2144
+ - https://github.com/opendatacube/datacube-core/pull/2143
+ - https://github.com/opendatacube/datacube-core/pull/2142
+ - https://github.com/opendatacube/datacube-core/pull/2155
+
+Full Changelog: https://github.com/opendatacube/datacube-core/compare/1.9.8...1.9.9
+
+Includes contributions from @pjonsson, @omad, @caitlinadams, @whatnick, and @Ariana-B
+
+The Open Data Cube Steering Council thanks and acknowledges the ongoing support of Geoscience Australia, CSIRO, and RISE.
+
+v1.9.8 (22 August 2025)
+=======================
+
+This release improves upon the STAC to EO3 conversion logic, and moves EO3 to STAC conversion code out of
+eo-datasets into datacube-core as the next step in the ongoing cross-repo consolidation and refactor of STAC
+handling logic.
+
+It also contains some code improvements and cleanup.
+
+What's Changed
+--------------
+
+ -  Update broken installation docs. by @SpacemanPaul in https://github.com/opendatacube/datacube-core/pull/2091
+ -  CI: fixate time stamp for image layers (reproducible docker builds) by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2094
+ -  Fix some typos by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2098
+ -  Dockerfile: upgrade to uv 0.8.6 by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2102
+ -  ruff: format code in doc strings by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2096
+ -  fields: type check field names by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2100
+ -  model: give Range types by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2101
+ -  testutils: adjust for type checker by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2112
+ -  model: give Not a type by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2103
+ -  Add/fix more type annotations by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2110
+ -  query: fail when center_time is None by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2111
+ -  Use datetime instead of dateutil by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2114
+ -  tests: fix faulty path by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2117
+ -  docs: remove requirements.txt by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2115
+ -  opt: fix error printout by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2118
+ -  postgis: remove type ignores by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2121
+ -  Fix some lint issues by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2125
+ -  query_group_by: improve type signature by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2119
+ -  Enable more lint rules by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2105
+ -  Make handling of coords in create_storage backwards compatible by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2126
+ -  postgis: tweak type signatures by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2129
+ -  Consolidate stac/eo3 conversion logic by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2077
+ -  Fix pre-commit errors by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2130
+
+Automated updates
+-----------------
+
+ - https://github.com/opendatacube/datacube-core/pull/2095
+ - https://github.com/opendatacube/datacube-core/pull/2104,
+ - https://github.com/opendatacube/datacube-core/pull/2106
+ - https://github.com/opendatacube/datacube-core/pull/2107
+ - https://github.com/opendatacube/datacube-core/pull/2108
+ - https://github.com/opendatacube/datacube-core/pull/2109
+ - https://github.com/opendatacube/datacube-core/pull/2122
+ - https://github.com/opendatacube/datacube-core/pull/2123
+ - https://github.com/opendatacube/datacube-core/pull/2124
+
+Full Changelog: https://github.com/opendatacube/datacube-core/compare/1.9.7...1.9.8
+
+Includes contributions from @SpacemanPaul, @pjonsson, and @Ariana-B
+
+The Open Data Cube Steering Council thanks and acknowledges the ongoing support of Geoscience Australia and RISE.
+
 v1.9.7 (5 August 2025)
 ======================
 

--- a/docs/source/about/whats_new.rst
+++ b/docs/source/about/whats_new.rst
@@ -8,6 +8,103 @@ What's New
 Next Release
 ============
 
+
+v1.9.11 (4 December 2025)
+=========================
+
+* cleanup of database schema and permissions management, especially in postgis driver (See **Schema Update** section below) (@SpacemanPaul)
+* support for upgrading some (most?) EO datasets to EO3 (@Ariana-B)
+* support for relative paths in STAC catalogs (@pjonsson)
+* and the usual minor tweaks, (@pjonsson and @snowman2)
+
+
+Schema Update
+-------------
+
+Users of the postgis index driver will need to upgrade their database schema on upgrade to 1.9.11
+
+This will require an ODC environment with database superuser privileges.  E.g.::
+
+   export ODC_DEFAULT_DB_URL=postgresql://postgres:/my_db
+   export ODC_DEFAULT_INDEX_DRIVER=postgis
+   datacube system init
+   unset ODC_DEFAULT_DB_URL ODC_DEFAULT_DB_URL
+
+This schema migration doesn't change any tables - it simply sets the owner of all dynamically
+created index tables to the ``odc_admin`` role.
+
+After this schema migration is applied, all future schema management will require only the ``odc_admin`` role,
+and superuser privileges will only be required to create the postgis extension when first creating a database
+index.
+
+What's Changed
+--------------
+
+* Update fallback version by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2216
+* CI: fetch tags for release by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2217
+* Dockerfile: install psql 18 by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2222
+* build(deps): bump the actions-deps group with 2 updates by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2223
+* Convert EO datasets and products to EO3 by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2179
+* postgis: create spatial_* as odc_admin by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2224
+* Update eo-datasets repo URL by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2225
+* build(deps): bump astral-sh/uv from 0.9.5 to 0.9.6 in /docker by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2229
+* Update to latest JSON schema version by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2226
+* Various minor cleanups by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2227
+* metadata-type-schema: improve validation by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2228
+* docs: update odc-apps-dc-tools link by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2231
+* Remove --confirm-ignore-lineage by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2232
+* docs: Fix `make clean` errors by @omad in https://github.com/opendatacube/datacube-core/pull/2234
+* docs: Fix Build Warnings - Don't double publish the same API autosummary methods/classes by @omad in https://github.com/opendatacube/datacube-core/pull/2235
+* readthedocs: fix uv link warning by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2237
+* docs: remove double word by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2238
+* postgis: remove leftover debug log by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2242
+* dataset: fix parameter help by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2243
+* dataset: only confirm without --all by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2244
+* Cleanup of database user and permission management in postgis driver by @SpacemanPaul in https://github.com/opendatacube/datacube-core/pull/2245
+* Update to latest Sphinx by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2248
+* Dockerfile: pin image by hash by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2250
+* cli: cleanup dataset add command by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2253
+* cli: return failure from dataset update command by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2254
+* hl: simplify type signature by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2255
+* PERF: Statically import parse_datetime by @snowman2 in https://github.com/opendatacube/datacube-core/pull/2257
+* CI: use anchors for paths by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2258
+* postgis: fix comment typo by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2262
+* eo3converter: pass along asset_absolute_paths by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2264
+* drivers: add/fix type signatures by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2266
+* postgis: fix search parameters by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2267
+* build(deps): bump the actions-deps group with 3 updates by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2270
+* Cleanup user role granting by @SpacemanPaul in https://github.com/opendatacube/datacube-core/pull/2268
+* Fix status badge links by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2273
+* Bump fallback version and update whats_new.rst for 1.9.11 release @SpacemanPaul in https://github.com/opendatacube/datacube-core/pull/2278
+
+Automated updates
+-----------------
+
+* [pre-commit.ci] pre-commit autoupdate by @pre-commit-ci[bot] in https://github.com/opendatacube/datacube-core/pull/2221
+* build(deps): bump astral-sh/uv from 0.9.4 to 0.9.5 in /docker by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2218
+* build(deps): bump astral-sh/uv from 0.9.6 to 0.9.7 in /docker by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2233
+* [pre-commit.ci] pre-commit autoupdate by @pre-commit-ci[bot] in https://github.com/opendatacube/datacube-core/pull/2239
+* build(deps): bump github/codeql-action from 4.31.0 to 4.31.2 in the actions-deps group by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2240
+* build(deps): bump astral-sh/uv from 0.9.7 to 0.9.8 in /docker by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2249
+* [pre-commit.ci] pre-commit autoupdate by @pre-commit-ci[bot] in https://github.com/opendatacube/datacube-core/pull/2251
+* build(deps): bump astral-sh/setup-uv from 7.1.2 to 7.1.3 in the actions-deps group by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2252
+* build(deps): bump astral-sh/uv from 0.9.8 to 0.9.9 in /docker by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2256
+* [pre-commit.ci] pre-commit autoupdate by @pre-commit-ci[bot] in https://github.com/opendatacube/datacube-core/pull/2259
+* build(deps): bump the actions-deps group with 2 updates by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2260
+* build(deps): bump astral-sh/uv from 0.9.9 to 0.9.10 in /docker by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2261
+* build(deps): bump astral-sh/uv from 0.9.10 to 0.9.11 in /docker by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2263
+* [pre-commit.ci] pre-commit autoupdate by @pre-commit-ci[bot] in https://github.com/opendatacube/datacube-core/pull/2269
+* build(deps): bump astral-sh/uv from 0.9.11 to 0.9.12 in /docker by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2271
+* build(deps): bump astral-sh/uv from 0.9.12 to 0.9.13 in /docker by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2272
+* [pre-commit.ci] pre-commit autoupdate by @pre-commit-ci[bot] in https://github.com/opendatacube/datacube-core/pull/2274
+* build(deps): bump github/codeql-action from 4.31.5 to 4.31.6 in the actions-deps group by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2275
+* build(deps): bump astral-sh/uv from 0.9.13 to 0.9.14 in /docker by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2276
+
+**Full Changelog**: https://github.com/opendatacube/datacube-core/compare/1.9.10...1.9.11
+
+The Open Data Cube Steering Council thanks and acknowledges the ongoing support of Geoscience Australia, CSIRO, and RISE.
+
+
 v1.9.10 (21 October 2025)
 =========================
 
@@ -18,58 +115,58 @@ code, tests, docs, and CI setup.
 What's Changed
 --------------
 
- - Group dependabot updates to GHA Actions Versions by @omad in https://github.com/opendatacube/datacube-core/pull/2164
- - storage: rework function for MyPy by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2158
- - pytest: output test times by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2165
- - storage: move num2numpy call by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2157
- - product: add missing space by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2166
- - tests: always import boto3/moto by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2159
- - Add more type signatures by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2154
- - Fix docs rendering on configuration page by @omad in https://github.com/opendatacube/datacube-core/pull/2167
- - drivers: remove SQLAlchemy 1.4 workaround by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2168
- - drivers: use has_schema method by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2172
- - CI: speed up Conda workflows by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2169
- - Update fallback version by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2170
- - Add experimental psycopg3 support by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2120
- - drivers: deprecate drop_db function by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2174
- - Migrate code from odc-cloud: Sync AWS Functions by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2175
- - Migrate code from odc-io modules by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2176
- - Tests: Speed up eo3converter test by mocking AWS services by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2177
- - Miscellaneous docs and pre-commit fixes by @omad in https://github.com/opendatacube/datacube-core/pull/2180
- - Update Ruff version in pre-commit by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2184
- - Remove f-strings without placeholders by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2185
- - Reduce product.grid_spec warning volume by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2191
- - Make dateutil an optional dependency by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2199
- - CI: remove pyspell job by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2201
- - CI: stop building with Conda by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2200
- - drivers: use SQLAlchemy inspector by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2195
- - tests: test with single time zone by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2194
- - Revert "Make dateutil an optional dependency" by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2206
- - Pass Exception to error callback by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2208
- - tests: include error message for cli by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2211
- - Resolve unexpected load behaviours by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2192
- - Dockerfile: update to latest uv by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2212
- - Resolve virtual product odc-geo reprojection incompatibility by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2202
+* Group dependabot updates to GHA Actions Versions by @omad in https://github.com/opendatacube/datacube-core/pull/2164
+* storage: rework function for MyPy by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2158
+* pytest: output test times by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2165
+* storage: move num2numpy call by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2157
+* product: add missing space by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2166
+* tests: always import boto3/moto by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2159
+* Add more type signatures by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2154
+* Fix docs rendering on configuration page by @omad in https://github.com/opendatacube/datacube-core/pull/2167
+* drivers: remove SQLAlchemy 1.4 workaround by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2168
+* drivers: use has_schema method by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2172
+* CI: speed up Conda workflows by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2169
+* Update fallback version by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2170
+* Add experimental psycopg3 support by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2120
+* drivers: deprecate drop_db function by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2174
+* Migrate code from odc-cloud: Sync AWS Functions by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2175
+* Migrate code from odc-io modules by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2176
+* Tests: Speed up eo3converter test by mocking AWS services by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2177
+* Miscellaneous docs and pre-commit fixes by @omad in https://github.com/opendatacube/datacube-core/pull/2180
+* Update Ruff version in pre-commit by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2184
+* Remove f-strings without placeholders by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2185
+* Reduce product.grid_spec warning volume by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2191
+* Make dateutil an optional dependency by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2199
+* CI: remove pyspell job by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2201
+* CI: stop building with Conda by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2200
+* drivers: use SQLAlchemy inspector by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2195
+* tests: test with single time zone by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2194
+* Revert "Make dateutil an optional dependency" by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2206
+* Pass Exception to error callback by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2208
+* tests: include error message for cli by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2211
+* Resolve unexpected load behaviours by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2192
+* Dockerfile: update to latest uv by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2212
+* Resolve virtual product odc-geo reprojection incompatibility by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2202
 
 Automated Updates
 -----------------
 
- - https://github.com/opendatacube/datacube-core/pull/2161
- - https://github.com/opendatacube/datacube-core/pull/2162
- - https://github.com/opendatacube/datacube-core/pull/2163
- - https://github.com/opendatacube/datacube-core/pull/2171
- - https://github.com/opendatacube/datacube-core/pull/2173
- - https://github.com/opendatacube/datacube-core/pull/2182
- - https://github.com/opendatacube/datacube-core/pull/2181
- - https://github.com/opendatacube/datacube-core/pull/2197
- - https://github.com/opendatacube/datacube-core/pull/2198
- - https://github.com/opendatacube/datacube-core/pull/2203
- - https://github.com/opendatacube/datacube-core/pull/2204
- - https://github.com/opendatacube/datacube-core/pull/2209
- - https://github.com/opendatacube/datacube-core/pull/2210
- - https://github.com/opendatacube/datacube-core/pull/2214
- - https://github.com/opendatacube/datacube-core/pull/2215
- - https://github.com/opendatacube/datacube-core/pull/2213
+* https://github.com/opendatacube/datacube-core/pull/2161
+* https://github.com/opendatacube/datacube-core/pull/2162
+* https://github.com/opendatacube/datacube-core/pull/2163
+* https://github.com/opendatacube/datacube-core/pull/2171
+* https://github.com/opendatacube/datacube-core/pull/2173
+* https://github.com/opendatacube/datacube-core/pull/2182
+* https://github.com/opendatacube/datacube-core/pull/2181
+* https://github.com/opendatacube/datacube-core/pull/2197
+* https://github.com/opendatacube/datacube-core/pull/2198
+* https://github.com/opendatacube/datacube-core/pull/2203
+* https://github.com/opendatacube/datacube-core/pull/2204
+* https://github.com/opendatacube/datacube-core/pull/2209
+* https://github.com/opendatacube/datacube-core/pull/2210
+* https://github.com/opendatacube/datacube-core/pull/2214
+* https://github.com/opendatacube/datacube-core/pull/2215
+* https://github.com/opendatacube/datacube-core/pull/2213
 
 Full Changelog: https://github.com/opendatacube/datacube-core/compare/1.9.9...1.9.10
 
@@ -86,37 +183,37 @@ testing, and CI cleanup.
 What's Changed
 --------------
 
- -  CI: make twine check strict by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2133
- -  Tutorial for odc-stac by @caitlinadams in https://github.com/opendatacube/datacube-core/pull/2055
- -  Add cyprus datacube by @whatnick in https://github.com/opendatacube/datacube-core/pull/2092
- -  Add some more type signatures by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2128
- -  cli: use UUID for dataset IDs by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2131
- -  index: use dsid_to_uuid function by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2132
- -  drivers: pass regular parameters by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2134
- -  drivers: set preserve_rowcount by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2135
- -  lineage: add type annotation by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2136
- -  Replace the automatic spell checker tool. by @omad in https://github.com/opendatacube/datacube-core/pull/2097
- -  test_config_docs: remove Python 2 support by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2139
- -  STAC/EO3 conversion improvements by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2146
- -  MANIFEST.in: graft model/schemas by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2148
- -  More STAC/EO3 logic fixes by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2150
- -  test_search_eo3: expect right type by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2138
- -  postgis: validate doc definition by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2141
- -  test_config_tool: enable test for postgis by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2140
- -  documents: add parse_doc_stream by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2147
- -  Use stacklevel on warnings to expose their call site and make sure they're displayed by @omad in https://github.com/opendatacube/datacube-core/pull/2151
- -  postgis: use parse_time for dates by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2152
- -  Add some type annotations by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2153
- -  Tweak STAC link handling by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2156
+*  CI: make twine check strict by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2133
+*  Tutorial for odc-stac by @caitlinadams in https://github.com/opendatacube/datacube-core/pull/2055
+*  Add cyprus datacube by @whatnick in https://github.com/opendatacube/datacube-core/pull/2092
+*  Add some more type signatures by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2128
+*  cli: use UUID for dataset IDs by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2131
+*  index: use dsid_to_uuid function by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2132
+*  drivers: pass regular parameters by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2134
+*  drivers: set preserve_rowcount by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2135
+*  lineage: add type annotation by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2136
+*  Replace the automatic spell checker tool. by @omad in https://github.com/opendatacube/datacube-core/pull/2097
+*  test_config_docs: remove Python 2 support by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2139
+*  STAC/EO3 conversion improvements by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2146
+*  MANIFEST.in: graft model/schemas by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2148
+*  More STAC/EO3 logic fixes by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2150
+*  test_search_eo3: expect right type by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2138
+*  postgis: validate doc definition by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2141
+*  test_config_tool: enable test for postgis by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2140
+*  documents: add parse_doc_stream by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2147
+*  Use stacklevel on warnings to expose their call site and make sure they're displayed by @omad in https://github.com/opendatacube/datacube-core/pull/2151
+*  postgis: use parse_time for dates by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2152
+*  Add some type annotations by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2153
+*  Tweak STAC link handling by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2156
 
 Automated Updates
 -----------------
 
- - https://github.com/opendatacube/datacube-core/pull/2137
- - https://github.com/opendatacube/datacube-core/pull/2144
- - https://github.com/opendatacube/datacube-core/pull/2143
- - https://github.com/opendatacube/datacube-core/pull/2142
- - https://github.com/opendatacube/datacube-core/pull/2155
+* https://github.com/opendatacube/datacube-core/pull/2137
+* https://github.com/opendatacube/datacube-core/pull/2144
+* https://github.com/opendatacube/datacube-core/pull/2143
+* https://github.com/opendatacube/datacube-core/pull/2142
+* https://github.com/opendatacube/datacube-core/pull/2155
 
 Full Changelog: https://github.com/opendatacube/datacube-core/compare/1.9.8...1.9.9
 
@@ -136,42 +233,42 @@ It also contains some code improvements and cleanup.
 What's Changed
 --------------
 
- -  Update broken installation docs. by @SpacemanPaul in https://github.com/opendatacube/datacube-core/pull/2091
- -  CI: fixate time stamp for image layers (reproducible docker builds) by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2094
- -  Fix some typos by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2098
- -  Dockerfile: upgrade to uv 0.8.6 by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2102
- -  ruff: format code in doc strings by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2096
- -  fields: type check field names by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2100
- -  model: give Range types by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2101
- -  testutils: adjust for type checker by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2112
- -  model: give Not a type by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2103
- -  Add/fix more type annotations by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2110
- -  query: fail when center_time is None by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2111
- -  Use datetime instead of dateutil by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2114
- -  tests: fix faulty path by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2117
- -  docs: remove requirements.txt by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2115
- -  opt: fix error printout by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2118
- -  postgis: remove type ignores by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2121
- -  Fix some lint issues by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2125
- -  query_group_by: improve type signature by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2119
- -  Enable more lint rules by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2105
- -  Make handling of coords in create_storage backwards compatible by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2126
- -  postgis: tweak type signatures by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2129
- -  Consolidate stac/eo3 conversion logic by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2077
- -  Fix pre-commit errors by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2130
+*  Update broken installation docs. by @SpacemanPaul in https://github.com/opendatacube/datacube-core/pull/2091
+*  CI: fixate time stamp for image layers (reproducible docker builds) by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2094
+*  Fix some typos by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2098
+*  Dockerfile: upgrade to uv 0.8.6 by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2102
+*  ruff: format code in doc strings by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2096
+*  fields: type check field names by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2100
+*  model: give Range types by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2101
+*  testutils: adjust for type checker by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2112
+*  model: give Not a type by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2103
+*  Add/fix more type annotations by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2110
+*  query: fail when center_time is None by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2111
+*  Use datetime instead of dateutil by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2114
+*  tests: fix faulty path by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2117
+*  docs: remove requirements.txt by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2115
+*  opt: fix error printout by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2118
+*  postgis: remove type ignores by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2121
+*  Fix some lint issues by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2125
+*  query_group_by: improve type signature by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2119
+*  Enable more lint rules by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2105
+*  Make handling of coords in create_storage backwards compatible by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2126
+*  postgis: tweak type signatures by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2129
+*  Consolidate stac/eo3 conversion logic by @Ariana-B in https://github.com/opendatacube/datacube-core/pull/2077
+*  Fix pre-commit errors by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2130
 
 Automated updates
 -----------------
 
- - https://github.com/opendatacube/datacube-core/pull/2095
- - https://github.com/opendatacube/datacube-core/pull/2104,
- - https://github.com/opendatacube/datacube-core/pull/2106
- - https://github.com/opendatacube/datacube-core/pull/2107
- - https://github.com/opendatacube/datacube-core/pull/2108
- - https://github.com/opendatacube/datacube-core/pull/2109
- - https://github.com/opendatacube/datacube-core/pull/2122
- - https://github.com/opendatacube/datacube-core/pull/2123
- - https://github.com/opendatacube/datacube-core/pull/2124
+* https://github.com/opendatacube/datacube-core/pull/2095
+* https://github.com/opendatacube/datacube-core/pull/2104,
+* https://github.com/opendatacube/datacube-core/pull/2106
+* https://github.com/opendatacube/datacube-core/pull/2107
+* https://github.com/opendatacube/datacube-core/pull/2108
+* https://github.com/opendatacube/datacube-core/pull/2109
+* https://github.com/opendatacube/datacube-core/pull/2122
+* https://github.com/opendatacube/datacube-core/pull/2123
+* https://github.com/opendatacube/datacube-core/pull/2124
 
 Full Changelog: https://github.com/opendatacube/datacube-core/compare/1.9.7...1.9.8
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,7 +240,7 @@ include = ['datacube*']
 
 [tool.setuptools_scm]
 write_to = 'datacube/_version.py'
-fallback_version = "1.9.10.dev0"
+fallback_version = "1.9.11.dev0"
 
 [tool.mypy]
 python_version = '3.10'


### PR DESCRIPTION
### Reason for this pull request

1.9.11 release

### Proposed changes

- bump fallback version
- update whats_new.rst with old and new release notes.





<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2278.org.readthedocs.build/en/2278/

<!-- readthedocs-preview opendatacube end -->