### PR TITLE
Add RasterExtension to STAC conversion

### DIFF
--- a/datacube/metadata/_stacconverter.py
+++ b/datacube/metadata/_stacconverter.py
@@ -19,6 +19,7 @@ from urllib.parse import urljoin
 from pystac import Asset, Item, Link, MediaType
 from pystac.extensions.eo import Band, EOExtension
 from pystac.extensions.projection import ProjectionExtension
+from pystac.extensions.raster import DataType, RasterBand, RasterExtension
 from pystac.extensions.sar import SarExtension
 from pystac.extensions.sat import SatExtension
 from pystac.extensions.view import ViewExtension
@@ -233,6 +234,8 @@ def ds2stac(
         item.links.append(link)
 
     EOExtension.ext(item, add_if_missing=True)
+    # Error: RasterExtension does not apply to type Item ???
+    # RasterExtension.ext(item, add_if_missing=True)
 
     if dataset.extent:
         proj = ProjectionExtension.ext(item, add_if_missing=True)
@@ -259,6 +262,7 @@ def ds2stac(
             # No URL to link to. URL is mandatory for Stac validation.
             continue
 
+        # TODO: migrate to new bands array - https://github.com/radiantearth/stac-spec/blob/master/best-practices.md#band-migration
         asset = Asset(
             href=_uri_resolve(asset_location, measurement["path"]),
             media_type=_media_type(Path(measurement["path"])),
@@ -282,6 +286,23 @@ def ds2stac(
                     transform=proj_fields["transform"],
                     epsg=dataset.crs.epsg,
                 )
+
+        try:
+            product = dataset.product
+            m = product.measurements[product.canonical_measurement(name)]
+            raster = RasterExtension.ext(asset)
+            rband = RasterBand.create(
+                nodata=m["nodata"],
+                data_type=DataType(m["dtype"]),
+                unit=m["units"],
+            )
+            raster.apply([rband])
+        except ValueError:
+            warnings.warn(
+                f"Cannot determine raster extension properties for asset {name} "
+                "as it is not defined in the Product.",
+                stacklevel=2,
+            )
 
         item.add_asset(name, asset=asset)
 

--- a/tests/test_eo3converter.py
+++ b/tests/test_eo3converter.py
@@ -298,6 +298,7 @@ def test_ds2stac(eo3_dataset: Dataset) -> None:
     assert set(output_stac["assets"].keys()) == set(
         list(eo3_dataset.measurements.keys()) + list(eo3_dataset.accessories.keys())
     )
+    assert output_stac["assets"]["nbart_blue"]["raster:bands"][0]["nodata"] == -999
     assert output_stac["links"] == [
         {
             "rel": "self",

--- a/tests/test_eo3converter.py
+++ b/tests/test_eo3converter.py
@@ -298,7 +298,17 @@ def test_ds2stac(eo3_dataset: Dataset) -> None:
     assert set(output_stac["assets"].keys()) == set(
         list(eo3_dataset.measurements.keys()) + list(eo3_dataset.accessories.keys())
     )
-    assert output_stac["assets"]["nbart_blue"]["raster:bands"][0]["nodata"] == -999
+    assert all(
+        p in output_stac["assets"]["nbart_blue"]
+        for p in (
+            "eo:bands",
+            "proj:code",
+            "proj:shape",
+            "proj:transform",
+            "raster:bands",
+        )
+    )
+    assert "raster:bands" not in output_stac["assets"]["nbar_blue"]
     assert output_stac["links"] == [
         {
             "rel": "self",
@@ -424,9 +434,13 @@ def test_infer_eo3_product(odc_dataset_doc) -> None:
 
 
 def test_dsdoc_to_stac(odc_dataset_doc, eo3_dataset) -> None:
-    from_doc = ds_doc_to_stac(odc_dataset_doc)
-    from_ds = ds2stac(eo3_dataset)
-    assert from_doc.to_dict() == from_ds.to_dict()
+    from_doc = ds_doc_to_stac(odc_dataset_doc).to_dict()
+    from_ds = ds2stac(eo3_dataset).to_dict()
+    # from_doc assets will be missing the raster ext, so compare them separately
+    from_doc_assets = from_doc.pop("assets")
+    from_ds_assets = from_ds.pop("assets")
+    assert from_doc == from_ds
+    assert from_doc_assets.keys() == from_ds_assets.keys()
 
 
 def test_s1_nrb(s1_nrb_stac, s1_nrb_product, without_aws_env) -> None:


### PR DESCRIPTION
### Reason for this pull request

Make use of the RasterExtension to include Measurement dtype and nodata information when converting to STAC. This should help resolve stac loading issues (like https://github.com/opendatacube/odc-stac/issues/248) in the future.

Note that STAC 1.1 has updated the [bands best practices](https://github.com/radiantearth/stac-spec/blob/master/best-practices.md#bands) but these do not yet seem to be reflected in PySTAC.


### Proposed changes

- Improve ds2stac by including additional Measurement information in the Assets with the RasterExtension when possible



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2281.org.readthedocs.build/en/2281/

<!-- readthedocs-preview opendatacube end -->