### PR TITLE
postgis: catch alembic key error

### DIFF
--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -246,17 +246,20 @@ def schema_is_latest(engine: Engine) -> bool:
     scriptdir = ScriptDirectory.from_config(cfg)
     # NB this assumes a single unbranched migration branch
     # Get Head revision from Alembic environment
-    with EnvironmentContext(cfg, scriptdir) as env_ctx:
-        latest_rev = env_ctx.get_head_revision()
-        # Get current revision from database
-        with engine.connect() as conn:
-            context = MigrationContext.configure(
-                connection=conn,
-                environment_context=env_ctx,
-                opts={"version_table_schema": "odc"},
-            )
-            current_rev = context.get_current_revision()
-
+    try:
+        with EnvironmentContext(cfg, scriptdir) as env_ctx:
+            latest_rev = env_ctx.get_head_revision()
+            # Get current revision from database
+            with engine.connect() as conn:
+                context = MigrationContext.configure(
+                    connection=conn,
+                    environment_context=env_ctx,
+                    opts={"version_table_schema": "odc"},
+                )
+                current_rev = context.get_current_revision()
+    except KeyError as e:
+        _LOG.error(f"Alembic key error: {e}\nIs your database schema up to date?")
+        return False
     # Do they match?
     if latest_rev == current_rev:
         return True


### PR DESCRIPTION
### Reason for this pull request

Alembic can raise a KeyError
in _remove_proxy when the schema
is outdated. This is the cause for:
https://github.com/opendatacube/datacube-ows/issues/1375 so catch the exception and log
a readable message.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2283.org.readthedocs.build/en/2283/

<!-- readthedocs-preview opendatacube end -->