### PR TITLE
dependabot: add 10 day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
       actions-deps:
         patterns:
           - "*"
+    cooldown:
+      default-days: "10"
   - package-ecosystem: docker
     directory: "/docker"
     schedule:


### PR DESCRIPTION
### Reason for this pull request

This makes Dependabot wait for
10 days before generating the PR
for a release. This gives
authors of actions some time
to retract a release if there
is a supply chain compromise.


### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2285.org.readthedocs.build/en/2285/

<!-- readthedocs-preview opendatacube end -->