### PR TITLE
Suppress driver warnings on optional dependencies (e.g. netcdf).

### DIFF
--- a/datacube/drivers/driver_cache.py
+++ b/datacube/drivers/driver_cache.py
@@ -31,8 +31,14 @@ def load_drivers(group: str) -> dict[str, Any]:
         try:
             driver_init = ep.load()
         except Exception as e:
-            _LOG.warning("Failed to resolve driver %s::%s", group, ep.name)
-            _LOG.warning("Error was: %s", repr(e))
+            if isinstance(e, ModuleNotFoundError):
+                # Driver cannot be loaded because it's missing a dependency
+                # e.g. netcdf reader/writer drivers when NetCDF4 is not installed.
+                _LOG.info("Failed to resolve driver %s::%s", group, ep.name)
+                _LOG.info("Error was: %s", repr(e))
+            else:
+                _LOG.warning("Failed to resolve driver %s::%s", group, ep.name)
+                _LOG.warning("Error was: %s", repr(e))
             return None
 
         try:


### PR DESCRIPTION
### Reason for this pull request

When a driver could not be loaded due to uninstalled optional dependencies (e.g. `netCDF4` for the netcdf reader and writer drivers, a distracting warning was displayed.


### Proposed changes

If a driver cannot be loaded due to a missing dependency, log at "info" level.  Only raise a warning for other (more "unexpected") error cases.



 - [x] Closes #2282
 - [x] Tests added / passed
 - [x] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2288.org.readthedocs.build/en/2288/

<!-- readthedocs-preview opendatacube end -->