### PR TITLE
Revert "postgis: catch alembic key error"

### DIFF
--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -246,20 +246,17 @@ def schema_is_latest(engine: Engine) -> bool:
     scriptdir = ScriptDirectory.from_config(cfg)
     # NB this assumes a single unbranched migration branch
     # Get Head revision from Alembic environment
-    try:
-        with EnvironmentContext(cfg, scriptdir) as env_ctx:
-            latest_rev = env_ctx.get_head_revision()
-            # Get current revision from database
-            with engine.connect() as conn:
-                context = MigrationContext.configure(
-                    connection=conn,
-                    environment_context=env_ctx,
-                    opts={"version_table_schema": "odc"},
-                )
-                current_rev = context.get_current_revision()
-    except KeyError as e:
-        _LOG.error(f"Alembic key error: {e}\nIs your database schema up to date?")
-        return False
+    with EnvironmentContext(cfg, scriptdir) as env_ctx:
+        latest_rev = env_ctx.get_head_revision()
+        # Get current revision from database
+        with engine.connect() as conn:
+            context = MigrationContext.configure(
+                connection=conn,
+                environment_context=env_ctx,
+                opts={"version_table_schema": "odc"},
+            )
+            current_rev = context.get_current_revision()
+
     # Do they match?
     if latest_rev == current_rev:
         return True


### PR DESCRIPTION
### Reason for this pull request

The error re-appeared when I moved
the database+images to production,
so after some more debugging I think
we're dealing with a race condition.

This reverts commit 12c3430b305bafbbd0e0227c6e2411545395dbf8.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2289.org.readthedocs.build/en/2289/

<!-- readthedocs-preview opendatacube end -->