### PR TITLE
Ensure truly safe loading of netcdf drivers.

### DIFF
--- a/datacube/drivers/driver_cache.py
+++ b/datacube/drivers/driver_cache.py
@@ -31,14 +31,8 @@ def load_drivers(group: str) -> dict[str, Any]:
         try:
             driver_init = ep.load()
         except Exception as e:
-            if isinstance(e, ModuleNotFoundError):
-                # Driver cannot be loaded because it's missing a dependency
-                # e.g. netcdf reader/writer drivers when NetCDF4 is not installed.
-                _LOG.info("Failed to resolve driver %s::%s", group, ep.name)
-                _LOG.info("Error was: %s", repr(e))
-            else:
-                _LOG.warning("Failed to resolve driver %s::%s", group, ep.name)
-                _LOG.warning("Error was: %s", repr(e))
+            _LOG.warning("Failed to resolve driver %s::%s", group, ep.name)
+            _LOG.warning("Error was: %s", repr(e))
             return None
 
         try:
@@ -48,11 +42,6 @@ def load_drivers(group: str) -> dict[str, Any]:
                 "Exception during driver init, driver name: %s::%s", group, ep.name
             )
             return None
-
-        if driver is None:
-            _LOG.warning(
-                "Driver init returned None, driver name: %s::%s", group, ep.name
-            )
 
         return driver
 

--- a/datacube/drivers/netcdf/__init__.py
+++ b/datacube/drivers/netcdf/__init__.py
@@ -2,13 +2,3 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from . import writer as netcdf_writer
-from ._write import create_netcdf_storage_unit, write_dataset_to_netcdf
-from .writer import Variable
-
-__all__ = [
-    "Variable",
-    "create_netcdf_storage_unit",
-    "netcdf_writer",
-    "write_dataset_to_netcdf",
-]

--- a/datacube/drivers/netcdf/_write.py
+++ b/datacube/drivers/netcdf/_write.py
@@ -6,9 +6,8 @@ import contextlib
 import logging
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import netCDF4
 import xarray
 from odc.geo import CRS
 from xarray.core.coordinates import DatasetCoordinates
@@ -18,6 +17,9 @@ from datacube.storage._hdf5 import HDF5_LOCK
 from datacube.utils import DatacubeException
 
 from . import writer as netcdf_writer
+
+if TYPE_CHECKING:
+    import netCDF4
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -50,7 +52,7 @@ def create_netcdf_storage_unit(
     variable_params: Mapping[str, Mapping[str, Any]],
     global_attributes: dict | None = None,
     netcdfparams: dict | None = None,
-) -> netCDF4.Dataset:
+) -> "netCDF4.Dataset":
     """
     Create a NetCDF file on disk.
 

--- a/datacube/drivers/netcdf/driver.py
+++ b/datacube/drivers/netcdf/driver.py
@@ -10,8 +10,6 @@ import xarray as xr
 from datacube.storage._rio import RasterDatasetDataSource
 from datacube.utils.uris import normalise_path
 
-from ._write import write_dataset_to_netcdf
-
 PROTOCOL = "file"
 FORMAT = "NetCDF"
 
@@ -29,7 +27,11 @@ class NetcdfReaderDriver:
         return RasterDatasetDataSource(band)
 
 
-def reader_driver_init() -> NetcdfReaderDriver:
+def reader_driver_init() -> NetcdfReaderDriver | None:
+    try:
+        import netCDF4
+    except ImportError:
+        return None
     return NetcdfReaderDriver()
 
 
@@ -73,6 +75,8 @@ class NetcdfWriterDriver:
         variable_params=None,
         **kwargs,
     ) -> dict:
+        from ._write import write_dataset_to_netcdf
+
         write_dataset_to_netcdf(
             dataset,
             urlsplit(file_uri).path,
@@ -84,5 +88,9 @@ class NetcdfWriterDriver:
         return {}
 
 
-def writer_driver_init() -> NetcdfWriterDriver:
+def writer_driver_init() -> NetcdfWriterDriver | None:
+    try:
+        import netCDF4
+    except ImportError:
+        return None
     return NetcdfWriterDriver()

--- a/datacube/drivers/netcdf/driver.py
+++ b/datacube/drivers/netcdf/driver.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from importlib.util import find_spec
 from pathlib import Path
 from urllib.parse import urlsplit
 
@@ -28,9 +29,7 @@ class NetcdfReaderDriver:
 
 
 def reader_driver_init() -> NetcdfReaderDriver | None:
-    try:
-        import netCDF4
-    except ImportError:
+    if not find_spec("netCDF4"):
         return None
     return NetcdfReaderDriver()
 
@@ -89,8 +88,6 @@ class NetcdfWriterDriver:
 
 
 def writer_driver_init() -> NetcdfWriterDriver | None:
-    try:
-        import netCDF4
-    except ImportError:
+    if not find_spec("netCDF4"):
         return None
     return NetcdfWriterDriver()

--- a/datacube/drivers/netcdf/writer.py
+++ b/datacube/drivers/netcdf/writer.py
@@ -12,12 +12,10 @@ from collections import namedtuple
 from collections.abc import Sequence
 from datetime import datetime, timezone
 from os import PathLike
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import netCDF4
 import numpy
 import numpy as np
-from netCDF4 import Dataset
 from odc.geo import CRS
 from odc.geo.geom import box
 from odc.geo.math import data_resolution_and_offset
@@ -25,6 +23,10 @@ from xarray import DataArray
 
 from datacube import __version__
 from datacube.utils.masking import describe_flags_def
+
+if TYPE_CHECKING:
+    import netCDF4
+    from netCDF4 import Dataset
 
 UTC: timezone = timezone.utc
 
@@ -54,7 +56,7 @@ _STANDARD_COORDINATES = {
 }
 
 
-def create_netcdf(netcdf_path: str | PathLike, **kwargs) -> Dataset:
+def create_netcdf(netcdf_path: str | PathLike, **kwargs) -> "Dataset":
     """
     Create and return an empty NetCDF file
 
@@ -62,6 +64,8 @@ def create_netcdf(netcdf_path: str | PathLike, **kwargs) -> Dataset:
     :param kwargs: See :class:`Dataset` for more information
     :return: open NetCDF Dataset
     """
+    from netCDF4 import Dataset
+
     nco = Dataset(netcdf_path, "w", **kwargs)
     nco.date_created = datetime.today().isoformat()
     nco.setncattr("Conventions", "CF-1.6, ACDD-1.3")
@@ -72,22 +76,24 @@ def create_netcdf(netcdf_path: str | PathLike, **kwargs) -> Dataset:
     return nco
 
 
-def append_netcdf(netcdf_path: PathLike) -> Dataset:
+def append_netcdf(netcdf_path: PathLike) -> "Dataset":
     """
     Open a NetCDF file in append mode
 
     :param netcdf_path:
     :return: open NetCDF Dataset
     """
+    from netCDF4 import Dataset
+
     return Dataset(netcdf_path, "a")
 
 
 def create_coordinate(
-    nco: Dataset,
+    nco: "Dataset",
     name: str,
     labels: np.ndarray[tuple[Any, ...], np.dtype[Any]],
     units: str,
-) -> netCDF4.Variable:
+) -> "netCDF4.Variable":
     labels = netcdfy_coord(labels)
 
     nco.createDimension(name, labels.size)
@@ -103,7 +109,7 @@ def create_coordinate(
 
 def create_variable(
     nco, name: str, var: Variable | DataArray, grid_mapping=None, attrs=None, **kwargs
-) -> netCDF4.Variable:
+) -> "netCDF4.Variable":
     assert var.dtype.kind != "U"  # Creates Non CF-Compliant NetCDF File
 
     def clamp_chunksizes(chunksizes: Sequence[int] | None, dim_names: Sequence[str]):

--- a/datacube/drivers/netcdf/writer.py
+++ b/datacube/drivers/netcdf/writer.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy
 import numpy as np
+from netCDF4 import Dataset
 from odc.geo import CRS
 from odc.geo.geom import box
 from odc.geo.math import data_resolution_and_offset
@@ -26,7 +27,6 @@ from datacube.utils.masking import describe_flags_def
 
 if TYPE_CHECKING:
     import netCDF4
-    from netCDF4 import Dataset
 
 UTC: timezone = timezone.utc
 
@@ -56,7 +56,7 @@ _STANDARD_COORDINATES = {
 }
 
 
-def create_netcdf(netcdf_path: str | PathLike, **kwargs) -> "Dataset":
+def create_netcdf(netcdf_path: str | PathLike, **kwargs) -> Dataset:
     """
     Create and return an empty NetCDF file
 
@@ -64,7 +64,6 @@ def create_netcdf(netcdf_path: str | PathLike, **kwargs) -> "Dataset":
     :param kwargs: See :class:`Dataset` for more information
     :return: open NetCDF Dataset
     """
-    from netCDF4 import Dataset
 
     nco = Dataset(netcdf_path, "w", **kwargs)
     nco.date_created = datetime.today().isoformat()
@@ -76,20 +75,18 @@ def create_netcdf(netcdf_path: str | PathLike, **kwargs) -> "Dataset":
     return nco
 
 
-def append_netcdf(netcdf_path: PathLike) -> "Dataset":
+def append_netcdf(netcdf_path: PathLike) -> Dataset:
     """
     Open a NetCDF file in append mode
 
     :param netcdf_path:
     :return: open NetCDF Dataset
     """
-    from netCDF4 import Dataset
-
     return Dataset(netcdf_path, "a")
 
 
 def create_coordinate(
-    nco: "Dataset",
+    nco: Dataset,
     name: str,
     labels: np.ndarray[tuple[Any, ...], np.dtype[Any]],
     units: str,

--- a/tests/storage/test_netcdfwriter.py
+++ b/tests/storage/test_netcdfwriter.py
@@ -14,8 +14,7 @@ from hypothesis.strategies import text
 from odc.geo import CRS
 from odc.geo.geobox import Coordinate
 
-from datacube.drivers.netcdf import write_dataset_to_netcdf
-from datacube.drivers.netcdf._write import _get_units
+from datacube.drivers.netcdf._write import _get_units, write_dataset_to_netcdf
 from datacube.drivers.netcdf.writer import (
     DEFAULT_GRID_MAPPING,
     Variable,

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -17,7 +17,8 @@ from rasterio.warp import Resampling
 from typing_extensions import override
 
 from datacube.drivers.datasource import DataSource
-from datacube.drivers.netcdf import Variable, create_netcdf_storage_unit
+from datacube.drivers.netcdf._write import create_netcdf_storage_unit
+from datacube.drivers.netcdf.writer import Variable
 from datacube.model import Dataset, MetadataType, Product
 from datacube.storage import BandInfo, reproject_and_fuse
 from datacube.storage._read import read_time_slice

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -67,15 +67,6 @@ def test_default_injection() -> None:
     }
 
 
-def test_netcdf_driver_import() -> None:
-    try:
-        import datacube.drivers.netcdf.driver
-    except ImportError:
-        raise Exception("Failed to load netcdf writer driver") from None
-
-    assert datacube.drivers.netcdf.driver.reader_driver_init is not None
-
-
 def test_writer_driver_mk_uri() -> None:
     from datacube.drivers.netcdf.driver import NetcdfWriterDriver
 


### PR DESCRIPTION
### Reason for this pull request

Distracting messages when reading from non-netcdf files when netCDF4 is not installed as per #2282


### Proposed changes

- Ensure netCDF driver can be loaded enough to cleanly report that it cannot be loaded enough to actually use
- Prevent `datacube.driver.netcdf.__init__` from importing stuff that might break.

 - [x] Closes #xxxx
 - [x] Tests added / passed
 - [x] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2305.org.readthedocs.build/en/2305/

<!-- readthedocs-preview opendatacube end -->