### PR TITLE
Reduce asset raster ext warnings volume

### DIFF
--- a/datacube/metadata/_stacconverter.py
+++ b/datacube/metadata/_stacconverter.py
@@ -308,7 +308,7 @@ def ds2stac(
 
         item.add_asset(name, asset=asset)
 
-    if len(undefined_measurements):
+    if undefined_measurements:
         # TODO: make the phrasing of this warning more helpful
         # It could be that the Product doesn't include the measurements at all
         # or that it's missing the required keys due to being inferred

--- a/datacube/metadata/_stacconverter.py
+++ b/datacube/metadata/_stacconverter.py
@@ -139,7 +139,9 @@ def _stac_links(
             ),
         )
     else:
-        warnings.warn("Unable to determine self link for STAC Item.", stacklevel=2)
+        warnings.warn(
+            "Unable to determine a 'self' link for the STAC Item.", stacklevel=2
+        )
 
     if ds_yaml_url:
         yield Link(
@@ -174,7 +176,9 @@ def _stac_links(
             target=urljoin(base_url, f"dataset/{dataset.id}"),
         )
     else:
-        warnings.warn("No collection provided for STAC Item.", stacklevel=2)
+        warnings.warn(
+            "Unable to determine a 'collection' link for the STAC Item.", stacklevel=2
+        )
 
 
 def ds2stac(
@@ -234,8 +238,8 @@ def ds2stac(
         item.links.append(link)
 
     EOExtension.ext(item, add_if_missing=True)
-    # Error: RasterExtension does not apply to type Item ???
-    # RasterExtension.ext(item, add_if_missing=True)
+
+    item.ext.add("raster")
 
     if dataset.extent:
         proj = ProjectionExtension.ext(item, add_if_missing=True)
@@ -256,6 +260,8 @@ def ds2stac(
 
     # url against which asset href can be resolved
     asset_location = asset_location or dataset.uri
+    # Track measurements not defined in the product
+    undefined_measurements = []
     # Add assets that are data
     for name, measurement in dataset.measurements.items():
         if not asset_location and not measurement.get("path"):
@@ -298,13 +304,18 @@ def ds2stac(
             )
             raster.apply([rband])
         except ValueError:
-            warnings.warn(
-                f"Cannot determine raster extension properties for asset {name} "
-                "as it is not defined in the Product.",
-                stacklevel=2,
-            )
+            undefined_measurements.append(name)
 
         item.add_asset(name, asset=asset)
+
+    if len(undefined_measurements):
+        # TODO: make the phrasing of this warning more helpful
+        # It could be that the Product doesn't include the measurements at all
+        # or that it's missing the required keys due to being inferred
+        warnings.warn(
+            f"Cannot determine raster extension properties for assets: {', '.join(undefined_measurements)}",
+            stacklevel=2,
+        )
 
     # Add assets that are accessories
     for name, accessory in dataset.accessories.items():

--- a/tests/test_eo3converter.py
+++ b/tests/test_eo3converter.py
@@ -7,6 +7,7 @@
 
 import math
 import uuid
+import warnings
 from typing import Any
 
 import moto
@@ -289,11 +290,13 @@ def test_accessories(sentinel_stac_ms: pystac.Item) -> None:
 
 
 def test_ds2stac(eo3_dataset: Dataset) -> None:
-    output_stac = ds2stac(
-        eo3_dataset,
-        self_url="https://localhost/stac/eo3_dataset.json",
-        base_url="https://localhost/",
-    ).to_dict()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        output_stac = ds2stac(
+            eo3_dataset,
+            self_url="https://localhost/stac/eo3_dataset.json",
+            base_url="https://localhost/",
+        ).to_dict()
     assert output_stac["properties"]["instruments"] == ["oli", "tirs"]
     assert set(output_stac["assets"].keys()) == set(
         list(eo3_dataset.measurements.keys()) + list(eo3_dataset.accessories.keys())
@@ -353,19 +356,23 @@ def test_ds2stac(eo3_dataset: Dataset) -> None:
 
 
 def test_sources(ds_legacy_sources: Dataset, ds_ext_lineage: Dataset) -> None:
-    assert ds2stac(ds_legacy_sources).to_dict()["properties"]["odc:lineage"] == {
-        "level1": ["b5f234fe-bba8-5483-9bc0-250360d429cf"]
-    }
-    assert ds2stac(ds_ext_lineage).to_dict()["properties"]["odc:lineage"] == {
-        "level1": ["b5f234fe-bba8-5483-9bc0-250360d429cf"]
-    }
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        assert ds2stac(ds_legacy_sources).to_dict()["properties"]["odc:lineage"] == {
+            "level1": ["b5f234fe-bba8-5483-9bc0-250360d429cf"]
+        }
+        assert ds2stac(ds_ext_lineage).to_dict()["properties"]["odc:lineage"] == {
+            "level1": ["b5f234fe-bba8-5483-9bc0-250360d429cf"]
+        }
 
 
 def test_roundtrip(eo3_dataset: Dataset, eo3_product: Product) -> None:
     original = eo3_dataset
-    roundtrip = _item_to_ds(
-        ds2stac(eo3_dataset, base_url="https://localhost/"), eo3_product, {}
-    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        roundtrip = _item_to_ds(
+            ds2stac(eo3_dataset, base_url="https://localhost/"), eo3_product, {}
+        )
     orig_doc = original.metadata_doc
     rt_doc = roundtrip.metadata_doc
 
@@ -446,8 +453,10 @@ def test_infer_eo3_product(odc_dataset_doc) -> None:
 
 
 def test_dsdoc_to_stac(odc_dataset_doc, eo3_dataset) -> None:
-    from_doc = ds_doc_to_stac(odc_dataset_doc).to_dict()
-    from_ds = ds2stac(eo3_dataset).to_dict()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        from_doc = ds_doc_to_stac(odc_dataset_doc).to_dict()
+        from_ds = ds2stac(eo3_dataset).to_dict()
     # from_doc assets will be missing the raster ext, so compare them separately
     from_doc_assets = from_doc.pop("assets")
     from_ds_assets = from_ds.pop("assets")
@@ -462,7 +471,9 @@ def test_s1_nrb(s1_nrb_stac, s1_nrb_product, without_aws_env) -> None:
             stac2ds([s1_nrb_stac], product_cache={"ga_s1_nrb_iw_hh_0": s1_nrb_product})
         )
     )
-    dc_stac = ds2stac(eo3_ds)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        dc_stac = ds2stac(eo3_ds)
     assert (
         "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
         in dc_stac.stac_extensions

--- a/tests/test_eo3converter.py
+++ b/tests/test_eo3converter.py
@@ -338,6 +338,18 @@ def test_ds2stac(eo3_dataset: Dataset) -> None:
             "href": f"https://localhost/dataset/{eo3_dataset.id}",
         },
     ]
+    assert (
+        "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+        in output_stac["stac_extensions"]
+    )
+    assert (
+        "https://stac-extensions.github.io/projection/v2.0.0/schema.json"
+        in output_stac["stac_extensions"]
+    )
+    assert (
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+        in output_stac["stac_extensions"]
+    )
 
 
 def test_sources(ds_legacy_sources: Dataset, ds_ext_lineage: Dataset) -> None:


### PR DESCRIPTION
### Reason for this pull request

Reduce the volume of warnings around missing info for asset raster extensions.


### Proposed changes

- Produce only 1 warning that includes all measurements/assets that are missing info in the Product definition necessary for the raster extension
- Improve wording for missing collection link warning
- Ensure raster ext is in the item stac extensions



 - [ ] Closes #2302
 - [ ] Tests added / passed
 - [ ] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2306.org.readthedocs.build/en/2306/

<!-- readthedocs-preview opendatacube end -->