### PR TITLE
Bypass rasterio/gdal compatibility issue

### DIFF
--- a/datacube/testutils/io.py
+++ b/datacube/testutils/io.py
@@ -458,12 +458,11 @@ def rio_slurp_reproject(fname, geobox, dtype=None, dst_nodata=None, **kw):
     _fix_resampling(kw)
 
     with rasterio.open(str(fname), "r") as src:
+        shape = geobox.shape
         if src.count == 1:
-            shape = geobox.shape
-            src_band = rasterio.band(src, 1)
+            src_bands = [rasterio.band(src, 1)]
         else:
-            shape = (src.count, *geobox.shape)
-            src_band = rasterio.band(src, tuple(range(1, src.count + 1)))
+            src_bands = [rasterio.band(src, i) for i in range(1, src.count + 1)]
 
         if dtype is None:
             dtype = src.dtypes[0]
@@ -472,16 +471,21 @@ def rio_slurp_reproject(fname, geobox, dtype=None, dst_nodata=None, **kw):
         if dst_nodata is None:
             dst_nodata = 0
 
-        pix = np.full(shape, dst_nodata, dtype=dtype)
+        out_bands = [np.full(shape, dst_nodata, dtype=dtype) for i in range(src.count)]
 
-        reproject(
-            src_band,
-            pix,
-            dst_nodata=dst_nodata,
-            dst_transform=geobox.transform,
-            dst_crs=str(geobox.crs),
-            **kw,
-        )
+        # reproject band by band as rasterio warp is broken for multiband input in GDAL 3.12
+        for src_band, out_band in zip(src_bands, out_bands):
+            reproject(
+                src_band,
+                out_band,
+                dst_nodata=dst_nodata,
+                dst_transform=geobox.transform,
+                dst_crs=str(geobox.crs),
+                **kw,
+            )
+
+        # Reassemble out_bands into a single output array
+        pix = np.stack(out_bands, axis=0) if src.count > 1 else out_bands[0]
 
         meta = src.meta
         meta["src_geobox"] = rio_geobox(meta)


### PR DESCRIPTION
### Reason for this pull request

From GDAL 3.11, multi-band warping (e.g. through rasterio) mangles nodata values. (See https://github.com/rasterio/rasterio/issues/3508) This affects `rio_slurp_reproject`, a testing utility function.  This in turn was making tests fail with gdal 3.11+.

### Proposed changes

- Only pass single bands to rasterio, if multi bands are passed in, reproject them separately and restack.

Once this merges we should be able finally upgrade the docker image to gdal 3.12.


 - [x] Tests added / passed
 - [x] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2316.org.readthedocs.build/en/2316/

<!-- readthedocs-preview opendatacube end -->