### PR TITLE
Ensure table and view ownership for postgres driver.

### DIFF
--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -311,9 +311,30 @@ def _ensure_extension(conn: Connection, extension_name: str = "POSTGIS") -> None
     conn.execute(sql)
 
 
+def role_has_role(conn: Connection, grant_role: UserRole, to_role: UserRole) -> bool:
+    return bool(
+        conn.execute(
+            text(
+                f"""
+            select 1
+            from pg_auth_members m
+            join pg_roles tr on tr.oid = m.roleid
+            join pg_roles gr on gr.oid = m.member
+            where gr.rolname = '{grant_role.value}'
+            and tr.rolname = '{to_role.value}'
+        """
+            )
+        ).scalar()
+    )
+
+
 def _ensure_role(conn: Connection, role: UserRole) -> None:
     if has_user(conn, role.value):
         _LOG.debug("Role exists: %s", role.value)
+        if (inherit := role.inherits_from()) is not None and not role_has_role(
+            conn, role, inherit
+        ):
+            conn.execute(text(f"grant {inherit.value} to {role.value}"))
         return
 
     sql = [

--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -311,17 +311,28 @@ def _ensure_extension(conn: Connection, extension_name: str = "POSTGIS") -> None
     conn.execute(sql)
 
 
-def role_has_role(conn: Connection, grant_role: UserRole, to_role: UserRole) -> bool:
+def check_role_inheritance(
+    conn: Connection, group_role: UserRole, role: UserRole
+) -> bool:
+    """
+    Check whether an extending role has been granted a base role.
+
+    :param conn: A SQLAlchemy connection object
+    :param base_role: The base role, the role that should be granted.
+    :param extending_role: The extending role, the role that should have the base role granted to it, so that it
+        can extend it with additional permissions
+    :return: True if the base_role has been granted to the extending_role.
+    """
     return bool(
         conn.execute(
             text(
                 f"""
             select 1
             from pg_auth_members m
-            join pg_roles tr on tr.oid = m.roleid
+            join pg_roles r on r.oid = m.roleid
             join pg_roles gr on gr.oid = m.member
-            where gr.rolname = '{grant_role.value}'
-            and tr.rolname = '{to_role.value}'
+            where gr.rolname = '{group_role.value}'
+            and r.rolname = '{role.value}'
         """
             )
         ).scalar()
@@ -331,8 +342,8 @@ def role_has_role(conn: Connection, grant_role: UserRole, to_role: UserRole) -> 
 def _ensure_role(conn: Connection, role: UserRole) -> None:
     if has_user(conn, role.value):
         _LOG.debug("Role exists: %s", role.value)
-        if (inherit := role.inherits_from()) is not None and not role_has_role(
-            conn, role, inherit
+        if (inherit := role.inherits_from()) is not None and not check_role_inheritance(
+            conn, inherit, role
         ):
             conn.execute(text(f"grant {inherit.value} to {role.value}"))
         return

--- a/datacube/drivers/postgres/_connections.py
+++ b/datacube/drivers/postgres/_connections.py
@@ -211,7 +211,7 @@ class PostgresDb:
         """
         is_new = _core.ensure_db(self._engine, with_permissions=with_permissions)
         if not is_new:
-            _core.update_schema(self._engine)
+            _core.update_schema(self._engine, with_permissions=with_permissions)
 
         return is_new
 

--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -401,18 +401,29 @@ def update_schema(engine: Engine, with_permissions: bool) -> None:
             _LOG.info("No schema updates required.")
 
 
-def role_has_role(conn: Connection, grant_role: UserRole, to_role: UserRole) -> bool:
-    # Identical to function in posgis driver, but expects posgres UserRoles
+def check_role_inheritance(
+    conn: Connection, group_role: UserRole, role: UserRole
+) -> bool:
+    """
+    Check whether an extending role has been granted a base role.
+
+    :param conn: A SQLAlchemy connection object
+    :param base_role: The base role, the role that should be granted.
+    :param extending_role: The extending role, the role that should have the base role granted to it, so that it
+        can extend it with additional permissions
+    :return: True if the base_role has been granted to the extending_role.
+    """
+    # Identical to function in postgis driver, but expects postgres UserRoles
     return bool(
         conn.execute(
             text(
                 f"""
             select 1
             from pg_auth_members m
-            join pg_roles tr on tr.oid = m.roleid
+            join pg_roles r on r.oid = m.roleid
             join pg_roles gr on gr.oid = m.member
-            where gr.rolname = '{grant_role.value}'
-            and tr.rolname = '{to_role.value}'
+            where gr.rolname = '{group_role.value}'
+            and r.rolname = '{role.value}'
         """
             )
         ).scalar()
@@ -422,8 +433,8 @@ def role_has_role(conn: Connection, grant_role: UserRole, to_role: UserRole) -> 
 def _ensure_role(conn, role: UserRole) -> None:
     if has_user(conn, role.value):
         _LOG.debug("Role exists: %s", role.value)
-        if (inherit := role.inherits_from()) is not None and not role_has_role(
-            conn, role, inherit
+        if (inherit := role.inherits_from()) is not None and not check_role_inheritance(
+            conn, inherit, role
         ):
             conn.execute(text(f"grant {inherit.value} to {role.value}"))
         return

--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -10,7 +10,7 @@ import contextlib
 import logging
 from collections.abc import Generator, Iterable
 from enum import Enum
-from typing import Literal, Union, cast
+from typing import Literal, Union
 
 from deprecat import deprecat
 from sqlalchemy import Connection, MetaData, inspect, text
@@ -147,7 +147,7 @@ def schema_qualified(name: str) -> str:
     return f"{SCHEMA_NAME}.{name}"
 
 
-def _get_quoted_connection_info(connection) -> tuple:
+def get_connection_info(connection) -> tuple:
     db, user = connection.execute(
         text("select quote_ident(current_database()), quote_ident(current_user)")
     ).fetchone()
@@ -165,7 +165,7 @@ def ensure_db(engine, with_permissions: bool = True) -> bool:
     is_new = not has_schema(engine)
     with engine.connect() as c:
         #  NB. Using default SQLA2.0 auto-begin commit-as-you-go behaviour
-        quoted_db_name, quoted_user = _get_quoted_connection_info(c)
+        db_name, db_user = get_connection_info(c)
 
         if with_permissions:
             _LOG.info("Ensuring user roles.")
@@ -174,7 +174,7 @@ def ensure_db(engine, with_permissions: bool = True) -> bool:
 
             c.execute(
                 text(f"""
-            grant all on database {quoted_db_name} to agdc_admin;
+            grant all on database {db_name} to agdc_admin;
             """)
             )
             c.commit()
@@ -195,11 +195,12 @@ def ensure_db(engine, with_permissions: bool = True) -> bool:
             _LOG.info("Creating added column.")
             install_added_column(c)
             if with_permissions:
-                c.execute(text(f"set role {quoted_user}"))
+                c.execute(text(f"set role {db_user}"))
             c.commit()
 
         if with_permissions:
             _LOG.info("Adding role grants.")
+            c.execute(text("set role agdc_admin"))
             c.execute(text(f"grant usage on schema {SCHEMA_NAME} to agdc_user"))
             c.execute(
                 text(f"grant select on all tables in schema {SCHEMA_NAME} to agdc_user")
@@ -232,6 +233,7 @@ def ensure_db(engine, with_permissions: bool = True) -> bool:
             )
             # Allow creation of indexes, views
             c.execute(text(f"grant create on schema {SCHEMA_NAME} to agdc_manage"))
+            c.execute(text(f"set role {db_user}"))
             c.commit()
 
     return is_new
@@ -269,10 +271,6 @@ def schema_is_latest(engine: Engine) -> bool:
     return True
 
 
-def get_current_user(conn: Connection) -> str:
-    return cast(str, conn.execute(text("select quote_ident(current_user)")).scalar())
-
-
 def user_is_super(conn: Connection, user: str) -> bool:
     return bool(
         conn.execute(
@@ -282,7 +280,7 @@ def user_is_super(conn: Connection, user: str) -> bool:
 
 
 def table_transfers_required(
-    conn: Connection, schema: str, tables: list[str]
+    conn: Connection, new_owner: str, schema: str, tables: list[str]
 ) -> list[tuple[str, str]]:
     """
     :return: List of tuples of tablename, current_owner of tables requiring transfer
@@ -294,13 +292,13 @@ def table_transfers_required(
             f"and tablename in {tuple(tables)}"
         )
     ):
-        if row.tableowner != "agdc_admin":
+        if row.tableowner != new_owner:
             transfers.append((row.tablename, row.tableowner))
     return transfers
 
 
 def view_transfers_required(
-    conn: Connection, schema: str, prefix: str
+    conn: Connection, new_owner: str, schema: str, prefix: str
 ) -> list[tuple[str, str]]:
     """
     :return: List of tuples of viewname, current_owner of views requiring transfer
@@ -312,7 +310,7 @@ def view_transfers_required(
             f"and viewname like '{prefix}%'"
         )
     ):
-        if row.viewowner != "agdc_admin":
+        if row.viewowner != new_owner:
             transfers.append((row.viewname, row.viewowner))
     return transfers
 
@@ -336,18 +334,14 @@ def update_schema(engine: Engine, with_permissions: bool) -> None:
     # Post 1.8 DB Incremental Sync triggers
     with engine.connect() as connection:
         updated = False
-        if not pg_column_exists(connection, "dataset", "updated"):
-            _LOG.info("Adding 'updated'/'added' fields and triggers to schema.")
-            connection.execute(text("begin"))
-            install_timestamp_trigger(connection)
-            install_added_column(connection)
-            connection.execute(text("commit"))
-            updated = True
+        _, user = get_connection_info(connection)
 
         if with_permissions:
-            # ensure tables and dynamic views are all owned by agdc_admin
+            is_super = user_is_super(connection, user)
+            # ensure tables are all owned by agdc_admin
             transfers = table_transfers_required(
                 connection,
+                "agdc_admin",
                 SCHEMA_NAME,
                 [
                     "metadata_type",
@@ -358,8 +352,6 @@ def update_schema(engine: Engine, with_permissions: bool) -> None:
                 ],
             )
             if transfers:
-                user = get_current_user(connection)
-                is_super = user_is_super(connection, user)
                 for table, current_owner in transfers:
                     if is_super or current_owner == user:
                         _LOG.info(f"Transferring ownership of {table} to agdc_admin")
@@ -375,10 +367,11 @@ def update_schema(engine: Engine, with_permissions: bool) -> None:
                             f"user {user} is not a superuser or current owner"
                         )
 
-            transfers = view_transfers_required(connection, SCHEMA_NAME, "dv_")
+            # ensure dynamic views are all owned by agdc_manage
+            transfers = view_transfers_required(
+                connection, "agdc_manage", SCHEMA_NAME, "dv_"
+            )
             if transfers:
-                user = get_current_user(connection)
-                is_super = user_is_super(connection, user)
                 for view, current_owner in transfers:
                     if is_super or current_owner == user:
                         _LOG.info(f"Transferring ownership of {view} to agdc_manage")
@@ -393,6 +386,16 @@ def update_schema(engine: Engine, with_permissions: bool) -> None:
                             f"Cannot transfer ownership of {view} from {current_owner} to agdc_manage: "
                             f"user {user} is not a superuser or current owner"
                         )
+
+        if not pg_column_exists(connection, "dataset", "updated"):
+            _LOG.info("Adding 'updated'/'added' fields and triggers to schema.")
+            connection.execute(text("begin"))
+            connection.execute(text("set role agdc_admin"))
+            install_timestamp_trigger(connection)
+            install_added_column(connection)
+            connection.execute(text(f"set role {user}"))
+            connection.execute(text("commit"))
+            updated = True
 
         if not updated:
             _LOG.info("No schema updates required.")

--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -10,7 +10,7 @@ import contextlib
 import logging
 from collections.abc import Generator, Iterable
 from enum import Enum
-from typing import Literal, Union
+from typing import cast, Literal, Union
 
 from deprecat import deprecat
 from sqlalchemy import Connection, MetaData, inspect, text
@@ -269,6 +269,65 @@ def schema_is_latest(engine: Engine) -> bool:
     return True
 
 
+def get_current_user(conn: Connection) -> str:
+    return cast(
+        str,
+        conn.execute(text("select quote_ident(current_user)")).scalar()
+    )
+
+
+def user_is_super(conn: Connection, user: str) -> bool:
+    return bool(conn.execute(
+        text(f"select rolsuper from pg_roles WHERE rolname = '{user}'")
+    ).scalar())
+
+
+def user_is_admin(conn: Connection, user: str) -> bool:
+    try:
+        conn.execute(text("set role odc_admin"))
+        conn.execute(text(f"set role {user}"))
+        return True
+    except ProgrammingError:
+        _LOG.warning(f"User {user} is not a member of agdc_admin role")
+        return False
+
+
+def table_transfers_required(
+    conn: Connection, schema: str, tables: list[str]
+) -> list[tuple[str, str]]:
+    """
+    :return: List of tuples of tablename, current_owner of tables requiring transfer
+    """
+    transfers: list[tuple[str, str]] = []
+    for row in conn.execute(
+        text(
+            f"select tablename, tableowner from pg_tables where schemaname = '{schema}' "
+            f"and tablename in {tuple(tables)}"
+        )
+    ):
+        if row.tableowner != "agdc_admin":
+            transfers.append((row.tablename, row.tableowner))
+    return transfers
+
+
+def view_transfers_required(
+    conn: Connection, schema: str, prefix: str
+) -> list[tuple[str, str]]:
+    """
+    :return: List of tuples of viewname, current_owner of views requiring transfer
+    """
+    transfers: list[tuple[str, str]] = []
+    for row in conn.execute(
+        text(
+            f"select viewname, viewowner from pg_views where schemaname = '{schema}' "
+            f"and viewname like '{prefix}%'"
+        )
+    ):
+        if row.viewowner != "agdc_admin":
+            transfers.append((row.viewname, row.viewowner))
+    return transfers
+
+
 def update_schema(engine: Engine) -> None:
     """
     Check and apply any missing schema changes to the database.
@@ -287,19 +346,87 @@ def update_schema(engine: Engine) -> None:
 
     # Post 1.8 DB Incremental Sync triggers
     with engine.connect() as connection:
+        updated = False
         if not pg_column_exists(connection, "dataset", "updated"):
             _LOG.info("Adding 'updated'/'added' fields and triggers to schema.")
             connection.execute(text("begin"))
             install_timestamp_trigger(connection)
             install_added_column(connection)
             connection.execute(text("commit"))
-        else:
+            updated = True
+
+        transfers = table_transfers_required(
+            connection,
+            SCHEMA_NAME,
+            [
+                "metadata_type",
+                "dataset_type",
+                "dataset",
+                "dataset_location",
+                "dataset_source",
+            ],
+        )
+        if transfers:
+            user = get_current_user(connection)
+            is_super = user_is_super(connection, user)
+            for table, current_owner in transfers:
+                if is_super or current_owner == user:
+                    _LOG.info(f"Transferring ownership of {table} to agdc_admin")
+                    connection.execute(
+                        text(f"alter table {SCHEMA_NAME}.{table} owner to agdc_admin")
+                    )
+                    updated = True
+                else:
+                    _LOG.warning(
+                        f"Cannot transfer ownership of {table} from {current_owner} to agdc_admin: "
+                        f"user {user} is not a superuser or current owner"
+                    )
+
+        transfers = view_transfers_required(connection, SCHEMA_NAME, "dv_")
+        if transfers:
+            user = get_current_user(connection)
+            is_super = user_is_super(connection, user)
+            for view, current_owner in transfers:
+                if is_super or current_owner == user:
+                    _LOG.info(f"Transferring ownership of {view} to agdc_admin")
+                    connection.execute(
+                        text(f"alter view {SCHEMA_NAME}.{view} owner to agdc_admin")
+                    )
+                    updated = True
+                else:
+                    _LOG.warning(
+                        f"Cannot transfer ownership of {view} from {current_owner} to agdc_admin: "
+                        f"user {user} is not a superuser or current owner"
+                    )
+
+        if not updated:
             _LOG.info("No schema updates required.")
+
+
+def role_has_role(conn: Connection, grant_role: UserRole, to_role: UserRole) -> bool:
+    return bool(
+        conn.execute(
+            text(
+                f"""
+            select 1
+            from pg_auth_members m
+            join pg_roles tr on tr.oid = m.roleid
+            join pg_roles gr on gr.oid = m.member
+            where gr.rolname = '{grant_role.value}'
+            and tr.rolname = '{to_role.value}'
+        """
+            )
+        ).scalar()
+    )
 
 
 def _ensure_role(conn, role: UserRole) -> None:
     if has_user(conn, role.value):
         _LOG.debug("Role exists: %s", role.value)
+        if (inherit := role.inherits_from()) is not None and not role_has_role(
+            conn, role, inherit
+        ):
+            conn.execute(text(f"grant {inherit.value} to {role.value}"))
         return
 
     sql = [

--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -10,7 +10,7 @@ import contextlib
 import logging
 from collections.abc import Generator, Iterable
 from enum import Enum
-from typing import cast, Literal, Union
+from typing import Literal, Union, cast
 
 from deprecat import deprecat
 from sqlalchemy import Connection, MetaData, inspect, text
@@ -270,16 +270,15 @@ def schema_is_latest(engine: Engine) -> bool:
 
 
 def get_current_user(conn: Connection) -> str:
-    return cast(
-        str,
-        conn.execute(text("select quote_ident(current_user)")).scalar()
-    )
+    return cast(str, conn.execute(text("select quote_ident(current_user)")).scalar())
 
 
 def user_is_super(conn: Connection, user: str) -> bool:
-    return bool(conn.execute(
-        text(f"select rolsuper from pg_roles WHERE rolname = '{user}'")
-    ).scalar())
+    return bool(
+        conn.execute(
+            text(f"select rolsuper from pg_roles WHERE rolname = '{user}'")
+        ).scalar()
+    )
 
 
 def user_is_admin(conn: Connection, user: str) -> bool:
@@ -328,7 +327,7 @@ def view_transfers_required(
     return transfers
 
 
-def update_schema(engine: Engine) -> None:
+def update_schema(engine: Engine, with_permissions: bool) -> None:
     """
     Check and apply any missing schema changes to the database.
 
@@ -355,49 +354,53 @@ def update_schema(engine: Engine) -> None:
             connection.execute(text("commit"))
             updated = True
 
-        transfers = table_transfers_required(
-            connection,
-            SCHEMA_NAME,
-            [
-                "metadata_type",
-                "dataset_type",
-                "dataset",
-                "dataset_location",
-                "dataset_source",
-            ],
-        )
-        if transfers:
-            user = get_current_user(connection)
-            is_super = user_is_super(connection, user)
-            for table, current_owner in transfers:
-                if is_super or current_owner == user:
-                    _LOG.info(f"Transferring ownership of {table} to agdc_admin")
-                    connection.execute(
-                        text(f"alter table {SCHEMA_NAME}.{table} owner to agdc_admin")
-                    )
-                    updated = True
-                else:
-                    _LOG.warning(
-                        f"Cannot transfer ownership of {table} from {current_owner} to agdc_admin: "
-                        f"user {user} is not a superuser or current owner"
-                    )
+        if with_permissions:
+            # ensure tables and dynamic views are all owned by agdc_admin
+            transfers = table_transfers_required(
+                connection,
+                SCHEMA_NAME,
+                [
+                    "metadata_type",
+                    "dataset_type",
+                    "dataset",
+                    "dataset_location",
+                    "dataset_source",
+                ],
+            )
+            if transfers:
+                user = get_current_user(connection)
+                is_super = user_is_super(connection, user)
+                for table, current_owner in transfers:
+                    if is_super or current_owner == user:
+                        _LOG.info(f"Transferring ownership of {table} to agdc_admin")
+                        connection.execute(
+                            text(
+                                f"alter table {SCHEMA_NAME}.{table} owner to agdc_admin"
+                            )
+                        )
+                        updated = True
+                    else:
+                        _LOG.warning(
+                            f"Cannot transfer ownership of {table} from {current_owner} to agdc_admin: "
+                            f"user {user} is not a superuser or current owner"
+                        )
 
-        transfers = view_transfers_required(connection, SCHEMA_NAME, "dv_")
-        if transfers:
-            user = get_current_user(connection)
-            is_super = user_is_super(connection, user)
-            for view, current_owner in transfers:
-                if is_super or current_owner == user:
-                    _LOG.info(f"Transferring ownership of {view} to agdc_admin")
-                    connection.execute(
-                        text(f"alter view {SCHEMA_NAME}.{view} owner to agdc_admin")
-                    )
-                    updated = True
-                else:
-                    _LOG.warning(
-                        f"Cannot transfer ownership of {view} from {current_owner} to agdc_admin: "
-                        f"user {user} is not a superuser or current owner"
-                    )
+            transfers = view_transfers_required(connection, SCHEMA_NAME, "dv_")
+            if transfers:
+                user = get_current_user(connection)
+                is_super = user_is_super(connection, user)
+                for view, current_owner in transfers:
+                    if is_super or current_owner == user:
+                        _LOG.info(f"Transferring ownership of {view} to agdc_admin")
+                        connection.execute(
+                            text(f"alter view {SCHEMA_NAME}.{view} owner to agdc_admin")
+                        )
+                        updated = True
+                    else:
+                        _LOG.warning(
+                            f"Cannot transfer ownership of {view} from {current_owner} to agdc_admin: "
+                            f"user {user} is not a superuser or current owner"
+                        )
 
         if not updated:
             _LOG.info("No schema updates required.")

--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -281,16 +281,6 @@ def user_is_super(conn: Connection, user: str) -> bool:
     )
 
 
-def user_is_admin(conn: Connection, user: str) -> bool:
-    try:
-        conn.execute(text("set role odc_admin"))
-        conn.execute(text(f"set role {user}"))
-        return True
-    except ProgrammingError:
-        _LOG.warning(f"User {user} is not a member of agdc_admin role")
-        return False
-
-
 def table_transfers_required(
     conn: Connection, schema: str, tables: list[str]
 ) -> list[tuple[str, str]]:
@@ -391,14 +381,16 @@ def update_schema(engine: Engine, with_permissions: bool) -> None:
                 is_super = user_is_super(connection, user)
                 for view, current_owner in transfers:
                     if is_super or current_owner == user:
-                        _LOG.info(f"Transferring ownership of {view} to agdc_admin")
+                        _LOG.info(f"Transferring ownership of {view} to agdc_manage")
                         connection.execute(
-                            text(f"alter view {SCHEMA_NAME}.{view} owner to agdc_admin")
+                            text(
+                                f"alter view {SCHEMA_NAME}.{view} owner to agdc_manage"
+                            )
                         )
                         updated = True
                     else:
                         _LOG.warning(
-                            f"Cannot transfer ownership of {view} from {current_owner} to agdc_admin: "
+                            f"Cannot transfer ownership of {view} from {current_owner} to agdc_manage: "
                             f"user {user} is not a superuser or current owner"
                         )
 
@@ -407,6 +399,7 @@ def update_schema(engine: Engine, with_permissions: bool) -> None:
 
 
 def role_has_role(conn: Connection, grant_role: UserRole, to_role: UserRole) -> bool:
+    # Identical to function in posgis driver, but expects posgres UserRoles
     return bool(
         conn.execute(
             text(

--- a/datacube/drivers/postgres/_dynamic.py
+++ b/datacube/drivers/postgres/_dynamic.py
@@ -15,7 +15,7 @@ from sqlalchemy.engine.mock import MockConnection
 
 from datacube.drivers.postgres._fields import PgField
 
-from ._core import schema_qualified
+from ._core import get_current_user, schema_qualified
 from ._schema import DATASET, METADATA_TYPE, PRODUCT
 from .sql import CreateView, pg_exists
 
@@ -91,6 +91,8 @@ def check_dynamic_fields(
     """
     Check that we have expected indexes and views for the given fields
     """
+    user = get_current_user(conn)
+    conn.execute(text("set role agdc_admin"))
     # If this type has time/space fields, create composite indexes (as they are often searched together)
     # We will probably move these into product configuration in the future.
     composite_indexes = (
@@ -133,6 +135,7 @@ def check_dynamic_fields(
         )
     # A view of all fields
     _ensure_view(conn, fields, name, rebuild_view, dataset_filter, delete_view)
+    conn.execute(text(f"set role {user}"))
 
 
 def _check_field_index(

--- a/datacube/drivers/postgres/_dynamic.py
+++ b/datacube/drivers/postgres/_dynamic.py
@@ -92,7 +92,7 @@ def check_dynamic_fields(
     Check that we have expected indexes and views for the given fields
     """
     user = get_current_user(conn)
-    conn.execute(text("set role agdc_admin"))
+    conn.execute(text("set role agdc_manage"))
     # If this type has time/space fields, create composite indexes (as they are often searched together)
     # We will probably move these into product configuration in the future.
     composite_indexes = (

--- a/datacube/drivers/postgres/_dynamic.py
+++ b/datacube/drivers/postgres/_dynamic.py
@@ -15,7 +15,7 @@ from sqlalchemy.engine.mock import MockConnection
 
 from datacube.drivers.postgres._fields import PgField
 
-from ._core import get_current_user, schema_qualified
+from ._core import get_connection_info, schema_qualified
 from ._schema import DATASET, METADATA_TYPE, PRODUCT
 from .sql import CreateView, pg_exists
 
@@ -91,8 +91,8 @@ def check_dynamic_fields(
     """
     Check that we have expected indexes and views for the given fields
     """
-    user = get_current_user(conn)
-    conn.execute(text("set role agdc_manage"))
+    _, user = get_connection_info(conn)
+    conn.execute(text("set role agdc_admin"))
     # If this type has time/space fields, create composite indexes (as they are often searched together)
     # We will probably move these into product configuration in the future.
     composite_indexes = (
@@ -134,6 +134,7 @@ def check_dynamic_fields(
             replace_existing=rebuild_indexes,
         )
     # A view of all fields
+    conn.execute(text("set role agdc_manage"))
     _ensure_view(conn, fields, name, rebuild_view, dataset_filter, delete_view)
     conn.execute(text(f"set role {user}"))
 

--- a/datacube/scripts/system.py
+++ b/datacube/scripts/system.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import logging
+import warnings
 
 import click
 from click import echo, style
@@ -12,6 +13,7 @@ import datacube
 from datacube.cfg import ODCEnvironment, psql_url_from_config
 from datacube.drivers.postgres._connections import IndexSetupError
 from datacube.index import index_connect
+from datacube.migration import ODC2DeprecationWarning
 from datacube.ui import click as ui
 from datacube.ui.click import cli, handle_exception
 
@@ -35,6 +37,7 @@ def system() -> None:
     is_flag=True,
     default=True,
     help="Include user roles and grants. (default: true)",
+    deprecated=True,
 )
 @click.option(
     "--recreate-views/--no-recreate-views",
@@ -59,6 +62,14 @@ def database_init(
     index, default_types, init_users, recreate_views, rebuild, lock_table
 ) -> None:
     echo("Initialising database...")
+
+    if not init_users:
+        warnings.warn(
+            "The --no-init-users flag is now deprecated. "
+            "Please use standard ODC database roles for permissions management.",
+            ODC2DeprecationWarning,
+            stacklevel=1,
+        )
 
     was_created = index.init_db(
         with_default_types=default_types, with_permissions=init_users


### PR DESCRIPTION
### Reason for this pull request

1. The postgres driver has been ensuring tables are created owned by the `agdc_admin` user for quite some time but there has never been any attempt to fix the ownership of tables created before this.

2. The postgres driver has never controlled the owner of views created by ODC - views have always been owned by the user that happened to create them.

3. Both the postgis and postgres driver have always created the `agdc_user`, `agdc_ingest`, `agdc_manage` and `agdc_admin` users, and for several releases have created them in an inheritance hierarchy (e.g. `agdc_admin` inherits from `agdc_manage`, which inherits from  `agdc_ingest`, etc.)   But neither driver ensures this inheritance hierarchy if the roles already exist.

### Proposed changes

`datacube system init` now ensures (under both postgres and postgis index drivers):

- That all ODC-created tables are owned by `agdc_admin`
- That all ODC-created dynamic views are owned by `agdc_manage`
- That the correct inheritance hierarchy exists between the ODC-created roles.

If permissions are such that the ownership of a table or view cannot be corrected by the active db user, a warning is raised.

Adding or updating a product or metadata type in the postgres driver now creates/re-creates dynamic views owned by `agdc_manage`

Calling `datacube system init --no-init-users` suppresses much of the above behaviour, but as this flag is not in general available when updating views, and user permission management is becoming more consistent (and is now expected by packages like datacube-ows and datacube-explorer) this option is now deprecated.

 - [x] Tests added / passed
 - [x] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2329.org.readthedocs.build/en/2329/

<!-- readthedocs-preview opendatacube end -->