### PR TITLE
Ensure empty driver-based loads return a nodata Dataset.

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -982,6 +982,8 @@ class Datacube:
         data = Datacube.create_storage(
             sources.coords, geobox, measurements, extra_dims=extra_dims
         )
+        if len(sources) == 0:
+            return data
         _cbk = mk_cbk(progress_cbk)
 
         # Create a list of read IO operations
@@ -1147,7 +1149,7 @@ class Datacube:
 
         geobox = _normalise_geobox(geobox)
 
-        if not legacy_load:
+        if not legacy_load and len(sources) > 0:
             from ..storage._loader import driver_based_load
 
             assert driver is not None  # Mypy is confused by legacy_load.
@@ -1162,7 +1164,7 @@ class Datacube:
                 patch_url=patch_url,
             )
 
-        if dask_chunks is not None:
+        if dask_chunks is not None and len(sources) > 0:
             return Datacube._dask_load(
                 sources,
                 geobox,
@@ -1172,6 +1174,7 @@ class Datacube:
                 extra_dims=extra_dims,
                 patch_url=patch_url,
             )
+        # Default here for empty loads
         return Datacube._xr_load(
             sources,
             geobox,

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -160,6 +160,48 @@ def test_load_data_dask(tmp_path) -> None:
     np.testing.assert_array_equal(aa, ds_data.aa.values[0, 100:228, 100:228])
 
 
+def test_load_nodata(tmp_path) -> None:
+    spatial = {
+        "resolution": (15, -15),
+        "offset": (11230, 1381110),
+    }
+
+    nodata = -999
+    aa = mk_test_image(128, 128, "int16", nodata=nodata)
+
+    ds, geobox = gen_tiff_dataset(
+        [SimpleNamespace(name="aa", values=aa, nodata=nodata)],
+        tmp_path,
+        prefix="ds1-",
+        timestamp="2018-07-19",
+        **spatial,
+    )
+
+    sources = Datacube.group_datasets([], "time")
+    mm = ds.product.measurements
+
+    expected = np.full([0, *geobox.shape], nodata, dtype=aa.dtype)
+    ds_data = Datacube.load_data(
+        sources,
+        geobox,
+        mm,
+    )  # spatial dims not equal!
+    assert ds_data.aa.nodata == nodata
+    np.testing.assert_array_equal(ds_data.aa.values, expected)
+    ds_data = Datacube.load_data(
+        sources, geobox, mm, dask_chunks={"x": 50, "y": 67}
+    )  # spatial dims not equal!
+    ds_data.compute()
+    assert ds_data.aa.nodata == nodata
+    np.testing.assert_array_equal(ds_data.aa.values, expected)
+    ds_data = Datacube.load_data(
+        sources, geobox, mm, dask_chunks={"x": 50, "y": 67}, driver = "rio",
+    )  # spatial dims not equal!
+    ds_data.compute()
+    assert ds_data.aa.nodata == nodata
+    np.testing.assert_array_equal(ds_data.aa.values, expected)
+
+
 def test_load_data_with_url_mangling(tmpdir) -> None:
     actual_tmpdir = Path(str(tmpdir))
     recorded_tmpdir = Path(str(tmpdir / "not" / "actual" / "location"))

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -195,7 +195,11 @@ def test_load_nodata(tmp_path) -> None:
     assert ds_data.aa.nodata == nodata
     np.testing.assert_array_equal(ds_data.aa.values, expected)
     ds_data = Datacube.load_data(
-        sources, geobox, mm, dask_chunks={"x": 50, "y": 67}, driver = "rio",
+        sources,
+        geobox,
+        mm,
+        dask_chunks={"x": 50, "y": 67},
+        driver="rio",
     )  # spatial dims not equal!
     ds_data.compute()
     assert ds_data.aa.nodata == nodata

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -188,9 +188,7 @@ def test_load_nodata(tmp_path) -> None:
     )
     assert ds_data.aa.nodata == nodata
     np.testing.assert_array_equal(ds_data.aa.values, expected)
-    ds_data = Datacube.load_data(
-        sources, geobox, mm, dask_chunks={"x": 50, "y": 67}
-    )
+    ds_data = Datacube.load_data(sources, geobox, mm, dask_chunks={"x": 50, "y": 67})
     ds_data.compute()
     assert ds_data.aa.nodata == nodata
     np.testing.assert_array_equal(ds_data.aa.values, expected)

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -185,12 +185,12 @@ def test_load_nodata(tmp_path) -> None:
         sources,
         geobox,
         mm,
-    )  # spatial dims not equal!
+    )
     assert ds_data.aa.nodata == nodata
     np.testing.assert_array_equal(ds_data.aa.values, expected)
     ds_data = Datacube.load_data(
         sources, geobox, mm, dask_chunks={"x": 50, "y": 67}
-    )  # spatial dims not equal!
+    )
     ds_data.compute()
     assert ds_data.aa.nodata == nodata
     np.testing.assert_array_equal(ds_data.aa.values, expected)
@@ -200,7 +200,7 @@ def test_load_nodata(tmp_path) -> None:
         mm,
         dask_chunks={"x": 50, "y": 67},
         driver="rio",
-    )  # spatial dims not equal!
+    )
     ds_data.compute()
     assert ds_data.aa.nodata == nodata
     np.testing.assert_array_equal(ds_data.aa.values, expected)


### PR DESCRIPTION
### Reason for this pull request

As reported in #2338, passing an empty source array to `Datacube.load_data` with a non-legacy loader (e.g. `driver="rio'`) raises an error.  The legacy loader by contrast returns an empty Dataset - an `xarray.Dataset` with the requested xy dimensions, coordinates,  and geobox but no time dimension (for each measurements).

Some downstream code (including datacube-ows) depend  loosely on this functionality - in any event it shouldn't raise an error.

### Proposed changes

- For a driver-based load with no sources, pass on to the legacy loader instead.
- shortcut return from the legacy loader when no sources are passed.
- Now driver loads failsafe return the same way legacy does it.

 - [x] Closes #2338
 - [x] Tests added / passed
 - [x] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2340.org.readthedocs.build/en/2340/

<!-- readthedocs-preview opendatacube end -->