### PR TITLE
Better backwards compatibility in index users api

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -982,8 +982,6 @@ class Datacube:
         data = Datacube.create_storage(
             sources.coords, geobox, measurements, extra_dims=extra_dims
         )
-        if len(sources) == 0:
-            return data
         _cbk = mk_cbk(progress_cbk)
 
         # Create a list of read IO operations
@@ -1149,7 +1147,12 @@ class Datacube:
 
         geobox = _normalise_geobox(geobox)
 
-        if not legacy_load and len(sources) > 0:
+        if len(sources) == 0:
+            return Datacube.create_storage(
+                sources.coords, geobox, measurements, extra_dims=extra_dims
+            )
+
+        if not legacy_load:
             from ..storage._loader import driver_based_load
 
             assert driver is not None  # Mypy is confused by legacy_load.
@@ -1164,7 +1167,7 @@ class Datacube:
                 patch_url=patch_url,
             )
 
-        if dask_chunks is not None and len(sources) > 0:
+        if dask_chunks is not None:
             return Datacube._dask_load(
                 sources,
                 geobox,
@@ -1174,7 +1177,6 @@ class Datacube:
                 extra_dims=extra_dims,
                 patch_url=patch_url,
             )
-        # Default here for empty loads
         return Datacube._xr_load(
             sources,
             geobox,

--- a/datacube/index/abstract/_users.py
+++ b/datacube/index/abstract/_users.py
@@ -18,7 +18,7 @@ class AbstractUserResource(ABC):
     """
 
     @abstractmethod
-    def grant_role(self, role: str, usernames: Iterable[str]) -> bool:
+    def grant_role(self, role: str, usernames: str | Iterable[str]) -> bool:
         """
         Grant a role to users
         :param role: name of the database role
@@ -40,7 +40,7 @@ class AbstractUserResource(ABC):
         """
 
     @abstractmethod
-    def delete_user(self, usernames: Iterable[str]) -> bool:
+    def delete_user(self, usernames: str | Iterable[str]) -> bool:
         """
         Delete database users
         :param usernames: usernames of users to be deleted
@@ -53,3 +53,7 @@ class AbstractUserResource(ABC):
         List all database users
         :return: Iterable of (role, username, description) tuples
         """
+
+    @staticmethod
+    def _to_str_list(sl: str | Iterable[str]) -> list[str]:
+        return [sl] if isinstance(sl, str) else list(sl)

--- a/datacube/index/abstract/_users.py
+++ b/datacube/index/abstract/_users.py
@@ -55,5 +55,5 @@ class AbstractUserResource(ABC):
         """
 
     @staticmethod
-    def _to_str_list(sl: str | Iterable[str]) -> list[str]:
-        return [sl] if isinstance(sl, str) else list(sl)
+    def _to_str_iter(sl: str | Iterable[str]) -> Iterable[str]:
+        return [sl] if isinstance(sl, str) else sl

--- a/datacube/index/memory/_users.py
+++ b/datacube/index/memory/_users.py
@@ -44,7 +44,8 @@ class UserResource(AbstractUserResource):
         }
 
     @override
-    def grant_role(self, role: str, usernames: Iterable[str]) -> bool:
+    def grant_role(self, role: str, usernames: str | Iterable[str]) -> bool:
+        usernames = self._to_str_list(usernames)
         if role not in self.roles:
             raise ValueError(f"{role} is not a known role")
         for user in usernames:
@@ -66,7 +67,8 @@ class UserResource(AbstractUserResource):
         return True
 
     @override
-    def delete_user(self, usernames: Iterable[str]) -> bool:
+    def delete_user(self, usernames: str | Iterable[str]) -> bool:
+        usernames = self._to_str_list(usernames)
         for user in usernames:
             if user in self.users:
                 del self.users[user]

--- a/datacube/index/memory/_users.py
+++ b/datacube/index/memory/_users.py
@@ -45,9 +45,9 @@ class UserResource(AbstractUserResource):
 
     @override
     def grant_role(self, role: str, usernames: str | Iterable[str]) -> bool:
-        usernames = self._to_str_iter(usernames)
         if role not in self.roles:
             raise ValueError(f"{role} is not a known role")
+        usernames = self._to_str_iter(usernames)
         for user in usernames:
             if user not in self.users:
                 raise ValueError(f"{user} is not a known username")
@@ -68,8 +68,7 @@ class UserResource(AbstractUserResource):
 
     @override
     def delete_user(self, usernames: str | Iterable[str]) -> bool:
-        usernames = self._to_str_iter(usernames)
-        for user in usernames:
+        for user in self._to_str_iter(usernames):
             if user in self.users:
                 del self.users[user]
         return True

--- a/datacube/index/memory/_users.py
+++ b/datacube/index/memory/_users.py
@@ -45,7 +45,7 @@ class UserResource(AbstractUserResource):
 
     @override
     def grant_role(self, role: str, usernames: str | Iterable[str]) -> bool:
-        usernames = self._to_str_list(usernames)
+        usernames = self._to_str_iter(usernames)
         if role not in self.roles:
             raise ValueError(f"{role} is not a known role")
         for user in usernames:
@@ -68,7 +68,7 @@ class UserResource(AbstractUserResource):
 
     @override
     def delete_user(self, usernames: str | Iterable[str]) -> bool:
-        usernames = self._to_str_list(usernames)
+        usernames = self._to_str_iter(usernames)
         for user in usernames:
             if user in self.users:
                 del self.users[user]

--- a/datacube/index/null/_users.py
+++ b/datacube/index/null/_users.py
@@ -14,7 +14,9 @@ class UserResource(AbstractUserResource):
         pass
 
     @override
-    def grant_role(self, role: str, usernames: Iterable[str]) -> bool:
+    def grant_role(self, role: str, usernames: str | Iterable[str]) -> bool:
+        if not self._to_str_list(usernames):
+            return True
         raise NotImplementedError()
 
     @override
@@ -24,8 +26,8 @@ class UserResource(AbstractUserResource):
         raise NotImplementedError()
 
     @override
-    def delete_user(self, usernames: Iterable[str]) -> bool:
-        raise NotImplementedError()
+    def delete_user(self, usernames: str | Iterable[str]) -> bool:
+        return True
 
     @override
     def list_users(self) -> Iterable[tuple[str, str, str]]:

--- a/datacube/index/null/_users.py
+++ b/datacube/index/null/_users.py
@@ -15,7 +15,7 @@ class UserResource(AbstractUserResource):
 
     @override
     def grant_role(self, role: str, usernames: str | Iterable[str]) -> bool:
-        if not self._to_str_list(usernames):
+        if not list(self._to_str_iter(usernames)):
             return True
         raise NotImplementedError()
 

--- a/datacube/index/postgis/_users.py
+++ b/datacube/index/postgis/_users.py
@@ -27,9 +27,8 @@ class UserResource(AbstractUserResource, IndexResourceAddIn):
         """
         Grant a role to users
         """
-        usernames = self._to_str_iter(usernames)
         with self._db_connection() as connection:
-            return connection.grant_role(role, usernames)
+            return connection.grant_role(role, self._to_str_iter(usernames))
 
     @override
     def create_user(
@@ -48,9 +47,8 @@ class UserResource(AbstractUserResource, IndexResourceAddIn):
         """
         Delete a user
         """
-        usernames = self._to_str_iter(usernames)
         with self._db_connection() as connection:
-            return connection.drop_users(usernames)
+            return connection.drop_users(self._to_str_iter(usernames))
 
     @override
     def list_users(self) -> Iterable[tuple[str, str, str | None]]:

--- a/datacube/index/postgis/_users.py
+++ b/datacube/index/postgis/_users.py
@@ -23,10 +23,11 @@ class UserResource(AbstractUserResource, IndexResourceAddIn):
         self._index = index
 
     @override
-    def grant_role(self, role: str, usernames: Iterable[str]) -> bool:
+    def grant_role(self, role: str, usernames: str | Iterable[str]) -> bool:
         """
         Grant a role to users
         """
+        usernames = self._to_str_list(usernames)
         with self._db_connection() as connection:
             return connection.grant_role(role, usernames)
 
@@ -43,10 +44,11 @@ class UserResource(AbstractUserResource, IndexResourceAddIn):
             )
 
     @override
-    def delete_user(self, usernames: Iterable[str]) -> bool:
+    def delete_user(self, usernames: str | Iterable[str]) -> bool:
         """
         Delete a user
         """
+        usernames = self._to_str_list(usernames)
         with self._db_connection() as connection:
             return connection.drop_users(usernames)
 

--- a/datacube/index/postgis/_users.py
+++ b/datacube/index/postgis/_users.py
@@ -27,7 +27,7 @@ class UserResource(AbstractUserResource, IndexResourceAddIn):
         """
         Grant a role to users
         """
-        usernames = self._to_str_list(usernames)
+        usernames = self._to_str_iter(usernames)
         with self._db_connection() as connection:
             return connection.grant_role(role, usernames)
 
@@ -48,7 +48,7 @@ class UserResource(AbstractUserResource, IndexResourceAddIn):
         """
         Delete a user
         """
-        usernames = self._to_str_list(usernames)
+        usernames = self._to_str_iter(usernames)
         with self._db_connection() as connection:
             return connection.drop_users(usernames)
 

--- a/datacube/index/postgres/_users.py
+++ b/datacube/index/postgres/_users.py
@@ -23,10 +23,11 @@ class UserResource(AbstractUserResource, IndexResourceAddIn):
         self._index = index
 
     @override
-    def grant_role(self, role: str, usernames: Iterable[str]) -> bool:
+    def grant_role(self, role: str, usernames: str | Iterable[str]) -> bool:
         """
         Grant a role to users
         """
+        usernames = self._to_str_list(usernames)
         with self._db_connection() as connection:
             return connection.grant_role(role, usernames)
 
@@ -43,10 +44,11 @@ class UserResource(AbstractUserResource, IndexResourceAddIn):
             )
 
     @override
-    def delete_user(self, usernames: Iterable[str]) -> bool:
+    def delete_user(self, usernames: str | Iterable[str]) -> bool:
         """
         Delete a user
         """
+        usernames = self._to_str_list(usernames)
         with self._db_connection() as connection:
             return connection.drop_users(usernames)
 

--- a/datacube/index/postgres/_users.py
+++ b/datacube/index/postgres/_users.py
@@ -27,7 +27,7 @@ class UserResource(AbstractUserResource, IndexResourceAddIn):
         """
         Grant a role to users
         """
-        usernames = self._to_str_list(usernames)
+        usernames = self._to_str_iter(usernames)
         with self._db_connection() as connection:
             return connection.grant_role(role, usernames)
 
@@ -48,7 +48,7 @@ class UserResource(AbstractUserResource, IndexResourceAddIn):
         """
         Delete a user
         """
-        usernames = self._to_str_list(usernames)
+        usernames = self._to_str_iter(usernames)
         with self._db_connection() as connection:
             return connection.drop_users(usernames)
 

--- a/datacube/index/postgres/_users.py
+++ b/datacube/index/postgres/_users.py
@@ -27,9 +27,8 @@ class UserResource(AbstractUserResource, IndexResourceAddIn):
         """
         Grant a role to users
         """
-        usernames = self._to_str_iter(usernames)
         with self._db_connection() as connection:
-            return connection.grant_role(role, usernames)
+            return connection.grant_role(role, self._to_str_iter(usernames))
 
     @override
     def create_user(
@@ -50,7 +49,7 @@ class UserResource(AbstractUserResource, IndexResourceAddIn):
         """
         usernames = self._to_str_iter(usernames)
         with self._db_connection() as connection:
-            return connection.drop_users(usernames)
+            return connection.drop_users(self._to_str_iter(usernames))
 
     @override
     def list_users(self) -> Iterable[tuple[str, str, str | None]]:

--- a/integration_tests/index/test_null_index.py
+++ b/integration_tests/index/test_null_index.py
@@ -36,10 +36,10 @@ def test_null_user_resource(null_config: ODCEnvironment) -> None:
         assert empty(dc.index.users.list_users())
         with pytest.raises(NotImplementedError):
             dc.index.users.create_user("user1", "password2", "role1")
-        with pytest.raises(NotImplementedError):
-            dc.index.users.delete_user(("user1", "user2"))
+        assert dc.index.users.delete_user(("user1", "user2"))
         with pytest.raises(NotImplementedError):
             dc.index.users.grant_role("role1", ("user1", "user2"))
+        assert dc.index.users.grant_role("role1", [])
 
 
 def test_null_metadata_types_resource(null_config: ODCEnvironment) -> None:


### PR DESCRIPTION
### Reason for this pull request

The refactor in #2334 changed the signatures of two index user resource api members, from:

```
def grant_role(self, role: str, *usernames: str) -> bool:
    ... 
def delete_user(self, *usernames: str) -> bool:
    ... 
```

to:

```
def grant_role(self, role: str, usernames: Iterable[str]) -> bool:
    ... 
def delete_user(self, usernames: Iterable[str]) -> bool:
    ... 
```

### Proposed changes

Lessen the backwards incompatibility impact by "partly reverting" from `Iterable[str]` to `str | Iterable[str]` so that calls like:

```
dc.index.delete_user(role, a_single_user)
```
don't have to change to:

```
dc.index.delete_user(role, [a_single_user])
```

Also includes a missed suggested cleanup of #2340.

 - [x] Tests added / passed
 - [x] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2341.org.readthedocs.build/en/2341/

<!-- readthedocs-preview opendatacube end -->