### PR TITLE
issue #2219  added comments to schema and role DB entries

### DIFF
--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -200,9 +200,15 @@ def ensure_db(engine: Engine, with_permissions: bool = True) -> bool:
                 # Belt and braces to cover corner cases
                 c.execute(text("grant odc_manage to odc_admin"))
                 # fill Descriptions of roles
-                c.execute("comment on role odc_admin is 'OpenDataCube Admin, used for creating roles'")
-                c.execute("comment on role odc_manage is 'OpenDataCube Manage, used for sequences and products'")
-                c.execute("comment on role odc_user is 'OpenDataCube User, used for normal select statements'")
+                c.execute(
+                    "comment on role odc_admin is 'OpenDataCube Admin, used for creating roles'"
+                )
+                c.execute(
+                    "comment on role odc_manage is 'OpenDataCube Manage, used for sequences and products'"
+                )
+                c.execute(
+                    "comment on role odc_user is 'OpenDataCube User, used for normal select statements'"
+                )
                 c.execute("comment on schema odc is 'OpenDataCube Schema'")
             c.commit()
 

--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -199,6 +199,11 @@ def ensure_db(engine: Engine, with_permissions: bool = True) -> bool:
                 c.execute(text(f"grant create on schema {SCHEMA_NAME} to odc_manage"))
                 # Belt and braces to cover corner cases
                 c.execute(text("grant odc_manage to odc_admin"))
+                # fill Descriptions of roles
+                c.execute("comment on role odc_admin is 'OpenDataCube Admin, used for creating roles'")
+                c.execute("comment on role odc_manage is 'OpenDataCube Manage, used for sequences and products'")
+                c.execute("comment on role odc_user is 'OpenDataCube User, used for normal select statements'")
+                c.execute("comment on schema odc is 'OpenDataCube Schema'")
             c.commit()
 
     return is_new


### PR DESCRIPTION
### Reason for this pull request

Description fields for ODC entries shown by \du+  and \dn+ are empty.  This PR adds descriptions.

As it turns out , "descriptions" are actually postgres comments.   

I don't see a means of running sql queries from tests/ , and I'm not sure if its worth having a test for this.  Any hints on better comments, tests, etc welcome.

 - [X ] Closes #2219  
 - [ ] Tests added / passed
 - [ X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2365.org.readthedocs.build/en/2365/

<!-- readthedocs-preview opendatacube end -->