### PR TITLE
Add spatial attributes to rio driver output to match legacy driver

### DIFF
--- a/datacube/storage/_loader.py
+++ b/datacube/storage/_loader.py
@@ -89,10 +89,11 @@ def driver_based_load(
         extra_coords=extra_coords,
     )
 
-    global_attrs = {} if geobox.crs is None else {
-        "crs": str(geobox.crs),
-        "grid_mapping": "spatial_ref"
-    }
+    global_attrs = (
+        {}
+        if geobox.crs is None
+        else {"crs": str(geobox.crs), "grid_mapping": "spatial_ref"}
+    )
     load_cfg = {
         m.name: RasterLoadParams(
             m.dtype,

--- a/datacube/storage/_loader.py
+++ b/datacube/storage/_loader.py
@@ -89,6 +89,10 @@ def driver_based_load(
         extra_coords=extra_coords,
     )
 
+    global_attrs = {} if geobox.crs is None else {
+        "crs": str(geobox.crs),
+        "grid_mapping": "spatial_ref"
+    }
     load_cfg = {
         m.name: RasterLoadParams(
             m.dtype,
@@ -96,7 +100,7 @@ def driver_based_load(
             resampling=m.get("resampling", "nearest"),
             fail_on_error=fail_on_error,
             dims=tuple(m.get("dims", ())),
-            meta=RasterBandMetadata(attrs=m.dataarray_attrs()),
+            meta=RasterBandMetadata(attrs=m.dataarray_attrs() | global_attrs),
             fuser_fqn=m.fuser,
         )
         for m in measurements

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -97,8 +97,18 @@ def test_load_data(tmpdir) -> None:
     assert ds_data.aa.nodata == nodata
     np.testing.assert_array_equal(aa, ds_data.aa.values[0])
 
+    ds_data_legacy = Datacube.load_data(
+        sources, geobox, mm, dask_chunks={}, driver="legacy"
+    )
+    assert ds_data_legacy.aa.attrs == {
+        "nodata": nodata,
+        "units": "1",
+        "crs": str(geobox.crs),
+        "grid_mapping": "spatial_ref",
+    }
+
     ds_data = Datacube.load_data(sources, geobox, mm, dask_chunks={}, driver="rio")
-    assert ds_data.aa.attrs == {"nodata": nodata, "units": "1"}
+    assert ds_data.aa.attrs == ds_data_legacy.aa.attrs
 
     # custom_fuser above cannot be used directly for driver-based loads as it is not serialisable to dask.
     with pytest.raises(ValueError):


### PR DESCRIPTION
### Reason for this pull request

Another incompatibility between legacy and rio loader drivers: spatial metadata missing.

### Proposed changes

- Add missing spatial attributes to rio driver
- Modify test to ensure that rio and legacy driver xarray attributes match exactly rather just checking a list of recognised attributes. 

 - [x] Tests added / passed
 - [x] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2369.org.readthedocs.build/en/2369/

<!-- readthedocs-preview opendatacube end -->