### PR TITLE
Handle non-UUID id strings

### DIFF
--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
-from uuid import NAMESPACE_DNS, UUID, uuid5
+from uuid import UUID, uuid5
 
 import numpy
 import toolz
@@ -43,6 +43,7 @@ try:
 except ImportError:
     from yaml import SafeLoader  # type: ignore[assignment]
 
+from datacube.metadata._eo3converter import UUID_NAMESPACE_STAC
 from datacube.utils.generic import map_with_lookahead
 from datacube.utils.uris import as_url, mk_part_uri, uri_to_local_path
 
@@ -489,8 +490,15 @@ class SimpleDocNav:
                     self._doc_uuid = (
                         doc_id if isinstance(doc_id, UUID) else UUID(doc_id)
                     )
-                except ValueError:  # don't assume the id will be a valid UUID string
-                    self._doc_uuid = uuid5(NAMESPACE_DNS, doc_id)
+                except ValueError:
+                    # mimic basic _compute_uuid logic from stac2ds conversion
+                    collection_id = self._doc.get(
+                        "collection",
+                        toolz.get_in(["properties", "odc:product"], self._doc, "_"),
+                    )
+                    self._doc_uuid = uuid5(
+                        UUID_NAMESPACE_STAC, f"{collection_id}\n{doc_id}\n"
+                    )
         return self._doc_uuid
 
     @property

--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
-from uuid import UUID
+from uuid import NAMESPACE_DNS, UUID, uuid5
 
 import numpy
 import toolz
@@ -485,7 +485,12 @@ class SimpleDocNav:
         if not self._doc_uuid:
             doc_id = self._doc.get("id", None)
             if doc_id:
-                self._doc_uuid = doc_id if isinstance(doc_id, UUID) else UUID(doc_id)
+                try:
+                    self._doc_uuid = (
+                        doc_id if isinstance(doc_id, UUID) else UUID(doc_id)
+                    )
+                except ValueError:  # don't assume the id will be a valid UUID string
+                    self._doc_uuid = uuid5(NAMESPACE_DNS, doc_id)
         return self._doc_uuid
 
     @property

--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -43,7 +43,6 @@ try:
 except ImportError:
     from yaml import SafeLoader  # type: ignore[assignment]
 
-from datacube.metadata._eo3converter import UUID_NAMESPACE_STAC
 from datacube.utils.generic import map_with_lookahead
 from datacube.utils.uris import as_url, mk_part_uri, uri_to_local_path
 
@@ -492,6 +491,8 @@ class SimpleDocNav:
                     )
                 except ValueError:
                     # mimic basic _compute_uuid logic from stac2ds conversion
+                    from datacube.metadata._eo3converter import UUID_NAMESPACE_STAC
+
                     collection_id = self._doc.get(
                         "collection",
                         toolz.get_in(["properties", "odc:product"], self._doc, "_"),


### PR DESCRIPTION
### Reason for this pull request

Now that SimpleDocNav accepts STAC document inputs, it can no longer assume that the id will be a valid UUID hex string.


### Proposed changes

- Use uuid5 to generate a deterministic UUID for `SimpleDocNav.id` if necessary



 - [x] Closes #2376
 - [ ] Tests added / passed
 - [x] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2377.org.readthedocs.build/en/2377/

<!-- readthedocs-preview opendatacube end -->