### PR TITLE
CI: update versions of actions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -43,7 +43,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install uv
-        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+        uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7.5.0
       - name: run linter
         run: |
           uv run ${LINT_COMMAND}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
         fetch-tags: true
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
     - name: Get Git commit timestamps
       run: |
@@ -48,7 +48,7 @@ jobs:
         echo "TIMESTAMP=$TIMESTAMP" >> $GITHUB_ENV
 
     - name: Build Docker
-      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
       with:
         file: docker/Dockerfile
         context: .
@@ -86,7 +86,7 @@ jobs:
         use_oidc: true
 
     - name: Install uv
-      uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+      uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7.5.0
 
     - name: Build Packages
       run: |
@@ -96,4 +96,4 @@ jobs:
     # Uses to OIDC identification between GitHub and PyPI
     - name: Upload package to PyPI on GitHub Release
       if: "github.repository_owner == 'opendatacube' && github.event.action == 'published'"
-      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -26,7 +26,7 @@ jobs:
         fetch-depth: 0
 
     - name: Run vulnerability scanner
-      uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.34.2
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
       with:
         scan-type: 'fs'
         ignore-unfixed: true
@@ -35,6 +35,6 @@ jobs:
         severity: 'MEDIUM,HIGH,CRITICAL'
 
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9
+      uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
       with:
         sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
### Reason for this pull request

We are getting a big yellow warning
about Node 20 actions being deprecated
now, so update the actions in CI
to hopefully remove the warning.


### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2380.org.readthedocs.build/en/2380/

<!-- readthedocs-preview opendatacube end -->