### PR TITLE
index/memory: avoid deprecation warnings

### DIFF
--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -290,11 +290,16 @@ class DatasetResource(AbstractDatasetResource):
     ) -> bool:
         skip_set: set[str | None] = {None}
         new_uris: list[str] = []
-        if existing and existing.uris:
-            for uri in existing.uris:
-                skip_set.add(uri)
-            if dataset.uris:
+        if existing:
+            if existing.has_multiple_uris():
+                for uri in existing.uris:
+                    skip_set.add(uri)
+            else:
+                skip_set.add(dataset.uri)
+            if dataset.has_multiple_uris():
                 new_uris = [uri for uri in dataset.uris if uri not in skip_set]
+            elif dataset.uri is not None:
+                new_uris = [dataset.uri]
         if len(new_uris):
             _LOG.info(
                 "Adding locations for dataset %s: %s", dataset.id, ", ".join(new_uris)


### PR DESCRIPTION
### Reason for this pull request

This reduces the number of deprecation
warnings triggered by the memory
index.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2383.org.readthedocs.build/en/2383/

<!-- readthedocs-preview opendatacube end -->