### PR TITLE
drivers/postgres: Fix argument order in during transfer ownership upgrades.

### DIFF
--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -281,10 +281,10 @@ def update_schema(engine: Engine, with_permissions: bool) -> None:
         if with_permissions:
             # ensure tables are all owned by agdc_admin
             transfers = transfers_required(
-                connection,
-                "agdc_admin",
-                SCHEMA_NAME,
-                "tables",
+                conn=connection,
+                new_owner="agdc_admin",
+                schema=SCHEMA_NAME,
+                object_type="tables",
                 objects=[
                     "metadata_type",
                     "dataset_type",
@@ -296,31 +296,31 @@ def update_schema(engine: Engine, with_permissions: bool) -> None:
             if transfers:
                 for table, current_owner in transfers:
                     transfer_ownership(
-                        connection,
-                        SCHEMA_NAME,
-                        table,
-                        current_owner,
-                        "agdc_admin",
-                        "tables",
+                        conn=connection,
+                        schema=SCHEMA_NAME,
+                        obj_name=table,
+                        current_owner=current_owner,
+                        new_owner="agdc_admin",
+                        object_type="tables",
                     )
 
             # ensure dynamic views are all owned by agdc_manage
             transfers = transfers_required(
-                connection,
-                "agdc_manage",
-                SCHEMA_NAME,
-                "views",
+                conn=connection,
+                new_owner="agdc_manage",
+                schema=SCHEMA_NAME,
+                object_type="views",
                 prefix="dv_",
             )
             if transfers:
                 for view, current_owner in transfers:
                     transfer_ownership(
-                        connection,
-                        SCHEMA_NAME,
-                        view,
-                        current_owner,
-                        "agdc_manage",
-                        "views",
+                        conn=connection,
+                        schema=SCHEMA_NAME,
+                        obj_name=view,
+                        current_owner=current_owner,
+                        new_owner="agdc_manage",
+                        object_type="views",
                     )
 
         if not pg_column_exists(connection, "dataset", "updated"):

--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -297,10 +297,10 @@ def update_schema(engine: Engine, with_permissions: bool) -> None:
                 for table, current_owner in transfers:
                     transfer_ownership(
                         connection,
-                        "agdc_admin",
                         SCHEMA_NAME,
                         table,
                         current_owner,
+                        "agdc_admin",
                         "tables",
                     )
 
@@ -316,10 +316,10 @@ def update_schema(engine: Engine, with_permissions: bool) -> None:
                 for view, current_owner in transfers:
                     transfer_ownership(
                         connection,
-                        "agdc_manage",
                         SCHEMA_NAME,
                         view,
                         current_owner,
+                        "agdc_manage",
                         "views",
                     )
 


### PR DESCRIPTION
### Reason for this pull request

Ownership transfers were not being handled correctly by system init in the postgres driver.


### Proposed changes

- ~~Fix argument order whenever calling transfer_ownership~~ switch to named arguments for transfer_ownership and transfers_required.

 - [x] Tests added / passed
 - [x] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2398.org.readthedocs.build/en/2398/

<!-- readthedocs-preview opendatacube end -->