### PR TITLE
Replace custom cached_property with stdlib

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -1352,11 +1352,12 @@ def select_datasets_inside_polygon(
     # Check against the bounding box of the original scene, can throw away some portions
     # (Only needed for index drivers without spatial index support)
     query_crs = polygon.crs
-    for dataset in datasets:
-        if dataset.extent and intersects(
-            polygon, dataset.extent.to_crs(query_crs, resolution="auto")
-        ):
-            yield dataset
+    if query_crs is not None:
+        for dataset in datasets:
+            if dataset.extent and intersects(
+                polygon, dataset.extent.to_crs(query_crs, resolution="auto")
+            ):
+                yield dataset
 
 
 def fuse_lazy(

--- a/datacube/drivers/postgis/_fields.py
+++ b/datacube/drivers/postgis/_fields.py
@@ -11,6 +11,7 @@ from collections import namedtuple
 from collections.abc import Callable, Sequence
 from datetime import date, datetime, timezone
 from decimal import Decimal
+from functools import cached_property
 from typing import Any, TypeAlias
 
 from sqlalchemy import and_, cast, func
@@ -26,7 +27,7 @@ from datacube import utils
 from datacube.drivers.postgis._schema import Dataset, search_field_index_map
 from datacube.model import Range
 from datacube.model.fields import _AVAILABLE_TYPES, Expression, Field
-from datacube.utils import cached_property, get_doc_offset, parse_time
+from datacube.utils import get_doc_offset, parse_time
 from datacube.utils.changes import Offset
 from datacube.utils.dates import tz_as_utc
 
@@ -86,8 +87,8 @@ class PgField(Field):
             return (
                 self.search_index_table,
                 and_(
-                    Dataset.id == self.search_index_table.dataset_ref,
-                    self.search_index_table.search_key == self.name,
+                    Dataset.id == self.search_index_table.dataset_ref,  # type: ignore[attr-defined]
+                    self.search_index_table.search_key == self.name,  # type: ignore[attr-defined]
                 ),
             )
         return (self.search_index_table,)
@@ -103,7 +104,7 @@ class PgField(Field):
     @property
     def search_alchemy_expression(self) -> ColumnExpressionArgument:
         if self.indexed:
-            return self.search_index_table.search_val
+            return self.search_index_table.search_val  # type: ignore[attr-defined]
         return self.alchemy_expression
 
     @property

--- a/datacube/index/abstract/_index.py
+++ b/datacube/index/abstract/_index.py
@@ -5,6 +5,7 @@
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping, Sequence
+from functools import cached_property
 from urllib.parse import ParseResult, urlparse
 
 from deprecat import deprecat
@@ -13,7 +14,7 @@ from odc.geo import CRS
 from datacube.cfg import ODCEnvironment, ODCOptionHandler
 from datacube.migration import ODC2DeprecationWarning
 from datacube.model import Field, MetadataType
-from datacube.utils import cached_property, report_to_user
+from datacube.utils import report_to_user
 from datacube.utils.generic import thread_local_cache
 from datacube.utils.json_types import JsonDict
 

--- a/datacube/index/abstract/_types.py
+++ b/datacube/index/abstract/_types.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 from collections.abc import Iterable, Sequence
+from functools import cached_property
 from typing import Literal, NamedTuple, TypeAlias
 from uuid import UUID
 
@@ -10,7 +11,6 @@ from deprecat import deprecat
 
 from datacube.migration import ODC2DeprecationWarning
 from datacube.model import Dataset, Product
-from datacube.utils import cached_property
 from datacube.utils.documents import JsonDict
 
 

--- a/datacube/index/eo3.py
+++ b/datacube/index/eo3.py
@@ -25,7 +25,7 @@ from odc.geo.geom import lonlat_bounds, multipolygon, polygon
 from odc.stac._mdtools import _group_geoboxes
 from toolz.dicttoolz import get_in
 
-from datacube.model import Dataset, Product, Range
+from datacube.model import Dataset, GridSpec, Product, Range
 from datacube.storage import BandInfo
 from datacube.storage._rio import RasterDatasetDataSource
 from datacube.utils import DatacubeException, DocReader
@@ -474,14 +474,11 @@ def make_grids(
                     },
                     None,
                 )
-            elif ds.product.grid_spec:
-                # assumes we'll get a legacy GridSpec since we're dealing with legacy datasets
+            elif (gs := ds.product.grid_spec) and isinstance(gs, GridSpec):
+                # Legacy GridSpec since we're dealing with legacy datasets.
                 shape, transform = _shape_and_transform(
                     ref_points,
-                    {
-                        "x": ds.product.grid_spec.resolution[1],
-                        "y": ds.product.grid_spec.resolution[0],
-                    },
+                    {"x": gs.resolution[1], "y": gs.resolution[0]},
                     None,
                 )
             else:

--- a/datacube/metadata/_stacconverter.py
+++ b/datacube/metadata/_stacconverter.py
@@ -229,7 +229,7 @@ def ds2stac(
         datetime=dt,
         properties=properties,
         geometry=geometry,
-        bbox=bbox,
+        bbox=None if bbox is None else list(bbox),
         collection=dataset.product.name,
     )
 

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -14,6 +14,7 @@ import warnings
 from collections import OrderedDict
 from collections.abc import Callable, Generator, Iterable, Iterator, Mapping, Sequence
 from datetime import datetime
+from functools import cached_property
 from pathlib import Path
 from typing import Any, TypeAlias
 from urllib.parse import urlparse
@@ -25,7 +26,6 @@ from typing_extensions import override
 
 from datacube.utils import (
     DocReader,
-    cached_property,
     parse_time,
     schema_validated,
     uri_to_local_path,

--- a/datacube/utils/__init__.py
+++ b/datacube/utils/__init__.py
@@ -30,7 +30,7 @@ from .math import (
     unsqueeze_data_array,
     unsqueeze_dataset,
 )
-from .py import cached_property, ignore_exceptions_if, import_function
+from .py import ignore_exceptions_if, import_function
 from .serialise import jsonify_document
 from .uris import get_part_from_uri, is_url, is_vsipath, mk_part_uri, uri_to_local_path
 
@@ -41,7 +41,6 @@ __all__ = [
     "NoDatesSafeLoader",
     "SimpleDocNav",
     "_readable_offset",
-    "cached_property",
     "check_write_path",
     "gen_password",
     "get_doc_offset",

--- a/datacube/utils/py.py
+++ b/datacube/utils/py.py
@@ -8,6 +8,9 @@ from collections.abc import Callable, Mapping
 from contextlib import contextmanager
 
 import toolz
+from deprecat import deprecat
+
+from datacube.migration import ODC2DeprecationWarning
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -46,6 +49,12 @@ def ignore_exceptions_if(
         yield
 
 
+@deprecat(
+    reason="This class has been deprecated. Please use cached_property from "
+    "functools instead.",
+    version="1.9.18",
+    category=ODC2DeprecationWarning,
+)
 class cached_property:  # pylint: disable=invalid-name  # noqa: N801
     """
     A property that is only computed once per instance and then replaces

--- a/tests/test_eo3.py
+++ b/tests/test_eo3.py
@@ -401,7 +401,9 @@ def test_eo1_dataset_conversion(
     assert compat_ds.is_eo3
     assert compat_ds.properties
     assert compat_ds.accessories
-    assert compat_ds.properties["datetime"] == compat_ds.center_time.strftime(
+    compat_ds_center_time = compat_ds.center_time
+    assert compat_ds_center_time is not None
+    assert compat_ds.properties["datetime"] == compat_ds_center_time.strftime(
         "%Y-%m-%d %H:%M:%S"
     )
     assert compat_ds.metadata_doc["lineage"]["source_datasets"] == {

--- a/tests/test_eo3converter.py
+++ b/tests/test_eo3converter.py
@@ -391,7 +391,11 @@ def test_roundtrip(eo3_dataset: Dataset, eo3_product: Product) -> None:
     )
 
     assert roundtrip.crs == original.crs
-    assert roundtrip.extent.area == pytest.approx(original.extent.area, abs=0.001)
+    roundtrip_extent = roundtrip.extent
+    assert roundtrip_extent is not None
+    original_extent = original.extent
+    assert original_extent is not None
+    assert roundtrip_extent.area == pytest.approx(original_extent.area, abs=0.001)
     assert all(
         x == pytest.approx(y)
         for x, y in zip(


### PR DESCRIPTION
### Reason for this pull request

Cherry-pick @omad's commit from #1866 and update it for the latest develop branch so we get improved type checking into the tree.

Since Python 3.8 there's functools.cached_property, which works the same way, but also passes type information through.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2406.org.readthedocs.build/en/2406/

<!-- readthedocs-preview opendatacube end -->