### PR TITLE
dataset: add a --workers parameter

### DIFF
--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -6,6 +6,7 @@ import csv
 import datetime
 import json
 import logging
+import multiprocessing
 import sys
 import uuid
 from collections import OrderedDict
@@ -154,6 +155,11 @@ def _mk_dataset_tuples(dss: Iterable[Dataset]) -> Generator[DatasetTuple]:
         yield DatasetTuple(ds.product, ds.metadata_doc, my_uris)
 
 
+# Needs to be top level definition so it can be pickled.
+def _ui_path_doc_stream(p: str | Path) -> list[tuple[str, SimpleDocNav]]:
+    return list(ui_path_doc_stream([p], logger=_LOG, uri=True))
+
+
 @dataset_cmd.command(
     "add",
     help="Add datasets to the Data Cube",
@@ -219,6 +225,9 @@ def _mk_dataset_tuples(dss: Iterable[Dataset]) -> Generator[DatasetTuple]:
     is_flag=True,
     default=False,
 )
+@click.option(
+    "--workers", default=1, type=int, help="Number of workers to use, default 1"
+)
 @click.argument("dataset-paths", type=str, nargs=-1)
 @ui.pass_index()
 def index_cmd(
@@ -231,6 +240,7 @@ def index_cmd(
     ignore_lineage: bool,
     archive_less_mature: bool,
     dataset_paths: list[str],
+    workers: int,
 ) -> None:
     if not dataset_paths:
         echo("Error: no datasets provided\n", err=True)
@@ -253,7 +263,21 @@ def index_cmd(
     with click.progressbar(
         dataset_paths, label="Indexing datasets", file=sys.stdout
     ) as pp:
-        doc_stream = ui_path_doc_stream(pp, logger=_LOG, uri=True)
+        doc_stream: list[tuple[str, SimpleDocNav]] | Generator[tuple[str, SimpleDocNav]]
+        if workers > 1:
+            doc_stream = []
+            # Shut down pool nicely to keep pytest-cov happy.
+            # https://pytest-cov.readthedocs.io/en/latest/subprocess-support.html#if-you-use-multiprocessing-pool
+            pool = multiprocessing.Pool(workers)
+            try:
+                results = [pool.apply_async(_ui_path_doc_stream, (p,)) for p in pp]
+                for res in results:
+                    doc_stream.extend(res.get())
+            finally:
+                pool.close()
+                pool.join()
+        else:
+            doc_stream = ui_path_doc_stream(pp, logger=_LOG, uri=True)
         index_datasets(
             dataset_stream(remap_uri_from_doc(doc_stream), ds_resolve),
             index,

--- a/integration_tests/test_dataset_add.py
+++ b/integration_tests/test_dataset_add.py
@@ -360,6 +360,9 @@ def test_dataset_add_stac(index, clirunner, ls8_stac_doc, eo3_products) -> None:
     ds, err = doc2ds(stac_doc, "file://something")
     assert err is not None
 
+    r = clirunner(["-v", "dataset", "add", "--workers", "2", path])
+    assert r.exit_code == 0, f"Output: {r.output}"
+
 
 # Current formulation of this test relies on non-EO3 test data
 @pytest.mark.parametrize("datacube_env_name", ("datacube", "datacube3"))


### PR DESCRIPTION
### Reason for this pull request

Add a --workers parameter that
reads dataset files in parallel.
This speeds up adding datasets
from remote storage such as S3
by quite a bit.


### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2409.org.readthedocs.build/en/2409/

<!-- readthedocs-preview opendatacube end -->