### PR TITLE
Postgis driver: Always use "as_role" for controlling active role.

### DIFF
--- a/datacube/drivers/postgis/_spatial.py
+++ b/datacube/drivers/postgis/_spatial.py
@@ -155,14 +155,13 @@ def ensure_spindex(
             # SpatialIndexRecord exists - actual index assumed to exist too.
             return
         role = "odc_admin" if with_permissions else None
-        with as_role(conn, role) as conn:
-            session = Session(conn)
+        with as_role(conn, role) as conn, Session(conn) as session:
             # SpatialIndexRecord doesn't exist - create the index table...
             orm_registry.metadata.create_all(engine, [sp_idx.__table__])  # type: ignore[attr-defined]
             # ... and add a SpatialIndexRecord
             session.add(SpatialIndexRecord(srid=crs_id, table_name=sp_idx.__tablename__))  # type: ignore[attr-defined]
             session.commit()
-            session.flush()
+
             if with_permissions:
                 for command in [
                     # Read access to odc_user

--- a/datacube/drivers/postgis/_spatial.py
+++ b/datacube/drivers/postgis/_spatial.py
@@ -155,14 +155,15 @@ def ensure_spindex(
             # SpatialIndexRecord exists - actual index assumed to exist too.
             return
         role = "odc_admin" if with_permissions else None
-        with as_role(conn, role) as conn, Session(conn) as session:
+        with as_role(conn, role) as conn:
             # SpatialIndexRecord doesn't exist - create the index table...
-            orm_registry.metadata.create_all(engine, [sp_idx.__table__])  # type: ignore[attr-defined]
-            # ... and add a SpatialIndexRecord
-            session.add(
-                SpatialIndexRecord(srid=crs_id, table_name=sp_idx.__tablename__)  # type: ignore[attr-defined]
-            )
-            session.commit()
+            orm_registry.metadata.create_all(conn, [sp_idx.__table__])  # type: ignore[attr-defined]
+            with Session(conn) as session:
+                # ... and add a SpatialIndexRecord
+                session.add(
+                    SpatialIndexRecord(srid=crs_id, table_name=sp_idx.__tablename__)  # type: ignore[attr-defined]
+                )
+                session.commit()
 
             if with_permissions:
                 for command in [
@@ -173,9 +174,9 @@ def ensure_spindex(
                     # Full access to odc_admin
                     f"grant all on {SCHEMA_NAME}.{sp_idx.__tablename__} to odc_admin;",  # type: ignore[attr-defined]
                 ]:
-                    session.execute(text(command))
+                    conn.execute(text(command))
                 # Grant statements in PostgreSQL behave like transactions, so commit them.
-                session.commit()
+                conn.commit()
 
 
 def drop_spindex(engine: Engine, sp_idx: type[SpatialIndex], crs_id: int) -> bool:

--- a/datacube/drivers/postgis/_spatial.py
+++ b/datacube/drivers/postgis/_spatial.py
@@ -160,8 +160,8 @@ def ensure_spindex(
             orm_registry.metadata.create_all(engine, [sp_idx.__table__])  # type: ignore[attr-defined]
             # ... and add a SpatialIndexRecord
             session.add(
-                SpatialIndexRecord(srid=crs_id, table_name=sp_idx.__tablename__)
-            )  # type: ignore[attr-defined]
+                SpatialIndexRecord(srid=crs_id, table_name=sp_idx.__tablename__)  # type: ignore[attr-defined]
+            )
             session.commit()
 
             if with_permissions:

--- a/datacube/drivers/postgis/_spatial.py
+++ b/datacube/drivers/postgis/_spatial.py
@@ -24,6 +24,7 @@ from sqlalchemy.sql.ddl import DropTable
 from ._core import METADATA, get_connection_info
 from ._schema import Base, Dataset, SpatialIndex, SpatialIndexRecord, orm_registry
 from .sql import SCHEMA_NAME
+from ..common_psql import as_role
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -146,36 +147,34 @@ def ensure_spindex(
     engine: Engine, sp_idx: type[SpatialIndex], crs_id: int, with_permissions: bool
 ) -> None:
     """Ensure a Spatial Index exists in a particular database."""
-    with Session(engine) as session:
-        results = session.execute(
+    with engine.connect() as conn:
+        results = Session(conn).execute(
             select(SpatialIndexRecord.srid).where(SpatialIndexRecord.srid == crs_id)
         )
         for _ in results:
             # SpatialIndexRecord exists - actual index assumed to exist too.
             return
-        _, quoted_user = get_connection_info(session.connection())
-        if with_permissions:
-            session.execute(text("set role odc_admin"))
+        role = "odc_admin" if with_permissions else None
+        with as_role(conn, role) as conn:
+            session = Session(conn)
+            # SpatialIndexRecord doesn't exist - create the index table...
+            orm_registry.metadata.create_all(engine, [sp_idx.__table__])  # type: ignore[attr-defined]
+            # ... and add a SpatialIndexRecord
+            session.add(SpatialIndexRecord(srid=crs_id, table_name=sp_idx.__tablename__))  # type: ignore[attr-defined]
             session.commit()
-        # SpatialIndexRecord doesn't exist - create the index table...
-        orm_registry.metadata.create_all(engine, [sp_idx.__table__])  # type: ignore[attr-defined]
-        # ... and add a SpatialIndexRecord
-        session.add(SpatialIndexRecord(srid=crs_id, table_name=sp_idx.__tablename__))  # type: ignore[attr-defined]
-        session.commit()
-        session.flush()
-        if with_permissions:
-            for command in [
-                # Read access to odc_user
-                f"grant select on {SCHEMA_NAME}.{sp_idx.__tablename__} to odc_user;",  # type: ignore[attr-defined]
-                # Insert access to odc_manage
-                f"grant insert on {SCHEMA_NAME}.{sp_idx.__tablename__} to odc_manage;",  # type: ignore[attr-defined]
-                # Full access to odc_admin
-                f"grant all on {SCHEMA_NAME}.{sp_idx.__tablename__} to odc_admin;",  # type: ignore[attr-defined]
-            ]:
-                session.execute(text(command))
-            session.execute(text(f"set role {quoted_user}"))
-            # Grant statements in PostgreSQL behave like transactions, so commit them.
-            session.commit()
+            session.flush()
+            if with_permissions:
+                for command in [
+                    # Read access to odc_user
+                    f"grant select on {SCHEMA_NAME}.{sp_idx.__tablename__} to odc_user;",  # type: ignore[attr-defined]
+                    # Insert access to odc_manage
+                    f"grant insert on {SCHEMA_NAME}.{sp_idx.__tablename__} to odc_manage;",  # type: ignore[attr-defined]
+                    # Full access to odc_admin
+                    f"grant all on {SCHEMA_NAME}.{sp_idx.__tablename__} to odc_admin;",  # type: ignore[attr-defined]
+                ]:
+                    session.execute(text(command))
+                # Grant statements in PostgreSQL behave like transactions, so commit them.
+                session.commit()
 
 
 def drop_spindex(engine: Engine, sp_idx: type[SpatialIndex], crs_id: int) -> bool:

--- a/datacube/drivers/postgis/_spatial.py
+++ b/datacube/drivers/postgis/_spatial.py
@@ -147,23 +147,22 @@ def ensure_spindex(
     engine: Engine, sp_idx: type[SpatialIndex], crs_id: int, with_permissions: bool
 ) -> None:
     """Ensure a Spatial Index exists in a particular database."""
-    with engine.connect() as conn:
-        results = Session(conn).execute(
+    with engine.connect() as conn, Session(conn) as session:
+        results = session.execute(
             select(SpatialIndexRecord.srid).where(SpatialIndexRecord.srid == crs_id)
         )
         for _ in results:
             # SpatialIndexRecord exists - actual index assumed to exist too.
             return
         role = "odc_admin" if with_permissions else None
-        with as_role(conn, role) as conn:
+        with as_role(session.connection(), role):
             # SpatialIndexRecord doesn't exist - create the index table...
             orm_registry.metadata.create_all(conn, [sp_idx.__table__])  # type: ignore[attr-defined]
-            with Session(conn) as session:
-                # ... and add a SpatialIndexRecord
-                session.add(
-                    SpatialIndexRecord(srid=crs_id, table_name=sp_idx.__tablename__)  # type: ignore[attr-defined]
-                )
-                session.commit()
+            # ... and add a SpatialIndexRecord
+            session.add(
+                SpatialIndexRecord(srid=crs_id, table_name=sp_idx.__tablename__)  # type: ignore[attr-defined]
+            )
+            session.commit()
 
             if with_permissions:
                 for command in [
@@ -174,9 +173,9 @@ def ensure_spindex(
                     # Full access to odc_admin
                     f"grant all on {SCHEMA_NAME}.{sp_idx.__tablename__} to odc_admin;",  # type: ignore[attr-defined]
                 ]:
-                    conn.execute(text(command))
+                    session.execute(text(command))
                 # Grant statements in PostgreSQL behave like transactions, so commit them.
-                conn.commit()
+                session.commit()
 
 
 def drop_spindex(engine: Engine, sp_idx: type[SpatialIndex], crs_id: int) -> bool:

--- a/datacube/drivers/postgis/_spatial.py
+++ b/datacube/drivers/postgis/_spatial.py
@@ -21,10 +21,10 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, mapped_column
 from sqlalchemy.sql.ddl import DropTable
 
-from ._core import METADATA, get_connection_info
+from ..common_psql import as_role
+from ._core import METADATA
 from ._schema import Base, Dataset, SpatialIndex, SpatialIndexRecord, orm_registry
 from .sql import SCHEMA_NAME
-from ..common_psql import as_role
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -159,7 +159,9 @@ def ensure_spindex(
             # SpatialIndexRecord doesn't exist - create the index table...
             orm_registry.metadata.create_all(engine, [sp_idx.__table__])  # type: ignore[attr-defined]
             # ... and add a SpatialIndexRecord
-            session.add(SpatialIndexRecord(srid=crs_id, table_name=sp_idx.__tablename__))  # type: ignore[attr-defined]
+            session.add(
+                SpatialIndexRecord(srid=crs_id, table_name=sp_idx.__tablename__)
+            )  # type: ignore[attr-defined]
             session.commit()
 
             if with_permissions:

--- a/datacube/drivers/postgres/_dynamic.py
+++ b/datacube/drivers/postgres/_dynamic.py
@@ -13,6 +13,7 @@ from sqlalchemy import Index, select, text
 from sqlalchemy.engine.base import Connection, Engine
 from sqlalchemy.engine.mock import MockConnection
 
+from datacube.drivers.common_psql import as_role
 from datacube.drivers.postgres._fields import PgField
 
 from ._core import get_connection_info, schema_qualified
@@ -46,35 +47,36 @@ def _ensure_view(
     # 'dv_' prefix: dynamic view. To distinguish from views that are created as part of the schema itself.
     view_name = schema_qualified(f"dv_{name}_dataset")
     exists = pg_exists(conn, view_name)
-    # This currently leaves a window of time without the views: it's primarily intended for development.
-    if exists and replace_existing:
-        _LOG.debug("Dropping view: %s (replace=%r)", view_name, replace_existing)
-        conn.execute(text(f"drop view {view_name}"))
-        exists = False
-    if not exists:
-        _LOG.debug("Creating view: %s", view_name)
-        select_fields = [
-            field.alchemy_expression.label(field.name)
-            for field in fields.values()
-            if not field.affects_row_selection
-        ]
-        conn.execute(
-            CreateView(
-                view_name,
-                select(*select_fields)
-                .select_from(DATASET.join(PRODUCT).join(METADATA_TYPE))
-                .where(where_expression),
+    with as_role(conn, "agdc_manage"):
+        # This currently leaves a window of time without the views: it's primarily intended for development.
+        if exists and replace_existing:
+            _LOG.debug("Dropping view: %s (replace=%r)", view_name, replace_existing)
+            conn.execute(text(f"drop view {view_name}"))
+            exists = False
+        if not exists:
+            _LOG.debug("Creating view: %s", view_name)
+            select_fields = [
+                field.alchemy_expression.label(field.name)
+                for field in fields.values()
+                if not field.affects_row_selection
+            ]
+            conn.execute(
+                CreateView(
+                    view_name,
+                    select(*select_fields)
+                    .select_from(DATASET.join(PRODUCT).join(METADATA_TYPE))
+                    .where(where_expression),
+                )
             )
-        )
-    elif exists and delete:
-        _LOG.debug(f"Dropping view: {view_name}")
-        conn.execute(text(f"drop view {view_name}"))
-    else:
-        _LOG.debug("View exists: %s (replace=%r)", view_name, replace_existing)
-    legacy_name = schema_qualified(f"{name}_dataset")
-    if pg_exists(conn, legacy_name):
-        _LOG.debug("Dropping legacy view: %s", legacy_name)
-        conn.execute(text(f"drop view {legacy_name}"))
+        elif exists and delete:
+            _LOG.debug(f"Dropping view: {view_name}")
+            conn.execute(text(f"drop view {view_name}"))
+        else:
+            _LOG.debug("View exists: %s (replace=%r)", view_name, replace_existing)
+        legacy_name = schema_qualified(f"{name}_dataset")
+        if pg_exists(conn, legacy_name):
+            _LOG.debug("Dropping legacy view: %s", legacy_name)
+            conn.execute(text(f"drop view {legacy_name}"))
 
 
 def check_dynamic_fields(
@@ -91,52 +93,49 @@ def check_dynamic_fields(
     """
     Check that we have expected indexes and views for the given fields
     """
-    _, user = get_connection_info(conn)
-    conn.execute(text("set role agdc_admin"))
-    # If this type has time/space fields, create composite indexes (as they are often searched together)
-    # We will probably move these into product configuration in the future.
-    composite_indexes = (
-        ("lat", "lon", "time"),
-        ("time", "lat", "lon"),
-        ("sat_path", "sat_row", "time"),
-    )
+    with as_role(conn, "agdc_admin"):
+        # If this type has time/space fields, create composite indexes (as they are often searched together)
+        # We will probably move these into product configuration in the future.
+        composite_indexes = (
+            ("lat", "lon", "time"),
+            ("time", "lat", "lon"),
+            ("sat_path", "sat_row", "time"),
+        )
 
-    all_exclusions = tuple(excluded_field_names)
-    for composite_names in composite_indexes:
-        # If all of the fields are available in this product, we'll create a composite index
-        # for them instead of individual indexes.
-        if contains_all(fields, *composite_names):
-            all_are_excluded = set(excluded_field_names) >= set(composite_names)
+        all_exclusions = tuple(excluded_field_names)
+        for composite_names in composite_indexes:
+            # If all of the fields are available in this product, we'll create a composite index
+            # for them instead of individual indexes.
+            if contains_all(fields, *composite_names):
+                all_are_excluded = set(excluded_field_names) >= set(composite_names)
+                _check_field_index(
+                    conn,
+                    [fields.get(f) for f in composite_names],
+                    name,
+                    dataset_filter,
+                    concurrently=concurrently,
+                    replace_existing=rebuild_indexes,
+                    # If all fields were excluded individually it should be removed.
+                    should_exist=not all_are_excluded,
+                    index_type="gist",
+                )
+                all_exclusions += composite_names
+
+        # Create indexes for the individual fields.
+        for field in fields.values():
+            if not field.postgres_index_type:
+                continue
             _check_field_index(
                 conn,
-                [fields.get(f) for f in composite_names],
+                [field],
                 name,
                 dataset_filter,
+                should_exist=field.indexed and (field.name not in all_exclusions),
                 concurrently=concurrently,
                 replace_existing=rebuild_indexes,
-                # If all fields were excluded individually it should be removed.
-                should_exist=not all_are_excluded,
-                index_type="gist",
             )
-            all_exclusions += composite_names
-
-    # Create indexes for the individual fields.
-    for field in fields.values():
-        if not field.postgres_index_type:
-            continue
-        _check_field_index(
-            conn,
-            [field],
-            name,
-            dataset_filter,
-            should_exist=field.indexed and (field.name not in all_exclusions),
-            concurrently=concurrently,
-            replace_existing=rebuild_indexes,
-        )
     # A view of all fields
-    conn.execute(text("set role agdc_manage"))
     _ensure_view(conn, fields, name, rebuild_view, dataset_filter, delete_view)
-    conn.execute(text(f"set role {user}"))
 
 
 def _check_field_index(

--- a/datacube/drivers/postgres/_dynamic.py
+++ b/datacube/drivers/postgres/_dynamic.py
@@ -16,7 +16,7 @@ from sqlalchemy.engine.mock import MockConnection
 from datacube.drivers.common_psql import as_role
 from datacube.drivers.postgres._fields import PgField
 
-from ._core import get_connection_info, schema_qualified
+from ._core import schema_qualified
 from ._schema import DATASET, METADATA_TYPE, PRODUCT
 from .sql import CreateView, pg_exists
 


### PR DESCRIPTION
### Reason for this pull request

Remove literal use of 'set role' and replace with common_psql tools `as_role` in postgis driver.

 - [x] Tests added / passed
 - [x] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2410.org.readthedocs.build/en/2410/

<!-- readthedocs-preview opendatacube end -->