### PR TITLE
user: add --passwd-stdin

### DIFF
--- a/datacube/scripts/user.py
+++ b/datacube/scripts/user.py
@@ -7,6 +7,7 @@ import logging
 import sys
 from collections import OrderedDict
 from collections.abc import Iterable, Sequence
+from getpass import getpass
 
 import click
 import yaml
@@ -108,6 +109,9 @@ def grant(index: Index, role: str, users: Sequence[str]) -> None:
 @click.argument("role", type=click.Choice(USER_ROLES), nargs=1)
 @click.argument("user", nargs=1)
 @click.option("--description")
+@click.option(
+    "--passwd-stdin", is_flag=True, default=False, help="Read user password from stdin"
+)
 @ui.pass_index()
 @ui.pass_config
 def create_user(
@@ -116,11 +120,22 @@ def create_user(
     role: str,
     user: str,
     description: str,
+    passwd_stdin: bool,
 ) -> None:
     """
     Create a User
     """
-    password = gen_password(12)
+    if passwd_stdin:
+        if sys.stdin.isatty():
+            password = getpass()
+            second_password = getpass("Confirm password: ")
+            if password != second_password:
+                click.echo("ERROR: Passwords do not match", err=True)
+                sys.exit(1)
+        else:
+            password = sys.stdin.read().rstrip()
+    else:
+        password = gen_password(12)
     result = index.users.create_user(user, password, role, description=description)
 
     if result:
@@ -129,7 +144,7 @@ def create_user(
                 host=index.url_parts.hostname or "localhost",
                 port=index.url_parts.port,
                 username=user,
-                password=password,
+                password="password taken from stdin" if passwd_stdin else password,
             )
         )
     else:

--- a/docs/source/installation/database/setup.rst
+++ b/docs/source/installation/database/setup.rst
@@ -211,10 +211,13 @@ ODC users are simply postgres users that have been granted one of the roles disc
 above.  Users can be created and role memberships maintained using conventional
 Postgresql tools, but Datacube does provide some basic user management tools::
 
-   datacube user create {user|manage|admin} USER
+   datacube user create {user|manage|admin} USER [--passwd-stdin]
 
-creates a new login user with the selected permissions - the password for the new user
-is written to stdout.
+creates a new login user with the selected permissions. The password for the new user
+is written to stdout unless a password is provided through the ``--passwd-stdin``
+parameter::
+
+   echo "$PASSWORD_VAR" | datacube user create {user|manage|admin} USER --passwd-stdin
 
 Permissions for an existing user (or users) can be adjusted using::
 

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -1022,6 +1022,7 @@ def clirunner(datacube_env_name: str):
         skip_env: bool = False,
         skip_config_paths: bool = False,
         verbose_flag: Literal[False] | str = "-v",
+        stdin_input: str | None = None,
     ) -> Result:
         # If raw config passed in, skip default test config
         exe_opts: list[str] = (
@@ -1036,7 +1037,7 @@ def clirunner(datacube_env_name: str):
         exe_opts.extend(opts)
 
         result = CliRunner().invoke(
-            cli_method, exe_opts, catch_exceptions=catch_exceptions
+            cli_method, exe_opts, input=stdin_input, catch_exceptions=catch_exceptions
         )
         if expect_success:
             assert result.exit_code == 0, (

--- a/integration_tests/test_config_tool.py
+++ b/integration_tests/test_config_tool.py
@@ -275,6 +275,22 @@ def test_user_creation(clirunner, example_user) -> None:
     assert_no_user(clirunner, username)
 
 
+@pytest.mark.parametrize("db_tz", ("UTC",), indirect=True)
+def test_user_creation_passwd_stdin(clirunner, index, tmp_path: Path) -> None:
+    username = "test_user_passwd"
+    password = "some random password"
+
+    args = ["user", "create", "user", username, "--passwd-stdin"]
+    r = clirunner(args, stdin_input=password)
+    assert password not in r.output
+    assert "password taken from stdin" in r.stdout
+    assert_user_with_role(clirunner, "ingest", username)
+
+    # Remove the user just added.
+    clirunner(["user", "delete", username])
+    assert_no_user(clirunner, username)
+
+
 def assert_user_with_role(clirunner, role, user_name: str) -> None:
     result = clirunner(["user", "list"])
     assert "{}{}".format("user: ", user_name) in result.output


### PR DESCRIPTION
### Reason for this pull request

Add a parameter that reads
the password from stdin.

Use as:

echo "$VAR_CONTAINING_PASSWORD" | datacube user create --passwd-stdin ..

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2416.org.readthedocs.build/en/2416/

<!-- readthedocs-preview opendatacube end -->