### PR TITLE
pyproject: restrict setuptools-scm < 10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
 ]
 
 [build-system]
-requires = ["setuptools>=69", "setuptools_scm[toml]>=8"]
+requires = ["setuptools>=69", "setuptools_scm[toml]>=8,<10"]
 # v69 includes py.typed files by default
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
### Reason for this pull request

The latest release seems to be broken
for us since it breaks the Docker image
build.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2420.org.readthedocs.build/en/2420/

<!-- readthedocs-preview opendatacube end -->