### PR TITLE
opt: ensure URL can be parsed

### DIFF
--- a/datacube/cfg/opt.py
+++ b/datacube/cfg/opt.py
@@ -260,7 +260,12 @@ class PostgresURLOptionHandler(ODCOptionHandler):
             and not value.startswith("postgresql+psycopg://")
         ):
             raise ConfigException("Database URL is not a postgresql connection URL")
-        # Don't bother splitting up the url, we'd just have to put it back together again later
+        # Ensure the database URL can be parsed.
+        try:
+            for field in ["username", "password", "hostname", "port", "path"]:
+                getattr(components, field)
+        except ValueError as e:
+            raise ConfigException(str(e)) from None
         return value
 
     @override

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -216,6 +216,8 @@ non_legit:
     index_driver: null
         """
         )
+    with pytest.raises(ConfigException):
+        _ = ODCConfig(raw_dict={"all": {}})
 
 
 def test_oldstyle_cfg() -> None:

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -547,6 +547,16 @@ def test_invalid_pg_url() -> None:
     )
     with pytest.raises(ConfigException):
         assert cfg["default"].index_driver == "postgres"
+    cfg = ODCConfig(
+        raw_dict={
+            "badurl": {
+                "db_url": "postgresql+psycopg://foo:password/with/slash@"
+                "server.subdomain.domain/mytestdb",
+            }
+        }
+    )
+    with pytest.raises(ConfigException):
+        _ = cfg["badurl"].db_url
 
 
 def test_pgurl_from_config(simple_dict) -> None:


### PR DESCRIPTION
### Reason for this pull request

The CLI gives a backtrace on parse failures of the database URL without this.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2425.org.readthedocs.build/en/2425/

<!-- readthedocs-preview opendatacube end -->