### PR TITLE
Use TYPE_CHECKING block for types

### DIFF
--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -620,7 +620,7 @@ class Datacube:
             grid_spec=grid_spec,
             load_hints=load_hints,
             datasets=datasets,
-            geopolygon=cast(Geometry | None, query.pop("geopolygon", None)),
+            geopolygon=cast("Geometry | None", query.pop("geopolygon", None)),
             **query,
         )
         group_by = query_group_by(**query)  # type: ignore[arg-type]

--- a/datacube/api/core.py
+++ b/datacube/api/core.py
@@ -9,50 +9,59 @@ import datetime
 import logging
 import uuid
 import warnings
-from collections.abc import Callable, Hashable, Iterable, Mapping, Sequence
+from collections.abc import Mapping
 from itertools import groupby
-from types import TracebackType
-from typing import TYPE_CHECKING, Any, Literal, TypeAlias, cast
+from typing import Any, Literal, TypeAlias, cast
 
 import deprecat
 import numpy
 import xarray
 from dask import array as da
-from odc.geo import CRS, XY, Resolution, res_, resyx_, yx_
+from odc.geo import CRS, res_, resyx_, yx_
 from odc.geo.geobox import GeoBox, GeoboxTiles
-from odc.geo.geom import Geometry, bbox_union, box, intersects
-from odc.geo.warp import Resampling
+from odc.geo.geom import bbox_union, box, intersects
 from odc.geo.xr import xr_coords
-from odc.loader.types import FuserFunc, ReaderDriverSpec
 from typing_extensions import override
 from xarray.core.coordinates import DataArrayCoordinates
 
-from datacube.cfg import GeneralisedCfg, GeneralisedEnv, GeneralisedRawCfg, ODCConfig
-from datacube.model import (
-    Dataset,
-    ExtraDimensions,
-    ExtraDimensionSlices,
-    Measurement,
-    Product,
-)
+from datacube.cfg import ODCConfig
 from datacube.model.utils import xr_apply
 from datacube.storage import BandInfo, reproject_and_fuse
 from datacube.utils import ignore_exceptions_if
 from datacube.utils.dates import normalise_dt
 
+from ..drivers import new_datasource
+from ..index import extract_geom_from_query, index_connect
+from ..migration import ODC2DeprecationWarning
+from .query import Query, query_group_by
+
+TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from collections.abc import Callable, Hashable, Iterable, Sequence
+    from types import TracebackType
+
+    from odc.geo import XY, Resolution
     from odc.geo.crs import MaybeCRS
+    from odc.geo.geom import Geometry
+    from odc.geo.warp import Resampling
+    from odc.loader.types import FuserFunc, ReaderDriverSpec
     from pandas import DataFrame
 
-    from datacube.model import GridSpec
+    from datacube.cfg import GeneralisedCfg, GeneralisedEnv, GeneralisedRawCfg
+    from datacube.model import (
+        Dataset,
+        ExtraDimensions,
+        ExtraDimensionSlices,
+        GridSpec,
+        Measurement,
+        Product,
+    )
     from datacube.utils.geometry import GeoBox as LegacyGeoBox
 
-from ..drivers import new_datasource
-from ..index import Index, extract_geom_from_query, index_connect
-from ..migration import ODC2DeprecationWarning
-from ..model import QueryField
-from ..storage import ProgressFunction
-from .query import GroupBy, Query, query_group_by
+    from ..index import Index
+    from ..model import QueryField
+    from ..storage import ProgressFunction
+    from .query import GroupBy
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/api/grid_workflow.py
+++ b/datacube/api/grid_workflow.py
@@ -5,32 +5,35 @@
 from __future__ import annotations
 
 import logging
-import typing
 from collections import OrderedDict
-from collections.abc import Generator, Hashable, Iterable, Mapping
 from typing import Literal
 
-import numpy as np
 import pandas as pd
 import xarray as xr
-from odc.geo.geom import Geometry, intersects
-from odc.geo.gridspec import GridSpec
+from odc.geo.geom import intersects
 from typing_extensions import override
 
-from datacube.model import Dataset, QueryField
 from datacube.utils import DatacubeException
 
 from .core import Datacube
-from .query import GroupBy, Query, query_group_by
+from .query import Query, query_group_by
 
-_LOG: logging.Logger = logging.getLogger(__name__)
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator, Hashable, Iterable, Mapping
 
-if typing.TYPE_CHECKING:
+    import numpy as np
     from odc.geo.geobox import GeoBox
+    from odc.geo.geom import Geometry
+    from odc.geo.gridspec import GridSpec
 
     from datacube.index import Index
+    from datacube.model import Dataset, Product, QueryField
     from datacube.model import GridSpec as OldGridSpec
-    from datacube.model import Product
+
+    from .query import GroupBy
+
+_LOG: logging.Logger = logging.getLogger(__name__)
 
 
 class GridWorkflowException(DatacubeException):

--- a/datacube/api/query.py
+++ b/datacube/api/query.py
@@ -6,28 +6,36 @@
 Storage Query and Access API module
 """
 
+from __future__ import annotations
+
 import collections
 import datetime
 import logging
 import math
 import warnings
-from collections.abc import Callable, Iterable, Sequence
 from typing import Any, Literal
 
 import numpy as np
 import pandas
-import xarray
 from odc.geo import Geometry
-from odc.geo.geobox import GeoBox
 from odc.geo.geom import lonlat_bounds, mid_longitude
 from pandas import to_datetime as pandas_to_datetime
 from typing_extensions import override
 
-from datacube.index import Index
-
 from ..index import extract_geom_from_query, strip_all_spatial_fields_from_query
-from ..model import Dataset, QueryField, Range
+from ..model import Range
 from ..utils.dates import normalise_dt, tz_aware
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Sequence
+
+    import xarray
+    from odc.geo.geobox import GeoBox
+
+    from datacube.index import Index
+
+    from ..model import Dataset, QueryField
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/cfg/api.py
+++ b/datacube/cfg/api.py
@@ -24,9 +24,12 @@ from .opt import (
     BoolOptionHandler,
     IndexDriverOptionHandler,
     IntOptionHandler,
-    ODCOptionHandler,
 )
 from .utils import ConfigDict, check_valid_env_name
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from .opt import ODCOptionHandler
 
 
 class ODCConfig:

--- a/datacube/cfg/cfg.py
+++ b/datacube/cfg/cfg.py
@@ -15,14 +15,15 @@ import warnings
 from enum import Enum
 from os import PathLike
 from os.path import expanduser
-from typing import TYPE_CHECKING
 
 from datacube.cfg.exceptions import ConfigException
-from datacube.cfg.utils import ConfigDict, SemaphoreCallback, smells_like_ini
+from datacube.cfg.utils import smells_like_ini
 from datacube.migration import ODC2DeprecationWarning
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from datacube.cfg.api import GeneralisedPath
+    from datacube.cfg.utils import ConfigDict, SemaphoreCallback
 
 _DEFAULT_CONFIG_SEARCH_PATH: list[str] = [
     "datacube.conf",  # i.e. in the current working directory.

--- a/datacube/cfg/opt.py
+++ b/datacube/cfg/opt.py
@@ -2,10 +2,11 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import os
 import warnings
-from typing import TYPE_CHECKING, Any
+from typing import Any
 from urllib.parse import quote_plus, urlparse
 
 from typing_extensions import override
@@ -14,6 +15,7 @@ from ..migration import ODC2DeprecationWarning
 from .exceptions import ConfigException
 from .utils import check_valid_option
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from .api import ODCEnvironment
 
@@ -45,7 +47,7 @@ class ODCOptionHandler:
     def __init__(
         self,
         name: str,
-        env: "ODCEnvironment",
+        env: ODCEnvironment,
         default: Any = None,
         legacy_env_aliases=None,
     ) -> None:
@@ -321,7 +323,7 @@ class PostgresURLPartHandler(ODCOptionHandler):
         urlhandler: PostgresURLOptionHandler,
         urlpart: str,
         name: str,
-        env: "ODCEnvironment",
+        env: ODCEnvironment,
     ) -> None:
         self.urlhandler = urlhandler
         self.urlpart = urlpart
@@ -343,7 +345,7 @@ class PostgresURLPartHandler(ODCOptionHandler):
         return None
 
 
-def config_options_for_psql_driver(env: "ODCEnvironment") -> list[ODCOptionHandler]:
+def config_options_for_psql_driver(env: ODCEnvironment) -> list[ODCOptionHandler]:
     """
     Config options for shared use by postgres-based index drivers
     (i.e. postgres and postgis drivers)
@@ -361,7 +363,7 @@ def config_options_for_psql_driver(env: "ODCEnvironment") -> list[ODCOptionHandl
     ]
 
 
-def psql_url_from_config(env: "ODCEnvironment"):
+def psql_url_from_config(env: ODCEnvironment):
     if env.db_url:
         return env.db_url
     if not env.db_database:

--- a/datacube/conftest.py
+++ b/datacube/conftest.py
@@ -2,7 +2,11 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from pathlib import Path
+from __future__ import annotations
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 # The only thing tested under datacube/ is doctests, so only collect files

--- a/datacube/drivers/_types.py
+++ b/datacube/drivers/_types.py
@@ -4,16 +4,22 @@
 # SPDX-License-Identifier: Apache-2.0
 """Defines abstract types for IO drivers."""
 
+from __future__ import annotations
+
 from abc import ABCMeta, abstractmethod
-from collections.abc import Iterable
 from concurrent.futures import Future
 from typing import Any, TypeAlias
 
 import numpy as np
-from affine import Affine
-from odc.geo.crs import CRS
 
-from datacube.storage import BandInfo
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from affine import Affine
+    from odc.geo.crs import CRS
+
+    from datacube.storage import BandInfo
 
 # pylint: disable=invalid-name,unsubscriptable-object,pointless-statement
 

--- a/datacube/drivers/common_psql/_ownership.py
+++ b/datacube/drivers/common_psql/_ownership.py
@@ -2,14 +2,19 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import logging
 from typing import Literal
 
-from sqlalchemy import Connection, text
+from sqlalchemy import text
 from sqlalchemy.exc import ProgrammingError
 
 from ._utils import as_role
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from sqlalchemy import Connection
 
 _LOG = logging.getLogger(__name__)
 

--- a/datacube/drivers/common_psql/_perms.py
+++ b/datacube/drivers/common_psql/_perms.py
@@ -2,19 +2,24 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import contextlib
 import logging
 from abc import ABCMeta, abstractmethod
-from collections.abc import Generator, Iterable
 from enum import Enum, EnumMeta
 
 from sqlalchemy import text
-from sqlalchemy.engine import Connection
 from sqlalchemy.exc import ProgrammingError
 from typing_extensions import Self
 
 from ._utils import escape_pg_identifier
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable
+
+    from sqlalchemy.engine import Connection
 
 _LOG = logging.getLogger(__name__)
 

--- a/datacube/drivers/common_psql/_schema.py
+++ b/datacube/drivers/common_psql/_schema.py
@@ -2,10 +2,14 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from sqlalchemy import inspect, text
-from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.schema import DropSchema
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Connection, Engine
 
 
 def has_schema(engine: Engine, schema_name: str) -> bool:

--- a/datacube/drivers/common_psql/_utils.py
+++ b/datacube/drivers/common_psql/_utils.py
@@ -2,11 +2,17 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import contextlib
-from collections.abc import Generator
 
-from sqlalchemy import Connection, text
+from sqlalchemy import text
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from sqlalchemy import Connection
 
 
 def escape_pg_identifier(conn: Connection, name: str) -> str:

--- a/datacube/drivers/common_psql/sql.py
+++ b/datacube/drivers/common_psql/sql.py
@@ -6,12 +6,18 @@
 Custom types for postgres & sqlalchemy
 """
 
+from __future__ import annotations
+
 import warnings
 
-from sqlalchemy import Connection, inspect, text
+from sqlalchemy import inspect, text
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql import sqltypes
 from sqlalchemy.sql.expression import ClauseElement, Executable
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from sqlalchemy import Connection
 
 INSTALL_TRIGGER_SQL_TEMPLATE = [
     "drop trigger if exists row_update_time_{table} on {schema}.{table}",

--- a/datacube/drivers/datasource.py
+++ b/datacube/drivers/datasource.py
@@ -4,14 +4,19 @@
 # SPDX-License-Identifier: Apache-2.0
 """Defines abstract types for IO reader drivers."""
 
+from __future__ import annotations
+
 from abc import ABCMeta, abstractmethod
-from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import TypeAlias
 
-import numpy as np
-from affine import Affine
-from odc.geo import CRS
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    import numpy as np
+    from affine import Affine
+    from odc.geo import CRS
 
 RasterShape: TypeAlias = tuple[int, int]  # pylint: disable=invalid-name
 RasterWindow: TypeAlias = tuple[slice, slice] | tuple[tuple[int, int], tuple[int, int]]  # pylint: disable=invalid-name

--- a/datacube/drivers/driver_cache.py
+++ b/datacube/drivers/driver_cache.py
@@ -2,9 +2,14 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import logging
-from collections.abc import Generator
 from typing import Any
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/drivers/indexes.py
+++ b/datacube/drivers/indexes.py
@@ -2,10 +2,14 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
-from ..index.abstract import AbstractIndexDriver
 from ._tools import singleton_setup
 from .driver_cache import load_drivers
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from ..index.abstract import AbstractIndexDriver
 
 
 class IndexDriverCache:

--- a/datacube/drivers/netcdf/_write.py
+++ b/datacube/drivers/netcdf/_write.py
@@ -2,24 +2,27 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import contextlib
 import logging
-from collections.abc import Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
-
-import xarray
-from odc.geo import CRS
-from xarray.core.coordinates import DatasetCoordinates
-from xarray.core.dataset_variables import DataVariables
+from typing import Any
 
 from datacube.storage._hdf5 import HDF5_LOCK
 from datacube.utils import DatacubeException
 
 from . import writer as netcdf_writer
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     import netCDF4
+    import xarray
+    from odc.geo import CRS
+    from xarray.core.coordinates import DatasetCoordinates
+    from xarray.core.dataset_variables import DataVariables
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -52,7 +55,7 @@ def create_netcdf_storage_unit(
     variable_params: Mapping[str, Mapping[str, Any]],
     global_attributes: dict | None = None,
     netcdfparams: dict | None = None,
-) -> "netCDF4.Dataset":
+) -> netCDF4.Dataset:
     """
     Create a NetCDF file on disk.
 

--- a/datacube/drivers/netcdf/driver.py
+++ b/datacube/drivers/netcdf/driver.py
@@ -2,14 +2,19 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from importlib.util import find_spec
-from pathlib import Path
-from urllib.parse import urlsplit
+from __future__ import annotations
 
-import xarray as xr
+from importlib.util import find_spec
+from urllib.parse import urlsplit
 
 from datacube.storage._rio import RasterDatasetDataSource
 from datacube.utils.uris import normalise_path
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import xarray as xr
 
 PROTOCOL = "file"
 FORMAT = "NetCDF"

--- a/datacube/drivers/netcdf/writer.py
+++ b/datacube/drivers/netcdf/writer.py
@@ -6,27 +6,31 @@
 Create netCDF4 Storage Units and write data to them
 """
 
+from __future__ import annotations
+
 import logging
 import numbers
 from collections import namedtuple
-from collections.abc import Sequence
 from datetime import datetime, timezone
-from os import PathLike
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import numpy
-import numpy as np
 from netCDF4 import Dataset
 from odc.geo import CRS
 from odc.geo.geom import box
 from odc.geo.math import data_resolution_and_offset
-from xarray import DataArray
 
 from datacube import __version__
 from datacube.utils.masking import describe_flags_def
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from os import PathLike
+
     import netCDF4
+    import numpy as np
+    from xarray import DataArray
 
 UTC: timezone = timezone.utc
 
@@ -90,7 +94,7 @@ def create_coordinate(
     name: str,
     labels: np.ndarray[tuple[Any, ...], np.dtype[Any]],
     units: str,
-) -> "netCDF4.Variable":
+) -> netCDF4.Variable:
     labels = netcdfy_coord(labels)
 
     nco.createDimension(name, labels.size)
@@ -106,7 +110,7 @@ def create_coordinate(
 
 def create_variable(
     nco, name: str, var: Variable | DataArray, grid_mapping=None, attrs=None, **kwargs
-) -> "netCDF4.Variable":
+) -> netCDF4.Variable:
     assert var.dtype.kind != "U"  # Creates Non CF-Compliant NetCDF File
 
     def clamp_chunksizes(chunksizes: Sequence[int] | None, dim_names: Sequence[str]):

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -13,17 +13,14 @@
 Persistence API implementation for postgis.
 """
 
-import datetime
+from __future__ import annotations
+
 import logging
-import uuid
-from collections.abc import Generator, Iterable, Mapping, Sequence
 from typing import Any
 from typing import cast as type_cast
 
 from odc.geo import CRS, Geometry
 from sqlalchemy import (
-    Connection,
-    RootTransaction,
     and_,
     cast,
     column,
@@ -37,26 +34,19 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import INTERVAL, insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
-from sqlalchemy.sql.expression import Select
 from typing_extensions import override
 
 from datacube.drivers.common_psql import create_user, drop_users, grant_role, has_role
-from datacube.index.abstract import DSID
-from datacube.index.abstract._types import SearchMode
 from datacube.index.fields import OrExpression
 from datacube.model import Range
-from datacube.model.fields import Expression
 from datacube.model.lineage import LineageDirection, LineageRelation
 from datacube.utils import json
 from datacube.utils.uris import split_uri
 
-from ...utils.changes import Offset
 from ._core import UserRole
 from ._fields import (
     DateDocField,
-    DateRangeDocField,
     NativeField,
-    PgExpression,
     PgField,
     SimpleDocField,
     UnindexableValue,
@@ -76,6 +66,22 @@ from ._spatial import (
     generate_dataset_spatial_values,
     geom_alchemy,
 )
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    import datetime
+    import uuid
+    from collections.abc import Generator, Iterable, Mapping, Sequence
+
+    from sqlalchemy import Connection, RootTransaction
+    from sqlalchemy.sql.expression import Select
+
+    from datacube.index.abstract import DSID
+    from datacube.index.abstract._types import SearchMode
+    from datacube.model.fields import Expression
+
+    from ...utils.changes import Offset
+    from ._fields import DateRangeDocField, PgExpression
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -776,7 +776,7 @@ class PostgisDbAPI:
         fields = []
         for fld in match_fields:
             if fld.name == "time":
-                time_field = type_cast(DateRangeDocField, fld)
+                time_field = type_cast("DateRangeDocField", fld)
             else:
                 fields.append(fld.alchemy_expression)
 

--- a/datacube/drivers/postgis/_connections.py
+++ b/datacube/drivers/postgis/_connections.py
@@ -13,26 +13,23 @@
 Postgis connection and setup
 """
 
+from __future__ import annotations
+
 import logging
 import re
-from collections.abc import Callable, Generator, Iterable, Mapping
 from contextlib import contextmanager
 from typing import Any
 
 from odc.geo import CRS
-from sqlalchemy import Connection, create_engine, event
-from sqlalchemy.engine import Engine
-from sqlalchemy.engine.url import URL as EngineUrl  # noqa: N811
+from sqlalchemy import create_engine, event
 from typing_extensions import override
 
 import datacube
-from datacube.drivers.postgis._fields import PgField
 from datacube.index.exceptions import IndexSetupError, NoIndexError
 from datacube.utils import json, jsonify_document
 
-from ...cfg import ODCEnvironment, psql_url_from_config
+from ...cfg import psql_url_from_config
 from . import _api, _core
-from ._schema import SpatialIndex
 from ._spatial import (
     crs_to_epsg,
     drop_spindex,
@@ -40,6 +37,19 @@ from ._spatial import (
     spindex_for_crs,
     spindexes,
 )
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator, Iterable, Mapping
+
+    from sqlalchemy import Connection
+    from sqlalchemy.engine import Engine
+    from sqlalchemy.engine.url import URL as EngineUrl  # noqa: N811
+
+    from datacube.drivers.postgis._fields import PgField
+
+    from ...cfg import ODCEnvironment
+    from ._schema import SpatialIndex
 
 _LIB_ID: str = "odc-" + str(datacube.__version__)
 
@@ -75,7 +85,7 @@ class PostGisDb:
         config_env: ODCEnvironment,
         application_name: str | None = None,
         validate_connection: bool = True,
-    ) -> "PostGisDb":
+    ) -> PostGisDb:
         app_name = cls._expand_app_name(application_name)
 
         return PostGisDb.create(
@@ -88,7 +98,7 @@ class PostGisDb:
         config_env: ODCEnvironment,
         application_name: str | None = None,
         validate: bool = True,
-    ) -> "PostGisDb":
+    ) -> PostGisDb:
         url = psql_url_from_config(config_env)
         engine = cls._create_engine(
             url,

--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -6,6 +6,8 @@
 Core SQL schema settings.
 """
 
+from __future__ import annotations
+
 import logging
 import os
 
@@ -14,7 +16,6 @@ from alembic.migration import MigrationContext
 from alembic.runtime.environment import EnvironmentContext
 from alembic.script import ScriptDirectory
 from sqlalchemy import MetaData, text
-from sqlalchemy.engine import Engine
 from typing_extensions import Self, override
 
 from datacube.drivers.common_psql import (
@@ -32,6 +33,10 @@ from datacube.drivers.postgis.sql import (
     TYPES_INIT_SQL,
     UPDATE_TIMESTAMP_SQL,
 )
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Engine
 
 
 class UserRole(UserRoleBase):

--- a/datacube/drivers/postgis/_fields.py
+++ b/datacube/drivers/postgis/_fields.py
@@ -6,9 +6,10 @@
 Build and index fields within documents.
 """
 
+from __future__ import annotations
+
 import math
 from collections import namedtuple
-from collections.abc import Callable, Sequence
 from datetime import date, datetime, timezone
 from decimal import Decimal
 from functools import cached_property
@@ -26,10 +27,16 @@ from typing_extensions import override
 from datacube import utils
 from datacube.drivers.postgis._schema import Dataset, search_field_index_map
 from datacube.model import Range
-from datacube.model.fields import _AVAILABLE_TYPES, Expression, Field
+from datacube.model.fields import Expression, Field
 from datacube.utils import get_doc_offset, parse_time
-from datacube.utils.changes import Offset
 from datacube.utils.dates import tz_as_utc
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    from datacube.model.fields import _AVAILABLE_TYPES
+    from datacube.utils.changes import Offset
 
 DatasetJoinArgs: TypeAlias = (
     tuple[FromClause] | tuple[FromClause, ColumnExpressionArgument]
@@ -331,7 +338,7 @@ class NumericDocField(SimpleDocField):
         )
 
     @override
-    def between(self, low, high) -> "RangeBetweenExpression":
+    def between(self, low, high) -> RangeBetweenExpression:
         # Numeric fields actually stored as ranges in current schema.
         # return ValueBetweenExpression(self, low, high)
         return RangeBetweenExpression(self, low, high, _range_class=PgRange)
@@ -428,7 +435,7 @@ class DateDocField(SimpleDocField):
         )
 
     @override
-    def between(self, low, high) -> "ValueBetweenExpression":
+    def between(self, low, high) -> ValueBetweenExpression:
         return ValueBetweenExpression(self, low, high)
 
     @override

--- a/datacube/drivers/postgis/_schema.py
+++ b/datacube/drivers/postgis/_schema.py
@@ -6,6 +6,8 @@
 Tables for indexing the datasets which were ingested into the AGDC.
 """
 
+from __future__ import annotations
+
 import logging
 from datetime import datetime
 from uuid import UUID

--- a/datacube/drivers/postgis/_spatial.py
+++ b/datacube/drivers/postgis/_spatial.py
@@ -6,8 +6,9 @@
 Tracking spatial indexes
 """
 
+from __future__ import annotations
+
 import logging
-from collections.abc import Mapping
 from threading import Lock
 
 from antimeridian import fix_shape
@@ -17,7 +18,6 @@ from odc.geo import Geometry as Geom
 from odc.geo.geom import multipolygon, polygon
 from sqlalchemy import ForeignKey, delete, select, text
 from sqlalchemy.dialects import postgresql as postgres
-from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, mapped_column
 from sqlalchemy.sql.ddl import DropTable
 
@@ -25,6 +25,12 @@ from ..common_psql import as_role
 from ._core import METADATA
 from ._schema import Base, Dataset, SpatialIndex, SpatialIndexRecord, orm_registry
 from .sql import SCHEMA_NAME
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from sqlalchemy.engine import Engine
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/drivers/postgis/alembic/env.py
+++ b/datacube/drivers/postgis/alembic/env.py
@@ -2,21 +2,29 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from collections.abc import Iterable, MutableMapping
+from __future__ import annotations
+
 from typing import Literal
 
 from alembic import context
-from alembic.config import Config
-from alembic.operations import MigrationScript
-from alembic.runtime.migration import MigrationContext
-from sqlalchemy.engine.base import Connection
-from sqlalchemy.sql.schema import MetaData
 
-from datacube.cfg import ODCConfig, ODCEnvironment
+from datacube.cfg import ODCConfig
 from datacube.drivers.postgis._connections import PostGisDb
 from datacube.drivers.postgis._schema import Base
 from datacube.drivers.postgis._spatial import is_spindex_table_name
 from datacube.drivers.postgis.sql import SCHEMA_NAME
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable, MutableMapping
+
+    from alembic.config import Config
+    from alembic.operations import MigrationScript
+    from alembic.runtime.migration import MigrationContext
+    from sqlalchemy.engine.base import Connection
+    from sqlalchemy.sql.schema import MetaData
+
+    from datacube.cfg import ODCEnvironment
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/datacube/drivers/postgis/sql.py
+++ b/datacube/drivers/postgis/sql.py
@@ -6,13 +6,19 @@
 Custom types for postgres & sqlalchemy
 """
 
-from sqlalchemy import Connection
+from __future__ import annotations
+
 from sqlalchemy.dialects.postgresql.ranges import AbstractRange, Range
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql.functions import GenericFunction
 from sqlalchemy.types import Double
 
 import datacube.drivers.common_psql.sql as common_psql
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from sqlalchemy import Connection
+
 
 SCHEMA_NAME = "odc"
 

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -13,18 +13,13 @@
 Persistence API implementation for postgres.
 """
 
-import datetime
+from __future__ import annotations
+
 import logging
-from collections.abc import Iterable, Iterator, Mapping, Sequence
 from typing import Any
 from typing import cast as type_cast
 
 from sqlalchemy import (
-    Connection,
-    FromClause,
-    Label,
-    RootTransaction,
-    Select,
     String,
     and_,
     bindparam,
@@ -40,16 +35,12 @@ from sqlalchemy import (
     values,
 )
 from sqlalchemy.dialects.postgresql import INTERVAL, JSONB, UUID, insert
-from sqlalchemy.engine import Row
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.sql.selectable import NamedFromClause
 from typing_extensions import override
 
 from datacube.drivers.common_psql import create_user, drop_users, grant_role, has_role
-from datacube.index.abstract import DSID
-from datacube.index.abstract._types import SearchMode
 from datacube.index.exceptions import MissingRecordError
-from datacube.index.fields import Expression, Field, OrExpression
+from datacube.index.fields import OrExpression
 from datacube.model import Range
 from datacube.utils.uris import split_uri
 
@@ -57,7 +48,6 @@ from . import _dynamic as dynamic
 from ._core import UserRole
 from ._fields import (  # noqa: F401
     DateDocField,
-    DateRangeDocField,
     NativeField,
     PgExpression,
     PgField,
@@ -65,6 +55,21 @@ from ._fields import (  # noqa: F401
     parse_fields,
 )
 from ._schema import DATASET, DATASET_LOCATION, DATASET_SOURCE, METADATA_TYPE, PRODUCT
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    import datetime
+    from collections.abc import Iterable, Iterator, Mapping, Sequence
+
+    from sqlalchemy import Connection, FromClause, Label, RootTransaction, Select
+    from sqlalchemy.engine import Row
+    from sqlalchemy.sql.selectable import NamedFromClause
+
+    from datacube.index.abstract import DSID
+    from datacube.index.abstract._types import SearchMode
+    from datacube.index.fields import Expression, Field
+
+    from ._fields import DateRangeDocField
 
 PGCODE_FOREIGN_KEY_VIOLATION = "23503"
 _LOG: logging.Logger = logging.getLogger(__name__)

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -746,7 +746,7 @@ class PostgresDbAPI:
             return self.get_duplicates_with_time(match_fields, expressions)
 
         group_expressions = tuple(
-            type_cast(PgField, f).alchemy_expression for f in match_fields
+            type_cast("PgField", f).alchemy_expression for f in match_fields
         )
 
         select_query = (
@@ -779,9 +779,9 @@ class PostgresDbAPI:
         time_field: Label[Any] | None = None
         for f in match_fields:
             if f.name == "time":
-                time_field = type_cast(DateRangeDocField, f).expression_with_leniency
+                time_field = type_cast("DateRangeDocField", f).expression_with_leniency
             else:
-                fields.append(type_cast(PgField, f).alchemy_expression)
+                fields.append(type_cast("PgField", f).alchemy_expression)
 
         if time_field is None:
             raise Exception("No time field in duplicates query")

--- a/datacube/drivers/postgres/_connections.py
+++ b/datacube/drivers/postgres/_connections.py
@@ -13,24 +13,34 @@
 Postgres connection and setup
 """
 
+from __future__ import annotations
+
 import logging
 import re
-from collections.abc import Callable, Generator, Mapping
 from contextlib import contextmanager
 from typing import Any
 
-from sqlalchemy import Connection, create_engine, event
-from sqlalchemy.engine import Engine
-from sqlalchemy.engine.url import URL as EngineUrl  # noqa: N811
+from sqlalchemy import create_engine, event
 from typing_extensions import override
 
 import datacube
-from datacube.drivers.postgres._fields import PgField
 from datacube.index.exceptions import IndexSetupError
 from datacube.utils import json, jsonify_document
 
-from ...cfg import ODCEnvironment, psql_url_from_config
+from ...cfg import psql_url_from_config
 from . import _api, _core
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator, Mapping
+
+    from sqlalchemy import Connection
+    from sqlalchemy.engine import Engine
+    from sqlalchemy.engine.url import URL as EngineUrl  # noqa: N811
+
+    from datacube.drivers.postgres._fields import PgField
+
+    from ...cfg import ODCEnvironment
 
 _LIB_ID: str = "odc-" + str(datacube.__version__)
 
@@ -65,7 +75,7 @@ class PostgresDb:
         config_env: ODCEnvironment,
         application_name: str | None = None,
         validate_connection: bool = True,
-    ) -> "PostgresDb":
+    ) -> PostgresDb:
         app_name = cls._expand_app_name(application_name)
 
         return PostgresDb.create(
@@ -78,7 +88,7 @@ class PostgresDb:
         config_env: ODCEnvironment,
         application_name: str | None = None,
         validate: bool = True,
-    ) -> "PostgresDb":
+    ) -> PostgresDb:
         url = psql_url_from_config(config_env)
         engine = cls._create_engine(
             url,

--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -6,10 +6,11 @@
 Core SQL schema settings.
 """
 
+from __future__ import annotations
+
 import logging
 
 from sqlalchemy import MetaData, text
-from sqlalchemy.engine import Engine
 from typing_extensions import Self, override
 
 from datacube.drivers.common_psql import (
@@ -33,6 +34,10 @@ from datacube.drivers.postgres.sql import (
     UPDATE_TIMESTAMP_SQL,
     pg_column_exists,
 )
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Engine
 
 
 class UserRole(UserRoleBase):

--- a/datacube/drivers/postgres/_dynamic.py
+++ b/datacube/drivers/postgres/_dynamic.py
@@ -6,19 +6,26 @@
 Methods for managing dynamic dataset field indexes and views.
 """
 
+from __future__ import annotations
+
 import logging
-from collections.abc import Mapping, Sequence
 
 from sqlalchemy import Index, select, text
-from sqlalchemy.engine.base import Connection, Engine
-from sqlalchemy.engine.mock import MockConnection
 
 from datacube.drivers.common_psql import as_role
-from datacube.drivers.postgres._fields import PgField
 
 from ._core import schema_qualified
 from ._schema import DATASET, METADATA_TYPE, PRODUCT
 from .sql import CreateView, pg_exists
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from sqlalchemy.engine.base import Connection, Engine
+    from sqlalchemy.engine.mock import MockConnection
+
+    from datacube.drivers.postgres._fields import PgField
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/drivers/postgres/_fields.py
+++ b/datacube/drivers/postgres/_fields.py
@@ -6,9 +6,10 @@
 Build and index fields within documents.
 """
 
+from __future__ import annotations
+
 from collections import namedtuple
-from collections.abc import Callable, Sequence
-from datetime import date, datetime
+from datetime import datetime
 from decimal import Decimal
 from typing import Any
 
@@ -20,12 +21,19 @@ from typing_extensions import override
 
 from datacube import utils
 from datacube.model import Range
-from datacube.model.fields import _AVAILABLE_TYPES, Expression, Field
+from datacube.model.fields import Expression, Field
 from datacube.utils import get_doc_offset
-from datacube.utils.changes import Offset
 from datacube.utils.dates import tz_aware
 
 from .sql import FLOAT8RANGE
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+    from datetime import date
+
+    from datacube.model.fields import _AVAILABLE_TYPES
+    from datacube.utils.changes import Offset
 
 
 class PgField(Field):
@@ -246,7 +254,7 @@ class IntDocField(SimpleDocField):
         return cast(value, postgres.INTEGER)
 
     @override
-    def between(self, low, high) -> "ValueBetweenExpression":
+    def between(self, low, high) -> ValueBetweenExpression:
         return ValueBetweenExpression(self, low, high)
 
     @override
@@ -278,7 +286,7 @@ class NumericDocField(SimpleDocField):
         return cast(value, postgres.NUMERIC)
 
     @override
-    def between(self, low, high) -> "ValueBetweenExpression":
+    def between(self, low, high) -> ValueBetweenExpression:
         return ValueBetweenExpression(self, low, high)
 
     @override
@@ -294,7 +302,7 @@ class DoubleDocField(SimpleDocField):
         return cast(value, postgres.DOUBLE_PRECISION)
 
     @override
-    def between(self, low, high) -> "ValueBetweenExpression":
+    def between(self, low, high) -> ValueBetweenExpression:
         return ValueBetweenExpression(self, low, high)
 
     @override
@@ -320,7 +328,7 @@ class DateDocField(SimpleDocField):
         raise ValueError(f"Value not readable as date: {value!r}")
 
     @override
-    def between(self, low, high) -> "ValueBetweenExpression":
+    def between(self, low, high) -> ValueBetweenExpression:
         return ValueBetweenExpression(self, low, high)
 
     @override

--- a/datacube/drivers/postgres/sql.py
+++ b/datacube/drivers/postgres/sql.py
@@ -6,13 +6,19 @@
 Custom types for postgres & sqlalchemy
 """
 
-from sqlalchemy import TIMESTAMP, Connection
+from __future__ import annotations
+
+from sqlalchemy import TIMESTAMP
 from sqlalchemy.dialects.postgresql.ranges import AbstractRange, Range
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql.functions import GenericFunction
 from sqlalchemy.types import Double
 
 import datacube.drivers.common_psql.sql as common_psql
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from sqlalchemy import Connection
 
 SCHEMA_NAME = "agdc"
 

--- a/datacube/drivers/rio/_reader.py
+++ b/datacube/drivers/rio/_reader.py
@@ -4,32 +4,34 @@
 # SPDX-License-Identifier: Apache-2.0
 """reader"""
 
-from collections.abc import Iterable
+from __future__ import annotations
+
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, NamedTuple, TypeAlias, TypeVar
 
 import numpy as np
 import rasterio
 import rasterio.crs
-from affine import Affine
 from odc.geo import CRS
-from rasterio.io import DatasetReader
 from typing_extensions import override
 
-from datacube.drivers._types import (
-    FutureGeoRasterReader,
-    FutureNdarray,
-    GeoRasterReader,
-    RasterShape,
-    RasterWindow,
-    ReaderDriver,
-    ReaderDriverEntry,
-)
-from datacube.storage import BandInfo
-from datacube.utils import (
-    get_part_from_uri,
-    uri_to_local_path,
-)
+from datacube.drivers._types import GeoRasterReader, ReaderDriver, ReaderDriverEntry
+from datacube.utils import get_part_from_uri, uri_to_local_path
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from affine import Affine
+    from rasterio.io import DatasetReader
+
+    from datacube.drivers._types import (
+        FutureGeoRasterReader,
+        FutureNdarray,
+        RasterShape,
+        RasterWindow,
+    )
+    from datacube.storage import BandInfo
 
 
 class Overrides(NamedTuple):

--- a/datacube/index/_api.py
+++ b/datacube/index/_api.py
@@ -6,11 +6,17 @@
 Access methods for indexing datasets & products.
 """
 
+from __future__ import annotations
+
 import logging
 
-from datacube.cfg import ODCConfig, ODCEnvironment
+from datacube.cfg import ODCConfig
 
-from .abstract import AbstractIndex as Index
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.cfg import ODCEnvironment
+
+    from .abstract import AbstractIndex as Index
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/index/_spatial.py
+++ b/datacube/index/_spatial.py
@@ -40,7 +40,7 @@ def extract_geom_from_query(**q: QueryField) -> Geometry | None:
     polygon_candidate = q.get("geopolygon")
     if polygon_candidate is not None:
         # New geometry-style spatial query
-        geom_term = cast(JsonDict | Geometry, polygon_candidate)
+        geom_term = cast("JsonDict | Geometry", polygon_candidate)
         try:
             geom = Geometry(geom_term)
         except ValueError:
@@ -93,7 +93,7 @@ def extract_geom_from_query(**q: QueryField) -> Geometry | None:
             lat = Range(lat - delta, lat + delta)
         else:
             # Treat as tuple
-            begin, end = cast(tuple[int | float, int | float], lat)
+            begin, end = cast("tuple[int | float, int | float]", lat)
             lat = Range(begin, end)
 
         if lon is None:
@@ -102,7 +102,7 @@ def extract_geom_from_query(**q: QueryField) -> Geometry | None:
             lon = Range(lon - delta, lon + delta)
         else:
             # Treat as tuple
-            begin, end = cast(tuple[int | float, int | float], lon)
+            begin, end = cast("tuple[int | float, int | float]", lon)
             lon = Range(begin, end)
         geom = box(lon.begin, lat.begin, lon.end, lat.end, crs=crs)
     return geom

--- a/datacube/index/_spatial.py
+++ b/datacube/index/_spatial.py
@@ -2,13 +2,19 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from typing import cast
 
 from odc.geo.crs import CRS
 from odc.geo.geom import Geometry, box
 
-from datacube.model import QueryDict, QueryField, Range
-from datacube.utils.documents import JsonDict
+from datacube.model import Range
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.model import QueryDict, QueryField
+    from datacube.utils.documents import JsonDict
 
 H_SPATIAL_KEYS = ("lon", "longitude", "x")
 V_SPATIAL_KEYS = ("lat", "latitude", "y")

--- a/datacube/index/abstract/_datasets.py
+++ b/datacube/index/abstract/_datasets.py
@@ -2,25 +2,37 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-import datetime
+from __future__ import annotations
+
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Generator, Iterable, Mapping, Sequence
 from datetime import timedelta
 from time import monotonic
 from typing import Any, NamedTuple
-from uuid import UUID
 
 from deprecat import deprecat
-from odc.geo import CRS, Geometry
+from odc.geo import CRS
 
 from datacube.migration import ODC2DeprecationWarning
-from datacube.model import Dataset, Field, Product, QueryDict, QueryField, Range
+from datacube.model import Dataset, Range
 from datacube.utils import report_to_user
-from datacube.utils.changes import AllowPolicy, Change, DocumentMismatchError, Offset
-from datacube.utils.documents import JsonDict
+from datacube.utils.changes import DocumentMismatchError
 
-from ._types import DSID, BatchStatus, DatasetTuple, SearchMode
+from ._types import BatchStatus, DatasetTuple
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    import datetime
+    from collections.abc import Generator, Iterable, Mapping, Sequence
+    from uuid import UUID
+
+    from odc.geo import Geometry
+
+    from datacube.model import Field, Product, QueryDict, QueryField
+    from datacube.utils.changes import AllowPolicy, Change, Offset
+    from datacube.utils.documents import JsonDict
+
+    from ._types import DSID, SearchMode
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/index/abstract/_index.py
+++ b/datacube/index/abstract/_index.py
@@ -2,29 +2,37 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Iterable, Mapping, Sequence
 from functools import cached_property
-from urllib.parse import ParseResult, urlparse
+from urllib.parse import urlparse
 
 from deprecat import deprecat
-from odc.geo import CRS
 
-from datacube.cfg import ODCEnvironment, ODCOptionHandler
 from datacube.migration import ODC2DeprecationWarning
-from datacube.model import Field, MetadataType
 from datacube.utils import report_to_user
 from datacube.utils.generic import thread_local_cache
-from datacube.utils.json_types import JsonDict
 
-from ._datasets import AbstractDatasetResource
-from ._lineage import AbstractLineageResource
-from ._metadata_types import AbstractMetadataTypeResource
-from ._products import AbstractProductResource
-from ._transactions import AbstractTransaction
-from ._types import DSID, BatchStatus
-from ._users import AbstractUserResource
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping, Sequence
+    from urllib.parse import ParseResult
+
+    from odc.geo import CRS
+
+    from datacube.cfg import ODCEnvironment, ODCOptionHandler
+    from datacube.model import Field, MetadataType
+    from datacube.utils.json_types import JsonDict
+
+    from ._datasets import AbstractDatasetResource
+    from ._lineage import AbstractLineageResource
+    from ._metadata_types import AbstractMetadataTypeResource
+    from ._products import AbstractProductResource
+    from ._transactions import AbstractTransaction
+    from ._types import DSID, BatchStatus
+    from ._users import AbstractUserResource
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -123,7 +131,7 @@ class AbstractIndex(ABC):
         cfg_env: ODCEnvironment,
         application_name: str | None = None,
         validate_connection: bool = True,
-    ) -> "AbstractIndex":
+    ) -> AbstractIndex:
         """Instantiate a new index from an ODCEnvironment configuration object"""
 
     @classmethod
@@ -233,7 +241,7 @@ class AbstractIndex(ABC):
 
     def clone(
         self,
-        origin_index: "AbstractIndex",
+        origin_index: AbstractIndex,
         batch_size: int = 1000,
         skip_lineage: bool = False,
         lineage_only: bool = False,
@@ -385,7 +393,7 @@ class AbstractIndex(ABC):
         """
         return thread_local_cache(f"txn-{self.index_id}", None)
 
-    def __enter__(self) -> "AbstractIndex":
+    def __enter__(self) -> AbstractIndex:
         return self
 
     def __exit__(self) -> None:
@@ -408,7 +416,7 @@ class AbstractIndexDriver(ABC):
         config_env: ODCEnvironment,
         application_name: str | None = None,
         validate_connection: bool = True,
-    ) -> "AbstractIndex":
+    ) -> AbstractIndex:
         return cls.index_class().from_config(
             config_env, application_name, validate_connection
         )

--- a/datacube/index/abstract/_lineage.py
+++ b/datacube/index/abstract/_lineage.py
@@ -2,19 +2,27 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Iterable, Mapping
 from time import monotonic
-from uuid import UUID
 
 from typing_extensions import override
 
-from datacube.model import LineageDirection, LineageRelation, LineageTree
-from datacube.model.lineage import LineageRelations
 from datacube.utils import report_to_user
 
-from ._types import DSID, BatchStatus
+from ._types import BatchStatus
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+    from uuid import UUID
+
+    from datacube.model import LineageDirection, LineageRelation, LineageTree
+    from datacube.model.lineage import LineageRelations
+
+    from ._types import DSID
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/index/abstract/_metadata_types.py
+++ b/datacube/index/abstract/_metadata_types.py
@@ -2,19 +2,26 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Iterable
 from pathlib import Path
 from time import monotonic
 from typing import cast
 
-from datacube.model import MetadataType
 from datacube.utils import InvalidDocException, jsonify_document, read_documents
-from datacube.utils.changes import Change, DocumentMismatchError, check_doc_unchanged
-from datacube.utils.documents import JsonDict
+from datacube.utils.changes import DocumentMismatchError, check_doc_unchanged
 
 from ._types import BatchStatus
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from datacube.model import MetadataType
+    from datacube.utils.changes import Change
+    from datacube.utils.documents import JsonDict
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/index/abstract/_metadata_types.py
+++ b/datacube/index/abstract/_metadata_types.py
@@ -307,4 +307,4 @@ class AbstractMetadataTypeResource(ABC):
         """
         # Default implementation calls get_all()
         for mdt in self.get_all():
-            yield cast(JsonDict, mdt.definition)
+            yield cast("JsonDict", mdt.definition)

--- a/datacube/index/abstract/_products.py
+++ b/datacube/index/abstract/_products.py
@@ -2,23 +2,33 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-import datetime
+from __future__ import annotations
+
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Generator, Iterable, Sequence
 from time import monotonic
-from typing import TYPE_CHECKING, cast
+from typing import cast
 
-from odc.geo import CRS, Geometry
+from odc.geo import CRS
 
-from datacube.model import MetadataType, Product, QueryDict, QueryField
+from datacube.model import Product
 from datacube.utils import InvalidDocException, jsonify_document
-from datacube.utils.changes import Change, DocumentMismatchError, check_doc_unchanged
-from datacube.utils.documents import JsonDict, JsonLike, UnknownMetadataType
+from datacube.utils.changes import DocumentMismatchError, check_doc_unchanged
+from datacube.utils.documents import UnknownMetadataType
 
 from ._types import BatchStatus
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
+    import datetime
+    from collections.abc import Generator, Iterable, Sequence
+
+    from odc.geo import Geometry
+
+    from datacube.model import MetadataType, QueryDict, QueryField
+    from datacube.utils.changes import Change
+    from datacube.utils.documents import JsonDict, JsonLike
+
     from ._index import AbstractIndex
 
 _LOG: logging.Logger = logging.getLogger(__name__)
@@ -35,7 +45,7 @@ class AbstractProductResource(ABC):
     raise a NotImplementedError)
     """
 
-    def __init__(self, index: "AbstractIndex") -> None:
+    def __init__(self, index: AbstractIndex) -> None:
         self._index = index
 
     def from_doc(

--- a/datacube/index/abstract/_products.py
+++ b/datacube/index/abstract/_products.py
@@ -80,7 +80,7 @@ class AbstractProductResource(ABC):
         else:
             # Otherwise they embedded a document, add it if needed:
             metadata_type = self._index.metadata_types.from_doc(
-                cast(JsonDict, metadata_type_in)
+                cast("JsonDict", metadata_type_in)
             )
             definition = dict(definition)
             definition["metadata_type"] = metadata_type.name
@@ -441,7 +441,7 @@ class AbstractProductResource(ABC):
         :returns: Iterable of metadata documents for all known products
         """
         for prod in self.get_all():
-            yield cast(JsonDict, prod.definition)
+            yield cast("JsonDict", prod.definition)
 
     @abstractmethod
     def spatial_extent(

--- a/datacube/index/abstract/_transactions.py
+++ b/datacube/index/abstract/_transactions.py
@@ -2,15 +2,20 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from threading import Lock
-from types import TracebackType
 from typing import Any
 
 from typing_extensions import override
 
 from datacube.index.exceptions import TransactionException
 from datacube.utils.generic import thread_local_cache
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from types import TracebackType
 
 
 class AbstractTransaction(ABC):
@@ -108,7 +113,7 @@ class AbstractTransaction(ABC):
         return TransactionException(errmsg, commit=False)
 
     # Context Manager Interface
-    def __enter__(self) -> "AbstractTransaction":
+    def __enter__(self) -> AbstractTransaction:
         self.begin()
         return self
 

--- a/datacube/index/abstract/_types.py
+++ b/datacube/index/abstract/_types.py
@@ -2,7 +2,10 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from collections.abc import Iterable, Sequence
+from __future__ import annotations
+
+# Iterable required for Sphinx's documentation plugin for named tuples.
+from collections.abc import Iterable  # noqa: TC003
 from functools import cached_property
 from typing import Literal, NamedTuple, TypeAlias
 from uuid import UUID
@@ -10,8 +13,19 @@ from uuid import UUID
 from deprecat import deprecat
 
 from datacube.migration import ODC2DeprecationWarning
-from datacube.model import Dataset, Product
-from datacube.utils.documents import JsonDict
+
+# Product required for Sphinx's documentation plugin for named tuples.
+from datacube.model import (
+    Dataset,
+    Product,  # noqa: TC001
+)
+
+# JsonDict required for Sphinx's documentation plugin for named tuples.
+from datacube.utils.documents import JsonDict  # noqa: TC001
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class BatchStatus(NamedTuple):

--- a/datacube/index/abstract/_users.py
+++ b/datacube/index/abstract/_users.py
@@ -2,8 +2,13 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from collections.abc import Iterable
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 class AbstractUserResource(ABC):

--- a/datacube/index/eo3.py
+++ b/datacube/index/eo3.py
@@ -41,7 +41,7 @@ class EO3Grid:
             raise ValueError("Each grid must have a shape")
         if len(shape) != 2:
             raise ValueError("Grid shape must be two dimensional")
-        self.shape = cast(tuple[int, int], tuple(int(x) for x in shape))
+        self.shape = cast("tuple[int, int]", tuple(int(x) for x in shape))
         xform = grid.get("transform")
         if xform is None:
             raise ValueError("Each grid must have a transform")

--- a/datacube/index/eo3.py
+++ b/datacube/index/eo3.py
@@ -5,20 +5,13 @@
 # TODO: type hints need attention
 """Tools for working with EO3 metadata"""
 
-from collections.abc import Generator, Iterable, Mapping
+from __future__ import annotations
+
 from functools import reduce
 from typing import Any, cast
-from uuid import UUID
 
 from affine import Affine
-from odc.geo import (
-    CRS,
-    BoundingBox,
-    CoordList,
-    Geometry,
-    SomeCRS,
-    xy_,
-)
+from odc.geo import CRS, xy_
 from odc.geo.crs import norm_crs
 from odc.geo.geobox import GeoBox
 from odc.geo.geom import lonlat_bounds, multipolygon, polygon
@@ -28,8 +21,17 @@ from toolz.dicttoolz import get_in
 from datacube.model import Dataset, GridSpec, Product, Range
 from datacube.storage import BandInfo
 from datacube.storage._rio import RasterDatasetDataSource
-from datacube.utils import DatacubeException, DocReader
-from datacube.utils.generic import T
+from datacube.utils import DatacubeException
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable, Mapping
+    from uuid import UUID
+
+    from odc.geo import BoundingBox, CoordList, Geometry, SomeCRS
+
+    from datacube.utils import DocReader
+    from datacube.utils.generic import T
 
 EO3_SCHEMA = "https://schemas.opendatacube.org/dataset"
 

--- a/datacube/index/fields.py
+++ b/datacube/index/fields.py
@@ -6,12 +6,18 @@
 Common datatypes for DB drivers.
 """
 
+from __future__ import annotations
+
 from datetime import date, datetime, time, timezone
 
 from typing_extensions import override
 
-from datacube.model import Not, QueryField, Range
+from datacube.model import Not, Range
 from datacube.model.fields import Expression, Field
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.model import QueryField
 
 __all__ = [
     "Expression",

--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -532,7 +532,7 @@ class Doc2Dataset:
 
         dataset, err = self._ds_resolve(doc, uri, source_tree)
         if dataset is None:
-            return None, cast(str | Exception, err)
+            return None, cast("str | Exception", err)
 
         reason = check_dataset_consistent(dataset)
         if reason is None:

--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -6,15 +6,15 @@
 High level indexing operations/utilities
 """
 
+from __future__ import annotations
+
 import logging
-from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequence
+from collections.abc import Callable, Mapping
 from typing import Any, TypeAlias, cast
-from uuid import UUID
 
 import toolz
 from pystac import Item
 
-from datacube.index.abstract import AbstractIndex
 from datacube.metadata import stac2ds
 from datacube.model import Dataset, LineageDirection, LineageTree, Product
 from datacube.model.utils import (
@@ -30,9 +30,17 @@ from datacube.utils import (
     json,
     jsonify_document,
 )
-from datacube.utils.changes import Offset, get_doc_changes
+from datacube.utils.changes import get_doc_changes
 
 from .eo3 import is_doc_eo3, is_doc_geo, prep_eo3
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable, MutableMapping, Sequence
+    from uuid import UUID
+
+    from datacube.index.abstract import AbstractIndex
+    from datacube.utils.changes import Offset
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -2,26 +2,25 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import datetime
 import logging
 import re
 import warnings
 from collections import namedtuple
-from collections.abc import Callable, Generator, Iterable, Mapping, Sequence
+from collections.abc import Iterable
 from itertools import chain
 from time import monotonic
 from typing import Any, NamedTuple, cast
-from uuid import UUID
 
 from deprecat import deprecat
-from odc.geo import CRS, Geometry
+from odc.geo import CRS
 from typing_extensions import override
 
 from datacube.index import fields
 from datacube.index.abstract import (
-    DSID,
     AbstractDatasetResource,
-    AbstractIndex,
     BatchStatus,
     DatasetSpatialMixin,
     NoLineageResource,
@@ -31,11 +30,22 @@ from datacube.index.fields import Field
 from datacube.index.memory._fields import build_custom_fields, get_dataset_fields
 from datacube.migration import ODC2DeprecationWarning
 from datacube.model import Dataset, LineageRelation, Product, Range, ranges_overlap
-from datacube.model._base import QueryField
 from datacube.utils import _readable_offset, changes, jsonify_document
-from datacube.utils.changes import AllowPolicy, Change, Offset, get_doc_changes
+from datacube.utils.changes import get_doc_changes
 from datacube.utils.dates import tz_aware
-from datacube.utils.documents import JsonDict, metadata_subset
+from datacube.utils.documents import metadata_subset
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator, Mapping, Sequence
+    from uuid import UUID
+
+    from odc.geo import Geometry
+
+    from datacube.index.abstract import DSID, AbstractIndex
+    from datacube.model._base import QueryField
+    from datacube.utils.changes import AllowPolicy, Change, Offset
+    from datacube.utils.documents import JsonDict
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -72,7 +72,7 @@ class DatasetResource(AbstractDatasetResource):
         )  # N.B. raises KeyError if id not in index.
         if include_sources:
             ds.sources = {
-                classifier: cast(Dataset, self.get(dsid, include_sources=True))
+                classifier: cast("Dataset", self.get(dsid, include_sources=True))
                 for classifier, dsid in self._derived_from.get(ds.id, {}).items()
             }
         return ds
@@ -84,7 +84,7 @@ class DatasetResource(AbstractDatasetResource):
     @override
     def get_derived(self, id_: DSID) -> Iterable[Dataset]:
         return (
-            cast(Dataset, self.get(dsid))
+            cast("Dataset", self.get(dsid))
             for dsid in self._derivations.get(dsid_to_uuid(id_), {}).values()
         )
 
@@ -134,7 +134,7 @@ class DatasetResource(AbstractDatasetResource):
             _LOG.warning(
                 "archive-less-mature functionality is not implemented for memory driver"
             )
-        return cast(Dataset, self.get(dataset.id))
+        return cast("Dataset", self.get(dataset.id))
 
     def persist_source_relationship(
         self, ds: Dataset, src: Dataset, classifier: str
@@ -283,7 +283,7 @@ class DatasetResource(AbstractDatasetResource):
             _LOG.warning(
                 "archive-less-mature functionality is not implemented for memory driver"
             )
-        return cast(Dataset, self.get(dataset.id))
+        return cast("Dataset", self.get(dataset.id))
 
     def _update_locations(
         self, dataset: Dataset, existing: Dataset | None = None
@@ -597,7 +597,7 @@ class DatasetResource(AbstractDatasetResource):
             for dsid in dsids:
                 if limit is not None and matches >= limit:
                     break
-                ds = cast(Dataset, self.get(dsid, include_sources=True))
+                ds = cast("Dataset", self.get(dsid, include_sources=True))
                 query_matches = True
                 for expr in query_exprs:
                     if not expr.evaluate(ds.metadata_doc):
@@ -607,7 +607,7 @@ class DatasetResource(AbstractDatasetResource):
                     continue
                 if source_product:
                     matching_source = None
-                    for sds in cast(Mapping[str, Dataset], ds.sources).values():
+                    for sds in cast("Mapping[str, Dataset]", ds.sources).values():
                         if sds.product != source_product:
                             continue
                         source_matches = True
@@ -636,7 +636,7 @@ class DatasetResource(AbstractDatasetResource):
         **query: QueryField,
     ) -> Iterable[Dataset]:
         return cast(
-            Iterable[Dataset],
+            "Iterable[Dataset]",
             self._search(
                 return_format=self.RET_FORMAT_DATASETS,
                 limit=limit,
@@ -654,7 +654,7 @@ class DatasetResource(AbstractDatasetResource):
         **query: QueryField,
     ) -> Iterable[tuple[Product, Iterable[Dataset]]]:
         return cast(
-            Iterable[tuple[Product, Iterable[Dataset]]],
+            "Iterable[tuple[Product, Iterable[Dataset]]]",
             self._search(
                 return_format=self.RET_FORMAT_PRODUCT_GROUPED,
                 limit=limit,
@@ -835,7 +835,7 @@ class DatasetResource(AbstractDatasetResource):
         YieldType = tuple[Product, Iterable[tuple[Range, int]]]  # noqa: N806
         query = dict(query)
         try:
-            start, end = cast(Range, query.pop("time"))
+            start, end = cast("Range", query.pop("time"))
         except KeyError:
             raise ValueError(
                 'Must specify "time" range in period-counting query'
@@ -853,7 +853,7 @@ class DatasetResource(AbstractDatasetResource):
             for p in periods:
                 count = 0
                 for ds in dss:
-                    if ranges_overlap(cast(Range, ds.time), p):
+                    if ranges_overlap(cast("Range", ds.time), p):
                         count += 1
                 period_counts.append((p, count))
             retval = (product, period_counts)
@@ -924,7 +924,7 @@ class DatasetResource(AbstractDatasetResource):
                 min_time = dsmin
             if max_time is None or dsmax > max_time:
                 max_time = dsmax
-        return cast(datetime.datetime, min_time), cast(datetime.datetime, max_time)
+        return cast("datetime.datetime", min_time), cast("datetime.datetime", max_time)
 
     # pylint: disable=redefined-outer-name
     @override

--- a/datacube/index/memory/_fields.py
+++ b/datacube/index/memory/_fields.py
@@ -2,12 +2,19 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from collections.abc import Mapping
+from __future__ import annotations
+
 from typing import Any
 
-from datacube.model.fields import Field, SimpleField
+from datacube.model.fields import SimpleField
 from datacube.model.fields import get_dataset_fields as generic_get_dataset_fields
-from datacube.utils.changes import Offset
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from datacube.model.fields import Field
+    from datacube.utils.changes import Offset
 
 
 # TODO: SimpleFields cannot handle non-metadata fields because e.g. the extract API expects a doc, not a Dataset model

--- a/datacube/index/memory/_metadata_types.py
+++ b/datacube/index/memory/_metadata_types.py
@@ -61,7 +61,7 @@ class MetadataTypeResource(AbstractMetadataTypeResource):
             self.next_id += 1
             self.by_id[persisted.id] = persisted
             self.by_name[persisted.name] = persisted
-        return cast(MetadataType, self.get_by_name(metadata_type.name))
+        return cast("MetadataType", self.get_by_name(metadata_type.name))
 
     @override
     def can_update(

--- a/datacube/index/memory/_metadata_types.py
+++ b/datacube/index/memory/_metadata_types.py
@@ -2,8 +2,9 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import logging
-from collections.abc import Iterable, Mapping
 from copy import deepcopy
 from typing import Any, cast
 
@@ -16,14 +17,14 @@ from datacube.index.abstract import (
 from datacube.index.memory._fields import get_dataset_fields
 from datacube.model import MetadataType
 from datacube.utils import _readable_offset, changes, jsonify_document
-from datacube.utils.changes import (
-    AllowPolicy,
-    Change,
-    Offset,
-    check_doc_unchanged,
-    get_doc_changes,
-)
-from datacube.utils.documents import JsonDict
+from datacube.utils.changes import check_doc_unchanged, get_doc_changes
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
+    from datacube.utils.changes import AllowPolicy, Change, Offset
+    from datacube.utils.documents import JsonDict
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/index/memory/_products.py
+++ b/datacube/index/memory/_products.py
@@ -2,36 +2,44 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-import datetime
-import logging
-from collections.abc import Iterable, Sequence
-from typing import cast
-from uuid import UUID
+from __future__ import annotations
 
-from odc.geo import CRS, Geometry
+import logging
+from typing import cast
+
+from odc.geo import CRS
 from typing_extensions import override
 
-from datacube.index.abstract import AbstractIndex, AbstractProductResource
+from datacube.index.abstract import AbstractProductResource
 from datacube.index.fields import as_expression
 from datacube.model import Product
-from datacube.model._base import QueryDict, QueryField
 from datacube.utils import _readable_offset, changes, jsonify_document
 from datacube.utils.changes import (
-    AllowPolicy,
-    Change,
-    Offset,
     check_doc_unchanged,
     classify_changes,
     get_doc_changes,
 )
-from datacube.utils.documents import JsonDict, metadata_subset
+from datacube.utils.documents import metadata_subset
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    import datetime
+    from collections.abc import Iterable, Sequence
+    from uuid import UUID
+
+    from odc.geo import Geometry
+
+    from datacube.index.abstract import AbstractIndex
+    from datacube.index.memory.index import Index
+    from datacube.model._base import QueryDict, QueryField
+    from datacube.utils.changes import AllowPolicy, Change, Offset
+    from datacube.utils.documents import JsonDict
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
 
 class ProductResource(AbstractProductResource):
     def __init__(self, index: AbstractIndex) -> None:
-        from datacube.index.memory.index import Index
 
         self._index: Index = cast("Index", index)
         self.by_id: dict[int, Product] = {}

--- a/datacube/index/memory/_products.py
+++ b/datacube/index/memory/_products.py
@@ -33,7 +33,7 @@ class ProductResource(AbstractProductResource):
     def __init__(self, index: AbstractIndex) -> None:
         from datacube.index.memory.index import Index
 
-        self._index: Index = cast(Index, index)
+        self._index: Index = cast("Index", index)
         self.by_id: dict[int, Product] = {}
         self.by_name: dict[str, Product] = {}
         self.next_id = 1
@@ -148,7 +148,7 @@ class ProductResource(AbstractProductResource):
             )
             raise ValueError(f"Unsafe changes in {product.name}: {errs}")
 
-        existing = cast(Product, self.get_by_name(product.name))
+        existing = cast("Product", self.get_by_name(product.name))
         if product.metadata_type.name != existing.metadata_type.name:
             raise ValueError(
                 "Unsafe change: cannot (currently) switch metadata types for a product"
@@ -157,7 +157,7 @@ class ProductResource(AbstractProductResource):
         _LOG.info(f"Updating product {product.name}")
 
         persisted = self.clone(product)
-        persisted.id = cast(int, existing.id)
+        persisted.id = cast("int", existing.id)
         self.by_id[persisted.id] = persisted
         self.by_name[persisted.name] = persisted
         return self.get_by_name(product.name)

--- a/datacube/index/memory/_users.py
+++ b/datacube/index/memory/_users.py
@@ -2,11 +2,15 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from collections.abc import Iterable
+from __future__ import annotations
 
 from typing_extensions import override
 
 from datacube.index.abstract import AbstractUserResource
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 class User:

--- a/datacube/index/memory/index.py
+++ b/datacube/index/memory/index.py
@@ -2,16 +2,15 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import logging
-from collections.abc import Mapping
 from threading import Lock
 from typing import Any
 
 from deprecat import deprecat
-from odc.geo import CRS
 from typing_extensions import override
 
-from datacube.cfg import ODCEnvironment
 from datacube.index.abstract import (
     AbstractIndex,
     AbstractIndexDriver,
@@ -23,8 +22,17 @@ from datacube.index.memory._metadata_types import MetadataTypeResource
 from datacube.index.memory._products import ProductResource
 from datacube.index.memory._users import UserResource
 from datacube.migration import ODC2DeprecationWarning
-from datacube.model import Field, MetadataType
-from datacube.utils.json_types import JsonDict
+from datacube.model import MetadataType
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from odc.geo import CRS
+
+    from datacube.cfg import ODCEnvironment
+    from datacube.model import Field
+    from datacube.utils.json_types import JsonDict
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -120,7 +128,7 @@ class Index(AbstractIndex):
         cfg_env: ODCEnvironment,
         application_name: str | None = None,
         validate_connection: bool = True,
-    ) -> "Index":
+    ) -> Index:
         return cls(cfg_env)
 
     @classmethod

--- a/datacube/index/null/_datasets.py
+++ b/datacube/index/null/_datasets.py
@@ -2,19 +2,27 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
-import datetime
-from collections.abc import Generator, Iterable, Mapping, Sequence
 from typing import Any, NamedTuple
 
 from deprecat import deprecat
-from odc.geo import CRS, Geometry
+from odc.geo import CRS
 from typing_extensions import override
 
-from datacube.index.abstract import DSID, AbstractDatasetResource
+from datacube.index.abstract import AbstractDatasetResource
 from datacube.migration import ODC2DeprecationWarning
-from datacube.model import Dataset, Product, QueryDict, QueryField
-from datacube.utils.changes import Change, Offset
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    import datetime
+    from collections.abc import Generator, Iterable, Mapping, Sequence
+
+    from odc.geo import Geometry
+
+    from datacube.index.abstract import DSID
+    from datacube.model import Dataset, Product, QueryDict, QueryField
+    from datacube.utils.changes import Change, Offset
 
 
 class DatasetResource(AbstractDatasetResource):

--- a/datacube/index/null/_metadata_types.py
+++ b/datacube/index/null/_metadata_types.py
@@ -2,14 +2,19 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from collections.abc import Iterable
+from __future__ import annotations
 
 from typing_extensions import override
 
 from datacube.index.abstract import AbstractMetadataTypeResource
-from datacube.model import MetadataType
-from datacube.utils.changes import Change
-from datacube.utils.documents import JsonDict
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from datacube.model import MetadataType
+    from datacube.utils.changes import Change
+    from datacube.utils.documents import JsonDict
 
 
 class MetadataTypeResource(AbstractMetadataTypeResource):

--- a/datacube/index/null/_products.py
+++ b/datacube/index/null/_products.py
@@ -2,17 +2,25 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-import datetime
-import logging
-from collections.abc import Iterable, Sequence
+from __future__ import annotations
 
-from odc.geo import CRS, Geometry
+import logging
+
+from odc.geo import CRS
 from typing_extensions import override
 
 from datacube.index.abstract import AbstractProductResource
-from datacube.model import Product, QueryDict, QueryField
-from datacube.utils.changes import Change
-from datacube.utils.json_types import JsonDict
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    import datetime
+    from collections.abc import Iterable, Sequence
+
+    from odc.geo import Geometry
+
+    from datacube.model import Product, QueryDict, QueryField
+    from datacube.utils.changes import Change
+    from datacube.utils.json_types import JsonDict
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/index/null/_users.py
+++ b/datacube/index/null/_users.py
@@ -2,11 +2,15 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from collections.abc import Iterable
+from __future__ import annotations
 
 from typing_extensions import override
 
 from datacube.index.abstract import AbstractUserResource
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 class UserResource(AbstractUserResource):

--- a/datacube/index/null/index.py
+++ b/datacube/index/null/index.py
@@ -2,15 +2,14 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import logging
-from collections.abc import Mapping
 from typing import Any
 
 from deprecat import deprecat
-from odc.geo import CRS
 from typing_extensions import override
 
-from datacube.cfg import ODCEnvironment
 from datacube.index.abstract import (
     AbstractIndex,
     AbstractIndexDriver,
@@ -22,9 +21,18 @@ from datacube.index.null._metadata_types import MetadataTypeResource
 from datacube.index.null._products import ProductResource
 from datacube.index.null._users import UserResource
 from datacube.migration import ODC2DeprecationWarning
-from datacube.model import Field, MetadataType
+from datacube.model import MetadataType
 from datacube.model.fields import get_dataset_fields
-from datacube.utils.json_types import JsonDict
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from odc.geo import CRS
+
+    from datacube.cfg import ODCEnvironment
+    from datacube.model import Field
+    from datacube.utils.json_types import JsonDict
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -106,7 +114,7 @@ class Index(AbstractIndex):
         cfg_env: ODCEnvironment,
         application_name: str | None = None,
         validate_connection: bool = True,
-    ) -> "Index":
+    ) -> Index:
         return cls(cfg_env)
 
     @classmethod

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -302,9 +302,9 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             assert isinstance(f, fields.Field), f"Not a field: {f!r}"
             return f
 
-        group_fields = [cast(PgField, load_field(f)) for f in args]
+        group_fields = [cast("PgField", load_field(f)) for f in args]
         expressions = [
-            cast(PgExpression, dataset_fields.get("product") == product.name)
+            cast("PgExpression", dataset_fields.get("product") == product.name)
         ]
 
         with self._db_connection() as connection:

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -8,17 +8,15 @@ API for dataset indexing, access and search.
 
 from __future__ import annotations
 
-import datetime
 import logging
 import warnings
 from collections import namedtuple
-from collections.abc import Generator, Iterable, Iterator, Mapping, Sequence
 from time import monotonic
-from typing import TYPE_CHECKING, Any, NamedTuple, cast
+from typing import Any, NamedTuple, cast
 from uuid import UUID
 
 from deprecat import deprecat
-from odc.geo import CRS, Geometry
+from odc.geo import CRS
 from typing_extensions import override
 
 from datacube.drivers.postgis._api import (
@@ -26,7 +24,7 @@ from datacube.drivers.postgis._api import (
     mk_simple_offset_field,
     non_native_fields,
 )
-from datacube.drivers.postgis._fields import PgExpression, PgField, SimpleDocField
+from datacube.drivers.postgis._fields import SimpleDocField
 from datacube.drivers.postgis._schema import Dataset as SQLDataset
 from datacube.drivers.postgis._schema import search_field_map
 from datacube.drivers.postgis._spatial import (
@@ -39,27 +37,36 @@ from datacube.index import (
     strip_all_spatial_fields_from_query,
 )
 from datacube.index.abstract import (
-    DSID,
     AbstractDatasetResource,
     BatchStatus,
     DatasetSpatialMixin,
     DatasetTuple,
     dsid_to_uuid,
 )
-from datacube.index.abstract._types import SearchMode
 from datacube.index.postgis._transaction import IndexResourceAddIn
 from datacube.migration import ODC2DeprecationWarning
-from datacube.model import Dataset, LineageTree, Product, Range
-from datacube.model._base import QueryDict, QueryField
+from datacube.model import Dataset, Range
 from datacube.model.fields import Field
 from datacube.utils import _readable_offset, changes, json, jsonify_document
-from datacube.utils.changes import Change, Offset, get_doc_changes
-from datacube.utils.documents import JsonDict
+from datacube.utils.changes import get_doc_changes
 from datacube.utils.uris import split_uri
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
+    import datetime
+    from collections.abc import Generator, Iterable, Iterator, Mapping, Sequence
+
+    from odc.geo import Geometry
+
     from datacube.drivers.postgis import PostGisDb
+    from datacube.drivers.postgis._fields import PgExpression, PgField
+    from datacube.index.abstract import DSID
+    from datacube.index.abstract._types import SearchMode
     from datacube.index.postgis.index import Index
+    from datacube.model import LineageTree, Product
+    from datacube.model._base import QueryDict, QueryField
+    from datacube.utils.changes import Change, Offset
+    from datacube.utils.documents import JsonDict
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/index/postgis/_lineage.py
+++ b/datacube/index/postgis/_lineage.py
@@ -2,23 +2,25 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from collections.abc import Iterable, Mapping
+from __future__ import annotations
+
 from time import monotonic
-from uuid import UUID
 
 from typing_extensions import override
 
-from datacube.drivers.postgis._connections import PostGisDb
-from datacube.index.abstract import (
-    DSID,
-    AbstractIndex,
-    AbstractLineageResource,
-    BatchStatus,
-    dsid_to_uuid,
-)
+from datacube.index.abstract import AbstractLineageResource, BatchStatus, dsid_to_uuid
 from datacube.index.postgis._transaction import IndexResourceAddIn
-from datacube.model import LineageDirection, LineageRelation, LineageTree
+from datacube.model import LineageDirection, LineageRelation
 from datacube.model.lineage import LineageRelations
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+    from uuid import UUID
+
+    from datacube.drivers.postgis._connections import PostGisDb
+    from datacube.index.abstract import DSID, AbstractIndex
+    from datacube.model import LineageTree
 
 
 class LineageResource(AbstractLineageResource, IndexResourceAddIn):

--- a/datacube/index/postgis/_metadata_types.py
+++ b/datacube/index/postgis/_metadata_types.py
@@ -5,9 +5,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterable, Mapping
 from time import monotonic
-from typing import TYPE_CHECKING
 
 from cachetools.func import lru_cache
 from typing_extensions import override
@@ -17,17 +15,18 @@ from datacube.index.postgis._transaction import IndexResourceAddIn
 from datacube.model import MetadataType
 from datacube.utils import _readable_offset, changes, jsonify_document
 from datacube.utils.changes import (
-    AllowPolicy,
-    Change,
-    Offset,
     check_doc_unchanged,
     get_doc_changes,
 )
-from datacube.utils.documents import JsonDict
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
     from datacube.drivers.postgis import PostGisDb
     from datacube.index.postgis.index import Index
+    from datacube.utils.changes import AllowPolicy, Change, Offset
+    from datacube.utils.documents import JsonDict
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/index/postgis/_products.py
+++ b/datacube/index/postgis/_products.py
@@ -4,29 +4,32 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import datetime
 import logging
-from collections.abc import Generator, Iterable, Mapping, Sequence
 from time import monotonic
-from typing import TYPE_CHECKING
 
 from cachetools.func import lru_cache
 from odc.geo.crs import CRS
-from odc.geo.geom import Geometry
 from typing_extensions import override
 
-from datacube.drivers.postgis import PostGisDb
 from datacube.index import fields
 from datacube.index.abstract import AbstractProductResource, BatchStatus
-from datacube.index.abstract._metadata_types import AbstractMetadataTypeResource
 from datacube.index.postgis._transaction import IndexResourceAddIn
-from datacube.model import Product, QueryDict, QueryField
+from datacube.model import Product
 from datacube.utils import _readable_offset, changes, jsonify_document
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes
-from datacube.utils.documents import JsonDict
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
+    import datetime
+    from collections.abc import Generator, Iterable, Mapping, Sequence
+
+    from odc.geo.geom import Geometry
+
+    from datacube.drivers.postgis import PostGisDb
+    from datacube.index.abstract._metadata_types import AbstractMetadataTypeResource
     from datacube.index.postgis.index import Index
+    from datacube.model import QueryDict, QueryField
+    from datacube.utils.documents import JsonDict
 
 
 _LOG: logging.Logger = logging.getLogger(__name__)

--- a/datacube/index/postgis/_transaction.py
+++ b/datacube/index/postgis/_transaction.py
@@ -2,16 +2,21 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
-from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any
 
 from typing_extensions import override
 
-from datacube.drivers.postgis import PostGisDb
 from datacube.drivers.postgis._api import PostgisDbAPI
 from datacube.index.abstract import AbstractTransaction
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from datacube.drivers.postgis import PostGisDb
 
 
 class PostgisTransaction(AbstractTransaction):

--- a/datacube/index/postgis/_users.py
+++ b/datacube/index/postgis/_users.py
@@ -4,16 +4,16 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from collections.abc import Iterable
-from typing import TYPE_CHECKING
-
 from typing_extensions import override
 
-from datacube.drivers.postgis import PostGisDb
 from datacube.index.abstract import AbstractUserResource
 from datacube.index.postgis._transaction import IndexResourceAddIn
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from datacube.drivers.postgis import PostGisDb
     from datacube.index.postgis.index import Index
 
 

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -2,8 +2,9 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import logging
-from collections.abc import Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
@@ -12,14 +13,11 @@ from deprecat import deprecat
 from odc.geo import CRS
 from typing_extensions import override
 
-from datacube.cfg.api import ODCEnvironment, ODCOptionHandler
 from datacube.cfg.opt import config_options_for_psql_driver
-from datacube.drivers.postgis import PostGisDb, PostgisDbAPI
+from datacube.drivers.postgis import PostGisDb
 from datacube.index.abstract import (
-    DSID,
     AbstractIndex,
     AbstractIndexDriver,
-    AbstractTransaction,
     default_metadata_type_docs,
 )
 from datacube.index.postgis._datasets import DatasetResource
@@ -30,7 +28,15 @@ from datacube.index.postgis._transaction import PostgisTransaction
 from datacube.index.postgis._users import UserResource
 from datacube.migration import ODC2DeprecationWarning
 from datacube.model import MetadataType
-from datacube.utils.json_types import JsonDict
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, Mapping, Sequence
+
+    from datacube.cfg.api import ODCEnvironment, ODCOptionHandler
+    from datacube.drivers.postgis import PostgisDbAPI
+    from datacube.index.abstract import DSID, AbstractTransaction
+    from datacube.utils.json_types import JsonDict
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -133,7 +139,7 @@ class Index(AbstractIndex):
         cfg_env: ODCEnvironment,
         application_name: str | None = None,
         validate_connection: bool = True,
-    ) -> "Index":
+    ) -> Index:
         db = PostGisDb.from_config(
             cfg_env,
             application_name=application_name,

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -8,13 +8,11 @@ API for dataset indexing, access and search.
 
 from __future__ import annotations
 
-import datetime
 import logging
 import warnings
 from collections import namedtuple
-from collections.abc import Generator, Iterable, Iterator, Mapping, Sequence
 from time import monotonic
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import Any, NamedTuple
 from uuid import UUID
 
 from deprecat import deprecat
@@ -25,26 +23,33 @@ from datacube.drivers.postgres._fields import SimpleDocField
 from datacube.drivers.postgres._schema import DATASET
 from datacube.index import fields
 from datacube.index.abstract import (
-    DSID,
     AbstractDatasetResource,
     BatchStatus,
     DatasetSpatialMixin,
     DatasetTuple,
     dsid_to_uuid,
 )
-from datacube.index.abstract._types import SearchMode
 from datacube.index.postgres._transaction import IndexResourceAddIn
 from datacube.migration import ODC2DeprecationWarning
-from datacube.model import Dataset, Product, Range
-from datacube.model._base import QueryDict, QueryField
-from datacube.model.fields import Expression, Field
+from datacube.model import Dataset
+from datacube.model.fields import Field
 from datacube.model.utils import flatten_datasets
 from datacube.utils import _readable_offset, changes, json, jsonify_document
-from datacube.utils.changes import Offset, get_doc_changes
+from datacube.utils.changes import get_doc_changes
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
+    import datetime
+    from collections.abc import Generator, Iterable, Iterator, Mapping, Sequence
+
     from datacube.drivers.postgres import PostgresDb
+    from datacube.index.abstract import DSID
+    from datacube.index.abstract._types import SearchMode
     from datacube.index.postgres.index import Index
+    from datacube.model import Product, Range
+    from datacube.model._base import QueryDict, QueryField
+    from datacube.model.fields import Expression
+    from datacube.utils.changes import Offset
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/index/postgres/_lineage.py
+++ b/datacube/index/postgres/_lineage.py
@@ -2,7 +2,8 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from collections.abc import Iterable
+from __future__ import annotations
+
 from time import monotonic
 
 from typing_extensions import override
@@ -10,6 +11,10 @@ from typing_extensions import override
 from datacube.index.abstract import BatchStatus, NoLineageResource
 from datacube.index.postgres._transaction import IndexResourceAddIn
 from datacube.model import LineageRelation
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 class LineageResource(NoLineageResource, IndexResourceAddIn):

--- a/datacube/index/postgres/_metadata_types.py
+++ b/datacube/index/postgres/_metadata_types.py
@@ -5,8 +5,6 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterable, Mapping
-from typing import TYPE_CHECKING
 
 from cachetools.func import lru_cache
 from typing_extensions import override
@@ -15,18 +13,16 @@ from datacube.index.abstract import AbstractMetadataTypeResource
 from datacube.index.postgres._transaction import IndexResourceAddIn
 from datacube.model import MetadataType
 from datacube.utils import _readable_offset, changes, jsonify_document
-from datacube.utils.changes import (
-    AllowPolicy,
-    Change,
-    Offset,
-    check_doc_unchanged,
-    get_doc_changes,
-)
-from datacube.utils.documents import JsonDict
+from datacube.utils.changes import check_doc_unchanged, get_doc_changes
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
     from datacube.drivers.postgres import PostgresDb
     from datacube.index.postgres.index import Index
+    from datacube.utils.changes import AllowPolicy, Change, Offset
+    from datacube.utils.documents import JsonDict
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/index/postgres/_products.py
+++ b/datacube/index/postgres/_products.py
@@ -4,27 +4,31 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import datetime
 import logging
-from collections.abc import Generator, Iterable, Mapping, Sequence
-from typing import TYPE_CHECKING
 
 from cachetools.func import lru_cache
-from odc.geo import CRS, Geometry
+from odc.geo import CRS
 from typing_extensions import override
 
-from datacube.drivers.postgres import PostgresDb
 from datacube.index import fields
 from datacube.index.abstract import AbstractProductResource
-from datacube.index.abstract._metadata_types import AbstractMetadataTypeResource
 from datacube.index.postgres._transaction import IndexResourceAddIn
-from datacube.model import Product, QueryField
+from datacube.model import Product
 from datacube.utils import _readable_offset, changes, jsonify_document
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes
-from datacube.utils.documents import JsonDict
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
+    import datetime
+    from collections.abc import Generator, Iterable, Mapping, Sequence
+
+    from odc.geo import Geometry
+
+    from datacube.drivers.postgres import PostgresDb
+    from datacube.index.abstract._metadata_types import AbstractMetadataTypeResource
     from datacube.index.postgres.index import Index
+    from datacube.model import QueryField
+    from datacube.utils.documents import JsonDict
 
 
 _LOG: logging.Logger = logging.getLogger(__name__)

--- a/datacube/index/postgres/_transaction.py
+++ b/datacube/index/postgres/_transaction.py
@@ -2,16 +2,21 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
-from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any
 
 from typing_extensions import override
 
-from datacube.drivers.postgres import PostgresDb
 from datacube.drivers.postgres._api import PostgresDbAPI
 from datacube.index.abstract import AbstractTransaction
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from datacube.drivers.postgres import PostgresDb
 
 
 class PostgresTransaction(AbstractTransaction):

--- a/datacube/index/postgres/_users.py
+++ b/datacube/index/postgres/_users.py
@@ -4,16 +4,16 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from collections.abc import Iterable
-from typing import TYPE_CHECKING
-
 from typing_extensions import override
 
-from datacube.drivers.postgres import PostgresDb
 from datacube.index.abstract import AbstractUserResource
 from datacube.index.postgres._transaction import IndexResourceAddIn
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from datacube.drivers.postgres import PostgresDb
     from datacube.index.postgres.index import Index
 
 

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -2,21 +2,20 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import logging
-from collections.abc import Iterable, Iterator, Mapping
 from contextlib import contextmanager
 from typing import Any
 
 from deprecat import deprecat
 from typing_extensions import override
 
-from datacube.cfg.api import ODCEnvironment
-from datacube.cfg.opt import ODCOptionHandler, config_options_for_psql_driver
-from datacube.drivers.postgres import PostgresDb, PostgresDbAPI
+from datacube.cfg.opt import config_options_for_psql_driver
+from datacube.drivers.postgres import PostgresDb
 from datacube.index.abstract import (
     AbstractIndex,
     AbstractIndexDriver,
-    AbstractTransaction,
     default_metadata_type_docs,
 )
 from datacube.index.postgres._datasets import DatasetResource
@@ -27,7 +26,16 @@ from datacube.index.postgres._transaction import PostgresTransaction
 from datacube.index.postgres._users import UserResource
 from datacube.migration import ODC2DeprecationWarning
 from datacube.model import MetadataType
-from datacube.utils.json_types import JsonDict
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, Mapping
+
+    from datacube.cfg.api import ODCEnvironment
+    from datacube.cfg.opt import ODCOptionHandler
+    from datacube.drivers.postgres import PostgresDbAPI
+    from datacube.index.abstract import AbstractTransaction
+    from datacube.utils.json_types import JsonDict
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -123,7 +131,7 @@ class Index(AbstractIndex):
         cfg_env: ODCEnvironment,
         application_name: str | None = None,
         validate_connection: bool = True,
-    ) -> "Index":
+    ) -> Index:
         db = PostgresDb.from_config(
             cfg_env,
             application_name=application_name,

--- a/datacube/metadata/_eo3converter.py
+++ b/datacube/metadata/_eo3converter.py
@@ -8,31 +8,23 @@ STAC -> EO3 utilities.
 Utilities for translating STAC Items to EO3 Datasets.
 """
 
+from __future__ import annotations
+
 import dataclasses
 import uuid
-from collections.abc import Iterable, Iterator, Sequence
 from functools import singledispatch
 from typing import Any
 
 from odc.geo import CRS, Geometry
 from odc.geo.geobox import GeoBox
-from odc.loader.types import (
-    BandKey,
-    RasterBandMetadata,
-    RasterSource,
-)
+from odc.loader.types import RasterSource
 from odc.stac._mdtools import (
     EPSG4326,
-    ConversionConfig,
     _collection_id,
     extract_collection_metadata,
     mk_1x1_geobox,
     mk_sample_item,
     parse_item,
-)
-from odc.stac.model import (
-    ParsedItem,
-    RasterCollectionMetadata,
 )
 from pystac import Collection, Item
 
@@ -40,6 +32,14 @@ from datacube.index.eo3 import prep_eo3
 from datacube.model import Dataset, Product
 
 from ._utils import EO3_MD_TYPE, stac_to_eo3_properties
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, Sequence
+
+    from odc.loader.types import BandKey, RasterBandMetadata
+    from odc.stac._mdtools import ConversionConfig
+    from odc.stac.model import ParsedItem, RasterCollectionMetadata
 
 # uuid.uuid5(uuid.NAMESPACE_URL, "https://stacspec.org")
 UUID_NAMESPACE_STAC = uuid.UUID("55d26088-a6d0-5c77-bf9a-3a7f3c6a6dab")

--- a/datacube/metadata/_stacconverter.py
+++ b/datacube/metadata/_stacconverter.py
@@ -8,10 +8,11 @@ EO3 -> STAC utilities.
 Utilities for translating EO3 Datasets to STAC Items.
 """
 
+from __future__ import annotations
+
 import math
 import mimetypes
 import warnings
-from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 from urllib.parse import urljoin
@@ -36,6 +37,10 @@ from datacube.utils import parse_time
 
 from ..migration import ODC2DeprecationWarning
 from ._utils import EO3_MD_TYPE, EO_MD_TYPE, eo3_to_stac_properties
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 def _lineage_fields(dataset: Dataset) -> dict:

--- a/datacube/metadata/_utils.py
+++ b/datacube/metadata/_utils.py
@@ -6,14 +6,20 @@
 Mirrored helper functions for STAC/EO3 conversion
 """
 
+from __future__ import annotations
+
 from datetime import datetime
 from typing import Any
 
 from pystac.utils import datetime_to_str
 
 from datacube.index.abstract import default_metadata_type_docs
-from datacube.model import Dataset, MetadataType, metadata_from_doc
+from datacube.model import metadata_from_doc
 from datacube.utils import parse_time
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.model import Dataset, MetadataType
 
 # Mapping between EO3 field names and STAC properties object field names
 # EO3 metadata was defined before STAC 1.0, so we used some extensions

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -8,12 +8,11 @@ Core classes used across modules.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import math
 import warnings
 from collections import OrderedDict
-from collections.abc import Callable, Generator, Iterable, Iterator, Mapping, Sequence
-from datetime import datetime
 from functools import cached_property
 from pathlib import Path
 from typing import Any, TypeAlias
@@ -22,8 +21,14 @@ from uuid import UUID
 
 import numpy as np
 from affine import Affine
+from deprecat import deprecat
+from odc.geo import CRS, BoundingBox, Geometry, res_, resyx_, wh_, yx_
+from odc.geo.geobox import GeoBox
+from odc.geo.geom import intersects, polygon
+from odc.geo.gridspec import GridSpec as GeoGridSpec
 from typing_extensions import override
 
+from datacube.migration import ODC2DeprecationWarning
 from datacube.utils import (
     DocReader,
     parse_time,
@@ -32,6 +37,7 @@ from datacube.utils import (
     without_lineage_sources,
 )
 
+from ..utils.uris import pick_uri
 from ._base import Not, QueryDict, QueryField, Range, ranges_overlap  # noqa: F401
 from .eo3 import validate_eo3_compatible_type
 from .fields import Field, get_dataset_fields
@@ -41,6 +47,22 @@ from .lineage import (
     LineageRelation,
     LineageTree,
 )
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import (
+        Callable,
+        Generator,
+        Iterable,
+        Iterator,
+        Mapping,
+        Sequence,
+    )
+    from datetime import datetime
+
+    from odc.geo import Resolution, SomeShape
+    from odc.stac.model import RasterCollectionMetadata
+
 
 __all__ = [
     "Dataset",
@@ -61,29 +83,6 @@ __all__ = [
     "metadata_from_doc",
     "ranges_overlap",
 ]
-
-import contextlib
-
-from deprecat import deprecat
-from odc.geo import (
-    CRS,
-    BoundingBox,
-    Geometry,
-    Resolution,
-    SomeShape,
-    res_,
-    resyx_,
-    wh_,
-    yx_,
-)
-from odc.geo.geobox import GeoBox
-from odc.geo.geom import intersects, polygon
-from odc.geo.gridspec import GridSpec as GeoGridSpec
-from odc.stac.model import RasterCollectionMetadata
-
-from datacube.migration import ODC2DeprecationWarning
-
-from ..utils.uris import pick_uri
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/model/eo3.py
+++ b/datacube/model/eo3.py
@@ -2,10 +2,15 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from collections.abc import Sequence
+from __future__ import annotations
+
 from typing import Any
 
 from datacube.utils.documents import InvalidDocException
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 required_sys_field_values = [
     "id",

--- a/datacube/model/fields.py
+++ b/datacube/model/fields.py
@@ -7,8 +7,9 @@
 This allows extraction of fields of interest from dataset metadata document.
 """
 
+from __future__ import annotations
+
 import decimal
-from collections.abc import Callable, Mapping
 from typing import Any, Generic, Literal, TypeAlias, get_args
 
 import toolz
@@ -17,6 +18,10 @@ from typing_extensions import override
 from datacube.utils import parse_time
 
 from ._base import OrderedT, Range
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
 
 # Allowed values for field 'type' (specified in a metadata type document)
 _AVAILABLE_TYPES: TypeAlias = Literal[

--- a/datacube/model/lineage.py
+++ b/datacube/model/lineage.py
@@ -94,7 +94,7 @@ class LineageTree:
     ) -> "LineageTree":
         if "id" not in serialised:
             raise ValueError("Serialised Lineage tree node must have an id")
-        id_ = UUID(cast(str, serialised["id"]))
+        id_ = UUID(cast("str", serialised["id"]))
         home = serialised.get("home")
         if direction is None:
             if LineageDirection.SOURCES.label in serialised:
@@ -116,14 +116,14 @@ class LineageTree:
                     for child_tree in child_trees
                 ]
                 for classifier, child_trees in cast(
-                    dict[str, list[SerialisedTree]], serialised[direction.label]
+                    "dict[str, list[SerialisedTree]]", serialised[direction.label]
                 ).items()
             }
         else:
             children = {}
         return LineageTree(
             dataset_id=id_,
-            home=cast(str | None, home),
+            home=cast("str | None", home),
             direction=direction,
             children=children,
         )

--- a/datacube/model/lineage.py
+++ b/datacube/model/lineage.py
@@ -2,13 +2,18 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from collections.abc import Iterable, Mapping, Sequence
+from __future__ import annotations
+
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Optional, TypeAlias, cast
+from typing import Any, TypeAlias, cast
 from uuid import UUID
 
 from typing_extensions import override
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping, Sequence
 
 
 class LineageDirection(Enum):
@@ -22,7 +27,7 @@ class LineageDirection(Enum):
     SOURCES = 1
     DERIVED = 2
 
-    def opposite(self) -> "LineageDirection":
+    def opposite(self) -> LineageDirection:
         if self == LineageDirection.SOURCES:
             return LineageDirection.DERIVED
         return LineageDirection.SOURCES
@@ -58,7 +63,7 @@ class LineageTree:
 
     direction: LineageDirection
     dataset_id: UUID
-    children: dict[str, list["LineageTree"]] | None = None
+    children: dict[str, list[LineageTree]] | None = None
     home: str | None = None
 
     @override
@@ -91,7 +96,7 @@ class LineageTree:
     @classmethod
     def deserialise(
         cls, serialised: SerialisedTree, direction: LineageDirection | None = None
-    ) -> "LineageTree":
+    ) -> LineageTree:
         if "id" not in serialised:
             raise ValueError("Serialised Lineage tree node must have an id")
         id_ = UUID(cast("str", serialised["id"]))
@@ -129,8 +134,8 @@ class LineageTree:
         )
 
     def find_subtree(
-        self, dsid: UUID, _state: list["LineageTree"] | None = None
-    ) -> Optional["LineageTree"]:
+        self, dsid: UUID, _state: list[LineageTree] | None = None
+    ) -> LineageTree | None:
         """
         Finds subtree with root at dsid, if there is one.
 
@@ -177,7 +182,7 @@ class LineageTree:
         doc: Mapping[str, Any],
         home: str | None = None,
         home_derived: str | None = None,
-    ) -> "LineageTree":
+    ) -> LineageTree:
         """
         Generate a shallow (depth=1) LineageTree from an EO3 dataset document
 
@@ -197,7 +202,7 @@ class LineageTree:
         direction: LineageDirection = LineageDirection.SOURCES,
         home: str | None = None,
         home_derived: str | None = None,
-    ) -> "LineageTree":
+    ) -> LineageTree:
         """
         Generate a shallow (depth=1) LineageTree from the sort of data found in an EO3 dataset
 
@@ -284,7 +289,7 @@ class LineageRelations:
         max_depth: int = 0,
         relations: Iterable[LineageRelation] | None = None,
         homes: Mapping[UUID, str] | None = None,
-        clone: Optional["LineageRelations"] = None,
+        clone: LineageRelations | None = None,
     ) -> None:
         """
         All arguments are optional.  Default gives an empty LineageRelations, and:
@@ -391,7 +396,7 @@ class LineageRelations:
                 self.extract_tree(rel.source_id, direction=LineageDirection.DERIVED)
             self.dataset_ids.update(new_ids)
 
-    def merge(self, pool: "LineageRelations") -> None:
+    def merge(self, pool: LineageRelations) -> None:
         """
         Merge in another LineageRelations collection, ensuring it is consistent with this one.
 
@@ -462,7 +467,7 @@ class LineageRelations:
 
     def relations_diff(
         self,
-        existing_relations: Optional["LineageRelations"] = None,
+        existing_relations: LineageRelations | None = None,
         allow_updates: bool = False,
     ) -> tuple[
         Mapping[LineageIDPair, str],

--- a/datacube/model/utils.py
+++ b/datacube/model/utils.py
@@ -2,11 +2,12 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import os
 import platform
 import sys
 import uuid
-from collections.abc import Callable, Generator, Mapping, Sequence
 from datetime import datetime, timezone
 from typing import Any, Literal, overload
 
@@ -15,15 +16,23 @@ import toolz
 import xarray
 import yaml
 from odc.geo import CRS
-from odc.geo.geom import Geometry, point
+from odc.geo.geom import point
 from pandas import to_datetime
-from xarray import DataArray
 
 import datacube
-from datacube.index import Index
-from datacube.model import Dataset, Product
+from datacube.model import Dataset
 from datacube.utils import InvalidDocException, SimpleDocNav
 from datacube.utils.py import sorted_items
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator, Mapping, Sequence
+
+    from odc.geo.geom import Geometry
+    from xarray import DataArray
+
+    from datacube.index import Index
+    from datacube.model import Product
 
 try:
     from yaml import CSafeDumper as SafeDumper

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -656,7 +656,7 @@ def _get_derived_set(index: Index, id_: UUID) -> set[Dataset]:
     Get a single flat set of all derived datasets.
     (children, grandchildren, great-grandchildren...)
     """
-    derived_set = {cast(Dataset, index.datasets.get(id_))}
+    derived_set = {cast("Dataset", index.datasets.get(id_))}
     to_process = {id_}
     while to_process:
         derived = index.datasets.get_derived(to_process.pop())

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -2,45 +2,53 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import csv
 import datetime
 import logging
 import multiprocessing
 import sys
-import uuid
 from collections import OrderedDict
-from collections.abc import (
-    Callable,
-    Generator,
-    Iterable,
-    Mapping,
-    MutableMapping,
-    Sequence,
-)
-from pathlib import Path
 from textwrap import dedent
 from typing import Any, Literal, cast
-from uuid import UUID
 
 import click
 import yaml
 import yaml.resolver
 from click import echo
 
-from datacube.index import Index
-from datacube.index.abstract import DSID, DatasetTuple
+from datacube.index.abstract import DatasetTuple
 from datacube.index.exceptions import MissingRecordError
 from datacube.index.hl import Doc2Dataset
-from datacube.model import Dataset
 from datacube.ui import click as ui
 from datacube.ui.click import cli, print_help_msg
 from datacube.ui.common import ui_path_doc_stream
 from datacube.ui.expression import parse_expressions
-from datacube.utils import SimpleDocNav, changes, json
-from datacube.utils.changes import AllowPolicy, Offset
+from datacube.utils import changes, json
 from datacube.utils.dates import tz_as_utc
 from datacube.utils.serialise import SafeDatacubeDumper
 from datacube.utils.uris import uri_resolve
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    import uuid
+    from collections.abc import (
+        Callable,
+        Generator,
+        Iterable,
+        Mapping,
+        MutableMapping,
+        Sequence,
+    )
+    from pathlib import Path
+    from uuid import UUID
+
+    from datacube.index import Index
+    from datacube.index.abstract import DSID
+    from datacube.model import Dataset
+    from datacube.utils import SimpleDocNav
+    from datacube.utils.changes import AllowPolicy, Offset
 
 _LOG: logging.Logger = logging.getLogger("datacube-dataset")
 

--- a/datacube/scripts/metadata.py
+++ b/datacube/scripts/metadata.py
@@ -2,6 +2,8 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import logging
 import sys
 
@@ -9,11 +11,14 @@ import click
 import yaml
 from click import echo, style
 
-from datacube.index import Index
 from datacube.ui import click as ui
 from datacube.ui.click import cli, exit_on_empty_file, print_help_msg
 from datacube.utils import InvalidDocException, json, read_documents
 from datacube.utils.serialise import SafeDatacubeDumper
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.index import Index
 
 _LOG: logging.Logger = logging.getLogger("datacube-md-type")
 

--- a/datacube/scripts/product.py
+++ b/datacube/scripts/product.py
@@ -2,6 +2,8 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import csv
 import logging
 import signal
@@ -13,11 +15,14 @@ import yaml
 import yaml.resolver
 from click import echo, style
 
-from datacube.index import Index
 from datacube.ui import click as ui
 from datacube.ui.click import cli, exit_on_empty_file, print_help_msg
 from datacube.utils import InvalidDocException, json, read_documents
 from datacube.utils.serialise import SafeDatacubeDumper
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.index import Index
 
 _LOG: logging.Logger = logging.getLogger("datacube-product")
 

--- a/datacube/scripts/search_tool.py
+++ b/datacube/scripts/search_tool.py
@@ -6,22 +6,28 @@
 Query datasets.
 """
 
+from __future__ import annotations
+
 import csv
 import datetime
 import shutil
 import sys
-from collections.abc import Callable, Collection
 from functools import partial, singledispatch
-from os import terminal_size as t_size
 from typing import Any
 
 import click
 from sqlalchemy.dialects.postgresql import Range
 
-from datacube.index import Index
 from datacube.ui import click as ui
 from datacube.ui.click import CLICK_SETTINGS
 from datacube.utils.dates import tz_as_utc
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable, Collection
+    from os import terminal_size as t_size
+
+    from datacube.index import Index
 
 PASS_INDEX = ui.pass_index("datacube-search")
 

--- a/datacube/scripts/spindex.py
+++ b/datacube/scripts/spindex.py
@@ -2,19 +2,25 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import logging
 import sys
-import uuid
-from collections.abc import Sequence
 
 import click
 from click import confirm, echo
 from odc.geo import CRS
 from pyproj.exceptions import CRSError
 
-from datacube.index import Index
 from datacube.ui import click as ui
 from datacube.ui.click import cli, print_help_msg
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    import uuid
+    from collections.abc import Sequence
+
+    from datacube.index import Index
 
 _LOG: logging.Logger = logging.getLogger("datacube-system")
 

--- a/datacube/scripts/system.py
+++ b/datacube/scripts/system.py
@@ -2,6 +2,8 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import logging
 import warnings
 
@@ -10,12 +12,16 @@ from click import echo, style
 from sqlalchemy.exc import OperationalError
 
 import datacube
-from datacube.cfg import ODCEnvironment, psql_url_from_config
+from datacube.cfg import psql_url_from_config
 from datacube.drivers.postgres._connections import IndexSetupError
 from datacube.index import index_connect
 from datacube.migration import ODC2DeprecationWarning
 from datacube.ui import click as ui
 from datacube.ui.click import cli, handle_exception
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.cfg import ODCEnvironment
 
 _LOG: logging.Logger = logging.getLogger("datacube-system")
 

--- a/datacube/scripts/user.py
+++ b/datacube/scripts/user.py
@@ -2,24 +2,30 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import csv
 import logging
 import sys
 from collections import OrderedDict
-from collections.abc import Iterable, Sequence
 from getpass import getpass
 
 import click
 import yaml
 import yaml.resolver
 
-from datacube.cfg import ODCEnvironment
-from datacube.index import Index
-from datacube.index.abstract import AbstractIndex
 from datacube.ui import click as ui
 from datacube.ui.click import cli
 from datacube.utils import gen_password
 from datacube.utils.serialise import SafeDatacubeDumper
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+    from datacube.cfg import ODCEnvironment
+    from datacube.index import Index
+    from datacube.index.abstract import AbstractIndex
 
 _LOG: logging.Logger = logging.getLogger("datacube-user")
 USER_ROLES = ("user", "manage", "admin")

--- a/datacube/storage/_base.py
+++ b/datacube/storage/_base.py
@@ -2,14 +2,20 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from collections.abc import Callable
+from __future__ import annotations
+
 from typing import Any
 from urllib.parse import urlparse
 
 from deprecat import deprecat
 
-from datacube.model import Dataset
 from datacube.utils.uris import pick_uri, uri_resolve
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from datacube.model import Dataset
 
 
 def _get_band_and_layer(b: dict[str, Any]) -> tuple[int | None, str | None]:

--- a/datacube/storage/_load.py
+++ b/datacube/storage/_load.py
@@ -9,29 +9,39 @@ Important functions are:
 
 """
 
+from __future__ import annotations
+
 import logging
 import numbers
 from collections import OrderedDict
-from collections.abc import Callable, Iterable, Iterator, Sequence
+from collections.abc import Callable
 from typing import Any, TypeAlias
 
 import numpy as np
-from odc.geo.geobox import GeoBox
 from odc.geo.roi import roi_is_empty
-from odc.geo.warp import Resampling
 from odc.geo.xr import xr_coords
-from odc.loader import FuserFunc, resolve_fuser
-from xarray.core.coordinates import DataArrayCoordinates
+from odc.loader import resolve_fuser
 from xarray.core.dataarray import DataArray as XrDataArray
 from xarray.core.dataset import Dataset as XrDataset
 
-from datacube.drivers._types import ReaderDriver
-from datacube.model import Measurement
 from datacube.utils import ignore_exceptions_if
 from datacube.utils.math import invalid_mask
 
-from ..drivers.datasource import DataSource
 from ._base import BandInfo
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, Sequence
+
+    from odc.geo.geobox import GeoBox
+    from odc.geo.warp import Resampling
+    from odc.loader import FuserFunc
+    from xarray.core.coordinates import DataArrayCoordinates
+
+    from datacube.drivers._types import ReaderDriver
+    from datacube.model import Measurement
+
+    from ..drivers.datasource import DataSource
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/storage/_loader.py
+++ b/datacube/storage/_loader.py
@@ -143,7 +143,7 @@ def driver_based_load(
                 band=band_idx,
                 subdataset=bi.layer,
                 geobox=ds_geobox(ds, band=n),
-                meta=cast(RasterBandMetadata, template.bands[(n, band_idx or 1)]),
+                meta=cast("RasterBandMetadata", template.bands[(n, band_idx or 1)]),
                 driver_data=bi.driver_data,
             )
 

--- a/datacube/storage/_loader.py
+++ b/datacube/storage/_loader.py
@@ -11,12 +11,10 @@ separate file to reduce formatting issues.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Generator, Mapping, Sequence
 from datetime import datetime
 from typing import Literal, cast
 
-import xarray as xr
-from odc.geo.geobox import GeoBox, GeoboxTiles
+from odc.geo.geobox import GeoboxTiles
 from odc.loader import (
     FixedCoord,
     RasterBandMetadata,
@@ -27,10 +25,19 @@ from odc.loader import (
     reader_driver,
     resolve_chunk_shape,
 )
-from odc.loader.types import ReaderDriverSpec
 
-from ..model import Dataset, ExtraDimensions, Measurement
-from . import BandInfo, ProgressFunction
+from . import BandInfo
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator, Mapping, Sequence
+
+    import xarray as xr
+    from odc.geo.geobox import GeoBox
+    from odc.loader.types import ReaderDriverSpec
+
+    from ..model import Dataset, ExtraDimensions, Measurement
+    from . import ProgressFunction
 
 
 def ds_geobox(ds: Dataset, **kw) -> GeoBox | None:

--- a/datacube/storage/_read.py
+++ b/datacube/storage/_read.py
@@ -74,7 +74,7 @@ def read_time_slice(
     rr = compute_reproject_roi(src_geobox, dst_geobox, ttol=0.9 if is_nn else 0.01)
 
     if roi_is_empty(rr.roi_dst):
-        return cast(tuple[slice, slice], rr.roi_dst)
+        return cast("tuple[slice, slice]", rr.roi_dst)
 
     scale = pick_read_scale(rr.scale, rdr)
 
@@ -172,7 +172,7 @@ def read_time_slice(
                 **gdal_scale_params,
             )
 
-    return cast(tuple[slice, slice], rr.roi_dst)
+    return cast("tuple[slice, slice]", rr.roi_dst)
 
 
 def read_time_slice_v2(
@@ -189,7 +189,7 @@ def read_time_slice_v2(
     rr = compute_reproject_roi(src_geobox, dst_geobox, ttol=0.9 if is_nn else 0.01)
 
     if roi_is_empty(rr.roi_dst):
-        return None, cast(tuple[slice, slice], rr.roi_dst)
+        return None, cast("tuple[slice, slice]", rr.roi_dst)
 
     scale = pick_read_scale(rr.scale, rdr)
 
@@ -254,4 +254,4 @@ def read_time_slice_v2(
                 dst_nodata=dst_nodata,
             )
 
-    return dst, cast(tuple[slice, slice], rr.roi_dst)
+    return dst, cast("tuple[slice, slice]", rr.roi_dst)

--- a/datacube/storage/_read.py
+++ b/datacube/storage/_read.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Dataset -> Raster"""
 
+from __future__ import annotations
+
 from typing import cast
 
 import numpy as np
@@ -11,17 +13,15 @@ from odc.geo import wh_
 from odc.geo.geobox import GeoBox, zoom_out
 from odc.geo.math import is_affine_st, is_almost_int
 from odc.geo.overlap import compute_reproject_roi
-from odc.geo.roi import (
-    roi_is_empty,
-    roi_is_full,
-    roi_pad,
-    roi_shape,
-    w_,
-)
-from odc.geo.types import Nodata
-from odc.geo.warp import Resampling, is_resampling_nn, rio_reproject, warp_affine
+from odc.geo.roi import roi_is_empty, roi_is_full, roi_pad, roi_shape, w_
+from odc.geo.warp import is_resampling_nn, rio_reproject, warp_affine
 
 from ..utils.math import valid_mask
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from odc.geo.types import Nodata
+    from odc.geo.warp import Resampling
 
 
 def rdr_geobox(rdr) -> GeoBox:

--- a/datacube/storage/_rio.py
+++ b/datacube/storage/_rio.py
@@ -10,9 +10,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
-from collections.abc import Generator
 from contextlib import contextmanager
-from threading import RLock
 from urllib.parse import urlparse
 
 import numpy as np
@@ -25,9 +23,16 @@ from datacube.utils import get_part_from_uri, is_vsipath, uri_to_local_path
 from datacube.utils.math import num2numpy
 from datacube.utils.rio import activate_from_config
 
-from ..drivers.datasource import DataSource, GeoRasterReader, RasterShape, RasterWindow
-from ._base import BandInfo
+from ..drivers.datasource import DataSource, GeoRasterReader
 from ._hdf5 import HDF5_LOCK
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from threading import RLock
+
+    from ..drivers.datasource import RasterShape, RasterWindow
+    from ._base import BandInfo
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/testutils/__init__.py
+++ b/datacube/testutils/__init__.py
@@ -6,6 +6,8 @@
 Useful methods for tests (particularly: reading/writing and checking files)
 """
 
+from __future__ import annotations
+
 import atexit
 import contextlib
 import math
@@ -16,14 +18,13 @@ import tempfile
 import typing
 import uuid
 import warnings
-from collections.abc import Callable, Generator, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from datetime import datetime
 from typing import Any
 
 import numpy as np
 import xarray as xr
 from affine import Affine
-from numpy.typing import NDArray
 from odc.geo import CRS, wh_
 from odc.geo.geobox import GeoBox
 
@@ -33,6 +34,12 @@ from datacube.ui.common import get_metadata_path
 from datacube.utils import SimpleDocNav, json, read_documents
 from datacube.utils.dates import mk_time_coord
 from datacube.utils.documents import parse_yaml
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator
+
+    from numpy.typing import NDArray
 
 _DEFAULT = object()
 

--- a/datacube/testutils/geom.py
+++ b/datacube/testutils/geom.py
@@ -2,14 +2,19 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from collections.abc import Callable
+from __future__ import annotations
 
-import numpy as np
 import odc.geo.testutils as odc_geom
-from affine import Affine
 from odc.geo import CRS
-from odc.geo.geobox import GeoBox
 from odc.geo.gridspec import GridSpec
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import numpy as np
+    from affine import Affine
+    from odc.geo.geobox import GeoBox
 
 # pylint: disable=invalid-name
 

--- a/datacube/testutils/io.py
+++ b/datacube/testutils/io.py
@@ -2,9 +2,9 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import inspect
-from collections.abc import Callable, Generator, Sequence
-from os import PathLike
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -12,7 +12,6 @@ from typing import Any
 import numpy as np
 import toolz
 import xarray as xr
-from affine import Affine
 from odc.geo import CRS, wh_
 from odc.geo.geobox import GeoBox, zoom_to
 from odc.geo.geobox import pad as gbox_pad
@@ -22,11 +21,19 @@ from typing_extensions import override
 
 from ..api import Datacube
 from ..index.eo3 import EO3Grid
-from ..model import Dataset
 from ..storage import BandInfo, reproject_and_fuse
 from ..storage._read import rdr_geobox
 from ..storage._rio import RasterDatasetDataSource, RasterioDataSource
 from . import suppress_deprecations
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator, Sequence
+    from os import PathLike
+
+    from affine import Affine
+
+    from ..model import Dataset
 
 
 class RasterFileDataSource(RasterioDataSource):

--- a/datacube/testutils/iodriver.py
+++ b/datacube/testutils/iodriver.py
@@ -4,13 +4,18 @@
 # SPDX-License-Identifier: Apache-2.0
 """Reader driver construction for tests"""
 
+from __future__ import annotations
+
 from pathlib import Path
 
-from datacube.drivers._types import GeoRasterReader, ReaderDriver
 from datacube.drivers.rio._reader import RDEntry
 from datacube.storage import BandInfo
 from datacube.testutils import mk_sample_dataset
 from datacube.testutils.threads import FakeThreadPoolExecutor
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.drivers._types import GeoRasterReader, ReaderDriver
 
 NetCDF = "NetCDF"  # pylint: disable=invalid-name
 GeoTIFF = "GeoTIFF"  # pylint: disable=invalid-name

--- a/datacube/ui/click.py
+++ b/datacube/ui/click.py
@@ -6,28 +6,37 @@
 Common functions for click-based cli scripts.
 """
 
+from __future__ import annotations
+
 import copy
 import functools
 import logging
 import os
 import sys
-from collections.abc import Callable, Mapping, Sequence
-from pathlib import Path
 from textwrap import dedent
 from typing import Literal
 
 import click
-from click import Command
 from lark.exceptions import UnexpectedEOF
 from sqlalchemy.exc import OperationalError, ProgrammingError
 from typing_extensions import override
 
 from datacube import __version__
 from datacube.api.core import Datacube
-from datacube.cfg import ConfigException, ODCConfig, ODCEnvironment
-from datacube.index import Index, index_connect
+from datacube.cfg import ConfigException, ODCConfig
+from datacube.index import index_connect
 from datacube.index.exceptions import NoIndexError
 from datacube.ui.expression import parse_expressions
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping, Sequence
+    from pathlib import Path
+
+    from click import Command
+
+    from datacube.cfg import ODCEnvironment
+    from datacube.index import Index
 
 _LOG_FORMAT_STRING = "%(asctime)s %(process)d %(name)s %(levelname)s %(message)s"
 CLICK_SETTINGS: dict[str, list[str]] = {"help_option_names": ["-h", "--help"]}

--- a/datacube/ui/common.py
+++ b/datacube/ui/common.py
@@ -6,7 +6,8 @@
 Common methods for UI code.
 """
 
-from collections.abc import Generator, Iterable
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Literal, overload
 
@@ -19,6 +20,10 @@ from datacube.utils import (
     is_url,
     read_documents,
 )
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable
 
 
 def get_metadata_path(possible_path: str | Path) -> str:

--- a/datacube/ui/expression.py
+++ b/datacube/ui/expression.py
@@ -17,14 +17,20 @@ Where DATE or DATE-RANGE is one of YYYY, YYYY-MM or YYYY-MM-DD
 and START, END are either numbers or dates.
 """
 
-from datetime import datetime
+from __future__ import annotations
+
 from typing import Any
 
 from lark import Lark, Transformer, v_args
 
 from datacube.api.query import _time_to_search_dims
 from datacube.model import Range
-from datacube.utils.generic import T
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from datacube.utils.generic import T
 
 search_grammar = r"""
     start: expression*

--- a/datacube/ui/task_app.py
+++ b/datacube/ui/task_app.py
@@ -2,6 +2,8 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import functools
 import itertools
 import logging
@@ -9,15 +11,19 @@ import os
 import pickle
 import re
 import time
-from collections.abc import Generator, Sequence
 from pathlib import Path
 
 import click
 import pandas as pd
 
-from datacube.index import Index
 from datacube.ui import click as dc_ui
 from datacube.utils import read_documents
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator, Sequence
+
+    from datacube.index import Index
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/utils/_misc.py
+++ b/datacube/utils/_misc.py
@@ -6,9 +6,14 @@
 Utility functions
 """
 
-import logging
+from __future__ import annotations
+
 import os
 import sys
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    import logging
 
 
 class DatacubeException(Exception):  # noqa: N818

--- a/datacube/utils/aws/__init__.py
+++ b/datacube/utils/aws/__init__.py
@@ -6,10 +6,11 @@
 Helper methods for working with AWS
 """
 
+from __future__ import annotations
+
 import functools
 import os
 import time
-from collections.abc import Generator
 from typing import IO, Any, TypeAlias
 from urllib.parse import urlparse
 from urllib.request import urlopen
@@ -18,12 +19,17 @@ import botocore
 import botocore.session
 from botocore.client import BaseClient
 from botocore.config import Config
-from botocore.credentials import Credentials, ReadOnlyCredentials
-from botocore.session import Session
 from odc.loader._rio import configure_s3_access as rio_configure_s3_access
-from sqlalchemy.engine.url import URL
 
 from datacube.utils.generic import thread_local_cache
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from botocore.credentials import Credentials, ReadOnlyCredentials
+    from botocore.session import Session
+    from sqlalchemy.engine.url import URL
 
 ByteRange: TypeAlias = slice | tuple[int, int]  # pylint: disable=invalid-name
 MaybeS3: TypeAlias = BaseClient | None

--- a/datacube/utils/aws/inventory.py
+++ b/datacube/utils/aws/inventory.py
@@ -2,18 +2,23 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import csv
-from collections.abc import Generator, Iterable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from gzip import GzipFile
 from io import BytesIO
 from types import SimpleNamespace
 
-from botocore.client import BaseClient
-
 from datacube.utils import json
 
 from . import s3_client, s3_fetch, s3_ls_dir
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable
+
+    from botocore.client import BaseClient
 
 
 def find_latest_manifest(prefix: str, s3: BaseClient | None, **kw) -> str:

--- a/datacube/utils/aws/queue.py
+++ b/datacube/utils/aws/queue.py
@@ -2,15 +2,20 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import itertools
 import logging
-from collections.abc import Generator, Iterable, Iterator, Mapping
 from typing import Any
 
 import boto3
 from toolz import dicttoolz
 
 from datacube.utils import json
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable, Iterator, Mapping
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/utils/changes.py
+++ b/datacube/utils/changes.py
@@ -103,7 +103,7 @@ def get_doc_changes(
             )
     elif isinstance(original, tuple) or isinstance(new, tuple):
         if not numpy.array_equal(
-            cast(Sequence[Any], original), cast(Sequence[Any], new)
+            cast("Sequence[Any]", original), cast("Sequence[Any]", new)
         ):
             changed_fields.append((base_prefix, original, new))
     else:

--- a/datacube/utils/cog.py
+++ b/datacube/utils/cog.py
@@ -2,26 +2,33 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import warnings
-from pathlib import Path
 from typing import Any
 
 import dask
 import numpy as np
 import rasterio
 import toolz
-import xarray as xr
 from dask.base import is_dask_collection
 from dask.delayed import Delayed
 from deprecat import deprecat
-from odc.geo.geobox import GeoBox
 from odc.geo.math import align_up
-from odc.geo.warp import Resampling, resampling_s2rio
+from odc.geo.warp import resampling_s2rio
 from rasterio.shutil import copy as rio_copy
 
 from datacube.migration import ODC2DeprecationWarning
 
 from .io import check_write_path
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import xarray as xr
+    from odc.geo.geobox import GeoBox
+    from odc.geo.warp import Resampling
 
 __all__ = ["to_cog", "write_cog"]
 

--- a/datacube/utils/dask.py
+++ b/datacube/utils/dask.py
@@ -4,19 +4,26 @@
 # SPDX-License-Identifier: Apache-2.0
 """Dask Distributed Tools"""
 
+from __future__ import annotations
+
 import logging
 import os
 import queue
 import threading
-from collections.abc import Iterable
 from random import randint
 from typing import Any
 
 import dask
 import toolz
-from botocore.credentials import ReadOnlyCredentials
-from dask.delayed import Delayed, DelayedLeaf, delayed
+from dask.delayed import delayed
 from dask.distributed import Client
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from botocore.credentials import ReadOnlyCredentials
+    from dask.delayed import Delayed, DelayedLeaf
 
 __all__ = [
     "compute_tasks",

--- a/datacube/utils/dates.py
+++ b/datacube/utils/dates.py
@@ -9,8 +9,9 @@ Includes sequence generation functions to be used by statistics apps
 
 """
 
-from collections.abc import Generator
-from datetime import date, datetime, timezone, tzinfo
+from __future__ import annotations
+
+from datetime import datetime, timezone
 
 import dateutil
 import dateutil.parser
@@ -18,6 +19,11 @@ import numpy as np
 import xarray as xr
 from dateutil.relativedelta import relativedelta
 from dateutil.rrule import DAILY, MONTHLY, YEARLY, rrule
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from datetime import date, tzinfo
 
 try:
     from ciso8601 import parse_datetime

--- a/datacube/utils/documents.py
+++ b/datacube/utils/documents.py
@@ -13,15 +13,12 @@ import gzip
 import logging
 import math
 from collections import OrderedDict
-from collections.abc import Callable, Generator, Mapping, Sequence
 from contextlib import contextmanager
 from copy import deepcopy
-from io import TextIOWrapper
-from os import PathLike
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 from urllib.parse import urlparse
-from urllib.request import Request, urlopen
+from urllib.request import urlopen
 from uuid import UUID, uuid5
 
 import numpy
@@ -30,13 +27,9 @@ import yaml
 from typing_extensions import override
 
 from datacube.utils import json
-from datacube.utils.changes import Offset
 
 # Compatibility-imports to preserve the API.
 from datacube.utils.json_types import JsonAtom, JsonDict, JsonLike  # noqa: F401
-
-if TYPE_CHECKING:
-    from datacube.model import Field
 
 try:
     from yaml import CSafeLoader as SafeLoader
@@ -45,6 +38,19 @@ except ImportError:
 
 from datacube.utils.generic import map_with_lookahead
 from datacube.utils.uris import as_url, mk_part_uri, uri_to_local_path
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator, Mapping, Sequence
+    from io import TextIOWrapper
+    from os import PathLike
+    from urllib.request import Request
+
+    from referencing import Resource
+    from referencing.typing import URI
+
+    from datacube.model import Field
+    from datacube.utils.changes import Offset
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -250,10 +256,8 @@ def validate_document(
 ) -> None:
     import jsonschema
     import referencing
-    from referencing import Resource
     from referencing.exceptions import NoSuchResource
     from referencing.jsonschema import DRAFT202012
-    from referencing.typing import URI
 
     # Allow schemas to reference other schemas in the given folder.
     def doc_reference(uri: URI) -> Resource:

--- a/datacube/utils/generic.py
+++ b/datacube/utils/generic.py
@@ -2,11 +2,16 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import itertools
 import threading
-from collections.abc import Callable, Generator, Iterable, Iterator
-from queue import Queue
 from typing import Any, TypeVar
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator, Iterable, Iterator
+    from queue import Queue
 
 EOS = object()
 _LCL = threading.local()

--- a/datacube/utils/geometry/_base.py
+++ b/datacube/utils/geometry/_base.py
@@ -2,14 +2,15 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-import array
+from __future__ import annotations
+
 import functools
 import itertools
 import math
 import warnings
 from collections import OrderedDict
-from collections.abc import Callable, Hashable, Iterable, Iterator, Mapping, Sequence
-from typing import Any, NamedTuple, Optional, TypeAlias, Union
+from collections.abc import Sequence
+from typing import Any, NamedTuple, TypeAlias
 
 import cachetools
 import numpy
@@ -25,10 +26,15 @@ from shapely import from_wkt, geometry, ops
 from shapely.geometry import base
 from typing_extensions import override
 
-from datacube.utils.generic import T
-
 from ..math import is_almost_int
 from .tools import is_affine_st, roi_normalise, roi_shape
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    import array
+    from collections.abc import Callable, Hashable, Iterable, Iterator, Mapping
+
+    from datacube.utils.generic import T
 
 
 class Coordinate(NamedTuple):
@@ -54,7 +60,7 @@ class BoundingBox(_BoundingBox):
     Bounding box, defining extent in cartesian coordinates.
     """
 
-    def buffered(self, ybuff: float, xbuff: float) -> "BoundingBox":
+    def buffered(self, ybuff: float, xbuff: float) -> BoundingBox:
         """
         Return a new BoundingBox, buffered in the x and y dimensions.
 
@@ -101,7 +107,7 @@ class BoundingBox(_BoundingBox):
         x0, y0, x1, y1 = self
         return list(itertools.product((x0, x1), (y0, y1)))
 
-    def transform(self, transform: Affine) -> "BoundingBox":
+    def transform(self, transform: Affine) -> BoundingBox:
         """
         Transform bounding box through a linear transform
 
@@ -114,7 +120,7 @@ class BoundingBox(_BoundingBox):
         return BoundingBox(min(xx), min(yy), max(xx), max(yy))
 
     @staticmethod
-    def from_xy(x: tuple[float, float], y: tuple[float, float]) -> "BoundingBox":
+    def from_xy(x: tuple[float, float], y: tuple[float, float]) -> BoundingBox:
         """
         BoundingBox from x and y ranges
 
@@ -126,7 +132,7 @@ class BoundingBox(_BoundingBox):
         return BoundingBox(x1, y1, x2, y2)
 
     @staticmethod
-    def from_points(p1: tuple[float, float], p2: tuple[float, float]) -> "BoundingBox":
+    def from_points(p1: tuple[float, float], p2: tuple[float, float]) -> BoundingBox:
         """
         BoundingBox from 2 points
 
@@ -334,7 +340,7 @@ class CRS:
         return self._crs
 
     @property
-    def valid_region(self) -> Optional["Geometry"]:
+    def valid_region(self) -> Geometry | None:
         """
         Return valid region of this CRS.
 
@@ -358,7 +364,7 @@ class CRS:
         return self._str
 
     def transformer_to_crs(
-        self, other: "CRS", always_xy: bool = True
+        self, other: CRS, always_xy: bool = True
     ) -> Callable[[Any, Any], tuple[Any, Any]]:
         """
         Returns a function that maps x, y -> x', y' where x, y are coordinates in
@@ -499,7 +505,7 @@ class Geometry:
 
     def __init__(
         self,
-        geom: Union[base.BaseGeometry, dict[str, Any], "Geometry"],
+        geom: base.BaseGeometry | dict[str, Any] | Geometry,
         crs: MaybeCRS = None,
     ) -> None:
         if isinstance(geom, Geometry):
@@ -517,67 +523,67 @@ class Geometry:
         else:
             raise ValueError(f"Unexpected type {type(geom)}")
 
-    def clone(self) -> "Geometry":
+    def clone(self) -> Geometry:
         return Geometry(self)
 
     @wrap_shapely()
-    def contains(self, other: "Geometry") -> bool:
+    def contains(self, other: Geometry) -> bool:
         return self.contains(other)
 
     @wrap_shapely()
-    def crosses(self, other: "Geometry") -> bool:
+    def crosses(self, other: Geometry) -> bool:
         return self.crosses(other)
 
     @wrap_shapely()
-    def disjoint(self, other: "Geometry") -> bool:
+    def disjoint(self, other: Geometry) -> bool:
         return self.disjoint(other)
 
     @wrap_shapely(suppress_geos_warnings=True)
-    def intersects(self, other: "Geometry") -> bool:
+    def intersects(self, other: Geometry) -> bool:
         return self.intersects(other)
 
     @wrap_shapely()
-    def touches(self, other: "Geometry") -> bool:
+    def touches(self, other: Geometry) -> bool:
         return self.touches(other)
 
     @wrap_shapely()
-    def within(self, other: "Geometry") -> bool:
+    def within(self, other: Geometry) -> bool:
         return self.within(other)
 
     @wrap_shapely()
-    def overlaps(self, other: "Geometry") -> bool:
+    def overlaps(self, other: Geometry) -> bool:
         return self.overlaps(other)
 
     @wrap_shapely()
-    def difference(self, other: "Geometry") -> "Geometry":
+    def difference(self, other: Geometry) -> Geometry:
         return self.difference(other)
 
     @wrap_shapely(suppress_geos_warnings=True)
-    def intersection(self, other: "Geometry") -> "Geometry":
+    def intersection(self, other: Geometry) -> Geometry:
         return self.intersection(other)
 
     @wrap_shapely()
-    def symmetric_difference(self, other: "Geometry") -> "Geometry":
+    def symmetric_difference(self, other: Geometry) -> Geometry:
         return self.symmetric_difference(other)
 
     @wrap_shapely()
-    def union(self, other: "Geometry") -> "Geometry":
+    def union(self, other: Geometry) -> Geometry:
         return self.union(other)
 
     @wrap_shapely()
-    def __and__(self, other: "Geometry") -> "Geometry":
+    def __and__(self, other: Geometry) -> Geometry:
         return self.__and__(other)
 
     @wrap_shapely()
-    def __or__(self, other: "Geometry") -> "Geometry":
+    def __or__(self, other: Geometry) -> Geometry:
         return self.__or__(other)
 
     @wrap_shapely()
-    def __xor__(self, other: "Geometry") -> "Geometry":
+    def __xor__(self, other: Geometry) -> Geometry:
         return self.__xor__(other)
 
     @wrap_shapely()
-    def __sub__(self, other: "Geometry") -> "Geometry":
+    def __sub__(self, other: Geometry) -> Geometry:
         return self.__sub__(other)
 
     def svg(self) -> str:
@@ -599,19 +605,19 @@ class Geometry:
         return self.geom.is_valid
 
     @property
-    def boundary(self) -> "Geometry":
+    def boundary(self) -> Geometry:
         return Geometry(self.geom.boundary, self.crs)
 
     @property
-    def exterior(self) -> "Geometry":
+    def exterior(self) -> Geometry:
         return Geometry(self.geom.exterior, self.crs)
 
     @property
-    def interiors(self) -> list["Geometry"]:
+    def interiors(self) -> list[Geometry]:
         return [Geometry(g, self.crs) for g in self.geom.interiors]
 
     @property
-    def centroid(self) -> "Geometry":
+    def centroid(self) -> Geometry:
         return Geometry(self.geom.centroid, self.crs)
 
     @property
@@ -635,11 +641,11 @@ class Geometry:
         return self.geom.xy
 
     @property
-    def convex_hull(self) -> "Geometry":
+    def convex_hull(self) -> Geometry:
         return Geometry(self.geom.convex_hull, self.crs)
 
     @property
-    def envelope(self) -> "Geometry":
+    def envelope(self) -> Geometry:
         return Geometry(self.geom.envelope, self.crs)
 
     @property
@@ -666,7 +672,7 @@ class Geometry:
     def json(self):
         return self.__geo_interface__
 
-    def segmented(self, resolution: float) -> "Geometry":
+    def segmented(self, resolution: float) -> Geometry:
         """
         Possibly add more points to the geometry so that no edge is longer than `resolution`.
         """
@@ -697,22 +703,22 @@ class Geometry:
 
         return Geometry(segmentize_shapely(self.geom), self.crs)
 
-    def interpolate(self, distance: float) -> "Geometry":
+    def interpolate(self, distance: float) -> Geometry:
         """
         Returns a point distance units along the line.
         Raises TypeError if geometry doesn't support this operation.
         """
         return Geometry(self.geom.interpolate(distance), self.crs)
 
-    def buffer(self, distance: float, resolution: float = 30) -> "Geometry":
+    def buffer(self, distance: float, resolution: float = 30) -> Geometry:
         return Geometry(self.geom.buffer(distance, resolution=resolution), self.crs)
 
-    def simplify(self, tolerance: float, preserve_topology: bool = True) -> "Geometry":
+    def simplify(self, tolerance: float, preserve_topology: bool = True) -> Geometry:
         return Geometry(
             self.geom.simplify(tolerance, preserve_topology=preserve_topology), self.crs
         )
 
-    def transform(self, func) -> "Geometry":
+    def transform(self, func) -> Geometry:
         """
         Applies func to all coordinates of Geometry and returns a new Geometry
         of the same type and in the same projection from the transformed coordinates.
@@ -724,13 +730,13 @@ class Geometry:
         """
         return Geometry(ops.transform(func, self.geom), self.crs)
 
-    def _to_crs(self, crs: CRS) -> "Geometry":
+    def _to_crs(self, crs: CRS) -> Geometry:
         assert self.crs is not None
         return Geometry(ops.transform(self.crs.transformer_to_crs(crs), self.geom), crs)
 
     def to_crs(
         self, crs: SomeCRS, resolution: float | None = None, wrapdateline: bool = False
-    ) -> "Geometry":
+    ) -> Geometry:
         """
         Convert geometry to a different Coordinate Reference System
 
@@ -766,7 +772,7 @@ class Geometry:
 
         return geom._to_crs(crs)
 
-    def split(self, splitter: "Geometry") -> Iterable["Geometry"]:
+    def split(self, splitter: Geometry) -> Iterable[Geometry]:
         """
         shapely.ops.split
         """
@@ -776,7 +782,7 @@ class Geometry:
         for g in ops.split(self.geom, splitter.geom).geoms:
             yield Geometry(g, self.crs)
 
-    def __iter__(self) -> Iterator["Geometry"]:
+    def __iter__(self) -> Iterator[Geometry]:
         sub_geoms = getattr(self.geom, "geoms", [])
         for geom in sub_geoms:
             yield Geometry(geom, self.crs)
@@ -1108,7 +1114,7 @@ class GeoBox:
         resolution: tuple[float, float],
         crs: MaybeCRS = None,
         align: tuple[float, float] | None = None,
-    ) -> "GeoBox":
+    ) -> GeoBox:
         """
         :param resolution: (y_resolution, x_resolution)
         :param crs: CRS to use, if different from the geopolygon
@@ -1139,7 +1145,7 @@ class GeoBox:
         )
         return GeoBox(crs=crs, affine=affine, width=width, height=height)
 
-    def buffered(self, ybuff, xbuff) -> "GeoBox":
+    def buffered(self, ybuff, xbuff) -> GeoBox:
         """
         Produce a tile buffered by ybuff, xbuff (in CRS units)
         """
@@ -1155,7 +1161,7 @@ class GeoBox:
             crs=self.crs,
         )
 
-    def __getitem__(self, roi) -> "GeoBox":
+    def __getitem__(self, roi) -> GeoBox:
         if isinstance(roi, int):
             roi = (slice(roi, roi + 1), slice(None, None))
 
@@ -1176,13 +1182,13 @@ class GeoBox:
 
         return GeoBox(width=w, height=h, affine=affine, crs=self.crs)
 
-    def __or__(self, other) -> "GeoBox":
+    def __or__(self, other) -> GeoBox:
         """
         A geobox that encompasses both self and other.
         """
         return geobox_union_conservative([self, other])
 
-    def __and__(self, other) -> "GeoBox":
+    def __and__(self, other) -> GeoBox:
         """
         A geobox that is contained in both self and other.
         """

--- a/datacube/utils/geometry/_warp.py
+++ b/datacube/utils/geometry/_warp.py
@@ -2,6 +2,8 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from typing import TypeAlias
 
 import numpy as np
@@ -9,7 +11,9 @@ import rasterio.crs
 import rasterio.warp
 from affine import Affine
 
-from . import GeoBox
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from . import GeoBox
 
 Resampling: TypeAlias = str | int | rasterio.warp.Resampling  # pylint: disable=invalid-name
 Nodata: TypeAlias = int | float | None  # pylint: disable=invalid-name

--- a/datacube/utils/geometry/gbox.py
+++ b/datacube/utils/geometry/gbox.py
@@ -6,16 +6,23 @@
 Geometric operations on GeoBox class
 """
 
+from __future__ import annotations
+
 import itertools
 import math
-from collections.abc import Iterable
 from typing import TypeAlias
 
 from affine import Affine
 from odc.geo.math import clamp
 
-from . import BoundingBox, GeoBox, Geometry
+from . import GeoBox
 from .tools import align_up
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from . import BoundingBox, Geometry
 
 # pylint: disable=invalid-name
 MaybeInt: TypeAlias = int | None

--- a/datacube/utils/io.py
+++ b/datacube/utils/io.py
@@ -2,10 +2,15 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import os
-from collections.abc import Generator
 from pathlib import Path
 from sys import stdin
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 def _norm_path(path: str | Path, in_home_dir: bool = False) -> Path:

--- a/datacube/utils/masking.py
+++ b/datacube/utils/masking.py
@@ -8,14 +8,19 @@ Tools for masking data based on a bit-mask variable with attached definition.
 The main functions are `make_mask(variable)` `describe_flags(variable)`
 """
 
+from __future__ import annotations
+
 from collections.abc import Iterable
 
 import pandas
 import xarray
-from pandas.core.frame import DataFrame
 from xarray import DataArray, Dataset
 
 from datacube.utils.math import valid_mask
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pandas.core.frame import DataFrame
 
 FLAGS_ATTR_NAME = "flags_definition"
 

--- a/datacube/utils/math.py
+++ b/datacube/utils/math.py
@@ -2,7 +2,8 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from collections.abc import Generator
+from __future__ import annotations
+
 from math import ceil
 from typing import Any
 
@@ -10,10 +11,15 @@ import numpy
 import odc.geo.math as geomath
 import xarray as xr
 from deprecat import deprecat
-from odc.geo import SomeResolution
 from odc.geo.xr import spatial_dims as xr_spatial_dims
 
 from datacube.migration import ODC2DeprecationWarning
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from odc.geo import SomeResolution
 
 
 def unsqueeze_data_array(

--- a/datacube/utils/py.py
+++ b/datacube/utils/py.py
@@ -2,15 +2,20 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import importlib
 import logging
-from collections.abc import Callable, Mapping
 from contextlib import contextmanager
 
 import toolz
 from deprecat import deprecat
 
 from datacube.migration import ODC2DeprecationWarning
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 

--- a/datacube/utils/rio/_rio.py
+++ b/datacube/utils/rio/_rio.py
@@ -4,19 +4,25 @@
 # SPDX-License-Identifier: Apache-2.0
 """rasterio environment management tools"""
 
+from __future__ import annotations
+
 import threading
-from collections.abc import Mapping
 from types import SimpleNamespace
 from typing import Literal
 
 import rasterio
 import rasterio.env
-from botocore.credentials import Credentials
 from deprecat import deprecat
 from rasterio.session import AWSSession, DummySession
 
 from datacube.migration import ODC2DeprecationWarning
 from datacube.utils.generic import thread_local_cache
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from botocore.credentials import Credentials
 
 _CFG_LOCK = threading.Lock()
 _CFG = SimpleNamespace(aws=None, cloud_defaults=False, kwargs={}, epoch=0)

--- a/datacube/utils/tar.py
+++ b/datacube/utils/tar.py
@@ -2,14 +2,19 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import datetime
 import itertools
 import tarfile
 import time
-from collections.abc import Generator
 from io import BytesIO
 from pathlib import Path
 from typing import IO
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 def tar_mode(

--- a/datacube/utils/xarray_geoextensions.py
+++ b/datacube/utils/xarray_geoextensions.py
@@ -14,14 +14,19 @@ This extension is reliant on an `xarray` object having a `.crs` property of type
 
 """
 
+from __future__ import annotations
+
 import warnings
 
 import xarray
-from affine import Affine
 from odc.geo import resxy_
 from odc.geo._xr_interop import _xarray_geobox as _xr_geobox
 from odc.geo.math import affine_from_axis
 from odc.geo.xr import spatial_dims
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from affine import Affine
 
 
 def _xarray_affine_impl(obj):

--- a/datacube/virtual/__init__.py
+++ b/datacube/virtual/__init__.py
@@ -94,7 +94,7 @@ class NameResolver:
 
         if kind == "transform":
             cls_name = recipe["transform"]
-            input_product = cast(Mapping, get("input"))
+            input_product = cast("Mapping", get("input"))
 
             self._assert(
                 input_product is not None, f"no input for transformation in {recipe}"
@@ -136,7 +136,7 @@ class NameResolver:
 
         if kind == "aggregate":
             cls_name = recipe["aggregate"]
-            input_product = cast(Mapping, get("input"))
+            input_product = cast("Mapping", get("input"))
             group_by = get("group_by")
 
             self._assert(
@@ -155,7 +155,7 @@ class NameResolver:
             )
 
         if kind == "reproject":
-            input_product = cast(Mapping, get("input"))
+            input_product = cast("Mapping", get("input"))
             output_crs = recipe["reproject"].get("output_crs")
             resolution = recipe["reproject"].get("resolution")
 

--- a/datacube/virtual/__init__.py
+++ b/datacube/virtual/__init__.py
@@ -2,8 +2,9 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import copy
-from collections.abc import Callable, Mapping
 from typing import Any, cast
 
 from datacube.model import Measurement
@@ -13,7 +14,6 @@ from datacube.utils.documents import parse_yaml
 from .catalog import Catalog
 from .impl import (
     Transformation,
-    VirtualProduct,
     VirtualProductException,
     from_validated_recipe,
     virtual_product_kind,
@@ -35,6 +35,12 @@ from .transformations import (
 )
 from .utils import reject_keys
 
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+    from .impl import VirtualProduct
+
 __all__ = ["Measurement", "Transformation", "construct"]
 
 
@@ -44,7 +50,7 @@ class NameResolver:
     def __init__(self, lookup_table) -> None:
         self.lookup_table = lookup_table
 
-    def clone(self) -> "NameResolver":
+    def clone(self) -> NameResolver:
         """Safely copy the resolver in order to possibly extend it."""
         return NameResolver(copy.deepcopy(self.lookup_table))
 

--- a/datacube/virtual/catalog.py
+++ b/datacube/virtual/catalog.py
@@ -6,7 +6,9 @@
 Catalog of virtual products.
 """
 
-from collections.abc import Iterable, Iterator, Mapping
+from __future__ import annotations
+
+from collections.abc import Mapping
 from itertools import chain
 from typing import Any
 
@@ -14,6 +16,10 @@ import yaml
 from typing_extensions import override
 
 from datacube.model.utils import SafeDumper
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
 
 
 class UnappliedTransform:

--- a/datacube/virtual/expr.py
+++ b/datacube/virtual/expr.py
@@ -2,11 +2,16 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import lark
 import numpy
 
-from datacube.utils.generic import T
 from datacube.utils.masking import valid_data_mask
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.utils.generic import T
 
 
 def formula_parser() -> lark.Lark:

--- a/datacube/virtual/impl.py
+++ b/datacube/virtual/impl.py
@@ -481,7 +481,7 @@ class Product(VirtualProduct):  # type: ignore[no-redef]
 
         measurement_dicts = self.output_measurements(
             grouped.product_definitions,
-            cast(list[str], load_settings.get("measurements")),
+            cast("list[str]", load_settings.get("measurements")),
         )
 
         if grouped.load_natively:
@@ -561,7 +561,7 @@ class Transform(VirtualProduct):
             isinstance(obj, Transformation), f"not a transformation object: {obj}"
         )
 
-        return cast(Transformation, obj)
+        return cast("Transformation", obj)
 
     @property
     def _input(self) -> VirtualProduct:
@@ -631,7 +631,7 @@ class Aggregate(VirtualProduct):
             isinstance(obj, Transformation), f"not a transformation object: {obj}"
         )
 
-        return cast(Transformation, obj)
+        return cast("Transformation", obj)
 
     @property
     def _input(self) -> VirtualProduct:
@@ -900,7 +900,7 @@ class Juxtapose(VirtualProduct):
             child.output_measurements(product_definitions) for child in self._children
         ]
 
-        result = cast(dict[str, Measurement], {})
+        result = cast("dict[str, Measurement]", {})
         for measurements in input_measurement_list:
             common = set(result) & set(measurements)
             self._assert(not common, f"common measurements {common} between children")

--- a/datacube/virtual/impl.py
+++ b/datacube/virtual/impl.py
@@ -8,11 +8,12 @@ to query and to load data, and combinators to combine multiple products into "vi
 products implementing the same interface.
 """
 
+from __future__ import annotations
+
 import uuid
 from abc import ABC, abstractmethod
 from collections import OrderedDict
-from collections.abc import Hashable, Iterable, Iterator, Mapping, Sequence
-from collections.abc import Mapping as TypeMapping
+from collections.abc import Mapping, Sequence
 from typing import Any, cast
 
 import dask.array
@@ -30,7 +31,6 @@ from typing_extensions import override
 from datacube import Datacube
 from datacube.api.core import output_geobox, per_band_load_data_settings
 from datacube.api.query import Query, query_group_by
-from datacube.index import Index
 from datacube.model import Measurement, Product
 from datacube.model.utils import SafeDumper, xr_apply, xr_iter
 from datacube.testutils.io import native_geobox
@@ -43,6 +43,13 @@ from .utils import (
     select_keys,
     select_unique,
 )
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Hashable, Iterable, Iterator
+    from collections.abc import Mapping as TypeMapping
+
+    from datacube.index import Index
 
 
 class VirtualProductException(Exception):  # noqa: N818
@@ -152,7 +159,7 @@ class VirtualDatasetBox:
 
         return self.box.shape + self.geobox.shape
 
-    def __getitem__(self, chunk) -> "VirtualDatasetBox":
+    def __getitem__(self, chunk) -> VirtualDatasetBox:
         if self.load_natively:
             raise VirtualProductException("slicing requires known geobox")
 
@@ -167,7 +174,7 @@ class VirtualDatasetBox:
             geopolygon=self.geopolygon,
         )
 
-    def map(self, func, dtype: str = "O") -> "VirtualDatasetBox":
+    def map(self, func, dtype: str = "O") -> VirtualDatasetBox:
         return VirtualDatasetBox(
             xr_apply(self.box, func, dtype=dtype),
             self.geobox,
@@ -176,7 +183,7 @@ class VirtualDatasetBox:
             geopolygon=self.geopolygon,
         )
 
-    def filter(self, predicate) -> "VirtualDatasetBox":
+    def filter(self, predicate) -> VirtualDatasetBox:
         mask = self.map(predicate, dtype="bool")
 
         # NOTE: this could possibly result in an empty box
@@ -358,7 +365,7 @@ class VirtualProduct(Mapping):
         return self.fetch(grouped, **query)
 
 
-class Product(VirtualProduct):  # type: ignore[no-redef]
+class Product(VirtualProduct):  # type: ignore[no-redef]  # noqa: F811
     """An existing datacube product."""
 
     # TODO: We have ODC model Products throughout this source file as type hints.  Are the Product type hints in this
@@ -989,7 +996,7 @@ class Reproject(VirtualProduct):
     """
 
     @property
-    def _input(self) -> "VirtualProduct":
+    def _input(self) -> VirtualProduct:
         """The input product of a transform product."""
         return from_validated_recipe(self["input"])
 

--- a/datacube/virtual/transformations.py
+++ b/datacube/virtual/transformations.py
@@ -2,8 +2,9 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import warnings
-from collections.abc import Collection, Iterable, Mapping
 
 import numpy
 import pandas as pd
@@ -23,6 +24,10 @@ from .expr import (
     formula_parser,
 )
 from .impl import Measurement, Transformation, VirtualProductException
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Collection, Iterable, Mapping
 
 
 def selective_apply_dict(

--- a/examples/io_plugin/dcio_example/xarray_3d.py
+++ b/examples/io_plugin/dcio_example/xarray_3d.py
@@ -4,19 +4,26 @@
 # SPDX-License-Identifier: Apache-2.0
 """xarray 3D driver plugin for 3D support testing"""
 
-from collections.abc import Generator
+from __future__ import annotations
+
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
-import numpy as np
 import xarray as xr
-from affine import Affine
-from odc.geo import CRS
 
-from datacube.storage import BandInfo
 from datacube.utils.math import num2numpy
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    import numpy as np
+    from affine import Affine
+    from odc.geo import CRS
+
+    from datacube.storage import BandInfo
 
 PROTOCOL = ["file", "xarray_3d"]
 FORMAT = "xarray_3d"

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -6,37 +6,38 @@
 Common methods for index integration tests.
 """
 
+from __future__ import annotations
+
 import itertools
 import os
 import warnings
-from collections.abc import Callable, Generator, Iterable, Sequence
 from copy import copy, deepcopy
 from datetime import timedelta
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Literal
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 import pytest
 import yaml
 from antimeridian import FixWindingWarning
-from click.testing import CliRunner, Result
+from click.testing import CliRunner
 from hypothesis import HealthCheck, settings
 from sqlalchemy import text
 
 import datacube.scripts.cli_app
 import datacube.utils
 from datacube import Datacube
-from datacube.cfg import ODCConfig, ODCEnvironment, psql_url_from_config
+from datacube.cfg import ODCConfig, psql_url_from_config
 from datacube.drivers.common_psql import drop_schema
 from datacube.drivers.postgis import PostGisDb
 from datacube.drivers.postgis import _core as pgis_core
 from datacube.drivers.postgres import PostgresDb
 from datacube.drivers.postgres import _core as pgres_core
-from datacube.index import Index, index_connect
-from datacube.index.abstract import AbstractIndex, default_metadata_type_docs
-from datacube.model import Dataset, LineageDirection, LineageTree, MetadataType, Product
-from datacube.utils import SimpleDocNav, read_documents
+from datacube.index import index_connect
+from datacube.index.abstract import default_metadata_type_docs
+from datacube.model import LineageDirection, LineageTree
+from datacube.utils import read_documents
 from integration_tests.utils import (
     GEOTIFF,
     _make_geotiffs,
@@ -44,6 +45,19 @@ from integration_tests.utils import (
     load_test_products,
     load_yaml_file,
 )
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator, Iterable, Sequence
+    from uuid import UUID
+
+    from click.testing import Result
+
+    from datacube.cfg import ODCEnvironment
+    from datacube.index import Index
+    from datacube.index.abstract import AbstractIndex
+    from datacube.model import Dataset, MetadataType, Product
+    from datacube.utils import SimpleDocNav
 
 _SINGLE_RUN_CONFIG_TEMPLATE = """
 

--- a/integration_tests/data_utils.py
+++ b/integration_tests/data_utils.py
@@ -11,8 +11,9 @@ Hypothesis is used for most of the data generation, which will hopefully improve
 of our tests when we can roll it into more tests.
 """
 
+from __future__ import annotations
+
 import string
-from collections.abc import Callable
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -31,6 +32,10 @@ from hypothesis.strategies import (
 )
 from odc.geo import CRS
 from odc.geo.geom import point
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 

--- a/integration_tests/index/search_utils.py
+++ b/integration_tests/index/search_utils.py
@@ -2,12 +2,18 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import csv
 import io
-from collections.abc import Iterable
 
 import datacube.scripts.search_tool
-from datacube.model import Dataset, Product
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from datacube.model import Dataset, Product
 
 
 def _load_product_query(

--- a/integration_tests/index/test_common_psql.py
+++ b/integration_tests/index/test_common_psql.py
@@ -2,10 +2,14 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from collections.abc import Generator
+from __future__ import annotations
 
 import pytest
 from sqlalchemy import text
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 # These tests use an empty/uninitialised database.
 # Doesn't matter whether it is postgis or postgres - use postgis for future-proofing

--- a/integration_tests/index/test_config_docs.py
+++ b/integration_tests/index/test_config_docs.py
@@ -6,6 +6,8 @@
 Module
 """
 
+from __future__ import annotations
+
 import copy
 
 import pytest
@@ -22,12 +24,16 @@ from datacube.drivers.postgres._fields import (
     NumericRangeDocField as PgrNumericRangeDocField,
 )
 from datacube.drivers.postgres._fields import PgField as PgrPgField
-from datacube.index import Index
 from datacube.index.abstract import default_metadata_type_docs
-from datacube.model import Dataset, DatasetType, MetadataType, Not, Product, Range
+from datacube.model import Dataset, Not, Range
 from datacube.testutils import sanitise_doc, suppress_deprecations
 from datacube.utils import changes
 from datacube.utils.documents import documents_equal
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.index import Index
+    from datacube.model import DatasetType, MetadataType, Product
 
 _DATASET_METADATA = {
     "id": "f7018d80-8807-11e5-aeaa-1040f381a756",

--- a/integration_tests/index/test_index_data.py
+++ b/integration_tests/index/test_index_data.py
@@ -8,6 +8,8 @@ Test database methods.
 Integration tests: these depend on a local Postgres instance.
 """
 
+from __future__ import annotations
+
 import copy
 import datetime
 from datetime import timezone
@@ -16,12 +18,16 @@ from uuid import UUID
 
 import pytest
 
-from datacube.index import Index
 from datacube.index.eo3 import prep_eo3
 from datacube.index.exceptions import MissingRecordError
-from datacube.model import Dataset, MetadataType, Product
+from datacube.model import Dataset, Product
 from datacube.testutils import suppress_deprecations
-from datacube.utils.json_types import JsonDict
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.index import Index
+    from datacube.model import MetadataType
+    from datacube.utils.json_types import JsonDict
 
 _telemetry_uuid = UUID("4ec8fe97-e8b9-11e4-87ff-1040f381a756")
 _telemetry_dataset = {

--- a/integration_tests/index/test_lineage.py
+++ b/integration_tests/index/test_lineage.py
@@ -2,13 +2,18 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from uuid import uuid4 as random_uuid
 
 import pytest
 
-from datacube.index import Index
 from datacube.model import InconsistentLineageException, LineageDirection, LineageTree
 from datacube.model.lineage import LineageRelations
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.index import Index
 
 
 @pytest.mark.parametrize("datacube_env_name", ("postgis", "postgis3"))

--- a/integration_tests/index/test_location.py
+++ b/integration_tests/index/test_location.py
@@ -2,12 +2,16 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import pytest
 
-from datacube.index import Index
 from datacube.model import Dataset
 from datacube.testutils import suppress_deprecations
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.index import Index
 
 
 @pytest.mark.parametrize("datacube_env_name", ("datacube", "datacube3"))

--- a/integration_tests/index/test_memory_index.py
+++ b/integration_tests/index/test_memory_index.py
@@ -2,6 +2,8 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import datetime
 from uuid import uuid4
 
@@ -9,10 +11,13 @@ import pytest
 
 import datacube.index.memory.index
 from datacube import Datacube
-from datacube.cfg import ODCEnvironment
 from datacube.model import Range
 from datacube.testutils import gen_dataset_test_dag, suppress_deprecations
 from datacube.utils import InvalidDocException, SimpleDocNav, read_documents
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.cfg import ODCEnvironment
 
 
 def test_init_memory(in_memory_config: ODCEnvironment) -> None:

--- a/integration_tests/index/test_null_index.py
+++ b/integration_tests/index/test_null_index.py
@@ -2,14 +2,19 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from unittest.mock import MagicMock
 from uuid import UUID
 
 import pytest
 
 from datacube import Datacube
-from datacube.cfg import ODCEnvironment
 from datacube.testutils import suppress_deprecations
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.cfg import ODCEnvironment
 
 test_uuid = UUID("4ec8fe97-e8b9-11e4-87ff-1040f381a756")
 

--- a/integration_tests/index/test_postgis_index.py
+++ b/integration_tests/index/test_postgis_index.py
@@ -2,13 +2,18 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import datetime
 
 import pytest
 from odc.geo import CRS
 
-from datacube.index.postgis.index import Index
 from datacube.model import Range
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.index.postgis.index import Index
 
 
 @pytest.mark.parametrize("datacube_env_name", ("postgis", "postgis3"))

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -6,6 +6,8 @@
 Module
 """
 
+from __future__ import annotations
+
 import datetime
 import warnings
 from collections import namedtuple
@@ -19,14 +21,18 @@ from antimeridian import FixWindingWarning
 import datacube.scripts.cli_app
 import datacube.scripts.search_tool
 from datacube import Datacube
-from datacube.cfg import ODCEnvironment
 from datacube.cfg.opt import _DEFAULT_DB_USER
-from datacube.index import Index
-from datacube.model import Dataset, Range
+from datacube.model import Range
 from datacube.testutils import suppress_deprecations
 from datacube.utils.dates import tz_as_utc
 
 from .search_utils import _cli_csv_search, _csv_search_raw, _load_product_query
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.cfg import ODCEnvironment
+    from datacube.index import Index
+    from datacube.model import Dataset
 
 
 def test_search_by_metadata(index: Index, ls8_eo3_product, wo_eo3_product) -> None:

--- a/integration_tests/index/test_search_legacy.py
+++ b/integration_tests/index/test_search_legacy.py
@@ -6,6 +6,8 @@
 Module
 """
 
+from __future__ import annotations
+
 import copy
 import datetime
 import uuid
@@ -22,14 +24,18 @@ from sqlalchemy.dialects.postgresql.ranges import Range as SQLARange
 import datacube.index.postgis.index
 import datacube.index.postgres.index
 from datacube import Datacube
-from datacube.cfg import ODCEnvironment
 from datacube.cfg.opt import _DEFAULT_DB_USER
-from datacube.index import Index
-from datacube.model import Dataset, MetadataType, Product, Range
+from datacube.model import Range
 from datacube.testutils import load_dataset_definition, suppress_deprecations
 from datacube.utils.dates import tz_as_utc
 
 from .search_utils import _cli_csv_search, _csv_search_raw, _load_product_query
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.cfg import ODCEnvironment
+    from datacube.index import Index
+    from datacube.model import Dataset, MetadataType, Product
 
 # These tests use non-EO3 metadata, so will not work with the postgis driver.
 # Mark all with @pytest.mark.parametrize("datacube_env_name", ("datacube", "datacube3"))

--- a/integration_tests/test_3d.py
+++ b/integration_tests/test_3d.py
@@ -2,8 +2,9 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import logging
-from collections.abc import Generator
 from copy import deepcopy
 from pathlib import Path
 from types import SimpleNamespace
@@ -24,6 +25,10 @@ from affine import Affine
 from odc.geo.geobox import GeoBox
 
 from datacube.api.core import Datacube
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 pytest.importorskip(
     "dcio_example.xarray_3d"

--- a/integration_tests/test_cli_spatial_indexes.py
+++ b/integration_tests/test_cli_spatial_indexes.py
@@ -2,10 +2,13 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import pytest
 
-from datacube.index import Index
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.index import Index
 
 
 @pytest.mark.parametrize("datacube_env_name", ("postgis", "postgis3"))

--- a/integration_tests/test_config_tool.py
+++ b/integration_tests/test_config_tool.py
@@ -6,12 +6,17 @@
 Module
 """
 
+from __future__ import annotations
+
 import logging
 import random
-from collections.abc import Generator
 from pathlib import Path
 
 import pytest
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 EXAMPLE_DATASET_TYPE_DOCS = list(
     map(

--- a/integration_tests/test_dataset_add.py
+++ b/integration_tests/test_dataset_add.py
@@ -2,6 +2,8 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import logging
 import math
 
@@ -9,9 +11,7 @@ import pytest
 import toolz
 import yaml
 
-from datacube.index import Index
 from datacube.index.hl import Doc2Dataset
-from datacube.model import MetadataType
 from datacube.scripts.dataset import _resolve_uri
 from datacube.testutils import (
     dataset_maker,
@@ -20,6 +20,11 @@ from datacube.testutils import (
     write_files,
 )
 from datacube.utils import SimpleDocNav
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.index import Index
+    from datacube.model import MetadataType
 
 logger = logging.getLogger(__name__)
 

--- a/integration_tests/test_model.py
+++ b/integration_tests/test_model.py
@@ -2,9 +2,15 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import pytest
 
-from datacube.model import Dataset, Product
+from datacube.model import Dataset
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.model import Product
 
 
 @pytest.mark.parametrize("datacube_env_name", ("datacube", "datacube3"))

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -2,10 +2,11 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import logging
 import os
 import shutil
-from collections.abc import Generator
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
@@ -15,8 +16,13 @@ import numpy as np
 import rasterio
 from click.testing import CliRunner
 
-from datacube.index import Index
 from datacube.utils.documents import load_from_yaml
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from datacube.index import Index
 
 # On Windows, symlinks are not supported in Python 2 and require
 # specific privileges otherwise, so we copy instead of linking

--- a/odc_search_profile.py
+++ b/odc_search_profile.py
@@ -1,12 +1,19 @@
+from __future__ import annotations
+
 import sys
-from collections.abc import Callable, Iterable
 from datetime import datetime, timezone
 from time import monotonic
 
 from odc.geo.geom import CRS, polygon
 
 from datacube import Datacube
-from datacube.model import Dataset, Range
+from datacube.model import Range
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+    from datacube.model import Dataset
 
 
 def benchmark(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,7 @@ extend-exclude = [
 docstring-code-format = true # Reformat code in doc strings.
 
 [tool.ruff.lint]
+future-annotations = true
 select = [
     "A",  # Don't shadow built-ins
     "B",  # flake8-bugbear
@@ -210,6 +211,7 @@ select = [
     "W",  # pycodestyle warnings
     "F",  # pyflakes
     "T10", # flake8-debugger
+    "TC",  # Import types in TYPE_CHECKING block
     "TID253", # Banned imports
 ]
 ignore = [
@@ -236,9 +238,10 @@ extend-ignore-names = [
 [tool.ruff.lint.per-file-ignores]
 # SQLAlchemy has overloaded ==, so use that (or is_) to compare with None.
 "datacube/drivers/postgis/_api.py" = ["E711"]
-"datacube/drivers/postgis/_schema.py" = ["E711"]
 "datacube/drivers/postgres/_api.py" = ["E711"]
 "datacube/drivers/postgres/_schema.py" = ["E711"]
+# SQLAlchemy uses the types for the schema so runtime types are required.
+"datacube/drivers/postgis/_schema.py" = ["E711", "TC002", "TC003"]
 
 [tool.ruff.lint.pycodestyle]
 max-line-length = 120

--- a/tests/api/test_core.py
+++ b/tests/api/test_core.py
@@ -2,8 +2,9 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import datetime
-from collections.abc import Iterable
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 from uuid import UUID
@@ -15,9 +16,14 @@ import xarray as xr
 from datacube import Datacube
 from datacube.api.core import _calculate_chunk_sizes, output_geobox
 from datacube.api.query import GroupBy
-from datacube.model import Dataset
 from datacube.testutils import mk_sample_dataset, suppress_deprecations
 from datacube.testutils.geom import AlbersGS
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from datacube.model import Dataset
 
 
 def test_grouping_datasets() -> None:

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -2,17 +2,23 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import datetime
 from types import SimpleNamespace
 
 import numpy as np
 import pandas
 import pytest
-from odc.geo import CRS, Geometry
+from odc.geo import CRS
 
 from datacube.api.query import GroupBy, Query, query_group_by, solar_day, solar_offset
 from datacube.model import Range
 from datacube.utils import parse_time
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from odc.geo import Geometry
 
 
 @pytest.fixture

--- a/tests/api/test_virtual.py
+++ b/tests/api/test_virtual.py
@@ -2,6 +2,8 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import warnings
 from copy import deepcopy
 from datetime import datetime
@@ -17,7 +19,6 @@ from typing_extensions import override
 from datacube.model import Dataset, MetadataType, Product
 from datacube.virtual import (
     DEFAULT_RESOLVER,
-    Catalog,
     Transformation,
     VirtualProductException,
     catalog_from_yaml,
@@ -26,6 +27,10 @@ from datacube.virtual import (
 from datacube.virtual.expr import FormulaEvaluator, evaluate_data, formula_parser
 from datacube.virtual.impl import Datacube
 from datacube.virtual.transformations import fiscal_year
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.virtual import Catalog
 
 ##########################################
 # Set up some common test data and fixtures

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,8 +9,9 @@ This module defines any fixtures or other extensions to py.test to be used throu
 tests in this and sub packages.
 """
 
+from __future__ import annotations
+
 import os
-from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 
@@ -18,7 +19,6 @@ import pystac
 import pystac.collection
 import pystac.item
 import pytest
-import xarray as xr
 from affine import Affine
 from odc.geo import CRS, wh_
 from odc.geo.geobox import GeoBox
@@ -35,6 +35,12 @@ from datacube.model import (
     metadata_from_doc,
 )
 from datacube.utils.documents import load_from_yaml, read_documents
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    import xarray as xr
 
 AWS_ENV_VARS = [
     "AWS_ACCESS_KEY_ID",

--- a/tests/index/test_api_index_dataset.py
+++ b/tests/index/test_api_index_dataset.py
@@ -9,11 +9,14 @@ from copy import deepcopy
 from typing import cast
 from uuid import UUID
 
-from datacube.drivers.postgres import PostgresDb
 from datacube.index.exceptions import DuplicateRecordError
 from datacube.index.postgres._datasets import DatasetResource
-from datacube.index.postgres.index import Index
 from datacube.model import Dataset, MetadataType, Product
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.drivers.postgres import PostgresDb
+    from datacube.index.postgres.index import Index
 
 _nbar_uuid = UUID("f2f12372-8366-11e5-817e-1040f381a756")
 _ortho_uuid = UUID("5cf41d98-eda9-11e4-8a8e-1040f381a756")

--- a/tests/index/test_api_index_dataset.py
+++ b/tests/index/test_api_index_dataset.py
@@ -229,7 +229,7 @@ class MockIndex:
 def test_index_dataset() -> None:
     mock_db = MockDb()
     mock_index = MockIndex(mock_db, _EXAMPLE_PRODUCT)
-    datasets = DatasetResource(cast(PostgresDb, mock_db), cast(Index, mock_index))
+    datasets = DatasetResource(cast("PostgresDb", mock_db), cast("Index", mock_index))
     datasets.add(_EXAMPLE_NBAR_DATASET)
 
     ids = {d.id for d in mock_db.dataset.values()}
@@ -255,7 +255,7 @@ def test_index_dataset() -> None:
 def test_index_already_ingested_source_dataset() -> None:
     mock_db = MockDb()
     mock_index = MockIndex(mock_db, _EXAMPLE_PRODUCT)
-    datasets = DatasetResource(cast(PostgresDb, mock_db), cast(Index, mock_index))
+    datasets = DatasetResource(cast("PostgresDb", mock_db), cast("Index", mock_index))
     assert _EXAMPLE_NBAR_DATASET.sources is not None
     ds = _EXAMPLE_NBAR_DATASET.sources["ortho"]
     assert ds is not None
@@ -272,7 +272,7 @@ def test_index_already_ingested_source_dataset() -> None:
 def test_index_two_levels_already_ingested() -> None:
     mock_db = MockDb()
     mock_index = MockIndex(mock_db, _EXAMPLE_PRODUCT)
-    datasets = DatasetResource(cast(PostgresDb, mock_db), cast(Index, mock_index))
+    datasets = DatasetResource(cast("PostgresDb", mock_db), cast("Index", mock_index))
     assert _EXAMPLE_NBAR_DATASET.sources is not None
     ds1 = _EXAMPLE_NBAR_DATASET.sources["ortho"]
     assert ds1.sources is not None

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -2,7 +2,8 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from collections.abc import Callable, Generator
+from __future__ import annotations
+
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
@@ -12,7 +13,7 @@ import numpy as np
 import pytest
 import rasterio.warp
 from affine import Affine
-from odc.geo import CRS, wh_
+from odc.geo import wh_
 from odc.geo.geobox import GeoBox
 from rasterio.warp import Resampling
 from typing_extensions import override
@@ -26,6 +27,12 @@ from datacube.storage._read import read_time_slice
 from datacube.storage._rio import RasterDatasetDataSource, _url2rasterio
 from datacube.testutils.geom import epsg3577, epsg4326
 from datacube.testutils.io import RasterFileDataSource
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator
+
+    from odc.geo import CRS
 
 identity = Affine.identity()
 

--- a/tests/test_3d.py
+++ b/tests/test_3d.py
@@ -2,14 +2,19 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from collections import OrderedDict
-from collections.abc import Generator
 from pathlib import Path
 
 import pytest
 
 from datacube.model import Product
 from datacube.utils.documents import read_documents
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 PROJECT_ROOT = Path(__file__).parents[1]
 GEDI_PRODUCT = (

--- a/tests/test_eo3.py
+++ b/tests/test_eo3.py
@@ -2,7 +2,8 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from collections.abc import Mapping
+from __future__ import annotations
+
 from copy import deepcopy
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -23,9 +24,15 @@ from datacube.index.eo3 import (
     prep_eo3,
 )
 from datacube.metadata._stacconverter import infer_eo_product
-from datacube.model import Dataset, Product
+from datacube.model import Dataset
 from datacube.testutils import mk_sample_product
 from datacube.utils.documents import InvalidDocException, parse_yaml
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from datacube.model import Product
 
 SAMPLE_DOC = """---
 $schema: https://schemas.opendatacube.org/dataset

--- a/tests/test_eo3converter.py
+++ b/tests/test_eo3converter.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=unused-argument,unused-variable,missing-module-docstring,wrong-import-position,import-error
 # pylint: disable=redefined-outer-name,protected-access,import-outside-toplevel
+from __future__ import annotations
 
 import math
 import uuid
@@ -15,7 +16,7 @@ import pystac
 import pytest
 from odc.geo.geom import Geometry
 from odc.stac import load
-from odc.stac._mdtools import RasterCollectionMetadata, has_proj_ext, has_raster_ext
+from odc.stac._mdtools import has_proj_ext, has_raster_ext
 from pystac.extensions.eo import EOExtension
 from pystac.extensions.item_assets import ItemAssetsExtension
 from pystac.extensions.projection import SCHEMA_URI as PROJECTION_SCHEMA_URI
@@ -32,10 +33,15 @@ from datacube.metadata import (
     stac2ds,
 )
 from datacube.metadata._eo3converter import _compute_uuid, _item_to_ds
-from datacube.model import Dataset, Product
 from datacube.testutils.io import native_geobox
 
 from .common import NO_WARN_CFG, STAC_CFG, mk_stac_item
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from odc.stac._mdtools import RasterCollectionMetadata
+
+    from datacube.model import Dataset, Product
 
 
 def test_infer_product_collection(

--- a/tests/test_ext_lineage.py
+++ b/tests/test_ext_lineage.py
@@ -2,8 +2,9 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import os
-from uuid import UUID
 from uuid import uuid4 as random_uuid
 
 import pytest
@@ -11,6 +12,10 @@ import pytest
 from datacube.model import InconsistentLineageException, LineageDirection, LineageTree
 from datacube.model.lineage import LineageIDPair, LineageRelations
 from datacube.utils import read_documents
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from uuid import UUID
 
 
 def test_directions() -> None:

--- a/tests/test_metadata_fields.py
+++ b/tests/test_metadata_fields.py
@@ -2,10 +2,11 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import datetime
 import decimal
 import sys
-from collections.abc import Mapping
 from textwrap import dedent
 from typing import Any
 
@@ -14,6 +15,10 @@ import yaml
 
 from datacube.model import Range, metadata_from_doc
 from datacube.model.fields import Expression, get_dataset_fields, parse_search_field
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 METADATA_DOC = yaml.safe_load("""---
 name: test

--- a/tests/test_utils_changes.py
+++ b/tests/test_utils_changes.py
@@ -6,7 +6,6 @@ import pytest
 
 from datacube.utils.changes import (
     MISSING,
-    Change,
     allow_addition,
     allow_any,
     allow_extension,
@@ -15,6 +14,10 @@ from datacube.utils.changes import (
     classify_changes,
     contains,
 )
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.utils.changes import Change
 
 
 def test_changes_contains() -> None:

--- a/tests/test_utils_docs.py
+++ b/tests/test_utils_docs.py
@@ -6,9 +6,10 @@
 Test utility functions from :module:`datacube.utils`
 """
 
+from __future__ import annotations
+
 import os
 from collections import OrderedDict
-from collections.abc import Iterable
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -53,6 +54,10 @@ from datacube.utils.documents import (
 )
 from datacube.utils.serialise import jsonify_document
 from datacube.utils.uris import as_url
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 doc_changes = [
     (1, 1, []),

--- a/tests/ui/test_common.py
+++ b/tests/ui/test_common.py
@@ -6,7 +6,6 @@
 Module
 """
 
-from collections.abc import Mapping, Sequence
 from pathlib import Path
 
 import pytest
@@ -17,6 +16,10 @@ from datacube.ui.common import (
     get_metadata_path,
     ui_path_doc_stream,
 )
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
 
 
 def test_get_metadata_path() -> None:

--- a/tests/ui/test_task_app.py
+++ b/tests/ui/test_task_app.py
@@ -6,8 +6,13 @@
 Module
 """
 
-from datacube.index import Index
+from __future__ import annotations
+
 from datacube.ui.task_app import task_app, wrap_task
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.index import Index
 
 
 def make_test_config(index: Index, config, **kwargs):


### PR DESCRIPTION
### Reason for this pull request

Put the type signature imports
under the "if TYPE_CHECKING" block
and define TYPE_CHECKING to False
for runtime in the same way
that OWS does it.

As a bonus, this also speeds up
starting the CLI since some
imports are not required.

The PR touches a lot of lines, but
everything except the `TYPE_CHECKING = False`
lines were done by Ruff's `--fix`.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2441.org.readthedocs.build/en/2441/

<!-- readthedocs-preview opendatacube end -->