### PR TITLE
Store lineage data when indexing from STAC

### DIFF
--- a/datacube/index/abstract/_datasets.py
+++ b/datacube/index/abstract/_datasets.py
@@ -8,7 +8,7 @@ import logging
 from abc import ABC, abstractmethod
 from datetime import timedelta
 from time import monotonic
-from typing import Any, NamedTuple
+from typing import Any, NamedTuple, cast
 
 from deprecat import deprecat
 from odc.geo import CRS
@@ -683,7 +683,7 @@ class AbstractDatasetResource(ABC):
             batch.append(ds_tup)
             if ds_tup.lineage:
                 lineage_cache.merge_from_eo3(
-                    dsid_to_uuid(str(ds_tup.metadata["id"])), ds_tup.lineage
+                    dsid_to_uuid(cast("str", ds_tup.metadata["id"])), ds_tup.lineage
                 )
             n_in_batch += 1
             if n_in_batch >= batch_size:

--- a/datacube/index/abstract/_datasets.py
+++ b/datacube/index/abstract/_datasets.py
@@ -14,7 +14,8 @@ from deprecat import deprecat
 from odc.geo import CRS
 
 from datacube.migration import ODC2DeprecationWarning
-from datacube.model import Dataset, Range
+from datacube.model import Dataset, Range, dsid_to_uuid
+from datacube.model.lineage import LineageRelations
 from datacube.utils import report_to_user
 from datacube.utils.changes import DocumentMismatchError
 
@@ -656,6 +657,8 @@ class AbstractDatasetResource(ABC):
         """
         Add a group of Dataset documents in bulk.
 
+        Will add lineage data if provided in the DatasetTuples - use Lineage API for more control
+
         API Note: This API method is not finalised and may be subject to change.
 
         :param datasets: An Iterable of DatasetTuples (i.e. as returned by get_all_docs)
@@ -675,8 +678,13 @@ class AbstractDatasetResource(ABC):
         batch = []
         job_started = monotonic()
         inter_batch_cache = self._init_bulk_add_cache()
+        lineage_cache = LineageRelations()
         for ds_tup in datasets:
             batch.append(ds_tup)
+            if ds_tup.lineage:
+                lineage_cache.merge_from_eo3(
+                    dsid_to_uuid(str(ds_tup.metadata["id"])), ds_tup.lineage
+                )
             n_in_batch += 1
             if n_in_batch >= batch_size:
                 batch_result = self._add_batch(
@@ -699,6 +707,9 @@ class AbstractDatasetResource(ABC):
             added += batch_result.completed
             skipped += batch_result.skipped
             increment_progress()
+
+        if lineage_cache.relations:
+            self._index.lineage.bulk_add(lineage_cache.relations, batch_size=batch_size)
 
         return BatchStatus(added, skipped, monotonic() - job_started)
 

--- a/datacube/index/abstract/_types.py
+++ b/datacube/index/abstract/_types.py
@@ -26,6 +26,8 @@ TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from datacube.model.lineage import Eo3LineageDict
+
 
 class BatchStatus(NamedTuple):
     """
@@ -61,6 +63,7 @@ class DatasetTuple(NamedTuple):
     product: Product
     metadata: JsonDict
     uri_: str | list[str]
+    lineage_: Eo3LineageDict | None = None
 
     @property
     def uri_is_string(self) -> bool:
@@ -86,6 +89,10 @@ class DatasetTuple(NamedTuple):
         if isinstance(self.uri_, str):
             return [self.uri_]
         return self.uri_
+
+    @property
+    def lineage(self) -> Eo3LineageDict:
+        return self.lineage_ or {}
 
 
 # The special handling of grid_spatial, etc. appears to NOT apply to EO3.

--- a/datacube/index/abstract/_types.py
+++ b/datacube/index/abstract/_types.py
@@ -18,6 +18,7 @@ from datacube.model import (
     Dataset,
     Product,  # noqa: TC001
 )
+from datacube.model.lineage import Eo3LineageDict  # noqa: TC001
 
 # JsonDict required for Sphinx's documentation plugin for named tuples.
 from datacube.utils.documents import JsonDict  # noqa: TC001
@@ -25,8 +26,6 @@ from datacube.utils.documents import JsonDict  # noqa: TC001
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Sequence
-
-    from datacube.model.lineage import Eo3LineageDict
 
 
 class BatchStatus(NamedTuple):
@@ -58,12 +57,13 @@ class DatasetTuple(NamedTuple):
     :param product: A Product model.
     :param metadata: The dataset metadata document
     :param uri\\_: The dataset location or list of locations
+    :param lineage: An optional EO3 document lineage section.
     """
 
     product: Product
     metadata: JsonDict
     uri_: str | list[str]
-    lineage_: Eo3LineageDict | None = None
+    lineage: Eo3LineageDict = {}
 
     @property
     def uri_is_string(self) -> bool:
@@ -89,10 +89,6 @@ class DatasetTuple(NamedTuple):
         if isinstance(self.uri_, str):
             return [self.uri_]
         return self.uri_
-
-    @property
-    def lineage(self) -> Eo3LineageDict:
-        return self.lineage_ or {}
 
 
 # The special handling of grid_spatial, etc. appears to NOT apply to EO3.

--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -16,7 +16,13 @@ import toolz
 from pystac import Item
 
 from datacube.metadata import stac2ds
-from datacube.model import Dataset, LineageDirection, LineageTree, Product
+from datacube.model import (
+    Dataset,
+    LineageDirection,
+    LineageTree,
+    Product,
+    dsid_to_uuid,
+)
 from datacube.model.utils import (
     BadMatch,
     dedup_lineage,
@@ -223,9 +229,9 @@ def resolve_with_lineage(
     :param home_index: Home for sources (ignored if source_tree is not none)
     :return:
     """
-    uuid_ = doc.id
-    if not uuid_:
+    if not doc.id:
         return None, "No id defined in dataset doc"
+    uuid_: UUID = dsid_to_uuid(doc.id)
     try:
         product = matcher(doc.doc)
     except BadMatch as e:

--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -228,9 +228,9 @@ def resolve_with_lineage(
     :param home_index: Home for sources (ignored if source_tree is not none)
     :return:
     """
-    if not doc.id:
-        return None, "No id defined in dataset doc"
     uuid_ = doc.id
+    if not uuid_:
+        return None, "No id defined in dataset doc"
     try:
         product = matcher(doc.doc)
     except BadMatch as e:

--- a/datacube/index/hl.py
+++ b/datacube/index/hl.py
@@ -21,7 +21,6 @@ from datacube.model import (
     LineageDirection,
     LineageTree,
     Product,
-    dsid_to_uuid,
 )
 from datacube.model.utils import (
     BadMatch,
@@ -231,7 +230,7 @@ def resolve_with_lineage(
     """
     if not doc.id:
         return None, "No id defined in dataset doc"
-    uuid_: UUID = dsid_to_uuid(doc.id)
+    uuid_ = doc.id
     try:
         product = matcher(doc.doc)
     except BadMatch as e:

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -235,7 +235,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             spatial_indexes={crs: [] for crs in crses},
         )
         dsids = []
-        for prod, metadata_doc, uri in batch_ds:
+        for prod, metadata_doc, uri, _ in batch_ds:
             dsid = UUID(str(metadata_doc["id"]))
             dsids.append(dsid)
             if isinstance(uri, list):

--- a/datacube/index/postgres/_datasets.py
+++ b/datacube/index/postgres/_datasets.py
@@ -240,7 +240,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
             "uris": [],
         }
         dsids = []
-        for prod, metadata_doc, uris in batch_ds:
+        for prod, metadata_doc, uris, _ in batch_ds:
             dsid = UUID(str(metadata_doc["id"]))
             dsids.append(dsid)
             batch["datasets"].append(

--- a/datacube/model/lineage.py
+++ b/datacube/model/lineage.py
@@ -203,9 +203,7 @@ class LineageTree:
     def to_eo3_doc(self) -> Eo3LineageDict:
         return {
             classifier: [source.dataset_id for source in sources]
-            for classifier, sources in (
-                () if self.children is None else self.children.items()
-            )
+            for classifier, sources in (self.children or {}).items()
         }
 
     @classmethod
@@ -374,7 +372,7 @@ class LineageRelations:
         home: str | None = None,
         home_derived: str | None = None,
     ) -> None:
-        id_derived = doc["id"]
+        id_derived = dsid_to_uuid(doc["id"])
         lineage = doc.get("lineage")
         if lineage:
             self.merge_from_eo3(id_derived, lineage, home, home_derived)
@@ -392,7 +390,7 @@ class LineageRelations:
                     LineageRelation(
                         classifier=classifier,
                         derived_id=id_derived,
-                        source_id=source,
+                        source_id=dsid_to_uuid(source),
                     )
                 )
                 if home is not None:

--- a/datacube/model/lineage.py
+++ b/datacube/model/lineage.py
@@ -386,15 +386,16 @@ class LineageRelations:
     ) -> None:
         for classifier, sources in lineage.items():
             for source in sources:
+                source_uuid = dsid_to_uuid(source)
                 self.merge_new_lineage_relation(
                     LineageRelation(
                         classifier=classifier,
                         derived_id=id_derived,
-                        source_id=dsid_to_uuid(source),
+                        source_id=source_uuid,
                     )
                 )
                 if home is not None:
-                    self.merge_new_home(source, home)
+                    self.merge_new_home(source_uuid, home)
         if home_derived is not None:
             self.merge_new_home(id_derived, home_derived)
 

--- a/datacube/model/lineage.py
+++ b/datacube/model/lineage.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, TypeAlias, cast
@@ -11,9 +12,11 @@ from uuid import UUID
 
 from typing_extensions import override
 
+from ._base import dsid_to_uuid
+
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping, Sequence
+    from collections.abc import Iterable
 
 
 class LineageDirection(Enum):
@@ -40,6 +43,7 @@ class LineageDirection(Enum):
 
 
 SerialisedTree: TypeAlias = dict[str, str | dict[str, list["SerialisedTree"]]]
+Eo3LineageDict: TypeAlias = Mapping[str, Sequence[UUID]]
 
 
 @dataclass
@@ -191,14 +195,24 @@ class LineageTree:
         :param home_derived: Home database for the derived dataset (defaults to None).
         :return: A depth==1 LineageTree
         """
-        lineage = doc.get("lineage")
-        return cls.from_data(doc["id"], lineage, home=home, home_derived=home_derived)
+        lineage: Eo3LineageDict | None = doc.get("lineage")
+        return cls.from_data(
+            dsid_to_uuid(doc["id"]), lineage, home=home, home_derived=home_derived
+        )
+
+    def to_eo3_doc(self) -> Eo3LineageDict:
+        return {
+            classifier: [source.dataset_id for source in sources]
+            for classifier, sources in (
+                () if self.children is None else self.children.items()
+            )
+        }
 
     @classmethod
     def from_data(
         cls,
         dsid: UUID,
-        sources: Mapping[str, Sequence[UUID]] | None = None,
+        sources: Eo3LineageDict | None = None,
         direction: LineageDirection = LineageDirection.SOURCES,
         home: str | None = None,
         home_derived: str | None = None,
@@ -218,7 +232,8 @@ class LineageTree:
         else:
             children = {
                 classifier: [
-                    cls(direction=direction, dataset_id=der, home=home) for der in ders
+                    cls(direction=direction, dataset_id=dsid_to_uuid(der), home=home)
+                    for der in ders
                 ]
                 for classifier, ders in sources.items()
             }
@@ -352,6 +367,38 @@ class LineageRelations:
                 )
         else:
             self._homes[id_] = home
+
+    def merge_from_eo3_doc(
+        self,
+        doc: Mapping[str, Any],
+        home: str | None = None,
+        home_derived: str | None = None,
+    ) -> None:
+        id_derived = doc["id"]
+        lineage = doc.get("lineage")
+        if lineage:
+            self.merge_from_eo3(id_derived, lineage, home, home_derived)
+
+    def merge_from_eo3(
+        self,
+        id_derived: UUID,
+        lineage: Eo3LineageDict,
+        home: str | None = None,
+        home_derived: str | None = None,
+    ) -> None:
+        for classifier, sources in lineage.items():
+            for source in sources:
+                self.merge_new_lineage_relation(
+                    LineageRelation(
+                        classifier=classifier,
+                        derived_id=id_derived,
+                        source_id=source,
+                    )
+                )
+                if home is not None:
+                    self.merge_new_home(source, home)
+        if home_derived is not None:
+            self.merge_new_home(id_derived, home_derived)
 
     def _merge_new_relation(self, ids: LineageIDPair, classifier: str) -> None:
         """

--- a/datacube/model/lineage.py
+++ b/datacube/model/lineage.py
@@ -12,7 +12,7 @@ from uuid import UUID
 
 from typing_extensions import override
 
-from ._base import dsid_to_uuid
+from ._base import DSID, dsid_to_uuid
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -43,7 +43,7 @@ class LineageDirection(Enum):
 
 
 SerialisedTree: TypeAlias = dict[str, str | dict[str, list["SerialisedTree"]]]
-Eo3LineageDict: TypeAlias = Mapping[str, Sequence[UUID]]
+Eo3LineageDict: TypeAlias = Mapping[str, Sequence[DSID]]
 
 
 @dataclass

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -160,7 +160,12 @@ def _mk_dataset_tuples(dss: Iterable[Dataset]) -> Generator[DatasetTuple]:
             ds._uris if ds.has_multiple_uris() else ds.uri if ds.uri is not None else []
         )
         assert isinstance(my_uris, (str, list))
-        yield DatasetTuple(ds.product, ds.metadata_doc, my_uris)
+        yield DatasetTuple(
+            ds.product,
+            ds.metadata_doc,
+            my_uris,
+            ds.source_tree.to_eo3_doc() if ds.source_tree else None,
+        )
 
 
 # Needs to be top level definition so it can be pickled.

--- a/datacube/scripts/dataset.py
+++ b/datacube/scripts/dataset.py
@@ -164,7 +164,7 @@ def _mk_dataset_tuples(dss: Iterable[Dataset]) -> Generator[DatasetTuple]:
             ds.product,
             ds.metadata_doc,
             my_uris,
-            ds.source_tree.to_eo3_doc() if ds.source_tree else None,
+            ds.source_tree.to_eo3_doc() if ds.source_tree else {},
         )
 
 

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -312,6 +312,14 @@ def ls8_stac_doc() -> tuple[dict, str]:
 
 
 @pytest.fixture
+def ls8_stac_lvl1_doc() -> tuple[dict, str]:
+    return (
+        get_eo3_test_data_doc("ga_ls8c_lvl1_stac.json"),
+        str(EO3_TESTDIR / "ga_ls8c_lvl1_stac.json"),
+    )
+
+
+@pytest.fixture
 def ls8_stac_update_path() -> str:
     return str(EO3_TESTDIR / "ga_ls8c_ard_3_stac_update.json")
 
@@ -383,6 +391,19 @@ def ls8_eo3_product(
 
 
 @pytest.fixture
+def ls8_lvl1_eo3_product(
+    index: Index, extended_eo3_metadata_type, extended_eo3_product_doc
+) -> Product:
+    extended_eo3_product_doc["name"] = "ga_ls8c_ard_3_level1"
+    extended_eo3_product_doc["metadata"]["product"]["name"] = "ga_ls8c_ard_3_level1"
+    del extended_eo3_product_doc["metadata"]["properties"]["odc:producer"]
+    del extended_eo3_product_doc["metadata"]["properties"]["odc:product_family"]
+    p = index.products.add_document(extended_eo3_product_doc)
+    assert p is not None
+    return p
+
+
+@pytest.fixture
 def wo_eo3_product(index: Index, base_eo3_product_doc) -> Product:
     p = index.products.add_document(base_eo3_product_doc)
     assert p is not None
@@ -417,10 +438,15 @@ def eo3_products(
     index: Index,
     extended_eo3_metadata_type,
     ls8_eo3_product,
-    wo_eo3_product,
+    ls8_lvl1_eo3_product,
     africa_s2_eo3_product,
 ):
-    return [africa_s2_eo3_product, ls8_eo3_product, wo_eo3_product]
+    return [
+        africa_s2_eo3_product,
+        ls8_eo3_product,
+        wo_eo3_product,
+        ls8_lvl1_eo3_product,
+    ]
 
 
 @pytest.fixture

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -396,8 +396,8 @@ def ls8_lvl1_eo3_product(
 ) -> Product:
     extended_eo3_product_doc["name"] = "ga_ls8c_ard_3_level1"
     extended_eo3_product_doc["metadata"]["product"]["name"] = "ga_ls8c_ard_3_level1"
-    del extended_eo3_product_doc["metadata"]["properties"]["odc:producer"]
-    del extended_eo3_product_doc["metadata"]["properties"]["odc:product_family"]
+    extended_eo3_product_doc["metadata"]["properties"]["odc:producer"] = "upstream"
+    extended_eo3_product_doc["metadata"]["properties"]["odc:product_family"] = "level1"
     p = index.products.add_document(extended_eo3_product_doc)
     assert p is not None
     return p

--- a/integration_tests/data/eo3/ga_ls8c_lvl1_stac.json
+++ b/integration_tests/data/eo3/ga_ls8c_lvl1_stac.json
@@ -48,6 +48,8 @@
       "landsat:wrs_row": 80,
       "odc:dataset_version": "3.1.0",
       "odc:file_format": "GeoTIFF",
+      "odc:producer": "upstream",
+      "odc:product_family": "level1",
       "created": "2020-06-18T05:07:06.303867Z",
       "odc:region_code": "088080",
       "proj:code": "EPSG:32656",
@@ -1134,5 +1136,5 @@
       "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
       "https://stac-extensions.github.io/view/v1.0.0/schema.json"
   ],
-  "collection": "ga_ls8c_ard_3"
+  "collection": "ga_ls8c_ard_3_level1"
 }

--- a/integration_tests/data/eo3/ga_ls8c_lvl1_stac.json
+++ b/integration_tests/data/eo3/ga_ls8c_lvl1_stac.json
@@ -1,0 +1,1138 @@
+{
+  "type": "Feature",
+  "stac_version": "1.1.0",
+  "id": "b5f234fe-bba8-5483-9bc0-250360d429cf",
+  "properties": {
+      "title": "ga_ls8c_ard_3-1-0_088080_2020-05-25_final",
+      "dea:dataset_maturity": "final",
+      "end_datetime": "2020-05-25T23:36:02.557719Z",
+      "start_datetime": "2020-05-25T23:35:32.815426Z",
+      "eo:cloud_cover": 42.42102985910952,
+      "gsd": 15.0,
+      "instruments": [
+          "oli",
+          "tirs"
+      ],
+      "platform": "landsat-8",
+      "view:sun_azimuth": 34.22994171,
+      "view:sun_elevation": 31.7895917,
+      "fmask:clear": 1.0427704509544131,
+      "fmask:cloud": 42.42102985910952,
+      "fmask:cloud_shadow": 2.919727915379625,
+      "fmask:snow": 0.00034972190505407335,
+      "fmask:water": 53.61612205265139,
+      "gqa:abs_iterative_mean_x": 0.17,
+      "gqa:abs_iterative_mean_xy": 0.24,
+      "gqa:abs_iterative_mean_y": 0.16,
+      "gqa:abs_x": 0.28,
+      "gqa:abs_xy": 0.4,
+      "gqa:abs_y": 0.28,
+      "gqa:cep90": "NaN",
+      "gqa:iterative_mean_x": 0.03,
+      "gqa:iterative_mean_xy": 0.12,
+      "gqa:iterative_mean_y": 0.12,
+      "gqa:iterative_stddev_x": 0.21,
+      "gqa:iterative_stddev_xy": 0.26,
+      "gqa:iterative_stddev_y": 0.15,
+      "gqa:mean_x": -0.08,
+      "gqa:mean_xy": 0.15,
+      "gqa:mean_y": 0.12,
+      "gqa:stddev_x": 0.42,
+      "gqa:stddev_xy": 0.58,
+      "gqa:stddev_y": 0.4,
+      "landsat:collection_category": "T1",
+      "landsat:collection_number": 1,
+      "landsat:landsat_product_id": "LC08_L1TP_088080_20200525_20200608_01_T1",
+      "landsat:landsat_scene_id": "LC80880802020146LGN00",
+      "landsat:wrs_path": 88,
+      "landsat:wrs_row": 80,
+      "odc:dataset_version": "3.1.0",
+      "odc:file_format": "GeoTIFF",
+      "created": "2020-06-18T05:07:06.303867Z",
+      "odc:region_code": "088080",
+      "proj:code": "EPSG:32656",
+      "proj:shape": [
+          7841, 
+          7781
+      ],
+      "proj:transform": [
+          30.0, 
+          0.0, 
+          526785.0, 
+          0.0, 
+          -30.0, 
+          -3077085.0, 
+          0.0, 
+          0.0, 
+          1.0
+      ],
+      "datetime": "2020-05-25T23:35:47.745731Z"
+  },
+  "geometry": {
+      "type": "Polygon",
+      "coordinates": [
+          [
+              [
+                  153.7385878898377,
+                  -27.81701549471511
+              ],
+              [
+                  153.7386050460989,
+                  -27.816958444141335
+              ],
+              [
+                  153.7408870777895,
+                  -27.81743186138652
+              ],
+              [
+                  153.74374919575374,
+                  -27.817950112487022
+              ],
+              [
+                  155.634437974109,
+                  -28.195665728285302
+              ],
+              [
+                  155.64656390412654,
+                  -28.198003116605665
+              ],
+              [
+                  155.6469914729725,
+                  -28.198261451847454
+              ],
+              [
+                  155.2205985724982,
+                  -29.92151128958127
+              ],
+              [
+                  155.2201572971803,
+                  -29.92243448617234
+              ],
+              [
+                  155.21918065761497,
+                  -29.922247599822754
+              ],
+              [
+                  155.21914643092472,
+                  -29.92238385153146
+              ],
+              [
+                  153.2865859478465,
+                  -29.537062581029243
+              ],
+              [
+                  153.28038700032272,
+                  -29.535721417545275
+              ],
+              [
+                  153.2796429434371,
+                  -29.53525889329016
+              ],
+              [
+                  153.27898977305418,
+                  -29.535123241623708
+              ],
+              [
+                  153.29231891428003,
+                  -29.485243884787124
+              ],
+              [
+                  153.4214079550725,
+                  -29.006049156688324
+              ],
+              [
+                  153.54919382814404,
+                  -28.528334994984274
+              ],
+              [
+                  153.73227439530447,
+                  -27.837474564334862
+              ],
+              [
+                  153.7376217743478,
+                  -27.817269375728674
+              ],
+              [
+                  153.73791928400988,
+                  -27.81689440711059
+              ],
+              [
+                  153.7385878898377,
+                  -27.81701549471511
+              ]
+          ]
+      ]
+  },
+  "links": [
+      {
+          "rel": "self",
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item.json",
+          "type": "application/json"
+      },
+      {
+          "rel": "odc_yaml",
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_ard_3-1-0_088080_2020-05-25_final.odc-metadata.yaml",
+          "type": "text/yaml",
+          "title": "ODC Dataset YAML"
+      },
+      {
+          "rel": "collection",
+          "href": "https://explorer.dev.dea.ga.gov.au/stac/collections/ga_ls8c_ard_3"
+      },
+      {
+          "rel": "product_overview",
+          "href": "https://explorer.dev.dea.ga.gov.au/product/ga_ls8c_ard_3",
+          "type": "text/html",
+          "title": "ODC Product Overview"
+      },
+      {
+          "rel": "alternative",
+          "href": "https://explorer.dev.dea.ga.gov.au/dataset/2aa69fcf-aa55-4747-9d95-3652f9fe79b0",
+          "type": "text/html",
+          "title": "ODC Dataset Overview"
+      }
+  ],
+  "assets": {
+      "nbar_blue": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_nbar_3-1-0_088080_2020-05-25_final_band02.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "nbar_blue",
+          "eo:bands": [
+              {
+                  "name": "nbar_blue"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "nbar_coastal_aerosol": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_nbar_3-1-0_088080_2020-05-25_final_band01.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "nbar_coastal_aerosol",
+          "eo:bands": [
+              {
+                  "name": "nbar_coastal_aerosol"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "nbar_green": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_nbar_3-1-0_088080_2020-05-25_final_band03.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "nbar_green",
+          "eo:bands": [
+              {
+                  "name": "nbar_green"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "nbar_nir": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_nbar_3-1-0_088080_2020-05-25_final_band05.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "nbar_nir",
+          "eo:bands": [
+              {
+                  "name": "nbar_nir"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "nbar_panchromatic": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_nbar_3-1-0_088080_2020-05-25_final_band08.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "nbar_panchromatic",
+          "eo:bands": [
+              {
+                  "name": "nbar_panchromatic"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              15681,
+              15561
+          ],
+          "proj:transform": [
+              15.0,
+              0.0,
+              526792.5,
+              0.0,
+              -15.0,
+              -3077092.5,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "nbar_red": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_nbar_3-1-0_088080_2020-05-25_final_band04.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "nbar_red",
+          "eo:bands": [
+              {
+                  "name": "nbar_red"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "nbar_swir_1": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_nbar_3-1-0_088080_2020-05-25_final_band06.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "nbar_swir_1",
+          "eo:bands": [
+              {
+                  "name": "nbar_swir_1"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "nbar_swir_2": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_nbar_3-1-0_088080_2020-05-25_final_band07.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "nbar_swir_2",
+          "eo:bands": [
+              {
+                  "name": "nbar_swir_2"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "nbart_blue": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_nbart_3-1-0_088080_2020-05-25_final_band02.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "nbart_blue",
+          "eo:bands": [
+              {
+                  "name": "nbart_blue"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "nbart_coastal_aerosol": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_nbart_3-1-0_088080_2020-05-25_final_band01.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "nbart_coastal_aerosol",
+          "eo:bands": [
+              {
+                  "name": "nbart_coastal_aerosol"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "nbart_green": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_nbart_3-1-0_088080_2020-05-25_final_band03.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "nbart_green",
+          "eo:bands": [
+              {
+                  "name": "nbart_green"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "nbart_nir": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_nbart_3-1-0_088080_2020-05-25_final_band05.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "nbart_nir",
+          "eo:bands": [
+              {
+                  "name": "nbart_nir"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "nbart_panchromatic": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_nbart_3-1-0_088080_2020-05-25_final_band08.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "nbart_panchromatic",
+          "eo:bands": [
+              {
+                  "name": "nbart_panchromatic"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              15681,
+              15561
+          ],
+          "proj:transform": [
+              15.0,
+              0.0,
+              526792.5,
+              0.0,
+              -15.0,
+              -3077092.5,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "nbart_red": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_nbart_3-1-0_088080_2020-05-25_final_band04.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "nbart_red",
+          "eo:bands": [
+              {
+                  "name": "nbart_red"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "nbart_swir_1": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_nbart_3-1-0_088080_2020-05-25_final_band06.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "nbart_swir_1",
+          "eo:bands": [
+              {
+                  "name": "nbart_swir_1"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "nbart_swir_2": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_nbart_3-1-0_088080_2020-05-25_final_band07.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "nbart_swir_2",
+          "eo:bands": [
+              {
+                  "name": "nbart_swir_2"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "oa_azimuthal_exiting": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_oa_3-1-0_088080_2020-05-25_final_azimuthal-exiting.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "oa_azimuthal_exiting",
+          "eo:bands": [
+              {
+                  "name": "oa_azimuthal_exiting"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "oa_azimuthal_incident": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_oa_3-1-0_088080_2020-05-25_final_azimuthal-incident.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "oa_azimuthal_incident",
+          "eo:bands": [
+              {
+                  "name": "oa_azimuthal_incident"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "oa_combined_terrain_shadow": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_oa_3-1-0_088080_2020-05-25_final_combined-terrain-shadow.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "oa_combined_terrain_shadow",
+          "eo:bands": [
+              {
+                  "name": "oa_combined_terrain_shadow"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "oa_exiting_angle": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_oa_3-1-0_088080_2020-05-25_final_exiting-angle.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "oa_exiting_angle",
+          "eo:bands": [
+              {
+                  "name": "oa_exiting_angle"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "oa_fmask": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_oa_3-1-0_088080_2020-05-25_final_fmask.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "oa_fmask",
+          "eo:bands": [
+              {
+                  "name": "oa_fmask"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "oa_incident_angle": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_oa_3-1-0_088080_2020-05-25_final_incident-angle.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "oa_incident_angle",
+          "eo:bands": [
+              {
+                  "name": "oa_incident_angle"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "oa_nbar_contiguity": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_oa_3-1-0_088080_2020-05-25_final_nbar-contiguity.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "oa_nbar_contiguity",
+          "eo:bands": [
+              {
+                  "name": "oa_nbar_contiguity"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "oa_nbart_contiguity": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_oa_3-1-0_088080_2020-05-25_final_nbart-contiguity.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "oa_nbart_contiguity",
+          "eo:bands": [
+              {
+                  "name": "oa_nbart_contiguity"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "oa_relative_azimuth": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_oa_3-1-0_088080_2020-05-25_final_relative-azimuth.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "oa_relative_azimuth",
+          "eo:bands": [
+              {
+                  "name": "oa_relative_azimuth"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "oa_relative_slope": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_oa_3-1-0_088080_2020-05-25_final_relative-slope.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "oa_relative_slope",
+          "eo:bands": [
+              {
+                  "name": "oa_relative_slope"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "oa_satellite_azimuth": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_oa_3-1-0_088080_2020-05-25_final_satellite-azimuth.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "oa_satellite_azimuth",
+          "eo:bands": [
+              {
+                  "name": "oa_satellite_azimuth"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "oa_satellite_view": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_oa_3-1-0_088080_2020-05-25_final_satellite-view.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "oa_satellite_view",
+          "eo:bands": [
+              {
+                  "name": "oa_satellite_view"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "oa_solar_azimuth": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_oa_3-1-0_088080_2020-05-25_final_solar-azimuth.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "oa_solar_azimuth",
+          "eo:bands": [
+              {
+                  "name": "oa_solar_azimuth"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "oa_solar_zenith": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_oa_3-1-0_088080_2020-05-25_final_solar-zenith.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "oa_solar_zenith",
+          "eo:bands": [
+              {
+                  "name": "oa_solar_zenith"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "oa_time_delta": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_oa_3-1-0_088080_2020-05-25_final_time-delta.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "oa_time_delta",
+          "eo:bands": [
+              {
+                  "name": "oa_time_delta"
+              }
+          ],
+          "proj:epsg": 32656,
+          "proj:shape": [
+              7841,
+              7781
+          ],
+          "proj:transform": [
+              30.0,
+              0.0,
+              526785.0,
+              0.0,
+              -30.0,
+              -3077085.0,
+              0.0,
+              0.0,
+              1.0
+          ],
+          "roles": [
+              "data"
+          ]
+      },
+      "thumbnail:nbar": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_nbar_3-1-0_088080_2020-05-25_final_thumbnail.jpg",
+          "type": "image/jpeg",
+          "title": "Thumbnail image",
+          "roles": [
+              "thumbnail"
+          ]
+      },
+      "thumbnail:nbart": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_nbart_3-1-0_088080_2020-05-25_final_thumbnail.jpg",
+          "type": "image/jpeg",
+          "title": "Thumbnail image",
+          "roles": [
+              "thumbnail"
+          ]
+      },
+      "checksum:sha1": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_ard_3-1-0_088080_2020-05-25_final.sha1",
+          "type": "text/plain",
+          "roles": [
+              "metadata"
+          ]
+      },
+      "metadata:processor": {
+          "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_ard_3-1-0_088080_2020-05-25_final.proc-info.yaml",
+          "type": "text/yaml",
+          "roles": [
+              "metadata"
+          ]
+      }
+  },
+  "bbox": [
+      153.27898977305418,
+      -29.92243448617234,
+      155.6469914729725,
+      -27.81689440711059
+  ],
+  "stac_extensions": [
+      "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
+      "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
+      "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+  ],
+  "collection": "ga_ls8c_ard_3"
+}

--- a/integration_tests/index/test_memory_index.py
+++ b/integration_tests/index/test_memory_index.py
@@ -586,7 +586,7 @@ def test_spatiotemporal_extent(mem_eo3_data: tuple) -> None:
         assert tmin2 == tmin and tmax2 == tmax
         ids = [
             doc["id"]
-            for prod, doc, uris in dc.index.datasets.get_all_docs_for_product(
+            for prod, doc, uris, _ in dc.index.datasets.get_all_docs_for_product(
                 product=ds.product
             )
         ]

--- a/integration_tests/test_dataset_add.py
+++ b/integration_tests/test_dataset_add.py
@@ -346,6 +346,7 @@ def test_dataset_add(dataset_add_configs, index_empty, clirunner) -> None:
 @pytest.mark.parametrize(
     "datacube_env_name", ("postgis", "postgis3", "datacube", "datacube3")
 )
+@pytest.mark.parametrize("db_tz", ("UTC",))
 def test_dataset_add_stac_ignore_lineage(
     index, clirunner, ls8_stac_doc, eo3_products
 ) -> None:
@@ -359,11 +360,24 @@ def test_dataset_add_stac_ignore_lineage(
     assert ds.source_tree is None
     assert ds.sources == {}
 
-    r = clirunner(["dataset", "add", path])
+    r = clirunner(["dataset", "add", "--ignore-lineage", path])
     assert r.exit_code == 0
 
 
+@pytest.mark.parametrize("datacube_env_name", ("postgis", "datacube"))
+@pytest.mark.parametrize("db_tz", ("UTC",))
+def test_dataset_add_stac_bad_product(index, ls8_stac_doc, eo3_products) -> None:
+    stac_doc, _ = ls8_stac_doc
+    stac_doc["collection"] = "bad_product"
+    doc2ds = Doc2Dataset(index, skip_lineage=True)
+    ds, err = doc2ds(stac_doc, "file:///something")
+    assert err is not None
+    assert "bad_product" in str(err)
+    assert ds is None
+
+
 @pytest.mark.parametrize("datacube_env_name", ("postgis", "postgis3"))
+@pytest.mark.parametrize("db_tz", ("UTC",))
 def test_dataset_add_stac_ext_lineage(
     index, clirunner, ls8_stac_doc, eo3_products
 ) -> None:
@@ -387,7 +401,25 @@ def test_dataset_add_stac_ext_lineage(
     assert st == ds.source_tree
 
 
+@pytest.mark.parametrize(
+    "datacube_env_name", ("datacube", "datacube3", "postgis", "postgis3")
+)
+@pytest.mark.parametrize("db_tz", ("UTC",))
+def test_dataset_add_stac_lineage(
+    index, clirunner, ls8_stac_doc, ls8_stac_lvl1_doc, eo3_products
+) -> None:
+    _, l1_path = ls8_stac_lvl1_doc
+    r = clirunner(["dataset", "add", l1_path])
+    assert r.exit_code == 0
+
+    _, path = ls8_stac_doc
+
+    r = clirunner(["dataset", "add", path])
+    assert r.exit_code == 0
+
+
 @pytest.mark.parametrize("datacube_env_name", ("postgis", "postgis3"))
+@pytest.mark.parametrize("db_tz", ("UTC",))
 def test_dataset_add_stac_workers_ext_lineage(
     index, clirunner, ls8_stac_doc, eo3_products
 ) -> None:
@@ -407,6 +439,7 @@ def test_dataset_add_stac_workers_ext_lineage(
 @pytest.mark.parametrize(
     "datacube_env_name", ("datacube", "datacube3", "postgis", "postgis3")
 )
+@pytest.mark.parametrize("db_tz", ("UTC",))
 def test_dataset_add_stac_workers_ignore_lineage(
     index, clirunner, ls8_stac_doc, eo3_products
 ) -> None:

--- a/integration_tests/test_dataset_add.py
+++ b/integration_tests/test_dataset_add.py
@@ -361,7 +361,7 @@ def test_dataset_add_stac_ignore_lineage(
     assert ds.sources == {}
 
     r = clirunner(["dataset", "add", "--ignore-lineage", path])
-    assert r.exit_code == 0
+    assert r.exit_code == 0, f"Output: {r.output}"
 
 
 @pytest.mark.parametrize("datacube_env_name", ("postgis", "datacube"))
@@ -395,7 +395,7 @@ def test_dataset_add_stac_ext_lineage(
     )
 
     r = clirunner(["dataset", "add", path])
-    assert r.exit_code == 0
+    assert r.exit_code == 0, f"Output: {r.output}"
 
     st = index.lineage.get_source_tree(ds.id)
     assert st == ds.source_tree
@@ -408,14 +408,29 @@ def test_dataset_add_stac_ext_lineage(
 def test_dataset_add_stac_lineage(
     index, clirunner, ls8_stac_doc, ls8_stac_lvl1_doc, eo3_products
 ) -> None:
-    _, l1_path = ls8_stac_lvl1_doc
+    l1_metadata, l1_path = ls8_stac_lvl1_doc
     r = clirunner(["dataset", "add", l1_path])
-    assert r.exit_code == 0
+    assert r.exit_code == 0, f"Output: {r.output}"
+    ds = index.datasets.get(l1_metadata["id"])
+    assert ds is not None
 
-    _, path = ls8_stac_doc
+    ls8_metadata, path = ls8_stac_doc
 
     r = clirunner(["dataset", "add", path])
-    assert r.exit_code == 0
+    assert r.exit_code == 0, f"Output: {r.output}"
+
+    ds = index.datasets.get(ls8_metadata["id"], include_sources=True)
+    assert ds is not None
+    if index.supports_external_lineage:
+        assert ds.source_tree is not None
+        assert (
+            str(next(iter(ds.source_tree.child_datasets())))
+            == "b5f234fe-bba8-5483-9bc0-250360d429cf"
+        )
+    else:
+        assert ds.source_tree is None
+        assert ds.sources is not None
+        assert str(ds.sources["level1"].id) == "b5f234fe-bba8-5483-9bc0-250360d429cf"
 
 
 @pytest.mark.parametrize("datacube_env_name", ("postgis", "postgis3"))

--- a/integration_tests/test_dataset_add.py
+++ b/integration_tests/test_dataset_add.py
@@ -343,8 +343,30 @@ def test_dataset_add(dataset_add_configs, index_empty, clirunner) -> None:
     assert "location" not in _ds.metadata_doc
 
 
+@pytest.mark.parametrize(
+    "datacube_env_name", ("postgis", "postgis3", "datacube", "datacube3")
+)
+def test_dataset_add_stac_ignore_lineage(
+    index, clirunner, ls8_stac_doc, eo3_products
+) -> None:
+    stac_doc, path = ls8_stac_doc
+    doc2ds = Doc2Dataset(index, skip_lineage=True)
+    ds, err = doc2ds(stac_doc, "file:///something")
+    assert err is None
+    assert ds is not None
+    assert str(ds.id) == stac_doc.get("id")
+    assert ds.product.name == "ga_ls8c_ard_3"
+    assert ds.source_tree is None
+    assert ds.sources == {}
+
+    r = clirunner(["dataset", "add", path])
+    assert r.exit_code == 0
+
+
 @pytest.mark.parametrize("datacube_env_name", ("postgis", "postgis3"))
-def test_dataset_add_stac(index, clirunner, ls8_stac_doc, eo3_products) -> None:
+def test_dataset_add_stac_ext_lineage(
+    index, clirunner, ls8_stac_doc, eo3_products
+) -> None:
     stac_doc, path = ls8_stac_doc
     doc2ds = Doc2Dataset(index)
     ds, err = doc2ds(stac_doc, "file:///something")
@@ -354,18 +376,47 @@ def test_dataset_add_stac(index, clirunner, ls8_stac_doc, eo3_products) -> None:
     assert ds.product.name == "ga_ls8c_ard_3"
     assert ds.source_tree is not None
     assert (
-        str(ds.source_tree.child_datasets().pop())
+        str(next(iter(ds.source_tree.child_datasets())))
         == "b5f234fe-bba8-5483-9bc0-250360d429cf"
     )
 
     r = clirunner(["dataset", "add", path])
     assert r.exit_code == 0
 
-    stac_doc["collection"] = "foo"
+    st = index.lineage.get_source_tree(ds.id)
+    assert st == ds.source_tree
+
+
+@pytest.mark.parametrize("datacube_env_name", ("postgis", "postgis3"))
+def test_dataset_add_stac_workers_ext_lineage(
+    index, clirunner, ls8_stac_doc, eo3_products
+) -> None:
+    stac_doc, path = ls8_stac_doc
+    doc2ds = Doc2Dataset(index)
     ds, err = doc2ds(stac_doc, "file://something")
-    assert err is not None
+    assert err is None
+    assert ds is not None
 
     r = clirunner(["-v", "dataset", "add", "--workers", "2", path])
+    assert r.exit_code == 0, f"Output: {r.output}"
+
+    st = index.lineage.get_source_tree(ds.id)
+    assert st == ds.source_tree
+
+
+@pytest.mark.parametrize(
+    "datacube_env_name", ("datacube", "datacube3", "postgis", "postgis3")
+)
+def test_dataset_add_stac_workers_ignore_lineage(
+    index, clirunner, ls8_stac_doc, eo3_products
+) -> None:
+    stac_doc, path = ls8_stac_doc
+    doc2ds = Doc2Dataset(index, skip_lineage=True)
+    ds, err = doc2ds(stac_doc, "file://something")
+    assert err is None
+    assert ds is not None
+
+    r = clirunner(["-v", "dataset", "add", "--workers", "2", "--ignore-lineage", path])
     assert r.exit_code == 0, f"Output: {r.output}"
 
 

--- a/tests/test_ext_lineage.py
+++ b/tests/test_ext_lineage.py
@@ -142,6 +142,27 @@ def test_lineage_serialisation(src_lineage_tree, src_tree_ids) -> None:
     assert tree_out == src_lineage_tree
 
 
+def test_lineage_eo3_merge(src_lineage_tree, src_tree_ids) -> None:
+    rels = LineageRelations()
+    rels.merge_from_eo3_doc(
+        {
+            "id": str(src_tree_ids["root"]),
+            "lineage": {
+                "ard": [str(src_tree_ids["ard1"])],
+            }
+        }
+    )
+    rels.merge_from_eo3(
+        src_tree_ids["ard1"],
+        home="level1db",
+        lineage={
+            "l1": [str(src_tree_ids["l1_1"]), str(src_tree_ids["l1_2"]), str(src_tree_ids["l1_3"])],
+            "atmos_corr": [str(src_tree_ids["atmos"])],
+        }
+    )
+    assert rels.extract_tree(src_tree_ids["root"], LineageDirection.SOURCES) == src_lineage_tree
+
+
 @pytest.fixture
 def src_lineage_tree_diffhome(src_tree_ids: dict[str, UUID]) -> LineageTree:
     ids = src_tree_ids

--- a/tests/test_ext_lineage.py
+++ b/tests/test_ext_lineage.py
@@ -149,18 +149,25 @@ def test_lineage_eo3_merge(src_lineage_tree, src_tree_ids) -> None:
             "id": str(src_tree_ids["root"]),
             "lineage": {
                 "ard": [str(src_tree_ids["ard1"])],
-            }
+            },
         }
     )
     rels.merge_from_eo3(
         src_tree_ids["ard1"],
         home="level1db",
         lineage={
-            "l1": [str(src_tree_ids["l1_1"]), str(src_tree_ids["l1_2"]), str(src_tree_ids["l1_3"])],
+            "l1": [
+                str(src_tree_ids["l1_1"]),
+                str(src_tree_ids["l1_2"]),
+                str(src_tree_ids["l1_3"]),
+            ],
             "atmos_corr": [str(src_tree_ids["atmos"])],
-        }
+        },
     )
-    assert rels.extract_tree(src_tree_ids["root"], LineageDirection.SOURCES) == src_lineage_tree
+    assert (
+        rels.extract_tree(src_tree_ids["root"], LineageDirection.SOURCES)
+        == src_lineage_tree
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
### Reason for this pull request

Lineage data was not being recorded when indexing a STAC document.


### Proposed changes

- Some bug fixes to `LineageTree` behaviour and usage.
- New methods to merge EO3 lineage dictionaries in a `LineageRelations` object.
- Add an optional lineage field to `DatasetTuple`.
- Ensure `doc2ds` handles lineage information correctly for STAC documents.
- Ensure `datasets.bulk_add` method can handle lineage info if it is passed in.  (delegated to `lineage.bulk_add`).
- Extend test coverage.

Some extra tests written.  Waiting for this test run to check if there's additional coverage needed.


 - [x] Tests added / passed
 - [x] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2443.org.readthedocs.build/en/2443/

<!-- readthedocs-preview opendatacube end -->