### PR TITLE
docs: fix docutils warnings

### DIFF
--- a/docs/source/about/whats_new.rst
+++ b/docs/source/about/whats_new.rst
@@ -11,10 +11,10 @@ Release History
 Includes functional and performance improvements to indexing, especially from STAC.
 
 What's Changed
-++++++++++++++
+--------------
 
 Significant Changes
--------------------
+^^^^^^^^^^^^^^^^^^^
 
 * index: align bulk_add and add API by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2393
 * dataset: use bulk-add for Postgis by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2403
@@ -27,7 +27,7 @@ Significant Changes
 * Store lineage data when indexing from STAC by @SpacemanPaul in https://github.com/opendatacube/datacube-core/pull/2443
 
 Minor Changes/Maintenance/Cleanup
----------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * test_eo3converter: remove hardcoded strings by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2401
 * Replace custom cached_property with stdlib by @pjonsson in https://github.com/opendatacube/datacube-core/pull/2406
@@ -54,7 +54,7 @@ Minor Changes/Maintenance/Cleanup
 * Prepare for 1.9.18 release by @SpacemanPaul in https://github.com/opendatacube/datacube-core/pull/2455
 
 Automated Updates
------------------
+^^^^^^^^^^^^^^^^^
 
 * build(deps): bump astral-sh/uv from 0.10.10 to 0.10.11 in /docker by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2400
 * build(deps): bump astral-sh/uv from 0.10.11 to 0.10.12 in /docker by @dependabot[bot] in https://github.com/opendatacube/datacube-core/pull/2407

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -55,6 +55,7 @@ The following pages provide a full API reference for the ``datacube`` python lib
    Writing GeoTIFFs <utilities/cogs>
    utilities/dask
    geometry/index
+   grid-processing/gridWorkflow
 
 .. toctree::
    :caption: DB utilities for apps and services

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -58,3 +58,5 @@ The following pages provide a full API reference for the ``datacube`` python lib
 
 .. toctree::
    :caption: DB utilities for apps and services
+
+   utilities/common_psql


### PR DESCRIPTION
### Reason for this pull request

The section markers are =, -,
and ^.

https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2457.org.readthedocs.build/en/2457/

<!-- readthedocs-preview opendatacube end -->