### PR TITLE
docs: fail on warnings

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -25,6 +25,7 @@ build:
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/source/conf.py
+   fail_on_warning: true
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
 # formats:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -30,7 +30,7 @@ plantuml_diags: $(SVG_FILES)
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) -W $(O)
 
 clean:
 	rm -rf build/


### PR DESCRIPTION
### Reason for this pull request

There are currently no warnings
in the documentation build,
so make the build fail on warnings
so we don't introduce new issues.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2459.org.readthedocs.build/en/2459/

<!-- readthedocs-preview opendatacube end -->