### PR TITLE
Fix Not expression handling in dataset search

### DIFF
--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -26,6 +26,7 @@ from sqlalchemy import (
     column,
     delete,
     func,
+    not_,
     or_,
     select,
     text,
@@ -37,7 +38,7 @@ from sqlalchemy.orm import Session
 from typing_extensions import override
 
 from datacube.drivers.common_psql import create_user, drop_users, grant_role, has_role
-from datacube.index.fields import OrExpression
+from datacube.index.fields import NotExpression, OrExpression
 from datacube.model import Range
 from datacube.model.lineage import LineageDirection, LineageRelation
 from datacube.utils import json
@@ -565,6 +566,8 @@ class PostgisDbAPI:
         def raw_expr(expression):
             if isinstance(expression, OrExpression):
                 return or_(raw_expr(expr) for expr in expression.exprs)
+            if isinstance(expression, NotExpression):
+                return not_(raw_expr(expression.expr))
             return expression.alchemy_expression
 
         return [raw_expr(expression) for expression in expressions]

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -29,6 +29,7 @@ from sqlalchemy import (
     distinct,
     func,
     literal,
+    not_,
     or_,
     select,
     text,
@@ -40,7 +41,7 @@ from typing_extensions import override
 
 from datacube.drivers.common_psql import create_user, drop_users, grant_role, has_role
 from datacube.index.exceptions import MissingRecordError
-from datacube.index.fields import OrExpression
+from datacube.index.fields import NotExpression, OrExpression
 from datacube.model import Range
 from datacube.utils.uris import split_uri
 
@@ -498,6 +499,8 @@ class PostgresDbAPI:
         def raw_expr(expression):
             if isinstance(expression, OrExpression):
                 return or_(raw_expr(expr) for expr in expression.exprs)
+            if isinstance(expression, NotExpression):
+                return not_(raw_expr(expression.expr))
             return expression.alchemy_expression
 
         return [raw_expr(expression) for expression in expressions]

--- a/datacube/index/postgis/_products.py
+++ b/datacube/index/postgis/_products.py
@@ -14,8 +14,7 @@ from typing_extensions import override
 from datacube.index import fields
 from datacube.index.abstract import AbstractProductResource, BatchStatus
 from datacube.index.postgis._transaction import IndexResourceAddIn
-from datacube.model import Not, Product
-from datacube.model._base import nested_nots
+from datacube.model import Not, Product, unnest_nots
 from datacube.utils import _readable_offset, changes, jsonify_document
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes
 
@@ -377,12 +376,12 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
                 return v
             return [v]
 
-        def _is_not_match(value: str, matching: list) -> bool:
+        def _exclude(value: str, matching: list) -> bool:
             # determine if product/metadata-types are non-matches, accounting for Not values
             to_match = []
             for m in matching:
                 if isinstance(m, Not):
-                    if not isinstance(mval := nested_nots(m), Not):
+                    if not isinstance(mval := unnest_nots(m), Not):
                         to_match.extend(_listify(mval))
                     elif value in mval.value:
                         return True
@@ -395,10 +394,10 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
             remaining_matchable = query.copy()
             # If they specified specific product/metadata-types, we can quickly skip non-matches.
             product = _listify(remaining_matchable.pop("product", []))
-            if product and _is_not_match(type_.name, product):
+            if product and _exclude(type_.name, product):
                 continue
             metadata_type = _listify(remaining_matchable.pop("metadata_type", []))
-            if metadata_type and _is_not_match(type_.metadata_type.name, metadata_type):
+            if metadata_type and _exclude(type_.metadata_type.name, metadata_type):
                 continue
 
             # Check that all the keys they specified match this product.

--- a/datacube/index/postgis/_products.py
+++ b/datacube/index/postgis/_products.py
@@ -377,19 +377,16 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
 
         def _is_not_match(value: str, matching: list) -> bool:
             # determine if product/metadata-types are non-matches, accounting for Not values
-            if any(isinstance(m, Not) for m in matching):
-                for m in matching:
-                    # value is a non-match if it matches any of the Not values
-                    if isinstance(m, Not):
-                        if value == m.value:
-                            return True
-                        continue
-                    # standard non-match
-                    if value != m:
+            to_match = []
+            for m in matching:
+                if isinstance(m, Not):
+                    mval = m.value
+                    if (isinstance(mval, list) and value in mval) or value == mval:
                         return True
-                # if the for loop exits, we only had matches
-                return False
-            return value not in matching
+                else:
+                    to_match.append(m)
+            # if to_match is empty, all the 'matching' values were 'Not's and we have a match
+            return to_match and value not in to_match
 
         for type_ in self.get_all():
             remaining_matchable = query.copy()

--- a/datacube/index/postgis/_products.py
+++ b/datacube/index/postgis/_products.py
@@ -15,6 +15,7 @@ from datacube.index import fields
 from datacube.index.abstract import AbstractProductResource, BatchStatus
 from datacube.index.postgis._transaction import IndexResourceAddIn
 from datacube.model import Not, Product
+from datacube.model._base import nested_nots
 from datacube.utils import _readable_offset, changes, jsonify_document
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes
 
@@ -369,8 +370,9 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
         """
 
         def _listify(v) -> list:
-            if isinstance(v, tuple):
-                return [v] if isinstance(v, Not) else list(v)
+            if isinstance(v, tuple) and not isinstance(v, Not):
+                # Not is a namedtuple
+                return list(v)
             if isinstance(v, list):
                 return v
             return [v]
@@ -380,8 +382,9 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
             to_match = []
             for m in matching:
                 if isinstance(m, Not):
-                    mval = m.value
-                    if (isinstance(mval, list) and value in mval) or value == mval:
+                    if not isinstance(mval := nested_nots(m), Not):
+                        to_match.extend(_listify(mval))
+                    elif value in mval.value:
                         return True
                 else:
                     to_match.append(m)

--- a/datacube/index/postgis/_products.py
+++ b/datacube/index/postgis/_products.py
@@ -386,7 +386,7 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
                 else:
                     to_match.append(m)
             # if to_match is empty, all the 'matching' values were 'Not's and we have a match
-            return to_match and value not in to_match
+            return len(to_match) > 0 and value not in to_match
 
         for type_ in self.get_all():
             remaining_matchable = query.copy()

--- a/datacube/index/postgis/_products.py
+++ b/datacube/index/postgis/_products.py
@@ -14,7 +14,7 @@ from typing_extensions import override
 from datacube.index import fields
 from datacube.index.abstract import AbstractProductResource, BatchStatus
 from datacube.index.postgis._transaction import IndexResourceAddIn
-from datacube.model import Product
+from datacube.model import Not, Product
 from datacube.utils import _readable_offset, changes, jsonify_document
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes
 
@@ -370,21 +370,35 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
 
         def _listify(v) -> list:
             if isinstance(v, tuple):
-                return list(v)
+                return [v] if isinstance(v, Not) else list(v)
             if isinstance(v, list):
                 return v
             return [v]
 
+        def _is_not_match(value: str, matching: list) -> bool:
+            # determine if product/metadata-types are non-matches, accounting for Not values
+            if any(isinstance(m, Not) for m in matching):
+                for m in matching:
+                    # value is a non-match if it matches any of the Not values
+                    if isinstance(m, Not):
+                        if value == m.value:
+                            return True
+                        continue
+                    # standard non-match
+                    if value != m:
+                        return True
+                # if the for loop exits, we only had matches
+                return False
+            return value not in matching
+
         for type_ in self.get_all():
             remaining_matchable = query.copy()
             # If they specified specific product/metadata-types, we can quickly skip non-matches.
-            if type_.name not in _listify(
-                remaining_matchable.pop("product", type_.name)
-            ):
+            product = _listify(remaining_matchable.pop("product", []))
+            if product and _is_not_match(type_.name, product):
                 continue
-            if type_.metadata_type.name not in _listify(
-                remaining_matchable.pop("metadata_type", type_.metadata_type.name)
-            ):
+            metadata_type = _listify(remaining_matchable.pop("metadata_type", []))
+            if metadata_type and _is_not_match(type_.metadata_type.name, metadata_type):
                 continue
 
             # Check that all the keys they specified match this product.

--- a/datacube/index/postgres/_products.py
+++ b/datacube/index/postgres/_products.py
@@ -383,7 +383,7 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
                 else:
                     to_match.append(m)
             # if to_match is empty, all the 'matching' values were 'Not's and we have a match
-            return to_match and value not in to_match
+            return len(to_match) > 0 and value not in to_match
 
         for type_ in self.get_all():
             remaining_matchable = query.copy()

--- a/datacube/index/postgres/_products.py
+++ b/datacube/index/postgres/_products.py
@@ -14,6 +14,7 @@ from datacube.index import fields
 from datacube.index.abstract import AbstractProductResource
 from datacube.index.postgres._transaction import IndexResourceAddIn
 from datacube.model import Not, Product
+from datacube.model._base import nested_nots
 from datacube.utils import _readable_offset, changes, jsonify_document
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes
 
@@ -377,8 +378,9 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
             to_match = []
             for m in matching:
                 if isinstance(m, Not):
-                    mval = m.value
-                    if (isinstance(mval, list) and value in mval) or value == mval:
+                    if not isinstance(mval := nested_nots(m), Not):
+                        to_match.extend(_listify(mval))
+                    elif value in mval.value:
                         return True
                 else:
                     to_match.append(m)

--- a/datacube/index/postgres/_products.py
+++ b/datacube/index/postgres/_products.py
@@ -367,8 +367,9 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
         """
 
         def _listify(v) -> list:
-            if isinstance(v, tuple):
-                return [v] if isinstance(v, Not) else list(v)
+            if isinstance(v, tuple) and not isinstance(v, Not):
+                # Not is a namedtumple
+                return list(v)
             if isinstance(v, list):
                 return v
             return [v]

--- a/datacube/index/postgres/_products.py
+++ b/datacube/index/postgres/_products.py
@@ -13,8 +13,7 @@ from typing_extensions import override
 from datacube.index import fields
 from datacube.index.abstract import AbstractProductResource
 from datacube.index.postgres._transaction import IndexResourceAddIn
-from datacube.model import Not, Product
-from datacube.model._base import nested_nots
+from datacube.model import Not, Product, unnest_nots
 from datacube.utils import _readable_offset, changes, jsonify_document
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes
 
@@ -374,12 +373,12 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
                 return v
             return [v]
 
-        def _is_not_match(value: str, matching: list) -> bool:
+        def _exclude(value: str, matching: list) -> bool:
             # determine if product/metadata-types are non-matches, accounting for Not values
             to_match = []
             for m in matching:
                 if isinstance(m, Not):
-                    if not isinstance(mval := nested_nots(m), Not):
+                    if not isinstance(mval := unnest_nots(m), Not):
                         to_match.extend(_listify(mval))
                     elif value in mval.value:
                         return True
@@ -392,10 +391,10 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
             remaining_matchable = query.copy()
             # If they specified specific product/metadata-types, we can quickly skip non-matches.
             product = _listify(remaining_matchable.pop("product", []))
-            if product and _is_not_match(type_.name, product):
+            if product and _exclude(type_.name, product):
                 continue
             metadata_type = _listify(remaining_matchable.pop("metadata_type", []))
-            if metadata_type and _is_not_match(type_.metadata_type.name, metadata_type):
+            if metadata_type and _exclude(type_.metadata_type.name, metadata_type):
                 continue
 
             # Check that all the keys they specified match this product.

--- a/datacube/index/postgres/_products.py
+++ b/datacube/index/postgres/_products.py
@@ -374,19 +374,16 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
 
         def _is_not_match(value: str, matching: list) -> bool:
             # determine if product/metadata-types are non-matches, accounting for Not values
-            if any(isinstance(m, Not) for m in matching):
-                for m in matching:
-                    # value is a non-match if it matches any of the Not values
-                    if isinstance(m, Not):
-                        if value == m.value:
-                            return True
-                        continue
-                    # standard non-match
-                    if value != m:
+            to_match = []
+            for m in matching:
+                if isinstance(m, Not):
+                    mval = m.value
+                    if (isinstance(mval, list) and value in mval) or value == mval:
                         return True
-                # if the for loop exits, we only had matches
-                return False
-            return value not in matching
+                else:
+                    to_match.append(m)
+            # if to_match is empty, all the 'matching' values were 'Not's and we have a match
+            return to_match and value not in to_match
 
         for type_ in self.get_all():
             remaining_matchable = query.copy()

--- a/datacube/index/postgres/_products.py
+++ b/datacube/index/postgres/_products.py
@@ -13,7 +13,7 @@ from typing_extensions import override
 from datacube.index import fields
 from datacube.index.abstract import AbstractProductResource
 from datacube.index.postgres._transaction import IndexResourceAddIn
-from datacube.model import Product
+from datacube.model import Not, Product
 from datacube.utils import _readable_offset, changes, jsonify_document
 from datacube.utils.changes import check_doc_unchanged, get_doc_changes
 
@@ -367,21 +367,35 @@ class ProductResource(AbstractProductResource, IndexResourceAddIn):
 
         def _listify(v) -> list:
             if isinstance(v, tuple):
-                return list(v)
+                return [v] if isinstance(v, Not) else list(v)
             if isinstance(v, list):
                 return v
             return [v]
 
+        def _is_not_match(value: str, matching: list) -> bool:
+            # determine if product/metadata-types are non-matches, accounting for Not values
+            if any(isinstance(m, Not) for m in matching):
+                for m in matching:
+                    # value is a non-match if it matches any of the Not values
+                    if isinstance(m, Not):
+                        if value == m.value:
+                            return True
+                        continue
+                    # standard non-match
+                    if value != m:
+                        return True
+                # if the for loop exits, we only had matches
+                return False
+            return value not in matching
+
         for type_ in self.get_all():
             remaining_matchable = query.copy()
             # If they specified specific product/metadata-types, we can quickly skip non-matches.
-            if type_.name not in _listify(
-                remaining_matchable.pop("product", type_.name)
-            ):
+            product = _listify(remaining_matchable.pop("product", []))
+            if product and _is_not_match(type_.name, product):
                 continue
-            if type_.metadata_type.name not in _listify(
-                remaining_matchable.pop("metadata_type", type_.metadata_type.name)
-            ):
+            metadata_type = _listify(remaining_matchable.pop("metadata_type", []))
+            if metadata_type and _is_not_match(type_.metadata_type.name, metadata_type):
                 continue
 
             # Check that all the keys they specified match this product.

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -46,6 +46,7 @@ from ._base import (
     Range,
     dsid_to_uuid,
     ranges_overlap,
+    unnest_nots,
 )
 from .eo3 import validate_eo3_compatible_type
 from .fields import Field, get_dataset_fields
@@ -93,6 +94,7 @@ __all__ = [
     "get_dataset_fields",
     "metadata_from_doc",
     "ranges_overlap",
+    "unnest_nots",
 ]
 
 _LOG: logging.Logger = logging.getLogger(__name__)

--- a/datacube/model/__init__.py
+++ b/datacube/model/__init__.py
@@ -38,7 +38,7 @@ from datacube.utils import (
 )
 
 from ..utils.uris import pick_uri
-from ._base import (  # noqa: F401
+from ._base import (
     DSID,
     Not,
     QueryDict,
@@ -84,6 +84,7 @@ __all__ = [
     "LineageTree",
     "Measurement",
     "MetadataType",
+    "Not",
     "Product",
     "QueryDict",
     "QueryField",

--- a/datacube/model/_base.py
+++ b/datacube/model/_base.py
@@ -62,7 +62,7 @@ def ranges_overlap(ra: Range, rb: Range) -> bool:
     return rb.end > ra.begin
 
 
-def nested_nots(n: Not) -> Not | T:
+def unnest_nots(n: Not) -> Not | object:
     """
     Handle an arbitrary amount of nested Nots, such that:
     - Not(Not(x)) == x;
@@ -71,8 +71,8 @@ def nested_nots(n: Not) -> Not | T:
     """
     if isinstance(n.value, Not):
         if isinstance(n.value.value, Not):
-            nested = Not(nested_nots(n.value))
-            return nested_nots(nested)
+            nested = Not(unnest_nots(n.value))
+            return unnest_nots(nested)
         return n.value.value
     return n
 

--- a/datacube/model/_base.py
+++ b/datacube/model/_base.py
@@ -62,6 +62,21 @@ def ranges_overlap(ra: Range, rb: Range) -> bool:
     return rb.end > ra.begin
 
 
+def nested_nots(n: Not) -> Not | T:
+    """
+    Handle an arbitrary amount of nested Nots, such that:
+    - Not(Not(x)) == x;
+    - Not(Not(Not(x))) == Not(x);
+    - and so on.
+    """
+    if isinstance(n.value, Not):
+        if isinstance(n.value.value, Not):
+            nested = Not(nested_nots(n.value))
+            return nested_nots(nested)
+        return n.value.value
+    return n
+
+
 QueryField: TypeAlias = (
     str | float | int | Range | datetime.datetime | Iterable[str | Geometry] | Not
 )

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -560,6 +560,12 @@ def test_search_not_expressions_eo3(
         == datasets
     )
 
+    # product=(Not(Not("x"))) should evaluate to product="x"
+    datasets = list(index.datasets.search(product=Not(Not("ga_ls8c_ard_3"))))
+    assert len(datasets) == 2
+    assert ls8_eo3_dataset in datasets
+    assert ls8_eo3_dataset2 in datasets
+
 
 def test_search_returning_eo3(
     index: Index,

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -554,6 +554,11 @@ def test_search_not_expressions_eo3(
     assert len(datasets) == 2
     assert africa_eo3_dataset in datasets
     assert s1_eo3_dataset in datasets
+    # a list of Nots should be equivalent to a Not of lists
+    assert (
+        list(index.datasets.search(product=Not(["ga_ls8c_ard_3", "ga_ls_wo_3"])))
+        == datasets
+    )
 
 
 def test_search_returning_eo3(

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -22,7 +22,7 @@ import datacube.scripts.cli_app
 import datacube.scripts.search_tool
 from datacube import Datacube
 from datacube.cfg.opt import _DEFAULT_DB_USER
-from datacube.model import Range
+from datacube.model import Not, Range
 from datacube.testutils import suppress_deprecations
 from datacube.utils.dates import tz_as_utc
 
@@ -514,6 +514,46 @@ def test_search_or_expressions_eo3(
     )
     assert len(datasets) == 1
     assert datasets[0].id == wo_eo3_dataset.id
+
+
+def test_search_not_expressions_eo3(
+    index: Index,
+    ls8_eo3_dataset: Dataset,
+    ls8_eo3_dataset2: Dataset,
+    wo_eo3_dataset: Dataset,
+    africa_eo3_dataset: Dataset,
+    s1_eo3_dataset: Dataset,
+) -> None:
+    datasets = list(index.datasets.search(product_family=Not("ard")))
+    assert len(datasets) == 2
+    assert wo_eo3_dataset in datasets
+    assert s1_eo3_dataset in datasets
+    # africa_eo3_dataset (product s2_l2a) doesn't have product_family property
+
+    datasets = list(index.datasets.search(product=Not("ga_ls_wo_3")))
+    assert len(datasets) == 4
+    assert wo_eo3_dataset not in datasets
+
+    datasets = list(
+        index.datasets.search(
+            product="ga_ls8c_ard_3",
+            time=Not(
+                Range(
+                    begin=datetime.datetime(2016, 5, 1, tzinfo=datetime.timezone.utc),
+                    end=datetime.datetime(2016, 5, 15, tzinfo=datetime.timezone.utc),
+                )
+            ),
+        )
+    )
+    assert len(datasets) == 1
+    assert datasets[0].id == ls8_eo3_dataset2.id
+
+    datasets = list(
+        index.datasets.search(product=[Not("ga_ls8c_ard_3"), Not("ga_ls_wo_3")])
+    )
+    assert len(datasets) == 2
+    assert africa_eo3_dataset in datasets
+    assert s1_eo3_dataset in datasets
 
 
 def test_search_returning_eo3(


### PR DESCRIPTION
### Reason for this pull request

The use of `Not` expressions is not currently supported by `datasets.search`:
- `datasets.search(product=Not(<name>))` returns the same as `datasets.search(product=<name>)`, same goes for if metadata_type is specified in the query
- For a field other than product/metadata_type, `datasets.search(<field>=Not(<value>))` raises an error - `NotExpression object has no attribute 'alchemy_expression'`


### Proposed changes

- Add logic to `products.search_robust` to handle `Not` values in the query for product/metadata_type
- Handle `NotExpression` case in `_alchemify_expressions`



 - [ ] Closes #xxxx
 - [x] Tests added / passed
 - [x] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2477.org.readthedocs.build/en/2477/

<!-- readthedocs-preview opendatacube end -->