### PR TITLE
New query timeout option

### DIFF
--- a/datacube/cfg/opt.py
+++ b/datacube/cfg/opt.py
@@ -360,6 +360,7 @@ def config_options_for_psql_driver(env: ODCEnvironment) -> list[ODCOptionHandler
         IntOptionHandler(
             "db_connection_timeout", env, default=_DEFAULT_CONN_TIMEOUT, minval=1
         ),
+        IntOptionHandler("db_query_timeout", env, default=0, minval=0),
     ]
 
 

--- a/datacube/drivers/common_psql/__init__.py
+++ b/datacube/drivers/common_psql/__init__.py
@@ -15,11 +15,14 @@ from ._perms import (
     has_roles,
 )
 from ._schema import create_schema, drop_schema, has_schema
+from ._timeout import catch_generator_timeout, catch_timeout
 from ._utils import as_role, ensure_extension, escape_pg_identifier, get_connection_info
 
 __all__ = [
     "UserRoleBase",
     "as_role",
+    "catch_generator_timeout",
+    "catch_timeout",
     "create_schema",
     "create_user",
     "drop_schema",

--- a/datacube/drivers/common_psql/_timeout.py
+++ b/datacube/drivers/common_psql/_timeout.py
@@ -14,24 +14,26 @@ from datacube.index.exceptions import QueryTimeout
 F: TypeAlias = Callable[..., Any]
 G: TypeAlias = Callable[..., Generator[Any]]
 
+try:
+    from psycopg2.errors import QueryCanceled as QueryCanceled2
+except ImportError:
+
+    class QueryCanceled2(Exception):  # type: ignore[no-redef]  # noqa: N818
+        pass
+
+
+try:
+    from psycopg.errors import QueryCanceled as QueryCanceled3
+except ImportError:
+
+    class QueryCanceled3(Exception):  # type: ignore[no-redef]  # noqa: N818
+        pass
+
 
 def catch_generator_timeout(gen: G) -> G:
     """
     Decorator to catch postgresql exceptions from query timeouts in a Generator function, and raise a QueryTimeout
     """
-    try:
-        from psycopg2.errors import QueryCanceled as QueryCanceled2
-    except ImportError:
-
-        class QueryCanceled2(Exception):  # type: ignore[no-redef]  # noqa: N818
-            pass
-
-    try:
-        from psycopg.errors import QueryCanceled as QueryCanceled3
-    except ImportError:
-
-        class QueryCanceled3(Exception):  # type: ignore[no-redef]  # noqa: N818
-            pass
 
     @wraps(gen)
     def timeout_wrapper(*args: Any, **kwargs: Any) -> Generator[Any]:
@@ -50,19 +52,6 @@ def catch_timeout(func: F) -> F:
     """
     Decorator to catch postgresql exceptions from query timeouts in a simple function, and raise a QueryTimeout
     """
-    try:
-        from psycopg2.errors import QueryCanceled as QueryCanceled2
-    except ImportError:
-
-        class QueryCanceled2(Exception):  # type: ignore[no-redef]  # noqa: N818
-            pass
-
-    try:
-        from psycopg.errors import QueryCanceled as QueryCanceled3
-    except ImportError:
-
-        class QueryCanceled3(Exception):  # type: ignore[no-redef]  # noqa: N818
-            pass
 
     @wraps(func)
     def timeout_wrapper(*args: Any, **kwargs: Any) -> Any:

--- a/datacube/drivers/common_psql/_timeout.py
+++ b/datacube/drivers/common_psql/_timeout.py
@@ -1,0 +1,77 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2026 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Callable, Generator
+from functools import wraps
+from typing import Any, TypeAlias, cast
+
+from sqlalchemy.exc import OperationalError
+
+from datacube.index.exceptions import QueryTimeout
+
+F: TypeAlias = Callable[..., Any]
+G: TypeAlias = Callable[..., Generator[Any]]
+
+
+def catch_generator_timeout(gen: G) -> G:
+    """
+    Decorator to catch postgresql exceptions from query timeouts in a Generator function, and raise a QueryTimeout
+    """
+    try:
+        from psycopg2.errors import QueryCanceled as QueryCanceled2
+    except ImportError:
+
+        class QueryCanceled2(Exception):  # type: ignore[no-redef]  # noqa: N818
+            pass
+
+    try:
+        from psycopg.errors import QueryCanceled as QueryCanceled3
+    except ImportError:
+
+        class QueryCanceled3(Exception):  # type: ignore[no-redef]  # noqa: N818
+            pass
+
+    @wraps(gen)
+    def timeout_wrapper(*args: Any, **kwargs: Any) -> Generator[Any]:
+        try:
+            yield from gen(*args, **kwargs)
+        except OperationalError as e:
+            # Timeouts manifest as SQLA OperationalError, wrapping a psycopg(2) QueryCanceled exception
+            if isinstance(e.orig, (QueryCanceled2, QueryCanceled3)):
+                raise QueryTimeout(str(e)) from None
+            raise
+
+    return cast("G", timeout_wrapper)
+
+
+def catch_timeout(func: F) -> F:
+    """
+    Decorator to catch postgresql exceptions from query timeouts in a simple function, and raise a QueryTimeout
+    """
+    try:
+        from psycopg2.errors import QueryCanceled as QueryCanceled2
+    except ImportError:
+
+        class QueryCanceled2(Exception):  # type: ignore[no-redef]  # noqa: N818
+            pass
+
+    try:
+        from psycopg.errors import QueryCanceled as QueryCanceled3
+    except ImportError:
+
+        class QueryCanceled3(Exception):  # type: ignore[no-redef]  # noqa: N818
+            pass
+
+    @wraps(func)
+    def timeout_wrapper(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return func(*args, **kwargs)
+        except OperationalError as e:
+            # Timeouts manifest as SQLA OperationalError, wrapping a psycopg(2) QueryCanceled exception
+            if isinstance(e.orig, (QueryCanceled2, QueryCanceled3)):
+                raise QueryTimeout(str(e)) from None
+            raise
+
+    return cast("F", timeout_wrapper)

--- a/datacube/drivers/postgis/_api.py
+++ b/datacube/drivers/postgis/_api.py
@@ -37,7 +37,14 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from typing_extensions import override
 
-from datacube.drivers.common_psql import create_user, drop_users, grant_role, has_role
+from datacube.drivers.common_psql import (
+    catch_generator_timeout,
+    catch_timeout,
+    create_user,
+    drop_users,
+    grant_role,
+    has_role,
+)
 from datacube.index.fields import NotExpression, OrExpression
 from datacube.model import Range
 from datacube.model.lineage import LineageDirection, LineageRelation
@@ -282,8 +289,43 @@ class PostgisDbAPI:
         self._sqla_txn.rollback()  # type: ignore[union-attr]
         self._end_transaction()
 
-    def execute(self, command):
-        return self._connection.execute(command)
+    @catch_generator_timeout
+    def stream_query(
+        self, command, batch_size=0, orm: bool = False, orm_scalars=False
+    ) -> Generator:
+        # For select queries whose results may be streamed
+        if batch_size > 0:
+            executor: Connection = self._connection.execution_options(
+                stream_results=True, yield_per=batch_size
+            )
+        else:
+            executor = self._connection
+        result = (
+            Session(executor).execute(command) if orm else executor.execute(command)
+        )
+        yield from result.scalars() if orm and orm_scalars else result
+
+    @catch_timeout
+    def run_query(self, command, orm: bool = False, orm_scalars=False) -> Sequence:
+        # For eager queries whose results are fetched up front
+        if orm:
+            result = Session(self._connection).execute(command)
+            if orm_scalars:
+                return result.scalars().all()
+            return result.all()
+        return list(self._connection.execute(command).fetchall())
+
+    @catch_timeout
+    def run_scalar_query(self, command, orm: bool = False) -> Any:
+        # For queries returning a single scalar value
+        if orm:
+            return Session(self._connection).execute(command).scalar_one_or_none()
+        return self._connection.execute(command).scalar()
+
+    @catch_timeout
+    def execute(self, command, args=None):
+        # For DDL and DML commands.
+        return self._connection.execute(command, args)
 
     def insert_dataset(self, metadata_doc, dataset_id, product_id) -> bool:
         """
@@ -295,7 +337,7 @@ class PostgisDbAPI:
             .where(Product.id == product_id)
             .scalar_subquery()
         )
-        ret = self._connection.execute(
+        ret = self.execute(
             insert(Dataset)
             .values(
                 id=dataset_id,
@@ -309,27 +351,29 @@ class PostgisDbAPI:
 
     def insert_dataset_bulk(self, values: Sequence[dict[str, Any]]) -> tuple[int, int]:
         requested = len(values)
-        res = self._connection.execute(
-            insert(Dataset)
-            .values(values)
-            .on_conflict_do_nothing(index_elements=[Dataset.id])
-            .returning(Dataset.id)
+        inserted = set(
+            self.execute(
+                insert(Dataset)
+                .values(values)
+                .on_conflict_do_nothing(index_elements=[Dataset.id])
+                .returning(Dataset.id)
+            )
         )
-        if requested - res.rowcount > 0:
-            inserted = set(res.fetchall())
+        count = len(inserted)
+        if requested - count:
             missing = [str(id_) for v in values if (id_ := v.get("id")) not in inserted]
             plural = len(missing) > 1
             _LOG.warning(
                 f"Dataset{'s' if plural else ''} {', '.join(missing)} "
                 f"{'are' if plural else 'is'} already in the database"
             )
-        return res.rowcount, requested - res.rowcount
+        return count, requested - count
 
     def update_dataset(self, metadata_doc, dataset_id, product_id) -> bool:
         """
         Update dataset
         """
-        res = self._connection.execute(
+        res = self.execute(
             update(Dataset)
             .returning(Dataset.id)
             .where(Dataset.id == dataset_id)
@@ -346,7 +390,7 @@ class PostgisDbAPI:
         """
         scheme, body = split_uri(uri)
 
-        r = self._connection.execute(
+        r = self.execute(
             update(Dataset)
             .returning(Dataset.uri)
             .where(Dataset.id == dataset_id)
@@ -363,7 +407,7 @@ class PostgisDbAPI:
         """
         if isinstance(value, Range):
             value = list(value)
-        r = self._connection.execute(
+        r = self.execute(
             insert(search_table)
             .values(
                 dataset_ref=dataset_id,
@@ -380,7 +424,7 @@ class PostgisDbAPI:
     def insert_dataset_search_bulk(self, search_type: str, values) -> int:
         search_table = search_field_index_map[search_type]
         stmt = insert(search_table).values(values)
-        r = self._connection.execute(
+        r = self.execute(
             stmt.on_conflict_do_update(
                 index_elements=[search_table.dataset_ref, search_table.search_key],
                 set_={"search_val": stmt.excluded.search_val},
@@ -400,7 +444,7 @@ class PostgisDbAPI:
         if values is None:
             return False
         SpatialIndex = self._db.spatial_index(crs)  # noqa: N806
-        r = self._connection.execute(
+        r = self.execute(
             insert(SpatialIndex)
             .values(**values)
             .on_conflict_do_update(
@@ -412,7 +456,7 @@ class PostgisDbAPI:
 
     def insert_dataset_spatial_bulk(self, crs, values) -> int:
         SpatialIndex = self._db.spatial_index(crs)  # noqa: N806
-        r = self._connection.execute(
+        r = self.execute(
             insert(SpatialIndex)
             .values(values)
             .on_conflict_do_nothing(index_elements=["dataset_ref"])
@@ -432,28 +476,23 @@ class PostgisDbAPI:
             .select_from(SpatialIndex)
             .where(SpatialIndex.dataset_ref.in_(ids))
         )
-        result = self._connection.execute(query)
-        for r in result:
-            extent_json = r[0]
-            if extent_json is None:
-                return None
-            return Geometry(json.loads(extent_json), crs=crs)
-        return None
+        result = self.run_scalar_query(query)
+        if result is None:
+            return None
+        return Geometry(json.loads(result), crs=crs)
 
     def contains_dataset(self, dataset_id) -> bool:
         return bool(
-            self._connection.execute(
-                select(Dataset.id).where(Dataset.id == dataset_id)
-            ).fetchone()
+            self.run_scalar_query(select(Dataset.id).where(Dataset.id == dataset_id))
         )
 
     def datasets_intersection(self, dataset_ids) -> list:
         """Compute set intersection: db_dataset_ids & dataset_ids"""
         return [
             ds.id
-            for ds in self._connection.execute(
+            for ds in self.run_query(
                 select(Dataset.id).where(Dataset.id.in_(dataset_ids))
-            ).fetchall()
+            )
         ]
 
     def get_datasets_for_location(
@@ -471,13 +510,10 @@ class PostgisDbAPI:
         else:
             raise ValueError(f"Unsupported query mode {mode}")
 
-        return (
-            Session(self._connection)
-            .execute(
-                select(Dataset).where(and_(Dataset.uri_scheme == scheme, body_query))
-            )
-            .scalars()
-            .all()
+        return self.run_query(
+            select(Dataset).where(and_(Dataset.uri_scheme == scheme, body_query)),
+            orm=True,
+            orm_scalars=True,
         )
 
     def all_dataset_ids(self, archived: bool | None = False) -> Sequence:
@@ -486,10 +522,10 @@ class PostgisDbAPI:
             query = query.where(Dataset.archived.is_not(None))
         elif archived is not None:
             query = query.where(Dataset.archived.is_(None))
-        return self._connection.execute(query).fetchall()
+        return self.run_query(query)
 
     def archive_dataset(self, dataset_id) -> bool:
-        r = self._connection.execute(
+        r = self.execute(
             update(Dataset)
             .where(Dataset.id == dataset_id)
             .where(Dataset.archived == None)
@@ -498,44 +534,33 @@ class PostgisDbAPI:
         return r.rowcount > 0
 
     def restore_dataset(self, dataset_id) -> bool:
-        r = self._connection.execute(
+        r = self.execute(
             update(Dataset).where(Dataset.id == dataset_id).values(archived=None)
         )
         return r.rowcount > 0
 
     def delete_dataset(self, dataset_id) -> bool:
         for table in search_field_indexes.values():
-            self._connection.execute(
-                delete(table).where(table.dataset_ref == dataset_id)
-            )
+            self.execute(delete(table).where(table.dataset_ref == dataset_id))
         for crs in self._db.spatially_indexed_crses():
             SpatialIndex = self._db.spatial_index(crs)  # noqa: N806
-            self._connection.execute(
+            self.execute(
                 delete(SpatialIndex).where(SpatialIndex.dataset_ref == dataset_id)
             )
-        r = self._connection.execute(delete(Dataset).where(Dataset.id == dataset_id))
+        r = self.execute(delete(Dataset).where(Dataset.id == dataset_id))
         return r.rowcount > 0
 
     def get_dataset(self, dataset_id: uuid.UUID) -> Dataset | None:
-        return (
-            Session(self._connection)
-            .execute(select(Dataset).where(Dataset.id == dataset_id))
-            .scalar_one_or_none()
+        return self.run_scalar_query(
+            select(Dataset).where(Dataset.id == dataset_id), orm=True
         )
 
     def get_datasets(self, dataset_ids: Iterable[uuid.UUID]) -> Sequence[Dataset]:
-        return (
-            Session(self._connection)
-            .execute(select(Dataset).where(Dataset.id.in_(dataset_ids)))
-            .scalars()
-            .all()
+        return self.run_query(
+            select(Dataset).where(Dataset.id.in_(dataset_ids)),
+            orm=True,
+            orm_scalars=True,
         )
-
-    def get_derived_datasets(self, dataset_id: uuid.UUID) -> Sequence[Dataset]:
-        raise NotImplementedError()
-
-    def get_dataset_sources(self, dataset_id: uuid.UUID) -> Sequence[Dataset]:
-        raise NotImplementedError()
 
     def search_datasets_by_metadata(
         self, metadata: dict, archived: bool | None
@@ -550,16 +575,16 @@ class PostgisDbAPI:
         elif archived is not None:
             where = and_(where, Dataset.archived.is_(None))
         query = select(Dataset).where(where)
-        return Session(self._connection).execute(query).scalars().all()
+        return self.run_query(query, orm=True, orm_scalars=True)
 
     def search_products_by_metadata(self, metadata: dict) -> Sequence:
         """
         Find any datasets that have the given metadata.
         """
         # Find any storage types whose 'dataset_metadata' document is a subset of the metadata.
-        return self._connection.execute(
+        return self.run_query(
             select(Product).where(Product.metadata_doc.contains(metadata))
-        ).fetchall()
+        )
 
     @staticmethod
     def _alchemify_expressions(expressions) -> list:
@@ -678,7 +703,7 @@ class PostgisDbAPI:
         def decode_row(raw: Iterable[Any]) -> dict[str, Any]:
             return {f.name: f.normalise_value(r) for r, f in zip(raw, select_fields)}
 
-        for row in self._connection.execute(select_query):
+        for row in self.stream_query(select_query):
             yield decode_row(row)
 
     def bulk_simple_dataset_search(self, products=None, batch_size: int = 0):
@@ -705,14 +730,7 @@ class PostgisDbAPI:
         )
         if products:
             query = query.where(Dataset.product_ref.in_(products))
-
-        if batch_size > 0:
-            conn = self._connection.execution_options(
-                stream_results=True, yield_per=batch_size
-            )
-        else:
-            conn = self._connection
-        return conn.execute(query)
+        return self.stream_query(query, batch_size=batch_size)
 
     def get_all_lineage(self, batch_size: int):
         """
@@ -728,9 +746,7 @@ class PostgisDbAPI:
             DatasetLineage.classifier,
             DatasetLineage.source_dataset_ref,
         )
-        return self._connection.execution_options(
-            stream_results=True, yield_per=batch_size
-        ).execute(query)
+        return self.stream_query(query, batch_size=batch_size)
 
     def insert_lineage_bulk(self, values) -> tuple[int, int]:
         """
@@ -742,9 +758,7 @@ class PostgisDbAPI:
         requested = len(values)
         # Simple bulk insert with on_conflict_do_nothing.
         # No need to check referential integrity as this is an external lineage index driver.
-        res = self._connection.execute(
-            insert(DatasetLineage).on_conflict_do_nothing(), values
-        )
+        res = self.execute(insert(DatasetLineage).on_conflict_do_nothing(), values)
         return res.rowcount, requested - res.rowcount
 
     def get_duplicates(
@@ -773,7 +787,7 @@ class PostgisDbAPI:
             .group_by(*group_expressions)
             .having(func.count(Dataset.id) > 1)
         )
-        for row in self._connection.execute(query):
+        for row in self.stream_query(query):
             drow = {"ids": row.ids}
             for f in match_fields:
                 drow[f.name] = getattr(row, f.name)
@@ -831,7 +845,7 @@ class PostgisDbAPI:
             .having(func.count(time_overlap.c.id) > 1)
         )
 
-        for row in self._connection.execute(query):
+        for row in self.stream_query(query):
             # TODO: Use decode_rows above - would require creating a field class for the ids array.
             drow: dict[str, Any] = {
                 "ids": row.ids,
@@ -866,7 +880,7 @@ class PostgisDbAPI:
             query = query.join(*join)
 
         select_query = query.where(where_expressions)
-        num = self._connection.scalar(select_query)
+        num = self.run_scalar_query(select_query)
         return 0 if num is None else num
 
     def count_datasets_through_time(
@@ -877,7 +891,7 @@ class PostgisDbAPI:
         time_field,
         expressions: Iterable[Expression],
     ) -> Generator[tuple[tuple[datetime.datetime, datetime.datetime], int]]:
-        results = self._connection.execute(
+        results = self.stream_query(
             self.count_datasets_through_time_query(
                 start, end, period, time_field, expressions
             )
@@ -964,7 +978,7 @@ class PostgisDbAPI:
         elif dsids:
             ds_query = ds_query.where(Dataset.id.in_(dsids))
         rowcount = 0
-        for result in self._connection.execute(ds_query):
+        for result in self.stream_query(ds_query):
             dsid, ds_metadata, mdt_def = result
             search_field_vals = extract_dataset_search_fields(ds_metadata, mdt_def)
             for field_name, field_info in search_field_vals.items():
@@ -1010,7 +1024,7 @@ class PostgisDbAPI:
             query = query.where(Product.name.in_(product_names))
         elif dsids:
             query = query.where(Dataset.id.in_(dsids))
-        for result in self._connection.execute(query):
+        for result in self.stream_query(query):
             dsid = result[0]
             geom = extract_geometry_from_eo3_projection(result[1])
             if not geom:
@@ -1036,27 +1050,23 @@ class PostgisDbAPI:
         return sorted(join_args, key=len)
 
     def get_product(self, id_: int):
-        return self._connection.execute(
-            select(Product).where(Product.id == id_)
-        ).first()
+        out = self.run_query(select(Product).where(Product.id == id_))
+        return out[0] if out else None
 
     def get_metadata_type(self, id_: int):
-        return self._connection.execute(
-            select(MetadataType).where(MetadataType.id == id_)
-        ).first()
+        out = self.run_query(select(MetadataType).where(MetadataType.id == id_))
+        return out[0] if out else None
 
     def get_product_by_name(self, name: str):
-        return self._connection.execute(
-            select(Product).where(Product.name == name)
-        ).first()
+        out = self.run_query(select(Product).where(Product.name == name))
+        return out[0] if out else None
 
     def get_metadata_type_by_name(self, name: str):
-        return self._connection.execute(
-            select(MetadataType).where(MetadataType.name == name)
-        ).first()
+        out = self.run_query(select(MetadataType).where(MetadataType.name == name))
+        return out[0] if out else None
 
     def insert_product(self, name: str, metadata, metadata_type_id, definition):
-        res = self._connection.execute(
+        res = self.execute(
             insert(Product).values(
                 name=name,
                 metadata_doc=metadata,
@@ -1065,11 +1075,11 @@ class PostgisDbAPI:
             )
         )
 
-        return res.inserted_primary_key[0]  # type: ignore[index]
+        return res.inserted_primary_key[0]
 
     def insert_product_bulk(self, values) -> tuple[int, int]:
         requested = len(values)
-        res = self._connection.execute(insert(Product), values)
+        res = self.execute(insert(Product), values)
         return res.rowcount, requested - res.rowcount
 
     def update_product(
@@ -1080,7 +1090,7 @@ class PostgisDbAPI:
         definition,
         update_metadata_type: bool = False,
     ):
-        res = self._connection.execute(
+        prod_id = self.run_scalar_query(
             update(Product)
             .returning(Product.id)
             .where(Product.name == name)
@@ -1090,15 +1100,13 @@ class PostgisDbAPI:
                 definition=definition,
             )
         )
-        prod = res.first()
-        assert prod is not None
-        prod_id = prod[0]
+        assert prod_id is not None
 
         if update_metadata_type:
             if not self._connection.in_transaction():
                 raise RuntimeError("Must update metadata types in transaction")
 
-            self._connection.execute(
+            self.execute(
                 update(Dataset)
                 .where(Dataset.product_ref == prod_id)
                 .values(metadata_type_ref=metadata_type_id)
@@ -1107,22 +1115,19 @@ class PostgisDbAPI:
         return prod_id
 
     def delete_product(self, name: str):
-        res = self._connection.execute(
+        return self.run_scalar_query(
             delete(Product).returning(Product.id).where(Product.name == name)
         )
-        prod = res.first()
-        assert prod is not None
-        return prod[0]
 
     def insert_metadata_type(self, name: str, definition):
-        res = self._connection.execute(
+        res = self.execute(
             insert(MetadataType).values(name=name, definition=definition)
         )
-        return res.inserted_primary_key[0]  # type: ignore[index]
+        return res.inserted_primary_key[0]
 
     def insert_metadata_bulk(self, values) -> tuple[int, int]:
         requested = len(values)
-        res = self._connection.execute(
+        res = self.execute(
             insert(MetadataType)
             .on_conflict_do_nothing(index_elements=["id"])
             .values(values)
@@ -1130,15 +1135,12 @@ class PostgisDbAPI:
         return res.rowcount, requested - res.rowcount
 
     def update_metadata_type(self, name: str, definition):
-        res = self._connection.execute(
+        return self.run_scalar_query(
             update(MetadataType)
             .returning(MetadataType.id)
             .where(MetadataType.name == name)
             .values(name=name, definition=definition)
         )
-        prod = res.first()
-        assert prod is not None
-        return prod[0]
 
     @staticmethod
     def _get_active_field_names(fields, metadata_doc) -> Generator:
@@ -1152,35 +1154,31 @@ class PostgisDbAPI:
                     continue
 
     def get_all_products(self) -> Sequence:
-        return self._connection.execute(
-            select(Product).order_by(Product.name.asc())
-        ).fetchall()
+        return self.run_query(select(Product).order_by(Product.name.asc()))
 
     def get_all_product_docs(self):
-        return self._connection.execute(select(Product.definition))
+        return self.stream_query(select(Product.definition))
 
     def _get_products_for_metadata_type(self, id_: DSID) -> Sequence:
-        return self._connection.execute(
+        return self.run_query(
             select(Product)
             .where(Product.metadata_type_ref == id_)
             .order_by(Product.name.asc())
-        ).fetchall()
+        )
 
     def get_all_metadata_types(self) -> Sequence:
-        return self._connection.execute(
-            select(MetadataType).order_by(MetadataType.name.asc())
-        ).fetchall()
+        return self.run_query(select(MetadataType).order_by(MetadataType.name.asc()))
 
     def get_all_metadata_type_defs(self) -> Generator:
-        for r in self._connection.execute(
+        for r in self.stream_query(
             select(MetadataType.definition).order_by(MetadataType.name.asc())
         ):
             yield r[0]
 
     def get_location(self, dataset_id: DSID):
-        return self._connection.execute(
+        return self.run_scalar_query(
             select(Dataset.uri).where(Dataset.id == dataset_id)
-        ).first()
+        )
 
     def remove_location(self, dataset_id: DSID, uri: str) -> bool:
         """
@@ -1189,7 +1187,7 @@ class PostgisDbAPI:
         :returns bool: Was the location deleted?
         """
         scheme, body = split_uri(uri)
-        res = self._connection.execute(
+        res = self.execute(
             update(Dataset)
             .where(
                 and_(
@@ -1207,7 +1205,7 @@ class PostgisDbAPI:
         return f"PostgisDb<connection={self._connection!r}>"
 
     def list_users(self) -> Generator:
-        result = self._connection.execute(
+        for row in self.stream_query(
             text("""
             select
                 group_role.rolname as role_name,
@@ -1219,10 +1217,10 @@ class PostgisDbAPI:
             where (group_role.rolname like 'odc_%%') and not (user_role.rolname like 'odc_%%')
             order by group_role.oid asc, user_role.oid asc;
         """)
-        )
-        for row in result:
+        ):
             yield UserRole(row.role_name).simple_str(), row.user_name, row.description
 
+    @catch_timeout
     def create_user(
         self,
         username: str,
@@ -1240,9 +1238,11 @@ class PostgisDbAPI:
             description,
         )
 
+    @catch_timeout
     def drop_users(self, users: Iterable[str]) -> bool:
         return drop_users(self._connection, users)
 
+    @catch_timeout
     def grant_role(self, role_str: str, users: Iterable[str]) -> bool:
         """
         Grant a role to a user.
@@ -1277,7 +1277,7 @@ class PostgisDbAPI:
                 where=(DatasetHome.home != home),
             )
         try:
-            res = self._connection.execute(qry, values)
+            res = self.execute(qry, values)
             return res.rowcount
         except IntegrityError:
             return 0
@@ -1289,9 +1289,7 @@ class PostgisDbAPI:
         :param ids: The IDs to delete home for
         :return: The number of home records deleted from the database.
         """
-        res = self._connection.execute(
-            delete(DatasetHome).where(DatasetHome.dataset_ref.in_(ids))
-        )
+        res = self.execute(delete(DatasetHome).where(DatasetHome.dataset_ref.in_(ids)))
         return res.rowcount
 
     def select_homes(self, ids) -> dict[uuid.UUID, str]:
@@ -1301,7 +1299,7 @@ class PostgisDbAPI:
         :param ids: Iterable of IDs
         :return: Mapping of ID to home string for IDs found in database.
         """
-        results = self._connection.execute(
+        results = self.stream_query(
             select(DatasetHome).where(DatasetHome.dataset_ref.in_(ids))
         )
         return {row.dataset_ref: row.home for row in results}
@@ -1315,7 +1313,7 @@ class PostgisDbAPI:
         :param dsids: Iterable of dataset IDs
         :return: Iterable of LineageRelation objects.
         """
-        results = self._connection.execute(
+        results = self.stream_query(
             select(DatasetLineage).where(
                 or_(
                     DatasetLineage.derived_dataset_ref.in_(dsids),
@@ -1359,7 +1357,7 @@ class PostgisDbAPI:
                         set_={"classifier": classifier},
                         where=(DatasetLineage.classifier != classifier),
                     )
-                    res = self._connection.execute(qry, values)
+                    res = self.execute(qry, values)
                     affected += res.rowcount
         else:
             for rel in relations:
@@ -1372,7 +1370,7 @@ class PostgisDbAPI:
                 ]
                 qry = insert(DatasetLineage)
                 try:
-                    res = self._connection.execute(qry, values)
+                    res = self.execute(qry, values)
                     affected += res.rowcount
                 except IntegrityError:
                     return 0
@@ -1406,7 +1404,7 @@ class PostgisDbAPI:
             qry = qry.where(DatasetLineage.source_dataset_ref.in_(roots))
         relations = []
         next_lvl_ids = set()
-        results = self._connection.execute(qry)
+        results = self.stream_query(qry)
         for row in results:
             rel = LineageRelation(
                 classifier=row.classifier,
@@ -1453,14 +1451,14 @@ class PostgisDbAPI:
             qry = qry.where(DatasetLineage.derived_dataset_ref.in_(ids))
         else:
             qry = qry.where(DatasetLineage.source_dataset_ref.in_(ids))
-        results = self._connection.execute(qry)
+        results = self.execute(qry)
         return results.rowcount
 
     def temporal_extent_by_prod(
         self, product_id: int
     ) -> tuple[datetime.datetime, datetime.datetime]:
         query = self.temporal_extent_full().where(Dataset.product_ref == product_id)
-        res = self._connection.execute(query)
+        res = self.run_query(query)
         for tmin, tmax in res:
             return time_min.normalise_value(tmin), time_max.normalise_value(tmax)
         raise RuntimeError("Product has no datasets and therefore no temporal extent")
@@ -1469,7 +1467,7 @@ class PostgisDbAPI:
         self, ids: Iterable[DSID]
     ) -> tuple[datetime.datetime, datetime.datetime]:
         query = self.temporal_extent_full().where(Dataset.id.in_(ids))
-        res = self._connection.execute(query)
+        res = self.run_query(query)
         for tmin, tmax in res:
             return time_min.normalise_value(tmin), time_max.normalise_value(tmax)
         raise ValueError("no dataset ids provided")
@@ -1485,7 +1483,7 @@ class PostgisDbAPI:
         """
         Find the database-local time of the last dataset that changed for this product.
         """
-        return self._connection.execute(
+        return self.run_scalar_query(
             select(
                 func.max(
                     func.greatest(
@@ -1494,4 +1492,4 @@ class PostgisDbAPI:
                     )
                 )
             ).where(Dataset.product_ref == product_id)
-        ).scalar()
+        )

--- a/datacube/drivers/postgis/_connections.py
+++ b/datacube/drivers/postgis/_connections.py
@@ -25,6 +25,7 @@ from sqlalchemy import create_engine, event
 from typing_extensions import override
 
 import datacube
+from datacube.drivers.common_psql import catch_timeout
 from datacube.index.exceptions import IndexSetupError, NoIndexError
 from datacube.utils import json, jsonify_document
 
@@ -228,6 +229,7 @@ class PostGisDb:
             )
         return full_name[-64:]
 
+    @catch_timeout
     def init(self, with_permissions: bool = True) -> bool:
         """
         Init a new database (if not already set up).

--- a/datacube/drivers/postgis/_connections.py
+++ b/datacube/drivers/postgis/_connections.py
@@ -106,6 +106,7 @@ class PostGisDb:
             config_env.db_iam_authentication,
             config_env.db_iam_timeout if config_env.db_iam_authentication else 600,
             config_env.db_connection_timeout,
+            config_env.db_query_timeout,
         )
         if validate:
             if not _core.database_exists(engine):
@@ -131,8 +132,12 @@ class PostGisDb:
         iam_rds_auth: bool = False,
         iam_rds_timeout: float | int = 600,
         pool_timeout: int = 60,
+        query_timeout: int = 0,
     ) -> Engine:
         connect_args: dict[str, Any] = {"application_name": application_name}
+        if query_timeout:
+            # Query timeout, in milliseconds.
+            connect_args["options"] = f"-c statement_timeout={query_timeout}"
         if str(url).startswith("postgresql+psycopg://"):
             try:
                 from psycopg import ClientCursor

--- a/datacube/drivers/postgis/_core.py
+++ b/datacube/drivers/postgis/_core.py
@@ -21,6 +21,7 @@ from typing_extensions import Self, override
 from datacube.drivers.common_psql import (
     UserRoleBase,
     as_role,
+    catch_timeout,
     create_schema,
     ensure_extension,
     ensure_role,
@@ -221,6 +222,7 @@ def ensure_db(engine: Engine, with_permissions: bool = True) -> bool:
     return is_new
 
 
+@catch_timeout
 def database_exists(engine: Engine) -> bool:
     """
     Have they init'd this database? (Thin wrapper around ``has_schema()``)

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -39,7 +39,14 @@ from sqlalchemy.dialects.postgresql import INTERVAL, JSONB, UUID, insert
 from sqlalchemy.exc import IntegrityError
 from typing_extensions import override
 
-from datacube.drivers.common_psql import create_user, drop_users, grant_role, has_role
+from datacube.drivers.common_psql import (
+    catch_generator_timeout,
+    catch_timeout,
+    create_user,
+    drop_users,
+    grant_role,
+    has_role,
+)
 from datacube.index.exceptions import MissingRecordError
 from datacube.index.fields import NotExpression, OrExpression
 from datacube.model import Range
@@ -60,7 +67,7 @@ from ._schema import DATASET, DATASET_LOCATION, DATASET_SOURCE, METADATA_TYPE, P
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     import datetime
-    from collections.abc import Iterable, Iterator, Mapping, Sequence
+    from collections.abc import Generator, Iterable, Iterator, Mapping, Sequence
 
     from sqlalchemy import Connection, FromClause, Label, RootTransaction, Select
     from sqlalchemy.engine import Row
@@ -223,8 +230,29 @@ class PostgresDbAPI:
         self._sqla_txn.rollback()  # type: ignore[union-attr]
         self._end_transaction()
 
-    def execute(self, command):
+    @catch_generator_timeout
+    def stream_query(self, command, batch_size=0):
+        # For select queries whose results may be streamed
+        if batch_size:
+            return self._connection.execution_options(
+                stream_results=True, yield_per=batch_size
+            ).execute(command)
         return self._connection.execute(command)
+
+    @catch_timeout
+    def run_query(self, command):
+        # For eager queries whose results are fetched up front
+        return list(self._connection.execute(command).fetchall())
+
+    @catch_timeout
+    def run_scalar_query(self, command):
+        # For queries returning a single scalar value
+        return self._connection.execute(command).scalar()
+
+    @catch_timeout
+    def execute(self, command, args=None):
+        # For DDL and DML commands.
+        return self._connection.execute(command, args)
 
     def insert_dataset(self, metadata_doc, dataset_id, product_id) -> bool:
         """
@@ -232,7 +260,7 @@ class PostgresDbAPI:
         :return: whether it was inserted
         """
         dataset_type_ref: Any = bindparam("dataset_type_ref")
-        ret = self._connection.execute(
+        ret = self.execute(
             insert(DATASET)
             .from_select(
                 ["id", "dataset_type_ref", "metadata_type_ref", "metadata"],
@@ -256,14 +284,14 @@ class PostgresDbAPI:
 
     def insert_dataset_bulk(self, values) -> tuple:
         requested = len(values)
-        res = self._connection.execute(insert(DATASET), values)
+        res = self.execute(insert(DATASET), values)
         return res.rowcount, requested - res.rowcount
 
     def update_dataset(self, metadata_doc, dataset_id, product_id) -> bool:
         """
         Update dataset
         """
-        res = self._connection.execute(
+        res = self.execute(
             DATASET.update()
             .returning(DATASET.c.id)
             .where(
@@ -283,7 +311,7 @@ class PostgresDbAPI:
         """
         scheme, body = split_uri(uri)
 
-        r = self._connection.execute(
+        r = self.execute(
             insert(DATASET_LOCATION).on_conflict_do_nothing(
                 index_elements=["uri_scheme", "uri_body", "dataset_ref"]
             ),
@@ -298,23 +326,21 @@ class PostgresDbAPI:
 
     def insert_dataset_location_bulk(self, values) -> tuple:
         requested = len(values)
-        res = self._connection.execute(insert(DATASET_LOCATION), values)
+        res = self.execute(insert(DATASET_LOCATION), values)
         return res.rowcount, requested - res.rowcount
 
     def contains_dataset(self, dataset_id) -> bool:
         return bool(
-            self._connection.execute(
-                select(DATASET.c.id).where(DATASET.c.id == dataset_id)
-            ).fetchone()
+            self.run_query(select(DATASET.c.id).where(DATASET.c.id == dataset_id))
         )
 
     def datasets_intersection(self, dataset_ids) -> list:
         """Compute set intersection: db_dataset_ids & dataset_ids"""
         return [
             r[0]
-            for r in self._connection.execute(
+            for r in self.run_query(
                 select(DATASET.c.id).where(DATASET.c.id.in_(dataset_ids))
-            ).fetchall()
+            )
         ]
 
     def get_datasets_for_location(self, uri: str, mode: SearchMode | None = None):
@@ -330,11 +356,11 @@ class PostgresDbAPI:
         else:
             raise ValueError(f"Unsupported query mode {mode}")
 
-        return self._connection.execute(
+        return self.run_query(
             select(*_DATASET_SELECT_FIELDS)
             .select_from(DATASET_LOCATION.join(DATASET))
             .where(and_(DATASET_LOCATION.c.uri_scheme == scheme, body_query))
-        ).fetchall()
+        )
 
     def all_dataset_ids(self, archived: bool | None = False):
         query = select(DATASET.c.id).select_from(DATASET)
@@ -342,13 +368,13 @@ class PostgresDbAPI:
             query = query.where(DATASET.c.archived.is_not(None))
         elif archived is not None:
             query = query.where(DATASET.c.archived.is_(None))
-        return self._connection.execute(query).fetchall()
+        return self.run_query(query)
 
     def insert_dataset_source(
         self, classifier, dataset_id: DSID, source_dataset_id: DSID
     ) -> bool:
         try:
-            r = self._connection.execute(
+            r = self.execute(
                 insert(DATASET_SOURCE).on_conflict_do_nothing(
                     index_elements=["classifier", "dataset_ref"]
                 ),
@@ -370,7 +396,7 @@ class PostgresDbAPI:
             raise
 
     def archive_dataset(self, dataset_id: DSID) -> None:
-        self._connection.execute(
+        self.execute(
             DATASET.update()
             .where(DATASET.c.id == dataset_id)
             .where(DATASET.c.archived == None)
@@ -378,33 +404,34 @@ class PostgresDbAPI:
         )
 
     def restore_dataset(self, dataset_id: DSID) -> None:
-        self._connection.execute(
+        self.execute(
             DATASET.update().where(DATASET.c.id == dataset_id).values(archived=None)
         )
 
     def delete_dataset(self, dataset_id: DSID) -> None:
-        self._connection.execute(
+        self.execute(
             DATASET_LOCATION.delete().where(
                 DATASET_LOCATION.c.dataset_ref == dataset_id
             )
         )
-        self._connection.execute(
+        self.execute(
             DATASET_SOURCE.delete().where(DATASET_SOURCE.c.dataset_ref == dataset_id)
         )
-        self._connection.execute(DATASET.delete().where(DATASET.c.id == dataset_id))
+        self.execute(DATASET.delete().where(DATASET.c.id == dataset_id))
 
     def get_dataset(self, dataset_id: DSID):
-        return self._connection.execute(
+        ds = self.run_query(
             select(*_DATASET_SELECT_FIELDS).where(DATASET.c.id == dataset_id)
-        ).first()
+        )
+        return ds[0] if ds else None
 
-    def get_datasets(self, dataset_ids: Iterable[DSID]) -> Sequence:
-        return self._connection.execute(
+    def get_datasets(self, dataset_ids: Iterable[DSID]) -> Generator:
+        return self.stream_query(
             select(*_DATASET_SELECT_FIELDS).where(DATASET.c.id.in_(dataset_ids))
-        ).fetchall()
+        )
 
     def get_derived_datasets(self, dataset_id: DSID) -> Sequence:
-        return self._connection.execute(
+        return self.run_query(
             select(*_DATASET_SELECT_FIELDS)
             .select_from(
                 DATASET.join(
@@ -412,7 +439,7 @@ class PostgresDbAPI:
                 )
             )
             .where(DATASET_SOURCE.c.source_dataset_ref == dataset_id)
-        ).fetchall()
+        )
 
     def get_dataset_sources(self, dataset_id: DSID) -> Sequence:
         # recursively build the list of (dataset_ref, source_dataset_ref) pairs starting from dataset_id
@@ -468,11 +495,12 @@ class PostgresDbAPI:
             aggd.join(DATASET, DATASET.c.id == aggd.c.dataset_ref)
         )
 
-        return self._connection.execute(query).fetchall()
+        return self.run_query(query)
 
+    @catch_timeout
     def search_datasets_by_metadata(
         self, metadata: dict, archived: bool | None = False
-    ) -> Sequence:
+    ) -> Generator:
         """
         Find any datasets that have the given metadata.
         """
@@ -483,16 +511,16 @@ class PostgresDbAPI:
         elif archived is not None:
             where_clause = and_(where_clause, DATASET.c.archived.is_(None))
         query = select(*_DATASET_SELECT_FIELDS).where(where_clause)
-        return self._connection.execute(query).fetchall()
+        return self.stream_query(query)
 
-    def search_products_by_metadata(self, metadata: dict) -> Sequence:
+    def search_products_by_metadata(self, metadata: dict) -> Generator:
         """
         Find any products that have the given metadata.
         """
         # Find any products types whose metadata document contains the passed in metadata
-        return self._connection.execute(
+        return self.stream_query(
             PRODUCT.select().where(PRODUCT.c.metadata.contains(metadata))
-        ).fetchall()
+        )
 
     @staticmethod
     def _alchemify_expressions(expressions) -> list:
@@ -654,7 +682,7 @@ class PostgresDbAPI:
             archived=archived,
             order_by=order_by,
         )
-        return self._connection.execute(select_query)
+        return self.stream_query(select_query)
 
     def bulk_simple_dataset_search(self, products=None, batch_size: int = 0):
         """
@@ -677,7 +705,7 @@ class PostgresDbAPI:
                 .select_from(PRODUCT)
                 .where(PRODUCT.c.name.in_(products))
             )
-            products = [row[0] for row in self._connection.execute(query)]
+            products = [row[0] for row in self.run_query(query)]
             if not products:
                 return []
         else:
@@ -690,9 +718,7 @@ class PostgresDbAPI:
         )
         if products:
             query = query.where(DATASET.c.dataset_type_ref.in_(products))
-        return self._connection.execution_options(
-            stream_results=True, yield_per=batch_size
-        ).execute(query)
+        return self.stream_query(query, batch_size=batch_size)
 
     def get_all_lineage(self, batch_size: int):
         """
@@ -708,9 +734,7 @@ class PostgresDbAPI:
             DATASET_SOURCE.c.classifier,
             DATASET_SOURCE.c.source_dataset_ref,
         )
-        return self._connection.execution_options(
-            stream_results=True, yield_per=batch_size
-        ).execute(query)
+        return self.stream_query(query, batch_size=batch_size)
 
     def insert_lineage_bulk(self, vals) -> tuple:
         """
@@ -771,7 +795,7 @@ class PostgresDbAPI:
             .group_by(*group_expressions)
             .having(func.count(DATASET.c.id) > 1)
         )
-        return self._connection.execute(select_query)
+        return self.stream_query(select_query)
 
     def get_duplicates_with_time(
         self, match_fields: Iterable[Field], expressions: Iterable[Expression]
@@ -833,7 +857,7 @@ class PostgresDbAPI:
             .having(func.count(overlapping.c.id) > 1)
         )
 
-        return self._connection.execute(final_query)
+        return self.stream_query(final_query)
 
     def count_datasets(
         self, expressions: Iterable[Expression], archived: bool | None = False
@@ -851,7 +875,7 @@ class PostgresDbAPI:
             .select_from(self._from_expression(DATASET, expressions))
             .where(where_exprs)
         )
-        num = self._connection.scalar(select_query)
+        num = self.run_scalar_query(select_query)
         return 0 if num is None else num
 
     def count_datasets_through_time(
@@ -862,7 +886,7 @@ class PostgresDbAPI:
         time_field,
         expressions: Iterable[Expression],
     ) -> Iterator[tuple[tuple[datetime.datetime, datetime.datetime], int]]:
-        results = self._connection.execute(
+        results = self.stream_query(
             self.count_datasets_through_time_query(
                 start, end, period, time_field, expressions
             )
@@ -941,24 +965,20 @@ class PostgresDbAPI:
         return from_expression
 
     def get_product(self, id_: int):
-        return self._connection.execute(
-            PRODUCT.select().where(PRODUCT.c.id == id_)
-        ).first()
+        out = self.run_query(PRODUCT.select().where(PRODUCT.c.id == id_))
+        return out[0] if out else None
 
     def get_metadata_type(self, id_: int):
-        return self._connection.execute(
-            METADATA_TYPE.select().where(METADATA_TYPE.c.id == id_)
-        ).first()
+        out = self.run_query(METADATA_TYPE.select().where(METADATA_TYPE.c.id == id_))
+        return out[0] if out else None
 
     def get_product_by_name(self, name: str):
-        return self._connection.execute(
-            PRODUCT.select().where(PRODUCT.c.name == name)
-        ).first()
+        out = self.run_query(PRODUCT.select().where(PRODUCT.c.name == name))
+        return out[0] if out else None
 
     def get_metadata_type_by_name(self, name: str):
-        return self._connection.execute(
-            METADATA_TYPE.select().where(METADATA_TYPE.c.name == name)
-        ).first()
+        out = self.run_query(METADATA_TYPE.select().where(METADATA_TYPE.c.name == name))
+        return out[0] if out else None
 
     def insert_product(
         self,
@@ -969,7 +989,7 @@ class PostgresDbAPI:
         definition,
         concurrently: bool = True,
     ):
-        res = self._connection.execute(
+        res = self.execute(
             PRODUCT.insert().values(
                 name=name,
                 metadata=metadata,
@@ -978,7 +998,7 @@ class PostgresDbAPI:
             )
         )
 
-        type_id = res.inserted_primary_key[0]  # type: ignore[index]
+        type_id = res.inserted_primary_key[0]
 
         # Initialise search fields.
         self._setup_product_fields(
@@ -1000,7 +1020,7 @@ class PostgresDbAPI:
         update_metadata_type: bool = False,
         concurrently: bool = False,
     ):
-        res = self._connection.execute(
+        prod = self.run_query(
             PRODUCT.update()
             .returning(PRODUCT.c.id)
             .where(PRODUCT.c.name == name)
@@ -1009,16 +1029,14 @@ class PostgresDbAPI:
                 metadata_type_ref=metadata_type_id,
                 definition=definition,
             )
-        )
-        prod = res.first()
-        assert prod is not None
+        )[0]
         type_id = prod[0]
 
         if update_metadata_type:
             if not self._connection.in_transaction():
                 raise RuntimeError("Must update metadata types in transaction")
 
-            self._connection.execute(
+            self.execute(
                 DATASET.update()
                 .where(DATASET.c.dataset_type_ref == type_id)
                 .values(
@@ -1038,11 +1056,9 @@ class PostgresDbAPI:
         return type_id
 
     def delete_product(self, name: str, fields, definition):
-        res = self._connection.execute(
+        prod = self.run_query(
             PRODUCT.delete().returning(PRODUCT.c.id).where(PRODUCT.c.name == name)
-        )
-        prod = res.first()
-        assert prod is not None
+        )[0]
         type_id = prod[0]
 
         # Update dynamic fields to remove deleted product fields
@@ -1060,24 +1076,22 @@ class PostgresDbAPI:
     def insert_metadata_type(
         self, name: str, definition, concurrently: bool = False
     ) -> None:
-        res = self._connection.execute(
+        res = self.execute(
             METADATA_TYPE.insert().values(name=name, definition=definition)
         )
-        type_id = res.inserted_primary_key[0]  # type: ignore[index]
+        type_id = res.inserted_primary_key[0]
 
         self._setup_metadata_type_fields(
             type_id, name, definition, concurrently=concurrently
         )
 
     def update_metadata_type(self, name: str, definition, concurrently: bool = False):
-        res = self._connection.execute(
+        prod = self.run_query(
             METADATA_TYPE.update()
             .returning(METADATA_TYPE.c.id)
             .where(METADATA_TYPE.c.name == name)
             .values(name=name, definition=definition)
-        )
-        prod = res.first()
-        assert prod is not None
+        )[0]
         type_id = prod[0]
 
         self._setup_metadata_type_fields(
@@ -1112,6 +1126,7 @@ class PostgresDbAPI:
                 concurrently=concurrently,
             )
 
+    @catch_timeout
     def _setup_metadata_type_fields(
         self,
         id_,
@@ -1151,6 +1166,7 @@ class PostgresDbAPI:
                 concurrently=concurrently,
             )
 
+    @catch_timeout
     def _setup_product_fields(
         self,
         id_,
@@ -1196,34 +1212,32 @@ class PostgresDbAPI:
                     continue
 
     def get_all_products(self) -> Sequence:
-        return self._connection.execute(
-            PRODUCT.select().order_by(PRODUCT.c.name.asc())
-        ).fetchall()
+        return self.run_query(PRODUCT.select().order_by(PRODUCT.c.name.asc()))
 
     def get_all_product_docs(self):
-        return self._connection.execute(select(PRODUCT.c.definition))
+        return self.stream_query(select(PRODUCT.c.definition))
 
     def _get_products_for_metadata_type(self, id_: int) -> Sequence:
-        return self._connection.execute(
+        return self.run_query(
             PRODUCT.select()
             .where(PRODUCT.c.metadata_type_ref == id_)
             .order_by(PRODUCT.c.name.asc())
-        ).fetchall()
+        )
 
     def get_all_metadata_types(self) -> Sequence:
-        return self._connection.execute(
+        return self.run_query(
             METADATA_TYPE.select().order_by(METADATA_TYPE.c.name.asc())
-        ).fetchall()
+        )
 
     def get_all_metadata_type_docs(self):
-        return self._connection.execute(select(METADATA_TYPE.c.definition))
+        return self.run_query(select(METADATA_TYPE.c.definition))
 
     def get_all_metadata_defs(self) -> list:
         return [
             r[0]
-            for r in self._connection.execute(
+            for r in self.run_query(
                 select(METADATA_TYPE.c.definition).order_by(METADATA_TYPE.c.name.asc())
-            ).fetchall()
+            )
         ]
 
     def temporal_extent_by_product(
@@ -1247,23 +1261,23 @@ class PostgresDbAPI:
             selection="greatest",
         )
 
-        res = self._connection.execute(
+        res = self.run_query(
             select(
                 func.min(time_min.alchemy_expression),
                 func.max(time_max.alchemy_expression),
             ).where(DATASET.c.dataset_type_ref == product_id)
-        ).first()
+        )
 
-        if res is None:
+        if not res:
             raise RuntimeError(
                 "Product has no datasets and therefore no temporal extent"
             )
-        return res  # type: ignore[return-value]
+        return res[0]
 
     def get_locations(self, dataset_id) -> list:
         return [
             record[0]
-            for record in self._connection.execute(
+            for record in self.run_query(
                 select(_dataset_uri_field(DATASET_LOCATION))
                 .where(
                     and_(
@@ -1272,7 +1286,7 @@ class PostgresDbAPI:
                     )
                 )
                 .order_by(DATASET_LOCATION.c.added.desc(), DATASET_LOCATION.c.id.desc())
-            ).fetchall()
+            )
         ]
 
     def get_archived_locations(self, dataset_id) -> list:
@@ -1281,7 +1295,7 @@ class PostgresDbAPI:
         """
         return [
             (location_uri, archived_time)
-            for location_uri, archived_time in self._connection.execute(
+            for location_uri, archived_time in self.run_query(
                 select(
                     _dataset_uri_field(DATASET_LOCATION), DATASET_LOCATION.c.archived
                 )
@@ -1292,7 +1306,7 @@ class PostgresDbAPI:
                     )
                 )
                 .order_by(DATASET_LOCATION.c.added.desc())
-            ).fetchall()
+            )
         ]
 
     def remove_location(self, dataset_id, uri: str) -> bool:
@@ -1302,7 +1316,7 @@ class PostgresDbAPI:
         :returns bool: Was the location deleted?
         """
         scheme, body = split_uri(uri)
-        res = self._connection.execute(
+        res = self.execute(
             delete(DATASET_LOCATION).where(
                 and_(
                     DATASET_LOCATION.c.dataset_ref == dataset_id,
@@ -1315,7 +1329,7 @@ class PostgresDbAPI:
 
     def archive_location(self, dataset_id, uri: str) -> bool:
         scheme, body = split_uri(uri)
-        res = self._connection.execute(
+        res = self.execute(
             DATASET_LOCATION.update()
             .where(
                 and_(
@@ -1331,7 +1345,7 @@ class PostgresDbAPI:
 
     def restore_location(self, dataset_id, uri: str) -> bool:
         scheme, body = split_uri(uri)
-        res = self._connection.execute(
+        res = self.execute(
             DATASET_LOCATION.update()
             .where(
                 and_(
@@ -1349,8 +1363,8 @@ class PostgresDbAPI:
     def __repr__(self) -> str:
         return f"PostgresDb<connection={self._connection!r}>"
 
-    def list_users(self) -> Iterator:
-        result = self._connection.execute(
+    def list_users(self) -> Generator:
+        result = self.stream_query(
             text("""
             select
                 group_role.rolname as role_name,
@@ -1366,6 +1380,7 @@ class PostgresDbAPI:
         for row in result:
             yield UserRole(row.role_name).simple_str(), row.user_name, row.description
 
+    @catch_timeout
     def create_user(
         self,
         username: str,
@@ -1383,9 +1398,11 @@ class PostgresDbAPI:
             description,
         )
 
+    @catch_timeout
     def drop_users(self, users: Iterable[str]) -> bool:
         return drop_users(self._connection, users)
 
+    @catch_timeout
     def grant_role(self, role_str: str, users: Iterable[str]) -> bool:
         """
         Grant a role to a user.
@@ -1404,7 +1421,7 @@ class PostgresDbAPI:
         """
         Find the database-local time of the last dataset that changed for this product.
         """
-        return self._connection.execute(
+        return self.run_scalar_query(
             select(
                 func.max(
                     func.greatest(
@@ -1413,4 +1430,4 @@ class PostgresDbAPI:
                     )
                 )
             ).where(DATASET.c.dataset_type_ref == product_id)
-        ).scalar()
+        )

--- a/datacube/drivers/postgres/_connections.py
+++ b/datacube/drivers/postgres/_connections.py
@@ -96,6 +96,7 @@ class PostgresDb:
             config_env.db_iam_authentication,
             config_env.db_iam_timeout if config_env.db_iam_authentication else 600,
             config_env.db_connection_timeout,
+            config_env.db_query_timeout,
         )
         if validate:
             if not _core.database_exists(engine):
@@ -121,8 +122,12 @@ class PostgresDb:
         iam_rds_auth: bool = False,
         iam_rds_timeout: float | int = 600,
         pool_timeout: int = 60,
+        query_timeout: int = 0,
     ) -> Engine:
         connect_args: dict[str, Any] = {"application_name": application_name}
+        if query_timeout:
+            # Query timeout, in milliseconds.
+            connect_args["options"] = f"-c statement_timeout={query_timeout}"
         if str(url).startswith("postgresql+psycopg://"):
             try:
                 from psycopg import ClientCursor

--- a/datacube/drivers/postgres/_connections.py
+++ b/datacube/drivers/postgres/_connections.py
@@ -24,6 +24,7 @@ from sqlalchemy import create_engine, event
 from typing_extensions import override
 
 import datacube
+from datacube.drivers.common_psql import catch_timeout
 from datacube.index.exceptions import IndexSetupError
 from datacube.utils import json, jsonify_document
 
@@ -217,6 +218,7 @@ class PostgresDb:
             )
         return full_name[-64:]
 
+    @catch_timeout
     def init(self, with_permissions: bool = True) -> bool:
         """
         Init a new database (if not already set up).

--- a/datacube/drivers/postgres/_core.py
+++ b/datacube/drivers/postgres/_core.py
@@ -16,6 +16,7 @@ from typing_extensions import Self, override
 from datacube.drivers.common_psql import (
     UserRoleBase,
     as_role,
+    catch_timeout,
     create_schema,
     ensure_role,
     get_connection_info,
@@ -232,6 +233,7 @@ def ensure_db(engine, with_permissions: bool = True) -> bool:
     return is_new
 
 
+@catch_timeout
 def database_exists(engine) -> bool:
     """
     Have they init'd this database? (Thin wrapper around ``has_schema()``)

--- a/datacube/index/exceptions.py
+++ b/datacube/index/exceptions.py
@@ -20,6 +20,10 @@ class IndexSetupError(Exception):
     pass
 
 
+class QueryTimeout(Exception):  # noqa: N818
+    pass
+
+
 class TransactionException(Exception):  # noqa: N818
     def __init__(self, *args, commit: bool = False, **kwargs) -> None:
         super().__init__(*args, **kwargs)

--- a/datacube/index/postgis/_datasets.py
+++ b/datacube/index/postgis/_datasets.py
@@ -520,10 +520,7 @@ class DatasetResource(AbstractDatasetResource, IndexResourceAddIn):
         :param id_: dataset id
         """
         with self._db_connection() as connection:
-            location = connection.get_location(id_)
-            if location:
-                return location[0]
-            return None
+            return connection.get_location(id_)
 
     @deprecat(
         reason="Multiple locations per dataset are now deprecated. "

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -14,6 +14,7 @@ from odc.geo import CRS
 from typing_extensions import override
 
 from datacube.cfg.opt import config_options_for_psql_driver
+from datacube.drivers.common_psql import catch_generator_timeout
 from datacube.drivers.postgis import PostGisDb
 from datacube.index.abstract import (
     AbstractIndex,
@@ -31,7 +32,7 @@ from datacube.model import MetadataType
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator, Mapping, Sequence
+    from collections.abc import Generator, Iterable, Mapping, Sequence
 
     from datacube.cfg.api import ODCEnvironment, ODCOptionHandler
     from datacube.drivers.postgis import PostgisDbAPI
@@ -225,7 +226,8 @@ class Index(AbstractIndex):
         return self._db.drop_spatial_index(crs)
 
     @contextmanager
-    def _active_connection(self, transaction: bool = False) -> Iterator[PostgisDbAPI]:
+    @catch_generator_timeout
+    def _active_connection(self, transaction: bool = False) -> Generator[PostgisDbAPI]:
         """
         Context manager representing a database connection.
 

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -12,6 +12,7 @@ from deprecat import deprecat
 from typing_extensions import override
 
 from datacube.cfg.opt import config_options_for_psql_driver
+from datacube.drivers.common_psql import catch_generator_timeout
 from datacube.drivers.postgres import PostgresDb
 from datacube.index.abstract import (
     AbstractIndex,
@@ -29,7 +30,7 @@ from datacube.model import MetadataType
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator, Mapping
+    from collections.abc import Generator, Iterable, Mapping
 
     from datacube.cfg.api import ODCEnvironment
     from datacube.cfg.opt import ODCOptionHandler
@@ -185,7 +186,8 @@ class Index(AbstractIndex):
         return f"Index<db={self._db!r}>"
 
     @contextmanager
-    def _active_connection(self, transaction: bool = False) -> Iterator[PostgresDbAPI]:
+    @catch_generator_timeout
+    def _active_connection(self, transaction: bool = False) -> Generator[PostgresDbAPI]:
         """
         Context manager representing a database connection.
 

--- a/docs/source/installation/database/configuration.rst
+++ b/docs/source/installation/database/configuration.rst
@@ -223,12 +223,23 @@ remaining configuration options only apply to the ``postgres`` and
 
    **Only used for the 'postgres' and 'postgis' index drivers.**
 
-   The database connection timeout, in seconds.
+   The database idle connection timeout, in seconds.
 
    Connections in the connection pool that are idle for more than the
    configured timeout are automatically closed.
 
    Defaults to 60.
+
+.. confval:: db_query_timeout
+
+   **Only used for the 'postgres' and 'postgis' index drivers.**
+
+   The database query timeout, in milliseconds.
+
+   Queries that take longer than the configured timeout will be cancelled and raise a
+   ``datacube.index.exceptions.QueryTimeout`` exception.
+
+   Defaults to 0, indicating no timeout.
 
 .. confval:: db_url
 

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -17,11 +17,13 @@ from typing import Any
 import pytest
 import yaml
 from antimeridian import FixWindingWarning
+from odc.geo import CRS
 
 import datacube.scripts.cli_app
 import datacube.scripts.search_tool
 from datacube import Datacube
 from datacube.cfg.opt import _DEFAULT_DB_USER
+from datacube.index.exceptions import QueryTimeout
 from datacube.model import Not, Range
 from datacube.testutils import suppress_deprecations
 from datacube.utils.dates import tz_as_utc
@@ -84,6 +86,69 @@ def test_search_dataset_equals_eo3(index: Index, ls8_eo3_dataset: Dataset) -> No
                 product_family="splunge",
             )
         )
+
+
+def test_search_with_query_timeout(
+    cfg_env: ODCEnvironment,
+    index: Index,
+    ls8_eo3_dataset: Dataset,
+    ls8_eo3_dataset2: Dataset,
+    ls8_eo3_dataset3: Dataset,
+    ls8_eo3_dataset4: Dataset,
+    africa_eo3_dataset: Dataset,
+    africa_eo3_dataset2: Dataset,
+    s1_eo3_dataset: Dataset,
+) -> None:
+    # Confirm things work without timeout
+    datasets = list(
+        index.datasets.search_by_metadata(
+            metadata={"product": {"name": ls8_eo3_dataset.product.name}}
+        )
+    )
+    assert len(datasets) == 4
+    datasets = list(
+        index.datasets.search(
+            platform="landsat-8",
+            time=Range(
+                datetime.datetime(2013, 1, 1, 23, 0, 0),
+                datetime.datetime(2017, 1, 12, 23, 59, 59),
+            ),
+            cloud_cover=Range(0.0, 100.0),
+            product=ls8_eo3_dataset.product.name,
+        )
+    )
+    assert len(datasets) == 4
+    cfg_env._normalised["db_query_timeout"] = 1
+    dc = Datacube(env=cfg_env, validate_connection=False)
+    # We use search_by_metadata because it does not use indexes and times out more easily
+    # We attempt 20 times because sometimes it manages to succeed even with the minimum timeout.
+    seen_timeout = False
+    no_timeouts = 0
+    while no_timeouts < 20:
+        try:
+            # Try a few different queries. Hopefully at least one is slow.
+            ids = set()
+            gen = dc.index.datasets.search_by_metadata(
+                metadata={"product": {"name": ls8_eo3_dataset.product.name}}
+            )
+            for ds in gen:
+                ids.add(ds.id)
+            gen = dc.index.datasets.search(
+                platform="landsat-8",
+                time=Range(
+                    datetime.datetime(2013, 1, 1, 23, 0, 0),
+                    datetime.datetime(2017, 1, 12, 23, 59, 59),
+                ),
+                product=africa_eo3_dataset.product.name,
+            )
+            for ds in gen:
+                ids.add(ds.id)
+            dc.index.datasets.spatial_extent(ids, crs=CRS("epsg:4326"))
+            no_timeouts += 1
+        except QueryTimeout:
+            seen_timeout = True
+            break
+    assert seen_timeout, "No timeouts seen in 20 attempts"
 
 
 def test_search_dataset_range_eo3(

--- a/tests/cfg/simple_cfg.ini
+++ b/tests/cfg/simple_cfg.ini
@@ -18,6 +18,7 @@ db_connection_timeout: 20
 index_driver: postgis
 db_url: postgresql+psycopg2://foo:bar@server.subdomain.domain/mytestdb
 db_iam_authentication: yes
+db_query_timeout: 3000
 
 [postgis]
 alias: new

--- a/tests/cfg/simple_cfg.yaml
+++ b/tests/cfg/simple_cfg.yaml
@@ -15,6 +15,7 @@ new:
    index_driver: postgis
    db_url: 'postgresql+psycopg2://foo:bar@server.subdomain.domain/mytestdb'
    db_iam_authentication: yes
+   db_query_timeout: 3000
 postgis:
    alias: new
 memory:

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -136,6 +136,7 @@ new:
    index_driver: postgis
    db_url: postgresql+psycopg2://foo:bar@server.subdomain.domain/mytestdb
    db_iam_authentication: yes
+   db_query_timeout: 3000
 postgis:
    alias: new
 memory:
@@ -166,6 +167,7 @@ def simple_dict() -> dict[str, dict[str, str | int]]:
         "index_driver": "postgis",
         "db_url": "postgresql+psycopg2://foo:bar@server.subdomain.domain/mytestdb",
         "db_iam_authentication": "yes",
+        "db_query_timeout": 3000,
     }
     d: dict[str, dict[str, str | int]] = {
         "default": {"alias": "legacy"},
@@ -306,7 +308,8 @@ def assert_simple_options(cfg) -> None:
     assert not cfg["default"]["db_iam_authentication"]
     with pytest.raises(KeyError):
         assert cfg["default"]["db_iam_timeout"]
-
+    assert cfg["default"].db_query_timeout == 0
+    assert cfg["new"].db_query_timeout == 3000
     assert (
         cfg["new2"].db_url
         == "postgresql+psycopg2://foo:bar@server.subdomain.domain/mytestdb"


### PR DESCRIPTION
### Reason for this pull request

Explorer tends to fail badly when the database seizes up due to excess activity, a query timeout in core is the first of several mitigation strategies being considered.

### Proposed changes

- Add a db_query_timeout configuration option (measured in milliseconds; default=0, meaning no timeout) to both postgres and postgis index drivers.
- Catch low-level DBAPI errors caused by query timeouts and replace with an index layer `QueryTimeout` exception.
- Document new config option and exception.
- Add new timeout test.


 - [x] Tests added / passed
 - [x] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2486.org.readthedocs.build/en/2486/

<!-- readthedocs-preview opendatacube end -->