### PR TITLE
Use raw SQL Alchemy connection in add column tests

### DIFF
--- a/integration_tests/index/test_update_columns.py
+++ b/integration_tests/index/test_update_columns.py
@@ -55,10 +55,10 @@ def test_added_column(clirunner, uninitialised_postgres_db) -> None:
         assert pg_column_exists(c, _schema.DATASET_LOCATION.name, "added")
 
         # Check for triggers
-        assert check_trigger(connection, _schema.METADATA_TYPE.name)
-        assert check_trigger(connection, _schema.PRODUCT.name)
-        assert check_trigger(connection, _schema.DATASET.name)
-        assert not check_trigger(connection, _schema.DATASET_LOCATION.name)
+        assert check_trigger(c, _schema.METADATA_TYPE.name)
+        assert check_trigger(c, _schema.PRODUCT.name)
+        assert check_trigger(c, _schema.DATASET.name)
+        assert not check_trigger(c, _schema.DATASET_LOCATION.name)
 
 
 @pytest.mark.parametrize("db_tz", ("UTC",), indirect=True)
@@ -71,10 +71,10 @@ def test_readd_column(clirunner, uninitialised_postgres_db) -> None:
     with uninitialised_postgres_db._connect() as connection:
         c = connection._connection
         # Drop all the columns for an init rerun
-        drop_column(connection, _schema.METADATA_TYPE.name, "updated")
-        drop_column(connection, _schema.PRODUCT.name, "updated")
-        drop_column(connection, _schema.DATASET.name, "updated")
-        drop_column(connection, _schema.DATASET_LOCATION.name, "added")
+        drop_column(c, _schema.METADATA_TYPE.name, "updated")
+        drop_column(c, _schema.PRODUCT.name, "updated")
+        drop_column(c, _schema.DATASET.name, "updated")
+        drop_column(c, _schema.DATASET_LOCATION.name, "added")
 
         assert not pg_column_exists(c, _schema.METADATA_TYPE.name, "updated")
         assert not pg_column_exists(c, _schema.PRODUCT.name, "updated")

--- a/integration_tests/index/test_update_columns.py
+++ b/integration_tests/index/test_update_columns.py
@@ -13,6 +13,11 @@ from sqlalchemy import text
 from datacube.drivers.postgres import _schema
 from datacube.drivers.postgres.sql import SCHEMA_NAME, pg_column_exists
 
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    # Ruff is getting this wrong.  Hopefully can remove noqa down the track.
+    from sqlalchemy import Connection  # noqa: TC004
+
 DROP_COLUMN = """
 alter table {schema}.{table} drop column {column}
 """
@@ -25,7 +30,7 @@ and tgrelid = '{schema}.{table}'::regclass;
 """
 
 
-def check_trigger(conn, table_name: str) -> bool:
+def check_trigger(conn: Connection, table_name: str) -> bool:
     trigger_result = conn.execute(
         text(TRIGGER_PRESENCE.format(schema=SCHEMA_NAME, table=table_name))
     ).fetchone()


### PR DESCRIPTION
### Reason for this pull request

Current code is ambiguous, and breaks in #2486.


### Proposed changes

- Use raw SQL Alchemy connection when calling check_trigger
- Add type annotation to check_trigger. [1]

[1] Triggered an infinite linter loop.  When I use format A ruff tells me to use format B and when I use format B ruff tells me to use format A.  This is one time where I don't feel guilty for giving up and using a `noqa` comment.


 - [x] Tests added / passed
 - [x] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2493.org.readthedocs.build/en/2493/

<!-- readthedocs-preview opendatacube end -->