### PR TITLE
tests: remove noqa

### DIFF
--- a/integration_tests/index/test_update_columns.py
+++ b/integration_tests/index/test_update_columns.py
@@ -7,6 +7,8 @@ Test creation of added/updated columns during
 `datacube system init`
 """
 
+from __future__ import annotations
+
 import pytest
 from sqlalchemy import text
 
@@ -15,8 +17,7 @@ from datacube.drivers.postgres.sql import SCHEMA_NAME, pg_column_exists
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    # Ruff is getting this wrong.  Hopefully can remove noqa down the track.
-    from sqlalchemy import Connection  # noqa: TC004
+    from sqlalchemy import Connection
 
 DROP_COLUMN = """
 alter table {schema}.{table} drop column {column}


### PR DESCRIPTION
### Reason for this pull request

Annotations aren't lazy unless
annotations from __future__ is
imported, so import that and
remove the noqa.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2494.org.readthedocs.build/en/2494/

<!-- readthedocs-preview opendatacube end -->