### PR TITLE
Enhance Lineage API

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,7 @@ repos:
         # This can be removed when we no longer support 3.10
         additional_dependencies:
           - tomli
+        files: ^.*\.py$
     - repo: https://github.com/Lucas-C/pre-commit-hooks
       rev: v1.5.6
       hooks:

--- a/datacube/drivers/postgres/_api.py
+++ b/datacube/drivers/postgres/_api.py
@@ -49,7 +49,7 @@ from datacube.drivers.common_psql import (
 )
 from datacube.index.exceptions import MissingRecordError
 from datacube.index.fields import NotExpression, OrExpression
-from datacube.model import Range
+from datacube.model import LineageRelation, Range
 from datacube.utils.uris import split_uri
 
 from . import _dynamic as dynamic
@@ -67,6 +67,7 @@ from ._schema import DATASET, DATASET_LOCATION, DATASET_SOURCE, METADATA_TYPE, P
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     import datetime
+    import uuid
     from collections.abc import Generator, Iterable, Iterator, Mapping, Sequence
 
     from sqlalchemy import Connection, FromClause, Label, RootTransaction, Select
@@ -440,6 +441,26 @@ class PostgresDbAPI:
             )
             .where(DATASET_SOURCE.c.source_dataset_ref == dataset_id)
         )
+
+    def get_derived_relations(self, dataset_id: uuid.UUID) -> list[LineageRelation]:
+        return [
+            LineageRelation(classifier=c, source_id=dataset_id, derived_id=d)
+            for c, d in self.stream_query(
+                select(DATASET_SOURCE.c.classifier, DATASET_SOURCE.c.dataset_ref).where(
+                    DATASET_SOURCE.c.source_dataset_ref == dataset_id
+                )
+            )
+        ]
+
+    def get_source_relations(self, dataset_id: uuid.UUID) -> list[LineageRelation]:
+        return [
+            LineageRelation(classifier=c, source_id=s, derived_id=dataset_id)
+            for c, s in self.stream_query(
+                select(
+                    DATASET_SOURCE.c.classifier, DATASET_SOURCE.c.source_dataset_ref
+                ).where(DATASET_SOURCE.c.dataset_ref == dataset_id)
+            )
+        ]
 
     def get_dataset_sources(self, dataset_id: DSID) -> Sequence:
         # recursively build the list of (dataset_ref, source_dataset_ref) pairs starting from dataset_id

--- a/datacube/index/abstract/_lineage.py
+++ b/datacube/index/abstract/_lineage.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
     from datacube.model import LineageDirection, LineageRelation, LineageTree
     from datacube.model._base import DSID
-    from datacube.model.lineage import LineageRelations
+    from datacube.model.lineage import Eo3LineageDict, LineageRelations
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -61,6 +61,15 @@ class AbstractLineageResource(ABC):
         :return: A derived-direction Lineage tree with id at the root.
         """
 
+    def get_derived_ids(self, id_: DSID) -> Eo3LineageDict:
+        """
+        Return the derived ids of a dataset.
+
+        :param id\\_: The ID of the dataset to get the derived ids of.
+        :return: An EO3-style lineage dict.
+        """
+        return self.get_derived_tree(id_, max_depth=1).to_eo3_doc()
+
     @abstractmethod
     def get_source_tree(self, id_: DSID, max_depth: int = 0) -> LineageTree:
         """
@@ -75,6 +84,15 @@ class AbstractLineageResource(ABC):
         :param max_depth: Maximum recursion depth.  Default/Zero = unlimited depth
         :return: A source-direction Lineage tree with id at the root.
         """
+
+    def get_source_ids(self, id_: DSID) -> Eo3LineageDict:
+        """
+        Return the derived ids of a dataset.
+
+        :param id\\_: The ID of the dataset to get the derived ids of.
+        :return: An EO3-style lineage dict.
+        """
+        return self.get_source_tree(id_, max_depth=1).to_eo3_doc()
 
     @abstractmethod
     def merge(

--- a/datacube/index/memory/_datasets.py
+++ b/datacube/index/memory/_datasets.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
 
     from datacube.index.abstract import AbstractIndex
     from datacube.model._base import DSID, QueryField
+    from datacube.model.lineage import Eo3LineageDict
     from datacube.utils.changes import AllowPolicy, Change, Offset
     from datacube.utils.documents import JsonDict
 
@@ -1037,6 +1038,18 @@ class DatasetResource(AbstractDatasetResource):
 
         return BatchStatus(b_added, b_skipped, monotonic() - b_started)
 
+    def _get_derived_ids(self, id_: UUID) -> Eo3LineageDict:
+        return {
+            classifier: [did]
+            for classifier, did in self._derivations.get(id_, {}).items()
+        }
+
+    def _get_source_ids(self, id_: UUID) -> Eo3LineageDict:
+        return {
+            classifier: [sid]
+            for classifier, sid in self._derived_from.get(id_, {}).items()
+        }
+
 
 class LineageResource(NoLineageResource):
     """
@@ -1051,3 +1064,11 @@ class LineageResource(NoLineageResource):
     @override
     def _add_batch(self, batch_rels: Iterable[LineageRelation]) -> BatchStatus:
         return self._index.datasets._add_lineage_batch(batch_rels)
+
+    @override
+    def get_derived_ids(self, id_: DSID) -> Eo3LineageDict:
+        return self._index.datasets._get_derived_ids(dsid_to_uuid(id_))
+
+    @override
+    def get_source_ids(self, id_: DSID) -> Eo3LineageDict:
+        return self._index.datasets._get_source_ids(dsid_to_uuid(id_))

--- a/datacube/index/postgres/_lineage.py
+++ b/datacube/index/postgres/_lineage.py
@@ -10,11 +10,15 @@ from typing_extensions import override
 
 from datacube.index.abstract import BatchStatus, NoLineageResource
 from datacube.index.postgres._transaction import IndexResourceAddIn
-from datacube.model import LineageRelation
+from datacube.model import LineageRelation, dsid_to_uuid
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Iterable
+    from uuid import UUID
+
+    from datacube.model import DSID
+    from datacube.model.lineage import Eo3LineageDict
 
 
 class LineageResource(NoLineageResource, IndexResourceAddIn):
@@ -43,3 +47,24 @@ class LineageResource(NoLineageResource, IndexResourceAddIn):
                 ]
             )
         return BatchStatus(b_added, b_skipped, monotonic() - b_started)
+
+    @override
+    def get_derived_ids(self, id_: DSID) -> Eo3LineageDict:
+        lineage: dict[str, list[UUID]] = {}
+        with self._db_connection() as connection:
+            for rel in connection.get_derived_relations(dsid_to_uuid(id_)):
+                if deriveds := lineage.get(rel.classifier):
+                    deriveds.append(rel.derived_id)
+                else:
+                    lineage[rel.classifier] = [rel.derived_id]
+        return lineage
+
+    @override
+    def get_source_ids(self, id_: DSID) -> Eo3LineageDict:
+        lineage: dict[str, list[UUID]] = {}
+        with self._db_connection() as connection:
+            for rel in connection.get_source_relations(dsid_to_uuid(id_)):
+                # Lineage rewriting forces single source per classifier in postgres driver
+                assert rel.classifier not in lineage, "Lineage rewrite error"
+                lineage[rel.classifier] = [rel.source_id]
+        return lineage

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -108,6 +108,7 @@ def ext_eo3_mdt_path() -> str:
 def eo3_product_paths() -> list[str]:
     return [
         str(EO3_TESTDIR / "ard_ls8.odc-product.yaml"),
+        str(EO3_TESTDIR / "ga_ls_fc_3.odc-product.yaml"),
         str(EO3_TESTDIR / "ga_ls_wo_3.odc-product.yaml"),
         str(EO3_TESTDIR / "s2_africa_product.yaml"),
     ]
@@ -186,6 +187,15 @@ def eo3_wo_dataset_doc() -> tuple[dict, str]:
 
 
 @pytest.fixture
+def eo3_fc_dataset_doc() -> tuple[dict, str]:
+    return (
+        get_eo3_test_data_doc("fc_dataset.yaml"),
+        "s3://dea-public-data/derivative/ga_ls_fc_3/1-6-0/090/086/2016/05/12/"
+        "ga_ls_fc_3_090086_2016-05-12_final.stac-item.json",
+    )
+
+
+@pytest.fixture
 def eo3_africa_dataset_doc() -> tuple[dict, str]:
     return (
         get_eo3_test_data_doc("s2_africa_dataset.yaml"),
@@ -251,6 +261,11 @@ def extended_eo3_product_doc() -> dict:
 @pytest.fixture
 def base_eo3_product_doc() -> dict:
     return get_eo3_test_data_doc("ga_ls_wo_3.odc-product.yaml")
+
+
+@pytest.fixture
+def base_eo3_product2_doc() -> dict:
+    return get_eo3_test_data_doc("ga_ls_fc_3.odc-product.yaml")
 
 
 @pytest.fixture
@@ -412,6 +427,13 @@ def wo_eo3_product(index: Index, base_eo3_product_doc) -> Product:
 
 
 @pytest.fixture
+def fc_eo3_product(index: Index, base_eo3_product2_doc) -> Product:
+    p = index.products.add_document(base_eo3_product2_doc)
+    assert p is not None
+    return p
+
+
+@pytest.fixture
 def africa_s2_eo3_product(index: Index, africa_s2_product_doc) -> Product:
     p = index.products.add_document(africa_s2_product_doc)
     assert p is not None
@@ -441,12 +463,15 @@ def eo3_products(
     ls8_eo3_product,
     ls8_lvl1_eo3_product,
     africa_s2_eo3_product,
+    wo_eo3_product,
+    fc_eo3_product,
 ):
     return [
         africa_s2_eo3_product,
         ls8_eo3_product,
         wo_eo3_product,
         ls8_lvl1_eo3_product,
+        fc_eo3_product,
     ]
 
 
@@ -483,6 +508,13 @@ def wo_eo3_dataset(
     index: Index, wo_eo3_product, eo3_wo_dataset_doc, ls8_eo3_dataset
 ) -> Dataset:
     return doc_to_ds(index, wo_eo3_product.name, *eo3_wo_dataset_doc)
+
+
+@pytest.fixture
+def fc_eo3_dataset(
+    index: Index, fc_eo3_product, eo3_fc_dataset_doc, ls8_eo3_dataset
+) -> Dataset:
+    return doc_to_ds(index, fc_eo3_product.name, *eo3_fc_dataset_doc)
 
 
 @pytest.fixture

--- a/integration_tests/data/eo3/fc_dataset.yaml
+++ b/integration_tests/data/eo3/fc_dataset.yaml
@@ -1,0 +1,98 @@
+$schema: https://schemas.opendatacube.org/dataset
+id: 92e963ab-d7d4-5b1b-80ee-3839fe99e21b
+
+label: ga_ls_fc_3_090086_2016-05-12_final
+product:
+  name: ga_ls_fc_3
+  href: https://collections.dea.ga.gov.au/product/ga_ls_fc_3
+
+crs: epsg:32655
+geometry:
+  type: Polygon
+  coordinates: [[[744887.1641292616, -4268586.69296148], [744884.9999999991, -4268595.0],
+    [558427.4207787119, -4219934.026804932], [557855.5131670194, -4219783.46049894],
+    [557709.1155350873, -4219707.51089463], [557632.5000000001, -4219687.5], [557812.9841364851,
+      -4218918.719827209], [565387.986437303, -4189848.7110030535], [575002.9904772384,
+      -4153068.6955619035], [602962.9904772406, -4046433.6955619026], [606937.9957531227,
+      -4031358.6754970923], [607088.0285426822, -4030803.553238912], [607117.4999999999,
+      -4030762.5000000005], [687286.8455741361, -4051713.5515318085], [794114.9999999988,
+      -4079624.9999999995], [794113.4191087743, -4079631.06827168], [794193.1066017186,
+      -4079651.8933982817], [794152.0157050926, -4079891.280781102], [745042.0157050904,
+      -4268441.280781103], [744982.499999999, -4268602.499999999], [744887.1641292616,
+      -4268586.69296148]]]
+grids:
+  default:
+    shape: [7941, 7901]
+    transform: [30.0, 0.0, 557385.0, 0.0, -30.0, -4030485.0, 0.0, 0.0, 1.0]
+
+properties:
+  datetime: 2016-05-12 23:50:37.621730Z
+  dea:dataset_maturity: final
+  dtr:end_datetime: 2016-05-12 23:50:52.031499Z
+  dtr:start_datetime: 2016-05-12 23:50:23.054165Z
+  eo:cloud_cover: 58.910716655901616
+  eo:gsd: 30.0  # Ground sample distance (m)
+  eo:instrument: OLI_TIRS
+  eo:platform: landsat-8
+  eo:sun_azimuth: 34.58516815
+  eo:sun_elevation: 26.29614366
+  fmask:clear: 22.3973998672305
+  fmask:cloud: 58.910716655901616
+  fmask:cloud_shadow: 1.3150997463296996
+  fmask:snow: 0.0006217170293219306
+  fmask:water: 17.376162013508864
+  gqa:abs_iterative_mean_x: 0.19
+  gqa:abs_iterative_mean_xy: 0.25
+  gqa:abs_iterative_mean_y: 0.16
+  gqa:abs_x: 0.43
+  gqa:abs_xy: 0.51
+  gqa:abs_y: 0.28
+  gqa:cep90: 0.49
+  gqa:iterative_mean_x: -0.1
+  gqa:iterative_mean_xy: 0.15
+  gqa:iterative_mean_y: 0.11
+  gqa:iterative_stddev_x: 0.24
+  gqa:iterative_stddev_xy: 0.3
+  gqa:iterative_stddev_y: 0.17
+  gqa:mean_x: -0.1
+  gqa:mean_xy: 0.11
+  gqa:mean_y: 0.05
+  gqa:stddev_x: 1.15
+  gqa:stddev_xy: 1.28
+  gqa:stddev_y: 0.56
+  landsat:collection_category: T1
+  landsat:collection_number: 1
+  landsat:landsat_product_id: LC08_L1TP_090086_20160512_20180203_01_T1
+  landsat:landsat_scene_id: LC80900862016133LGN02
+  landsat:wrs_path: 90
+  landsat:wrs_row: 86
+  odc:collection_number: 3
+  odc:dataset_version: 1.6.0
+  odc:file_format: GeoTIFF
+  odc:naming_conventions: dea_c3
+  odc:processing_datetime: 2026-03-29 21:58:41.189540Z
+  odc:producer: ga.gov.au
+  odc:product_family: fc
+  odc:region_code: '090086'
+
+measurements:
+  bs:
+    path: ga_ls_fc_3_090086_2016-05-12_final_bs.tif
+  npv:
+    path: ga_ls_fc_3_090086_2016-05-12_final_npv.tif
+  pv:
+    path: ga_ls_fc_3_090086_2016-05-12_final_pv.tif
+  ue:
+    path: ga_ls_fc_3_090086_2016-05-12_final_ue.tif
+
+accessories:
+  thumbnail:
+    path: ga_ls_fc_3_090086_2016-05-12_final_thumbnail.jpg
+  metadata:processor:
+    path: ga_ls_fc_3_090086_2016-05-12_final.proc-info.yaml
+  checksum:sha1:
+    path: ga_ls_fc_3_090086_2016-05-12_final.sha1
+
+lineage:
+  ard:
+  - c21648b1-a6fa-4de0-9dc3-9c445d8b295a

--- a/integration_tests/data/eo3/ga_ls_fc_3.odc-product.yaml
+++ b/integration_tests/data/eo3/ga_ls_fc_3.odc-product.yaml
@@ -1,0 +1,43 @@
+name: ga_ls_fc_3
+license: CC-BY-4.0
+metadata_type: eo3
+description: Geoscience Australia Landsat Fractional Cover Collection 3
+metadata:
+  product:
+    name: ga_ls_fc_3
+  properties:
+    odc:file_format: GeoTIFF
+    odc:product_family: fc
+measurements:
+- name: bs
+  dtype: uint8
+  units: percent
+  nodata: 255
+  aliases:
+  - bare
+- name: pv
+  dtype: uint8
+  units: percent
+  nodata: 255
+  aliases:
+  - green_veg
+- name: npv
+  dtype: uint8
+  units: percent
+  nodata: 255
+  aliases:
+  - dead_veg
+- name: ue
+  dtype: uint8
+  units: '1'
+  nodata: 255
+  aliases:
+  - err
+load:
+  crs: EPSG:3577
+  align:
+    x: 0
+    y: 0
+  resolution:
+    x: 30
+    y: -30

--- a/integration_tests/index/test_memory_index.py
+++ b/integration_tests/index/test_memory_index.py
@@ -313,6 +313,10 @@ def test_mem_ds_lineage(mem_eo3_data: tuple) -> None:
     assert len(derived) == 1
     assert derived[0].id == wo_id
     assert "cloud_cover" in dc.index.products.get_field_names(ls8_ds.product)
+    derived = dc.index.lineage.get_derived_ids(ls8_id)
+    assert derived == {"ard": [wo_id]}
+    sources = dc.index.lineage.get_source_ids(wo_id)
+    assert sources == {"ard": [ls8_id]}
 
 
 def test_mem_ds_search_dups(mem_eo3_data: tuple) -> None:

--- a/integration_tests/index/test_search_eo3.py
+++ b/integration_tests/index/test_search_eo3.py
@@ -1437,3 +1437,13 @@ def test_search_boolean_eo3(index: Index, s1_eo3_dataset) -> None:
         )
     )
     assert len(res) == 0
+
+
+@pytest.mark.parametrize("db_tz", ("UTC",), indirect=True)
+def test_shared_lineage_api(
+    index: Index, ls8_eo3_dataset, wo_eo3_dataset, fc_eo3_dataset
+) -> None:
+    derived = index.lineage.get_derived_ids(ls8_eo3_dataset.id)
+    assert derived == {"ard": [wo_eo3_dataset.id, fc_eo3_dataset.id]}
+    sources = index.lineage.get_source_ids(wo_eo3_dataset.id)
+    assert sources == {"ard": [ls8_eo3_dataset.id]}


### PR DESCRIPTION
### Reason for this pull request

In the postgres driver, the only way to access source lineage (e.g. to reconstruct an EO3 metadata document with lineage) is the `dc.index.datasets.get(id_, include_sources=True)` However this has  significant shortcomings:

- it is not depth bounded (the use case above only requires the first level of source datasets)
- it retrieves and returns the full metadata document for all source datasets (the use case above only requires ids and classifiers)

These issues are addressed by the new lineage API implemented by the postgis driver, but there is no workaround for index drivers that use the legacy lineage API (postgres and memory).  This is particularly inconvenient in Explorer.

### Proposed changes

- New lineage API method supported by both old and new style lineage APIs: `get_derived_ids` and `get_source_ids`
- Default implementations of the new methods for index drivers supporting the new lineage API, implemented in terms of existing methods in the new lineage API.
- Native implementations for the postgres and memory drivers
- Tests of the new methods.

This is hopefully the first of several PRs to core and explorer aimed at improving the performance of inefficient database queries in Explorer. 

 - [x] Tests added / passed
 - [x] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2496.org.readthedocs.build/en/2496/

<!-- readthedocs-preview opendatacube end -->