### PR TITLE
readthedocs: use Ubuntu 26.04/Python 3.14

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-24.04
+  os: ubuntu-26.04
   tools:
-    python: "3.12"
+    python: "3.14"
   jobs:
     post_checkout:
       - git fetch --prune --unshallow


### PR DESCRIPTION
### Reason for this pull request

Bump the build environment to
the latest Ubuntu LTS and its
Python version.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2510.org.readthedocs.build/en/2510/

<!-- readthedocs-preview opendatacube end -->