### PR TITLE
pyproject: remove Python 3.10 pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,9 +71,7 @@ netcdf = ['netcdf4']
 # orjson = ['orjson']
 postgres = ['psycopg2']
 psycopg3 = ['psycopg']
-# tifffile 2026 (a scikit-image dependency) tells pip/uv it is Python 3.10 compatible, but isn't.
-# Remove pins after we move minimum to Python 3.12
-scikit-image = ['scikit-image<0.26','tifffile<2026']
+scikit-image = ['scikit-image']
 
 [dependency-groups]
 dev = [
@@ -110,12 +108,11 @@ doc = [
     'nbsphinx',
     'pydata-sphinx-theme',
     'recommonmark',
-    "Sphinx>=8.1.3,<9; python_version<'3.11'",
-    "Sphinx>=8.2.3,<9; python_version>='3.11'",
+    "Sphinx>=8.2.3,<9",
     'sphinx_autodoc_typehints',  # Propagate mypy info into docs
-    'sphinx-click',
+    'sphinx-click', # Version 6.2.0 has Sphinx 9 compatibility issues.
     'sphinx-design',
-    'sphinx-toolbox', # Sphinx 9 compatibility issues
+    'sphinx-toolbox',
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -839,7 +839,6 @@ s3 = [
 ]
 scikit-image = [
     { name = "scikit-image" },
-    { name = "tifffile" },
 ]
 
 [package.dev-dependencies]
@@ -922,10 +921,9 @@ requires-dist = [
     { name = "python-dateutil" },
     { name = "pyyaml" },
     { name = "rasterio", specifier = ">=1.4.4" },
-    { name = "scikit-image", marker = "extra == 'scikit-image'", specifier = "<0.26" },
+    { name = "scikit-image", marker = "extra == 'scikit-image'" },
     { name = "shapely", specifier = ">=2.0" },
     { name = "sqlalchemy", specifier = ">=2.0" },
-    { name = "tifffile", marker = "extra == 'scikit-image'", specifier = "<2026" },
     { name = "toolz" },
     { name = "xarray", specifier = ">=0.9" },
 ]
@@ -952,8 +950,7 @@ dev = [
     { name = "pytest-httpserver" },
     { name = "recommonmark" },
     { name = "ruff" },
-    { name = "sphinx", marker = "python_full_version < '3.11'", specifier = ">=8.1.3,<9" },
-    { name = "sphinx", marker = "python_full_version >= '3.11'", specifier = ">=8.2.3,<9" },
+    { name = "sphinx", specifier = ">=8.2.3,<9" },
     { name = "sphinx-autodoc-typehints" },
     { name = "sphinx-click" },
     { name = "sphinx-design" },
@@ -974,8 +971,7 @@ doc = [
     { name = "nbsphinx" },
     { name = "pydata-sphinx-theme" },
     { name = "recommonmark" },
-    { name = "sphinx", marker = "python_full_version < '3.11'", specifier = ">=8.1.3,<9" },
-    { name = "sphinx", marker = "python_full_version >= '3.11'", specifier = ">=8.2.3,<9" },
+    { name = "sphinx", specifier = ">=8.2.3,<9" },
     { name = "sphinx-autodoc-typehints" },
     { name = "sphinx-click" },
     { name = "sphinx-design" },


### PR DESCRIPTION
### Reason for this pull request

The sphinx-click package is still not
Sphinx 9 compatible, so remove the pins
relating to older Python versions
but stay on Sphinx 8 for now.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2513.org.readthedocs.build/en/2513/

<!-- readthedocs-preview opendatacube end -->