### PR TITLE
CI: disable uv cache for releases

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -45,6 +45,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
+          # Prevent cache poisoning for releases.
+          enable-cache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           python-version: ${{ matrix.python-version }}
       - name: Install the project
         run: uv sync --locked --group=dev

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,6 +88,9 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      with:
+        # Prevent cache poisoning for releases.
+        enable-cache: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
     - name: Build Packages
       run: |


### PR DESCRIPTION
### Reason for this pull request

There is a risk of cache poisoning
when producing the release packages,
so disable the uv cache on releases.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2518.org.readthedocs.build/en/2518/

<!-- readthedocs-preview opendatacube end -->