### PR TITLE
[docs] Fix edit page links.  Add a target for database roles

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -139,7 +139,7 @@ html_context = {
     "github_user": "opendatacube",
     "github_repo": "datacube-core",
     "github_version": "develop",
-    "doc_path": "docs",
+    "doc_path": "docs/source",
 }
 
 html_logo = "_static/odc-logo-horizontal.svg"

--- a/docs/source/installation/database/setup.rst
+++ b/docs/source/installation/database/setup.rst
@@ -186,6 +186,7 @@ creation::
 
    datacube spindex update 3577
 
+.. _user-and-permissions-management:
 
 User and Permissions Management
 ===============================


### PR DESCRIPTION
### Reason for this pull request

The "Edit this page" links in our docs are broken. This is because the docs source moved from `docs/` to `docs/source`.

I wanted to link from the Explorer docs to the section in Core Docs about Database roles. So adding a reference target I could point to.
<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2524.org.readthedocs.build/en/2524/

<!-- readthedocs-preview opendatacube end -->