### PR TITLE
[cli] Be explicit about CLI name

### DIFF
--- a/datacube/scripts/search_tool.py
+++ b/datacube/scripts/search_tool.py
@@ -79,7 +79,9 @@ OUTPUT_FORMATS: dict[str, Callable[[Any, Collection, list[dict[str, Any]]], None
 }
 
 
-@click.group(help="Search the Data Cube", context_settings=CLICK_SETTINGS)
+@click.group(
+    name="datacube-search", help="Search the Data Cube", context_settings=CLICK_SETTINGS
+)
 @ui.global_cli_options
 @click.option(
     "-f",

--- a/datacube/ui/click.py
+++ b/datacube/ui/click.py
@@ -246,7 +246,11 @@ global_cli_options = compose(
 )
 
 
-@click.group(help="Data Cube command-line interface", context_settings=CLICK_SETTINGS)
+@click.group(
+    name="datacube",
+    help="Data Cube command-line interface",
+    context_settings=CLICK_SETTINGS,
+)
 @global_cli_options
 def cli() -> None:
     pass


### PR DESCRIPTION
### Reason for this pull request
I was experimenting with building man pages for the `datacube` command using [click-extra](https://kdeldycke.github.io/click-extra/man-page.html), but all the pages were named `cli` instead of `datacube`.

Setting the `name` argument here fixes that.

As far as I can tell this change is completely harmless otherwise.


 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2525.org.readthedocs.build/en/2525/

<!-- readthedocs-preview opendatacube end -->