### PR TITLE
[cli] datacube-worker was already removed, finish it off 🧹

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,6 @@ doc = [
 [project.scripts]
 datacube = 'datacube.scripts.cli_app:cli'
 datacube-search = 'datacube.scripts.search_tool:cli'
-datacube-worker = 'datacube.execution.worker:main'
 
 [project.entry-points."datacube.plugins.io.read"]
 netcdf = 'datacube.drivers.netcdf.driver:reader_driver_init'


### PR DESCRIPTION
### Reason for this pull request

We removed `datacube-worker` code a while ago, but it was still in `pyproject.toml` entrypoints, which meant a CLI script was still being created... that didn't work.

Tidy tidy 🧹 .

```
uv run datacube-worker --help
Traceback (most recent call last):
  File "/Users/aye011/dev/odc/datacube-core/.venv/bin/datacube-worker", line 4, in <module>
    from datacube.execution.worker import main
ModuleNotFoundError: No module named 'datacube.execution'
```


<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2526.org.readthedocs.build/en/2526/

<!-- readthedocs-preview opendatacube end -->