### PR TITLE
Refactor: make get_dataset_fields per instance

### DIFF
--- a/datacube/index/abstract/_index.py
+++ b/datacube/index/abstract/_index.py
@@ -131,9 +131,8 @@ class AbstractIndex(ABC):
     ) -> AbstractIndex:
         """Instantiate a new index from an ODCEnvironment configuration object"""
 
-    @classmethod
     @abstractmethod
-    def get_dataset_fields(cls, doc: dict) -> Mapping[str, Field]:
+    def get_dataset_fields(self, doc: dict) -> Mapping[str, Field]:
         """Return dataset search fields from a metadata type document"""
 
     @abstractmethod

--- a/datacube/index/abstract/_index.py
+++ b/datacube/index/abstract/_index.py
@@ -9,9 +9,6 @@ from abc import ABC, abstractmethod
 from functools import cached_property
 from urllib.parse import urlparse
 
-from deprecat import deprecat
-
-from datacube.migration import ODC2DeprecationWarning
 from datacube.utils import report_to_user
 from datacube.utils.generic import thread_local_cache
 
@@ -23,9 +20,8 @@ if TYPE_CHECKING:
     from odc.geo import CRS
 
     from datacube.cfg import ODCEnvironment, ODCOptionHandler
-    from datacube.model import Field, MetadataType
+    from datacube.model import Field
     from datacube.model._base import DSID
-    from datacube.utils.json_types import JsonDict
 
     from ._datasets import AbstractDatasetResource
     from ._lineage import AbstractLineageResource
@@ -421,16 +417,6 @@ class AbstractIndexDriver(ABC):
         return cls.index_class().from_config(
             config_env, application_name, validate_connection
         )
-
-    @staticmethod
-    @abstractmethod
-    @deprecat(
-        reason="The 'metadata_type_from_doc' static method has been deprecated. "
-        "Please use the 'index.metadata_type.from_doc()' instead.",
-        version="1.9.0",
-        category=ODC2DeprecationWarning,
-    )
-    def metadata_type_from_doc(definition: JsonDict) -> MetadataType: ...
 
     @staticmethod
     def get_config_option_handlers(env: ODCEnvironment) -> Iterable[ODCOptionHandler]:

--- a/datacube/index/memory/index.py
+++ b/datacube/index/memory/index.py
@@ -8,8 +8,6 @@ import logging
 from threading import Lock
 from typing import Any, override
 
-from deprecat import deprecat
-
 from datacube.index.abstract import (
     AbstractIndex,
     AbstractIndexDriver,
@@ -20,8 +18,6 @@ from datacube.index.memory._fields import get_dataset_fields
 from datacube.index.memory._metadata_types import MetadataTypeResource
 from datacube.index.memory._products import ProductResource
 from datacube.index.memory._users import UserResource
-from datacube.migration import ODC2DeprecationWarning
-from datacube.model import MetadataType
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -31,7 +27,6 @@ if TYPE_CHECKING:
 
     from datacube.cfg import ODCEnvironment
     from datacube.model import Field
-    from datacube.utils.json_types import JsonDict
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -130,9 +125,8 @@ class Index(AbstractIndex):
     ) -> Index:
         return cls(cfg_env)
 
-    @classmethod
     @override
-    def get_dataset_fields(cls, doc: Mapping[str, Any]) -> dict[str, Field]:
+    def get_dataset_fields(self, doc: Mapping[str, Any]) -> dict[str, Field]:
         return get_dataset_fields(doc)
 
     @override

--- a/datacube/index/memory/index.py
+++ b/datacube/index/memory/index.py
@@ -161,21 +161,6 @@ class MemoryIndexDriver(AbstractIndexDriver):
     def index_class(cls) -> type[AbstractIndex]:
         return Index
 
-    @staticmethod
-    @override
-    @deprecat(
-        reason="The 'metadata_type_from_doc' static method has been deprecated. "
-        "Please use the 'index.metadata_type.from_doc()' instead.",
-        version="1.9.0",
-        category=ODC2DeprecationWarning,
-    )
-    def metadata_type_from_doc(definition: JsonDict) -> MetadataType:
-        """
-        :param definition:
-        """
-        MetadataType.validate(definition)  # type: ignore[attr-defined]
-        return MetadataType(definition, search_field_extractor=Index.get_dataset_fields)
-
 
 def index_driver_init() -> MemoryIndexDriver:
     return MemoryIndexDriver()

--- a/datacube/index/null/index.py
+++ b/datacube/index/null/index.py
@@ -147,21 +147,6 @@ class NullIndexDriver(AbstractIndexDriver):
     def index_class(cls) -> type[AbstractIndex]:
         return Index
 
-    @staticmethod
-    @override
-    @deprecat(
-        reason="The 'metadata_type_from_doc' static method has been deprecated. "
-        "Please use the 'index.metadata_type.from_doc()' instead.",
-        version="1.9.0",
-        category=ODC2DeprecationWarning,
-    )
-    def metadata_type_from_doc(definition: JsonDict) -> MetadataType:
-        """
-        :param definition:
-        """
-        MetadataType.validate(definition)  # type: ignore[attr-defined]
-        return MetadataType(definition, search_field_extractor=Index.get_dataset_fields)
-
 
 def index_driver_init() -> NullIndexDriver:
     return NullIndexDriver()

--- a/datacube/index/null/index.py
+++ b/datacube/index/null/index.py
@@ -7,8 +7,6 @@ from __future__ import annotations
 import logging
 from typing import Any, override
 
-from deprecat import deprecat
-
 from datacube.index.abstract import (
     AbstractIndex,
     AbstractIndexDriver,
@@ -19,8 +17,6 @@ from datacube.index.null._datasets import DatasetResource
 from datacube.index.null._metadata_types import MetadataTypeResource
 from datacube.index.null._products import ProductResource
 from datacube.index.null._users import UserResource
-from datacube.migration import ODC2DeprecationWarning
-from datacube.model import MetadataType
 from datacube.model.fields import get_dataset_fields
 
 TYPE_CHECKING = False
@@ -31,7 +27,6 @@ if TYPE_CHECKING:
 
     from datacube.cfg import ODCEnvironment
     from datacube.model import Field
-    from datacube.utils.json_types import JsonDict
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -116,9 +111,8 @@ class Index(AbstractIndex):
     ) -> Index:
         return cls(cfg_env)
 
-    @classmethod
     @override
-    def get_dataset_fields(cls, doc: Mapping[str, Any]) -> dict[str, Field]:
+    def get_dataset_fields(self, doc: Mapping[str, Any]) -> dict[str, Field]:
         return get_dataset_fields(doc)
 
     @override

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -9,7 +9,6 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, override
 
-from deprecat import deprecat
 from odc.geo import CRS
 
 from datacube.cfg.opt import config_options_for_psql_driver
@@ -26,8 +25,6 @@ from datacube.index.postgis._metadata_types import MetadataTypeResource
 from datacube.index.postgis._products import ProductResource
 from datacube.index.postgis._transaction import PostgisTransaction
 from datacube.index.postgis._users import UserResource
-from datacube.migration import ODC2DeprecationWarning
-from datacube.model import MetadataType
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -37,7 +34,6 @@ if TYPE_CHECKING:
     from datacube.drivers.postgis import PostgisDbAPI
     from datacube.index.abstract import AbstractTransaction
     from datacube.model._base import DSID
-    from datacube.utils.json_types import JsonDict
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -148,7 +144,6 @@ class Index(AbstractIndex):
         )
         return cls(db, cfg_env)
 
-    @classmethod
     @override
     def get_dataset_fields(cls, doc: Mapping[str, Any]) -> dict:
         return PostGisDb.get_dataset_fields(doc)

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -273,22 +273,6 @@ class PostgisIndexDriver(AbstractIndexDriver):
 
     @staticmethod
     @override
-    @deprecat(
-        reason="The 'metadata_type_from_doc' static method has been deprecated. "
-        "Please use the 'index.metadata_type.from_doc()' instead.",
-        version="1.9.0",
-        category=ODC2DeprecationWarning,
-    )
-    def metadata_type_from_doc(definition: JsonDict) -> MetadataType:
-        """
-        :param definition:
-        """
-        # TODO: Validate metadata is ODCv2 compliant - e.g. either non-raster or EO3.
-        MetadataType.validate(definition)  # type: ignore[attr-defined]
-        return MetadataType(definition, search_field_extractor=Index.get_dataset_fields)
-
-    @staticmethod
-    @override
     def get_config_option_handlers(env: ODCEnvironment) -> Iterable[ODCOptionHandler]:
         return config_options_for_psql_driver(env)
 

--- a/datacube/index/postgis/index.py
+++ b/datacube/index/postgis/index.py
@@ -145,8 +145,8 @@ class Index(AbstractIndex):
         return cls(db, cfg_env)
 
     @override
-    def get_dataset_fields(cls, doc: Mapping[str, Any]) -> dict:
-        return PostGisDb.get_dataset_fields(doc)
+    def get_dataset_fields(self, doc: Mapping[str, Any]) -> dict:
+        return self._db.get_dataset_fields(doc)
 
     @override
     def init_db(

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -8,8 +8,6 @@ import logging
 from contextlib import contextmanager
 from typing import Any, override
 
-from deprecat import deprecat
-
 from datacube.cfg.opt import config_options_for_psql_driver
 from datacube.drivers.common_psql import catch_generator_timeout
 from datacube.drivers.postgres import PostgresDb
@@ -24,8 +22,6 @@ from datacube.index.postgres._metadata_types import MetadataTypeResource
 from datacube.index.postgres._products import ProductResource
 from datacube.index.postgres._transaction import PostgresTransaction
 from datacube.index.postgres._users import UserResource
-from datacube.migration import ODC2DeprecationWarning
-from datacube.model import MetadataType
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -35,7 +31,6 @@ if TYPE_CHECKING:
     from datacube.cfg.opt import ODCOptionHandler
     from datacube.drivers.postgres import PostgresDbAPI
     from datacube.index.abstract import AbstractTransaction
-    from datacube.utils.json_types import JsonDict
 
 _LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -139,9 +134,8 @@ class Index(AbstractIndex):
         )
         return cls(db, cfg_env)
 
-    @classmethod
     @override
-    def get_dataset_fields(cls, doc: Mapping[str, Any]) -> Mapping[str, Any]:
+    def get_dataset_fields(self, doc: Mapping[str, Any]) -> Mapping[str, Any]:
         return PostgresDb.get_dataset_fields(doc)
 
     @override

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -136,7 +136,7 @@ class Index(AbstractIndex):
 
     @override
     def get_dataset_fields(self, doc: Mapping[str, Any]) -> Mapping[str, Any]:
-        return PostgresDb.get_dataset_fields(doc)
+        return self._db.get_dataset_fields(doc)
 
     @override
     def init_db(

--- a/datacube/index/postgres/index.py
+++ b/datacube/index/postgres/index.py
@@ -234,21 +234,6 @@ class PostgresIndexDriver(AbstractIndexDriver):
 
     @staticmethod
     @override
-    @deprecat(
-        reason="The 'metadata_type_from_doc' static method has been deprecated. "
-        "Please use the 'index.metadata_type.from_doc()' instead.",
-        version="1.9.0",
-        category=ODC2DeprecationWarning,
-    )
-    def metadata_type_from_doc(definition: JsonDict) -> MetadataType:
-        """
-        :param definition:
-        """
-        MetadataType.validate(definition)  # type: ignore[attr-defined]
-        return MetadataType(definition, search_field_extractor=Index.get_dataset_fields)
-
-    @staticmethod
-    @override
     def get_config_option_handlers(env: ODCEnvironment) -> Iterable[ODCOptionHandler]:
         return config_options_for_psql_driver(env)
 

--- a/integration_tests/index/test_pluggable_indexes.py
+++ b/integration_tests/index/test_pluggable_indexes.py
@@ -2,14 +2,25 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
+from typing import Type
+
 import pytest
+
+from datacube.index.postgres.index import Index as PgIndex
+from datacube.index.postgis.index import Index as PGISIndex
 
 from datacube.index.postgres.index import Index
 
+@pytest.fixture
+def index_cls(datacube_env_name) -> Type[PgIndex | PGISIndex]:
+    if datacube_env_name.startswith("postgis"):
+        return PGISIndex
+    return PgIndex
 
-@pytest.mark.parametrize("datacube_env_name", ("datacube", "datacube3"))
-def test_with_standard_index(uninitialised_postgres_db, cfg_env) -> None:
-    index = Index(uninitialised_postgres_db, cfg_env)
+
+@pytest.mark.parametrize("datacube_env_name", ("datacube", "datacube3", "postgis", "postgis3"))
+def test_with_standard_index(uninitialised_postgres_db, cfg_env, index_cls) -> None:
+    index = index_cls(uninitialised_postgres_db, cfg_env)
     index.init_db()
 
 

--- a/integration_tests/index/test_pluggable_indexes.py
+++ b/integration_tests/index/test_pluggable_indexes.py
@@ -2,28 +2,53 @@
 #
 # Copyright (c) 2015-2026 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from typing import Type
 
 import pytest
 import yaml
 
-from datacube.index.postgres.index import Index as PgIndex
 from datacube.index.postgis.index import Index as PGISIndex
+from datacube.index.postgres.index import Index as PgIndex
 from datacube.model import MetadataType
 
-from datacube.index.postgres.index import Index
+TYPE_CHECKING = False
+
 
 @pytest.fixture
-def index_cls(datacube_env_name) -> Type[PgIndex | PGISIndex]:
+def index_cls(datacube_env_name) -> type[PgIndex | PGISIndex]:
     if datacube_env_name.startswith("postgis"):
         return PGISIndex
     return PgIndex
 
 
-@pytest.mark.parametrize("datacube_env_name", ("datacube", "datacube3", "postgis", "postgis3"))
+@pytest.mark.parametrize(
+    "datacube_env_name", ("datacube", "datacube3", "postgis", "postgis3")
+)
 def test_with_standard_index(uninitialised_postgres_db, cfg_env, index_cls) -> None:
     index = index_cls(uninitialised_postgres_db, cfg_env)
     index.init_db()
+
+
+@pytest.mark.parametrize("datacube_env_name", ("datacube3", "postgis3"))
+def test_metadata_type_with_standard_index(index) -> None:
+    metadata_doc = yaml.safe_load("""
+    name: minimal
+    description: minimal metadata definition
+    dataset:
+        id: [id]
+        sources: [lineage, source_datasets]
+        label: [label]
+        creation_dt: ["properties", "odc:processing_datetime"]
+        search_fields:
+            some_custom_field:
+                description: some custom field
+                offset: [properties, custom]
+        """)
+
+    metadata = index.metadata_types.from_doc(metadata_doc)
+    assert isinstance(metadata, MetadataType)
+    assert metadata.id is None
+    assert metadata.name == "minimal"
+    assert "some_custom_field" in metadata.dataset_fields
 
 
 def test_system_init(uninitialised_postgres_db, clirunner) -> None:

--- a/integration_tests/index/test_pluggable_indexes.py
+++ b/integration_tests/index/test_pluggable_indexes.py
@@ -5,9 +5,11 @@
 from typing import Type
 
 import pytest
+import yaml
 
 from datacube.index.postgres.index import Index as PgIndex
 from datacube.index.postgis.index import Index as PGISIndex
+from datacube.model import MetadataType
 
 from datacube.index.postgres.index import Index
 

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -5,20 +5,17 @@
 from types import SimpleNamespace
 
 import pytest
-import yaml
 
 from datacube.drivers import (
-    index_driver_by_name,
     index_drivers,
     new_datasource,
     reader_drivers,
     writer_drivers,
 )
 from datacube.drivers.indexes import IndexDriverCache
-from datacube.model import MetadataType
 from datacube.storage import BandInfo
 from datacube.storage._rio import RasterDatasetDataSource
-from datacube.testutils import mk_sample_dataset, suppress_deprecations
+from datacube.testutils import mk_sample_dataset
 
 
 def test_new_datasource_fallback() -> None:
@@ -77,32 +74,6 @@ def test_writer_driver_mk_uri() -> None:
     file_path = "/path/to/my_file.nc"
     file_uri = writer_driver.mk_uri(file_path=file_path)
     assert file_uri == f"file://{file_path}"
-
-
-def test_metadata_type_from_doc() -> None:
-    metadata_doc = yaml.safe_load("""
-name: minimal
-description: minimal metadata definition
-dataset:
-    id: [id]
-    sources: [lineage, source_datasets]
-    label: [label]
-    creation_dt: [creation_dt]
-    search_fields:
-        some_custom_field:
-            description: some custom field
-            offset: [a,b,c,custom]
-    """)
-
-    for name in index_drivers():
-        driver = index_driver_by_name(name)
-        assert driver is not None
-        with suppress_deprecations():
-            metadata = driver.metadata_type_from_doc(metadata_doc)  # deprecated method
-            assert isinstance(metadata, MetadataType)
-            assert metadata.id is None
-            assert metadata.name == "minimal"
-            assert "some_custom_field" in metadata.dataset_fields
 
 
 def test_reader_cache_throws_on_missing_fallback() -> None:


### PR DESCRIPTION
### Reason for this pull request

Refactor to support future PRs for better schema management.

Eventual is to allow the postgis driver to support multiple schema versions simultaneously so software upgrades and database migrations don't have to be synchronised.

### Proposed changes

- Remove the long deprecated driver-level field generator function
- Make index-level field generator function instance method instead of class method
- Move actual implementation from module level to inside the `PostgisDbApi` object.
- Update existing tests, add new tests.

Doing this on my own time.

 - [x] Tests added / passed
 - [x] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2552.org.readthedocs.build/en/2552/

<!-- readthedocs-preview opendatacube end -->