### PR TITLE
Add sorting of release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+changelog:
+  categories:
+    - title: What's Changed
+      labels:
+        - "*"
+      exclude:
+        labels:
+          - dependencies
+    - title: Automated Updates
+      labels:
+        - dependencies


### PR DESCRIPTION
### Reason for this pull request

Put in the example from
https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#example-configurations but with the headings used
for our releases.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2558.org.readthedocs.build/en/2558/

<!-- readthedocs-preview opendatacube end -->