### PR TITLE
click: require -v -v to print trace

### DIFF
--- a/datacube/ui/click.py
+++ b/datacube/ui/click.py
@@ -358,8 +358,8 @@ def handle_exception(msg: str, e: Exception) -> None:
     """
     Exit following an exception in a CLI app
 
-    If verbosity (-v flag) specified, dump out a stack trace. Otherwise,
-    simply print the given error message.
+    If verbosity (-v flag) is specified twice, dump out a stack trace.
+    Otherwise, simply print the given error message.
 
     Include a '%s' in the message to print the single line message from the
     exception.
@@ -368,7 +368,7 @@ def handle_exception(msg: str, e: Exception) -> None:
     :param msg: Message to User with optional %s
     """
     ctx = click.get_current_context()
-    if ctx.obj["verbosity"] >= 1:
+    if ctx.obj["verbosity"] >= 2:
         raise e
     if "%s" in msg:
         click.echo(msg % e, err=True)


### PR DESCRIPTION
### Reason for this pull request

I do want some logging when initializing
the database, but getting a backtrace
for a configuration error seems
excessive.

Require at least two -v parameters
to resort to printing backtraces.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2578.org.readthedocs.build/en/2578/

<!-- readthedocs-preview opendatacube end -->