### PR TITLE
system: catch OperationalError on init

### DIFF
--- a/datacube/scripts/system.py
+++ b/datacube/scripts/system.py
@@ -76,10 +76,12 @@ def database_init(
             ODC2DeprecationWarning,
             stacklevel=1,
         )
-
-    was_created = index.init_db(
-        with_default_types=default_types, with_permissions=init_users
-    )
+    try:
+        was_created = index.init_db(
+            with_default_types=default_types, with_permissions=init_users
+        )
+    except OperationalError as e:
+        handle_exception("Error Connecting to Database: %s", e)
 
     if was_created:
         echo(style("Created.", bold=True))


### PR DESCRIPTION
### Reason for this pull request

Specifying the wrong hostname or port
makes the CLI crash on system init,
so catch the exception and give
an error message instead.

### Proposed changes

- 
- 



 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [X] Pull Request Title will make sense in ODC Release Notes

<!--
See https://github.com/blog/2111-issue-and-pull-request-templates for more
information on pull request templates.

-->


<!-- readthedocs-preview opendatacube start -->
----
📚 Documentation preview 📚: https://opendatacube--2579.org.readthedocs.build/en/2579/

<!-- readthedocs-preview opendatacube end -->